### PR TITLE
fix: prevent export dialog from closing immediately

### DIFF
--- a/src/renderer/pages/conversation/grouped-history/hooks/useExport.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useExport.ts
@@ -26,6 +26,7 @@ export const useExport = ({ conversations, selectedConversationIds, setSelectedC
   const [exportModalVisible, setExportModalVisible] = useState(false);
   const [exportTargetPath, setExportTargetPath] = useState('');
   const [exportModalLoading, setExportModalLoading] = useState(false);
+  const [exportFinished, setExportFinished] = useState(false);
   const [showExportDirectorySelector, setShowExportDirectorySelector] = useState(false);
   const [currentExportRequestId, setCurrentExportRequestId] = useState<string | null>(null);
   const exportCanceledRef = useRef(false);
@@ -80,6 +81,7 @@ export const useExport = ({ conversations, selectedConversationIds, setSelectedC
     setExportTask(null);
     setExportTargetPath('');
     setExportModalLoading(false);
+    setExportFinished(false);
     setCurrentExportRequestId(null);
   }, [currentExportRequestId, exportModalLoading]);
 
@@ -88,6 +90,7 @@ export const useExport = ({ conversations, selectedConversationIds, setSelectedC
       exportCanceledRef.current = false;
       setExportTask(task);
       setExportModalVisible(true);
+      setExportFinished(false);
       const desktopPath = await getDesktopPath();
       setExportTargetPath(desktopPath);
     },
@@ -250,10 +253,7 @@ export const useExport = ({ conversations, selectedConversationIds, setSelectedC
 
         if (success) {
           Message.success(t('conversation.history.exportSuccess'));
-          setExportModalVisible(false);
-          setExportTask(null);
-          setExportTargetPath('');
-          setCurrentExportRequestId(null);
+          setExportFinished(true);
         } else {
           Message.error(t('conversation.history.exportFailed'));
         }
@@ -282,10 +282,7 @@ export const useExport = ({ conversations, selectedConversationIds, setSelectedC
         Message.success(t('conversation.history.exportSuccess'));
         setSelectedConversationIds(new Set());
         onBatchModeChange?.(false);
-        setExportModalVisible(false);
-        setExportTask(null);
-        setExportTargetPath('');
-        setCurrentExportRequestId(null);
+        setExportFinished(true);
       } else {
         Message.error(t('conversation.history.exportFailed'));
       }
@@ -308,6 +305,7 @@ export const useExport = ({ conversations, selectedConversationIds, setSelectedC
     exportModalVisible,
     exportTargetPath,
     exportModalLoading,
+    exportFinished,
     showExportDirectorySelector,
     setShowExportDirectorySelector,
     closeExportModal,

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -55,7 +55,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     markAsRead,
   });
 
-  const { exportTask, exportModalVisible, exportTargetPath, exportModalLoading, showExportDirectorySelector, setShowExportDirectorySelector, closeExportModal, handleSelectExportDirectoryFromModal, handleSelectExportFolder, handleExportConversation, handleBatchExport, handleConfirmExport } = useExport({
+  const { exportTask, exportModalVisible, exportTargetPath, exportModalLoading, exportFinished, showExportDirectorySelector, setShowExportDirectorySelector, closeExportModal, handleSelectExportDirectoryFromModal, handleSelectExportFolder, handleExportConversation, handleBatchExport, handleConfirmExport } = useExport({
     conversations,
     selectedConversationIds,
     setSelectedConversationIds,
@@ -145,23 +145,25 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
           </div>
 
           <div className='flex gap-12px justify-end'>
-            <button
-              className='px-24px py-8px rounded-20px text-14px font-medium transition-all'
-              style={{
-                border: '1px solid var(--color-border-2)',
-                backgroundColor: 'var(--color-fill-2)',
-                color: 'var(--color-text-1)',
-              }}
-              onMouseEnter={(event) => {
-                event.currentTarget.style.backgroundColor = 'var(--color-fill-3)';
-              }}
-              onMouseLeave={(event) => {
-                event.currentTarget.style.backgroundColor = 'var(--color-fill-2)';
-              }}
-              onClick={closeExportModal}
-            >
-              {t('common.cancel')}
-            </button>
+            {!exportFinished && (
+              <button
+                className='px-24px py-8px rounded-20px text-14px font-medium transition-all'
+                style={{
+                  border: '1px solid var(--color-border-2)',
+                  backgroundColor: 'var(--color-fill-2)',
+                  color: 'var(--color-text-1)',
+                }}
+                onMouseEnter={(event) => {
+                  event.currentTarget.style.backgroundColor = 'var(--color-fill-3)';
+                }}
+                onMouseLeave={(event) => {
+                  event.currentTarget.style.backgroundColor = 'var(--color-fill-2)';
+                }}
+                onClick={closeExportModal}
+              >
+                {t('common.cancel')}
+              </button>
+            )}
             <button
               className='px-24px py-8px rounded-20px text-14px font-medium transition-all'
               style={{
@@ -181,11 +183,15 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
                 }
               }}
               onClick={() => {
-                void handleConfirmExport();
+                if (exportFinished) {
+                  closeExportModal();
+                } else {
+                  void handleConfirmExport();
+                }
               }}
               disabled={exportModalLoading}
             >
-              {exportModalLoading ? t('conversation.history.exporting') : t('common.confirm')}
+              {exportModalLoading ? t('conversation.history.exporting') : exportFinished ? t('common.close') : t('common.confirm')}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Added `exportFinished` state to `useExport` hook to track completion.
- Updated export modal to remain open after success, showing a "Close" button instead of "Confirm".
- Hidden the "Cancel" button after export completes.

## Test plan
1. Go to conversation history.
2. Select one or more topics to export.
3. Click "Export" and choose a destination.
4. Click "Confirm".
5. Observe that the dialog stays open after "Export succeeded" message appears.
6. Verify the "Confirm" button changes to "Close" and "Cancel" disappears.
7. Click "Close" to dismiss the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)