### PR TITLE
fix: disallow workspace change and resolve openclaw agent workspace

### DIFF
--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -8,6 +8,7 @@ import type { ICreateConversationParams } from '@/common/ipcBridge';
 import type { TChatConversation, TProviderWithModel } from '@/common/storage';
 import { uuid } from '@/common/utils';
 import fs from 'fs/promises';
+import fsSync from 'fs';
 import path from 'path';
 import { getSystemDir } from './initStorage';
 import { SUDOCLAW_DIR } from './services/sudoclaw/SudoclawInstallService';
@@ -152,9 +153,33 @@ export const createNanobotAgent = async (options: ICreateConversationParams): Pr
   };
 };
 
+function getSudoclawWorkspaceRoot(): string {
+  try {
+    const configPath = path.join(SUDOCLAW_DIR, 'openclaw.json');
+    const raw = fsSync.readFileSync(configPath, 'utf-8');
+    const cfg = JSON.parse(raw);
+    const configured = cfg?.agents?.defaults?.workspace;
+    if (typeof configured === 'string' && configured.trim()) {
+      return configured.trim();
+    }
+  } catch {
+    // fall through to default
+  }
+  return getSystemDir().workDir;
+}
+
 export const createOpenClawAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
-  const { workspace, customWorkspace } = await buildWorkspaceWidthFiles(`openclaw-temp-${Date.now()}`, extra.workspace, extra.defaultFiles, extra.customWorkspace);
+  // Use workspace root from openclaw.json so the agent's working dir matches the UI workspace panel.
+  // Falls back to getSystemDir().workDir if openclaw.json is missing or has no workspace configured.
+  const tempName = `sudoclaw-temp-${Date.now()}`;
+  let resolvedWorkspace = extra.workspace;
+  if (!resolvedWorkspace) {
+    const root = getSudoclawWorkspaceRoot();
+    resolvedWorkspace = path.join(root, tempName);
+    await fs.mkdir(resolvedWorkspace, { recursive: true });
+  }
+  const { workspace, customWorkspace } = await buildWorkspaceWidthFiles(tempName, resolvedWorkspace, extra.defaultFiles, extra.customWorkspace);
   const expectedIdentityHash = await computeOpenClawIdentityHash(workspace);
 
   const stateDir = SUDOCLAW_DIR;

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -15,7 +15,7 @@ import { iconColors } from '@/renderer/theme/colors';
 import { emitter } from '@/renderer/utils/emitter';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import { getLastDirectoryName, isTemporaryWorkspace as checkIsTemporaryWorkspace, getWorkspaceDisplayName as getDisplayName } from '@/renderer/utils/workspace';
-import { Checkbox, Empty, Input, Message, Modal, Tooltip, Tree } from '@arco-design/web-react';
+import { Checkbox, Empty, Input, Message, Modal, Popover, Tooltip, Tree } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
 import { Down, FileText, FolderOpen, Refresh, Search } from '@icon-park/react';
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
@@ -218,9 +218,9 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
   }, [workspace, isTemporaryWorkspace, t]);
 
   // Workspace migration handlers
-  const handleOpenMigrationModal = useCallback(() => {
-    setShowMigrationModal(true);
-  }, []);
+  // const handleOpenMigrationModal = useCallback(() => {
+  //   setShowMigrationModal(true);
+  // }, []);
 
   // Handle directory selection from DirectorySelectionModal (webui)
   const handleSelectDirectoryFromModal = useCallback((paths: string[] | undefined) => {
@@ -736,16 +736,11 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
           <div className='workspace-toolbar-row flex items-center justify-between gap-8px'>
             <div className='flex items-center gap-8px cursor-pointer flex-1 min-w-0' onClick={() => setIsWorkspaceCollapsed(!isWorkspaceCollapsed)}>
               <Down size={16} fill={iconColors.primary} className={`line-height-0 transition-transform duration-200 flex-shrink-0 ${isWorkspaceCollapsed ? '-rotate-90' : 'rotate-0'}`} />
-              <span className='workspace-title-label font-bold text-14px text-t-primary overflow-hidden text-ellipsis whitespace-nowrap'>{workspaceDisplayName}</span>
+              <Popover content={<span style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{workspace}</span>} position='top' trigger='hover' className='workspace-path-popover'>
+                <span className='workspace-title-label font-bold text-14px text-t-primary overflow-hidden text-ellipsis whitespace-nowrap'>{workspaceDisplayName}</span>
+              </Popover>
             </div>
             <div className='workspace-toolbar-actions flex items-center gap-8px flex-shrink-0'>
-              {isTemporaryWorkspace && (
-                <Tooltip content={t('conversation.workspace.changeWorkspace')}>
-                  <span>
-                    <ChangeWorkspaceIcon className='workspace-toolbar-icon-btn line-height-0 cursor-pointer w-24px h-24px flex-shrink-0' onClick={handleOpenMigrationModal} />
-                  </span>
-                </Tooltip>
-              )}
               <Tooltip content={t('conversation.workspace.refresh')}>
                 <span>
                   <Refresh className={treeHook.loading ? 'workspace-toolbar-icon-btn loading lh-[1] flex cursor-pointer' : 'workspace-toolbar-icon-btn flex cursor-pointer'} theme='outline' size='16' fill={iconColors.secondary} onClick={() => treeHook.refreshWorkspace()} />


### PR DESCRIPTION
## Summary
- Removes the change-workspace button from the workspace toolbar for temporary workspaces
- Adds a popover on the workspace title to show the full workspace path on hover
- Fixes the OpenClaw agent to use the workspace root from `openclaw.json` instead of a generated temp directory

## Test plan
- [ ] Verify the change-workspace icon no longer appears in the workspace toolbar
- [ ] Hover over workspace title and confirm full path is shown in popover
- [ ] Create an OpenClaw agent and confirm its working directory matches the workspace configured in `openclaw.json`
- [ ] Confirm fallback to `getSystemDir().workDir` when `openclaw.json` is missing or has no workspace configured