### PR TITLE
fix: inject per-session workspace directive into OpenClaw first message

### DIFF
--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -153,7 +153,7 @@ export const createNanobotAgent = async (options: ICreateConversationParams): Pr
   };
 };
 
-function getSudoclawWorkspaceRoot(): string {
+export function getSudoclawWorkspaceRoot(): string {
   try {
     const configPath = path.join(SUDOCLAW_DIR, 'openclaw.json');
     const raw = fsSync.readFileSync(configPath, 'utf-8');

--- a/src/process/task/OpenClawAgentManager.ts
+++ b/src/process/task/OpenClawAgentManager.ts
@@ -15,6 +15,7 @@ import type { AcpBackendAll } from '@/types/acpTypes';
 import { getDatabase } from '@process/database';
 import { addMessage, addOrUpdateMessage } from '@process/message';
 import { cronBusyGuard } from '@process/services/cron/CronBusyGuard';
+import { getSudoclawWorkspaceRoot } from '@process/initAgent';
 import { SUDOCLAW_DEFAULT_PORT, SUDOCLAW_DIR } from '@process/services/sudoclaw/SudoclawInstallService';
 import WorkerManage from '@process/WorkerManage';
 import BaseAgentManager from '@process/task/BaseAgentManager';
@@ -223,9 +224,25 @@ class OpenClawAgentManager extends BaseAgentManager<OpenClawAgentManagerData> {
         addMessage(this.conversation_id, userMessage);
       }
 
-      // Send message to agent (use agentContent if provided, e.g. with injected skills)
+      // On the first message, prepend a workspace directive so the agent uses the
+      // per-conversation workspace dir for all file operations and bash commands.
+      let agentContent = data.agentContent || data.content;
+      if (this.isFirstMessage && this.workspace) {
+        this.isFirstMessage = false;
+        const configuredWorkspace = getSudoclawWorkspaceRoot();
+        agentContent =
+          `[System: Very important — DO NOT use configured workspace '${configuredWorkspace}'! ` +
+          `Your working directory for this session ONLY is '${this.workspace}'. ` +
+          `All file operations, bash commands, and output (when calling write() tool) should use this session working directory unless the user explicitly specifies otherwise. ` +
+          `For write(), unless user explicitly specifies an output location, double check that it's not mistakenly output to '${configuredWorkspace}', otherwise move it to the session directory. ]\n\n` +
+          agentContent;
+      } else {
+        this.isFirstMessage = false;
+      }
+
+      // Send message to agent
       const result = await this.agent.sendMessage({
-        content: data.agentContent || data.content,
+        content: agentContent,
         files: data.files,
         msg_id: data.msg_id,
       });


### PR DESCRIPTION
## Summary

- OpenClaw gateway runs as a shared process and uses a single configured workspace root (`~/.nexus/.sudoclaw/workspace`) for all sessions, causing all conversations to write files to the same directory regardless of which per-conversation workspace the UI shows.
- On the first message of each new OpenClaw session, inject a `[System: ...]` directive into the agent content telling it to use the per-conversation workspace dir (`sudoclaw-temp-<ts>`) instead of the configured root.
- Export `getSudoclawWorkspaceRoot()` from `initAgent.ts` so the manager can read the configured workspace path to name it explicitly in the directive.

## Test plan

- [ ] Start a new OpenClaw conversation — verify files created by the agent land in `~/.nexus/.sudoclaw/workspace/sudoclaw-temp-<ts>/` not in `~/.nexus/.sudoclaw/workspace/` directly
- [ ] Start a second concurrent conversation — verify each session writes to its own temp dir
- [ ] Resume an existing conversation (via session key) — directive is not re-injected (only fires on `isFirstMessage`)
- [ ] Verify memory, identity, skills still load correctly (workspace directive only affects agent behavior, not bootstrap file loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)