### PR TITLE
feat: add Nexus Python server with demo HTTP endpoint and test button

### DIFF
--- a/nexus/server.py
+++ b/nexus/server.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Nexus Demo Server
+A minimal HTTP server bundled with the Electron app.
+Usage: python3 server.py [port]
+"""
+
+import json
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class NexusHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        # Suppress default access log noise; errors still go to stderr
+        pass
+
+    def _send_json(self, status: int, data: dict):
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/ping":
+            self._send_json(200, {
+                "status": "ok",
+                "message": "Nexus Python server is running!",
+                "timestamp": int(time.time() * 1000),
+                "port": self.server.server_address[1],
+            })
+        elif self.path == "/info":
+            self._send_json(200, {
+                "name": "nexus",
+                "version": "0.1.0",
+                "python": sys.version,
+                "platform": sys.platform,
+            })
+        else:
+            self._send_json(404, {"error": "Not found", "path": self.path})
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.end_headers()
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    server = HTTPServer(("127.0.0.1", port), NexusHandler)
+    print(f"[Nexus] Server started on http://127.0.0.1:{port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("[Nexus] Server stopped", flush=True)
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -365,6 +365,14 @@ export const document = {
   convert: bridge.buildProvider<import('./types/conversion').DocumentConversionResponse, import('./types/conversion').DocumentConversionRequest>('document.convert'),
 };
 
+// Nexus Python server / 内置 Python 服务
+export const nexus = {
+  /** Ping the Nexus server to verify it is running */
+  ping: bridge.buildProvider<IBridgeResponse<{ message: string; timestamp: number; port: number }>, void>('nexus.ping'),
+  /** Get the current status of the Nexus server */
+  getStatus: bridge.buildProvider<IBridgeResponse<{ running: boolean; port: number }>, void>('nexus.get-status'),
+};
+
 // Deep link protocol handling / 深度链接协议处理
 export const deepLink = {
   /** Emitted when app is opened via aionui:// protocol URL */

--- a/src/index.ts
+++ b/src/index.ts
@@ -841,6 +841,14 @@ app.on('before-quit', async () => {
   // 在应用退出前清理工作进程
   WorkerManage.clear();
 
+  // Stop Nexus Python server
+  try {
+    const { nexusService } = await import('./process/services/nexus/NexusService');
+    nexusService.stop();
+  } catch {
+    // Ignore cleanup errors
+  }
+
   // Shutdown Channel subsystem
   try {
     const { getChannelManager } = await import('@/channels');

--- a/src/process/bridge/index.ts
+++ b/src/process/bridge/index.ts
@@ -29,6 +29,7 @@ import { initWebuiBridge } from './webuiBridge';
 import { initSystemSettingsBridge } from './systemSettingsBridge';
 import { initWindowControlsBridge } from './windowControlsBridge';
 import { initExtensionsBridge } from './extensionsBridge';
+import { initNexusBridge } from './nexusBridge';
 
 /**
  * 初始化所有IPC桥接模块
@@ -59,6 +60,7 @@ export function initAllBridges(): void {
   initSystemSettingsBridge();
   initExtensionsBridge();
   initStarOfficeBridge();
+  initNexusBridge();
 }
 
 /**
@@ -74,7 +76,7 @@ export async function initializeAcpDetector(): Promise<void> {
 
 // 导出初始化函数供单独使用
 
-export { initAcpConversationBridge, initApplicationBridge, initAuthBridge, initBedrockBridge, initChannelBridge, initConversationBridge, initCronBridge, initDatabaseBridge, initDialogBridge, initDocumentBridge, initExtensionsBridge, initFsBridge, initGeminiBridge, initGeminiConversationBridge, initMcpBridge, initModelBridge, initPreviewHistoryBridge, initShellBridge, initStarOfficeBridge, initSystemSettingsBridge, initUpdateBridge, initWebuiBridge, initWindowControlsBridge };
+export { initAcpConversationBridge, initApplicationBridge, initAuthBridge, initBedrockBridge, initChannelBridge, initConversationBridge, initCronBridge, initDatabaseBridge, initDialogBridge, initDocumentBridge, initExtensionsBridge, initFsBridge, initGeminiBridge, initGeminiConversationBridge, initMcpBridge, initModelBridge, initNexusBridge, initPreviewHistoryBridge, initShellBridge, initStarOfficeBridge, initSystemSettingsBridge, initUpdateBridge, initWebuiBridge, initWindowControlsBridge };
 
 // 导出窗口控制相关工具函数
 export { registerWindowMaximizeListeners } from './windowControlsBridge';

--- a/src/process/bridge/nexusBridge.ts
+++ b/src/process/bridge/nexusBridge.ts
@@ -1,0 +1,25 @@
+import { ipcBridge } from '../../common';
+import { nexusService } from '../services/nexus/NexusService';
+
+export function initNexusBridge(): void {
+  ipcBridge.nexus.ping.provider(async () => {
+    if (!nexusService.isRunning) {
+      return { success: false, msg: 'Nexus server is not running' };
+    }
+    try {
+      const res = await fetch(`http://127.0.0.1:${nexusService.port}/ping`);
+      const data = (await res.json()) as { message: string; timestamp: number; port: number };
+      return { success: true, data };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { success: false, msg };
+    }
+  });
+
+  ipcBridge.nexus.getStatus.provider(() => {
+    return Promise.resolve({
+      success: true,
+      data: { running: nexusService.isRunning, port: nexusService.port },
+    });
+  });
+}

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -17,6 +17,7 @@ import './initBridge';
 import './i18n'; // Initialize i18n for main process
 import { getChannelManager } from '@/channels';
 import { ExtensionRegistry } from '@/extensions';
+import { nexusService } from './services/nexus/NexusService';
 
 export const initializeProcess = async () => {
   await initStorage();
@@ -35,5 +36,13 @@ export const initializeProcess = async () => {
   } catch (error) {
     console.error('[Process] Failed to initialize ChannelManager:', error);
     // Don't fail app startup if channel fails to initialize
+  }
+
+  // Start Nexus Python server
+  try {
+    await nexusService.start();
+  } catch (error) {
+    console.error('[Process] Failed to start Nexus server:', error);
+    // Don't fail app startup if Nexus server fails to start
   }
 };

--- a/src/process/services/nexus/NexusService.ts
+++ b/src/process/services/nexus/NexusService.ts
@@ -1,0 +1,93 @@
+import { app } from 'electron';
+import { spawn, ChildProcess } from 'child_process';
+import * as net from 'net';
+import * as path from 'path';
+
+const NEXUS_PORT = 8080;
+
+class NexusService {
+  private process: ChildProcess | null = null;
+  private _running = false;
+
+  get isRunning(): boolean {
+    return this._running;
+  }
+
+  get port(): number {
+    return NEXUS_PORT;
+  }
+
+  async start(): Promise<void> {
+    if (this._running) return;
+
+    const scriptPath = this.resolveScriptPath();
+    console.log(`[Nexus] Starting server from: ${scriptPath}`);
+
+    if (app.isPackaged) {
+      // Production: run the PyInstaller-compiled binary
+      this.process = spawn(scriptPath, [String(NEXUS_PORT)], { stdio: 'pipe' });
+    } else {
+      // Development: run the .py script directly with python3
+      this.process = spawn('python3', [scriptPath, String(NEXUS_PORT)], { stdio: 'pipe' });
+    }
+
+    this.process.stdout?.on('data', (d: Buffer) => {
+      console.log(`[Nexus] ${d.toString().trim()}`);
+    });
+    this.process.stderr?.on('data', (d: Buffer) => {
+      console.error(`[Nexus] ${d.toString().trim()}`);
+    });
+    this.process.on('exit', (code) => {
+      console.log(`[Nexus] Process exited with code ${code}`);
+      this._running = false;
+    });
+    this.process.on('error', (err) => {
+      console.error(`[Nexus] Failed to start process:`, err);
+      this._running = false;
+    });
+
+    await this.waitForPort(NEXUS_PORT);
+    this._running = true;
+    console.log(`[Nexus] Server ready on http://127.0.0.1:${NEXUS_PORT}`);
+  }
+
+  stop(): void {
+    if (this.process) {
+      this.process.kill();
+      this.process = null;
+    }
+    this._running = false;
+  }
+
+  private resolveScriptPath(): string {
+    if (app.isPackaged) {
+      const ext = process.platform === 'win32' ? '.exe' : '';
+      return path.join(process.resourcesPath, 'nexus', `server${ext}`);
+    }
+    return path.join(app.getAppPath(), 'nexus', 'server.py');
+  }
+
+  private waitForPort(port: number, timeoutMs = 10000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const deadline = Date.now() + timeoutMs;
+
+      const attempt = () => {
+        const socket = net.connect(port, '127.0.0.1', () => {
+          socket.destroy();
+          resolve();
+        });
+        socket.on('error', () => {
+          if (Date.now() >= deadline) {
+            reject(new Error(`[Nexus] Server did not start within ${timeoutMs}ms`));
+            return;
+          }
+          setTimeout(attempt, 200);
+        });
+      };
+
+      attempt();
+    });
+  }
+}
+
+export const nexusService = new NexusService();

--- a/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
@@ -4,17 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Divider, Typography } from '@arco-design/web-react';
-import React from 'react';
+import { Button, Divider, Typography } from '@arco-design/web-react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { useSettingsViewMode } from '../settingsViewContext';
 import packageJson from '../../../../../package.json';
+import { nexus as nexusIpc } from '@/common/ipcBridge';
 
 const AboutModalContent: React.FC = () => {
   const { t } = useTranslation();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
+
+  const [nexusResult, setNexusResult] = useState<string | null>(null);
+  const [nexusTesting, setNexusTesting] = useState(false);
+
+  const handleTestNexus = async () => {
+    setNexusTesting(true);
+    setNexusResult(null);
+    try {
+      const res = await nexusIpc.ping.invoke();
+      if (res?.success && res.data) {
+        setNexusResult(`✓ ${res.data.message}  (port ${res.data.port})`);
+      } else {
+        setNexusResult(`✗ ${res?.msg ?? 'Unknown error'}`);
+      }
+    } catch (err) {
+      setNexusResult(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setNexusTesting(false);
+    }
+  };
+
   return (
     <div className='flex flex-col h-full w-full'>
       {/* Content Area */}
@@ -31,7 +53,32 @@ const AboutModalContent: React.FC = () => {
             <div className='flex items-center justify-center gap-8px mb-16px'>
               <span className='px-10px py-4px rd-6px text-13px bg-fill-2 text-t-primary font-500'>v{packageJson.version}</span>
             </div>
+          </div>
 
+          {/* Nexus Server Test Section */}
+          <Divider className='my-0' />
+          <div className='flex flex-col gap-12px pt-20px pb-24px'>
+            <div className='text-13px font-500 text-t-primary'>Nexus 服务测试</div>
+            <div className='flex items-center gap-12px flex-wrap'>
+              <Button
+                type='outline'
+                size='small'
+                loading={nexusTesting}
+                onClick={handleTestNexus}
+              >
+                测试 Nexus 接口
+              </Button>
+              {nexusResult && (
+                <span
+                  className={classNames(
+                    'text-13px font-mono',
+                    nexusResult.startsWith('✓') ? 'color-green-6' : 'color-red-6',
+                  )}
+                >
+                  {nexusResult}
+                </span>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Add nexus/server.py: pure stdlib Python HTTP server on port 8080 with /ping and /info endpoints
- Add NexusService.ts: spawns and manages the Python process lifecycle (dev: python3, prod: compiled binary)
- Add nexusBridge.ts + ipcBridge nexus entries: expose ping/getStatus via IPC
- Start NexusService in initializeProcess and stop on before-quit
- Add "测试 Nexus 接口" button in About settings page that calls the ping endpoint and shows the result

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
