### PR TITLE
fix: nexus installation on windows

### DIFF
--- a/src/process/bridge/nexusBridge.ts
+++ b/src/process/bridge/nexusBridge.ts
@@ -92,6 +92,7 @@ export function initNexusBridge(): void {
       const fs = await import('fs');
       const path = await import('path');
       const os = await import('os');
+      const tar = await import('tar');
       const { exec } = await import('child_process');
       const util = await import('util');
 
@@ -119,7 +120,7 @@ export function initNexusBridge(): void {
       // 解压
       await fs.promises.mkdir(envDir, { recursive: true });
       console.log(`[NexusBridge] Extracting local nexus file to ${envDir}...`);
-      await execAsync(`tar -xzf "${tempTarGzPath}" -C "${envDir}"`);
+      await tar.x({ file: tempTarGzPath, cwd: envDir });
 
       // 运行 conda-unpack 修复硬编码路径
       // Windows 下路径为 Scripts\conda-unpack.exe，macOS/Linux 为 bin/conda-unpack

--- a/src/process/services/nexus/DynamicNexusService.ts
+++ b/src/process/services/nexus/DynamicNexusService.ts
@@ -5,6 +5,7 @@ import { app } from 'electron';
 import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import * as net from 'net';
+import * as tar from 'tar';
 import { getDataPath } from '@process/utils';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 
@@ -185,16 +186,21 @@ class DynamicNexusService {
         // Extract
         fs.mkdirSync(envDir, { recursive: true });
         this.emitSetup('extracting', 'Extracting Nexus environment...');
-        await execAsync(`tar -xzf "${tempTarGzPath}" -C "${envDir}"`);
+        await tar.x({ file: tempTarGzPath, cwd: envDir });
 
         // Run conda-unpack to fix hardcoded paths
         const condaUnpack = this.getCondaUnpackPath(envDir);
         if (fs.existsSync(condaUnpack)) {
           if (!this.isWindows) fs.chmodSync(condaUnpack, 0o755);
           this.emitSetup('unpacking', 'Running conda-unpack to fix install paths...');
-          // Use python from conda env to run conda-unpack (shebang may point to wrong path)
-          const pythonBin = this.getPythonPath(envDir);
-          await execAsync(`"${pythonBin}" "${condaUnpack}"`);
+          if (this.isWindows) {
+            // On Windows, conda-unpack.exe is a binary executable, run it directly
+            await execAsync(`"${condaUnpack}"`);
+          } else {
+            // On macOS/Linux, use python from conda env to run conda-unpack (shebang may point to wrong path)
+            const pythonBin = this.getPythonPath(envDir);
+            await execAsync(`"${pythonBin}" "${condaUnpack}"`);
+          }
         }
 
         // Ensure nexusd is executable


### PR DESCRIPTION
## Summary
- Switch from shell `tar` command to `tar` npm package for more reliable extraction on Windows.
- Run `conda-unpack.exe` directly on Windows instead of through Python interpreter to avoid `SyntaxError`.

## Test plan
- Verified that Nexus Server extracts correctly without drive letter errors on Windows.
- Verified that `conda-unpack` runs successfully as a binary executable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)