### PR TITLE
fix: [Bug] 安全防护页面开关状态不一致

### DIFF
--- a/src/renderer/pages/settings/SecuritySettings.tsx
+++ b/src/renderer/pages/settings/SecuritySettings.tsx
@@ -35,9 +35,9 @@ const SecuritySettings: React.FC = () => {
             </div>
             <p className='text-14px text-t-secondary mb-16px leading-relaxed'>当智能体调用各类工具时，系统会进行全过程的安全管控。识别并拦截可能破坏系统、窃取数据、尝试提权的高风险行为，保障您的电脑环境安全。</p>
             <div className='flex items-center justify-end gap-12px'>
-              <Tag color='green' size='small' className='rd-12px px-12px'>
-                <span className='w-6px h-6px rd-50% bg-[#52c41a] inline-block mr-6px'></span>
-                保护中
+              <Tag color={envProtection ? 'green' : 'gray'} size='small' className='rd-12px px-12px'>
+                <span className={`w-6px h-6px rd-50% inline-block mr-6px ${envProtection ? 'bg-[#52c41a]' : 'bg-[#8c8c8c]'}`}></span>
+                {envProtection ? '保护中' : '已关闭'}
               </Tag>
               <Switch checked={envProtection} onChange={setEnvProtection} />
             </div>
@@ -61,9 +61,9 @@ const SecuritySettings: React.FC = () => {
             </div>
             <p className='text-14px text-t-secondary mb-16px leading-relaxed'>对输入给智能体的任务、提示词进行智能安全识别，自动检测是否包含个人隐私、敏感密钥、账号凭证等高风险信息，保障用户信息安全。</p>
             <div className='flex items-center justify-end gap-12px'>
-              <Tag color='green' size='small' className='rd-12px px-12px'>
-                <span className='w-6px h-6px rd-50% bg-[#52c41a] inline-block mr-6px'></span>
-                保护中
+              <Tag color={infoProtection ? 'green' : 'gray'} size='small' className='rd-12px px-12px'>
+                <span className={`w-6px h-6px rd-50% inline-block mr-6px ${infoProtection ? 'bg-[#52c41a]' : 'bg-[#8c8c8c]'}`}></span>
+                {infoProtection ? '保护中' : '已关闭'}
               </Tag>
               <Switch checked={infoProtection} onChange={setInfoProtection} />
             </div>
@@ -87,9 +87,9 @@ const SecuritySettings: React.FC = () => {
             </div>
             <p className='text-14px text-t-secondary mb-16px leading-relaxed'>所有 Skill 在安装和接入前，系统都会进行多层安全检测，包括来源可信度、代码审查、权限评估等，确保所有接入的技能纯净无害。</p>
             <div className='flex items-center justify-end gap-12px'>
-              <Tag color='green' size='small' className='rd-12px px-12px'>
-                <span className='w-6px h-6px rd-50% bg-[#52c41a] inline-block mr-6px'></span>
-                保护中
+              <Tag color={skillScan ? 'green' : 'gray'} size='small' className='rd-12px px-12px'>
+                <span className={`w-6px h-6px rd-50% inline-block mr-6px ${skillScan ? 'bg-[#52c41a]' : 'bg-[#8c8c8c]'}`}></span>
+                {skillScan ? '保护中' : '已关闭'}
               </Tag>
               <Switch checked={skillScan} onChange={setSkillScan} />
             </div>


### PR DESCRIPTION
## Summary

Fixed state synchronization issue in Security Protection page where the switch UI updated but the underlying protection status did not reflect the change.

## Changes

- Updated `Tag` component in `SecuritySettings.tsx` to dynamically change color and text based on switch state.
- Changed status text from "保护中" to "已关闭" when disabled.
- Changed status color from green to gray when disabled.

## Testing

Verified by inspection of `sudowork/src/renderer/pages/settings/SecuritySettings.tsx`.

Fixes sudoprivacy/sudowork#8