### PR TITLE
feat: add system theme mode

### DIFF
--- a/src/renderer/components/ThemeSwitcher.tsx
+++ b/src/renderer/components/ThemeSwitcher.tsx
@@ -5,85 +5,58 @@
  */
 
 import { useThemeContext } from '@/renderer/context/ThemeContext';
-import { IconMoon, IconMoonFill, IconSun, IconSunFill } from '@arco-design/web-react/icon';
+import type { ThemePreference } from '@/renderer/hooks/useTheme';
+import { IconMoonFill, IconSunFill } from '@arco-design/web-react/icon';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
+const SystemIcon: React.FC<{ style?: React.CSSProperties }> = ({ style }) => (
+  <svg width='1em' height='1em' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg' style={style}>
+    <rect x='4' y='8' width='40' height='28' rx='3' stroke='currentColor' strokeWidth='4' fill='currentColor' fillOpacity='0.15' />
+    <path d='M14 44h20' stroke='currentColor' strokeWidth='4' strokeLinecap='round' />
+    <path d='M24 36v8' stroke='currentColor' strokeWidth='4' strokeLinecap='round' />
+  </svg>
+);
 
 /**
  * 主题切换器组件 / Theme switcher component
  *
- * 提供明暗模式切换功能
- * Provides light/dark mode switching functionality
+ * 三个紧凑的图标按钮: 浅色 / 系统 / 深色
+ * Three compact icon buttons: Light / System / Dark
  */
 export const ThemeSwitcher = () => {
-  const { theme, setTheme } = useThemeContext();
+  const { themePreference, setTheme } = useThemeContext();
   const { t } = useTranslation();
-  const trackInset = 6;
-  const splitGap = 1;
-  const options = [
-    { value: 'light' as const, label: t('settings.lightMode'), icon: IconSun, activeIcon: IconSunFill },
-    { value: 'dark' as const, label: t('settings.darkMode'), icon: IconMoon, activeIcon: IconMoonFill },
+
+  const options: { value: ThemePreference; label: string; icon: React.ReactNode }[] = [
+    { value: 'light', label: t('settings.lightMode'), icon: <IconSunFill style={{ fontSize: 14 }} /> },
+    { value: 'system', label: t('settings.systemMode'), icon: <SystemIcon style={{ fontSize: 14 }} /> },
+    { value: 'dark', label: t('settings.darkMode'), icon: <IconMoonFill style={{ fontSize: 14 }} /> },
   ];
 
   return (
-    <div className='relative inline-grid grid-cols-2 p-6px rd-full border border-solid border-[var(--color-border-2)] bg-1 w-full max-w-240px md:w-auto md:min-w-216px' role='radiogroup' aria-label={t('settings.theme')}>
-      <span
-        aria-hidden='true'
-        className='absolute rd-full border border-solid border-[var(--color-border-2)] transition-all duration-260 ease-[cubic-bezier(0.2,0.8,0.2,1)]'
-        style={{
-          top: trackInset,
-          bottom: trackInset,
-          left: theme === 'light' ? trackInset : `calc(50% + ${splitGap}px)`,
-          right: theme === 'light' ? `calc(50% + ${splitGap}px)` : trackInset,
-          backgroundColor: 'var(--color-fill-2)',
-          boxShadow: theme === 'dark' ? '0 1px 4px rgba(0, 0, 0, 0.18)' : '0 2px 8px rgba(0, 0, 0, 0.08)',
-        }}
-      />
+    <div className='inline-flex items-center gap-2px rd-6px bg-[var(--color-fill-1)] p-2px' role='radiogroup' aria-label={t('settings.theme')}>
       {options.map((option) => {
-        const isActive = theme === option.value;
-        const Icon = option.icon;
-        const ActiveIcon = option.activeIcon;
-
+        const isActive = themePreference === option.value;
         return (
           <button
             key={option.value}
             type='button'
             role='radio'
             aria-checked={isActive}
-            className='relative z-1 h-33px min-w-0 px-10px md:px-12px rd-full text-13px font-500 inline-flex items-center justify-center gap-6px transition-all duration-180 active:scale-[0.985] disabled:cursor-not-allowed'
+            aria-label={option.label}
+            title={option.label}
+            className='inline-flex items-center justify-center w-26px h-26px rd-5px transition-all duration-160 cursor-pointer border-none'
             style={{
-              color: isActive ? (theme === 'dark' ? 'var(--color-text-1)' : 'rgb(var(--primary-6))') : 'var(--color-text-2)',
-              backgroundColor: 'transparent',
-              border: '1px solid transparent',
-              cursor: isActive ? 'default' : 'pointer',
+              color: isActive ? 'rgb(var(--primary-6))' : 'var(--color-text-4)',
+              backgroundColor: isActive ? 'var(--color-bg-2)' : 'transparent',
+              boxShadow: isActive ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
             }}
             onClick={() => {
-              if (!isActive) {
-                void setTheme(option.value);
-              }
+              if (!isActive) void setTheme(option.value);
             }}
           >
-            <span className='relative inline-flex items-center justify-center w-14px h-14px'>
-              <Icon
-                style={{
-                  fontSize: 14,
-                  opacity: isActive ? 0 : 0.8,
-                  transform: isActive ? 'scale(0.6) rotate(-20deg)' : 'scale(1) rotate(0deg)',
-                  transition: 'transform 220ms ease, opacity 220ms ease',
-                  position: 'absolute',
-                }}
-              />
-              <ActiveIcon
-                style={{
-                  fontSize: 14,
-                  opacity: isActive ? 1 : 0,
-                  transform: isActive ? 'scale(1.08) rotate(0deg)' : 'scale(0.65) rotate(20deg)',
-                  transition: 'transform 220ms ease, opacity 220ms ease',
-                  position: 'absolute',
-                }}
-              />
-            </span>
-            {option.label}
+            {option.icon}
           </button>
         );
       })}

--- a/src/renderer/context/ThemeContext.tsx
+++ b/src/renderer/context/ThemeContext.tsx
@@ -7,7 +7,7 @@
 // context/ThemeContext.tsx - Unified Theme Management Context 统一主题管理上下文
 import type { PropsWithChildren } from 'react';
 import React, { createContext, useContext } from 'react';
-import type { Theme } from '../hooks/useTheme';
+import type { Theme, ThemePreference } from '../hooks/useTheme';
 import useTheme from '../hooks/useTheme';
 import type { ColorScheme } from '../hooks/useColorScheme';
 import useColorScheme from '../hooks/useColorScheme';
@@ -18,9 +18,11 @@ import useFontScale from '../hooks/useFontScale';
  * Separates light/dark mode from color schemes 分离明暗模式和配色方案
  */
 interface ThemeContextValue {
-  // Light/Dark mode 明暗模式
+  // Light/Dark mode 明暗模式 (resolved effective theme)
   theme: Theme;
-  setTheme: (theme: Theme) => Promise<void>;
+  // Theme preference 主题偏好 (user's choice including 'system')
+  themePreference: ThemePreference;
+  setTheme: (preference: ThemePreference) => Promise<void>;
 
   // Color scheme 配色方案
   colorScheme: ColorScheme;
@@ -38,11 +40,11 @@ const ThemeContext = createContext<ThemeContextValue | null>(null);
  * Manages both light/dark mode and color schemes 同时管理明暗模式和配色方案
  */
 export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const [theme, setTheme] = useTheme();
+  const [theme, themePreference, setTheme] = useTheme();
   const [colorScheme, setColorScheme] = useColorScheme();
   const [fontScale, setFontScale] = useFontScale();
 
-  return <ThemeContext.Provider value={{ theme, setTheme, colorScheme, setColorScheme, fontScale, setFontScale }}>{children}</ThemeContext.Provider>;
+  return <ThemeContext.Provider value={{ theme, themePreference, setTheme, colorScheme, setColorScheme, fontScale, setFontScale }}>{children}</ThemeContext.Provider>;
 };
 
 /**

--- a/src/renderer/hooks/useTheme.ts
+++ b/src/renderer/hooks/useTheme.ts
@@ -3,74 +3,85 @@ import { ConfigStorage } from '@/common/storage';
 import { useCallback, useEffect, useState } from 'react';
 
 export type Theme = 'light' | 'dark';
+export type ThemePreference = 'light' | 'dark' | 'system';
 
-const DEFAULT_THEME: Theme = 'light';
+const DEFAULT_PREFERENCE: ThemePreference = 'light';
 const THEME_CACHE_KEY = '__aionui_theme';
 
-// Initialize theme immediately when module loads
-const initTheme = async () => {
+const getSystemTheme = (): Theme => {
+  if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+  return 'light';
+};
+
+const resolveTheme = (preference: ThemePreference): Theme => {
+  if (preference === 'system') return getSystemTheme();
+  return preference;
+};
+
+// Apply theme to document
+const applyTheme = (theme: Theme) => {
+  document.documentElement.setAttribute('data-theme', theme);
+  document.body.setAttribute('arco-theme', theme);
   try {
-    const theme = (await ConfigStorage.get('theme')) as Theme;
-    const initialTheme = theme || DEFAULT_THEME;
-    document.documentElement.setAttribute('data-theme', initialTheme);
-    document.body.setAttribute('arco-theme', initialTheme);
-    try {
-      localStorage.setItem(THEME_CACHE_KEY, initialTheme);
-    } catch (_e) {
-      /* noop */
-    }
-    return initialTheme;
+    localStorage.setItem(THEME_CACHE_KEY, theme);
+  } catch (_e) {
+    /* noop */
+  }
+};
+
+// Initialize theme immediately when module loads
+const initTheme = async (): Promise<ThemePreference> => {
+  try {
+    const preference = ((await ConfigStorage.get('theme')) as ThemePreference) || DEFAULT_PREFERENCE;
+    applyTheme(resolveTheme(preference));
+    return preference;
   } catch (error) {
     console.error('Failed to load initial theme:', error);
-    document.documentElement.setAttribute('data-theme', DEFAULT_THEME);
-    document.body.setAttribute('arco-theme', DEFAULT_THEME);
-    return DEFAULT_THEME;
+    applyTheme(resolveTheme(DEFAULT_PREFERENCE));
+    return DEFAULT_PREFERENCE;
   }
 };
 
 // Run theme initialization immediately
-let initialThemePromise: Promise<Theme> | null = null;
+let initialThemePromise: Promise<ThemePreference> | null = null;
 if (typeof window !== 'undefined') {
   initialThemePromise = initTheme();
 }
 
-const useTheme = (): [Theme, (theme: Theme) => Promise<void>] => {
-  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
+const useTheme = (): [Theme, ThemePreference, (preference: ThemePreference) => Promise<void>] => {
+  const [preference, setPreferenceState] = useState<ThemePreference>(DEFAULT_PREFERENCE);
+  const [theme, setThemeState] = useState<Theme>(resolveTheme(DEFAULT_PREFERENCE));
 
-  // Apply theme to document
-  const applyTheme = useCallback((newTheme: Theme) => {
-    document.documentElement.setAttribute('data-theme', newTheme);
-    document.body.setAttribute('arco-theme', newTheme);
-    try {
-      localStorage.setItem(THEME_CACHE_KEY, newTheme);
-    } catch (_e) {
-      /* noop */
-    }
-  }, []);
-
-  // Set theme with persistence
-  const setTheme = useCallback(
-    async (newTheme: Theme) => {
+  // Set theme preference with persistence
+  const setPreference = useCallback(
+    async (newPreference: ThemePreference) => {
+      const prev = preference;
       try {
-        setThemeState(newTheme);
-        applyTheme(newTheme);
-        await ConfigStorage.set('theme', newTheme);
+        setPreferenceState(newPreference);
+        const resolved = resolveTheme(newPreference);
+        setThemeState(resolved);
+        applyTheme(resolved);
+        await ConfigStorage.set('theme', newPreference);
       } catch (error) {
         console.error('Failed to save theme:', error);
-        // Revert on error
-        setThemeState(theme);
-        applyTheme(theme);
+        setPreferenceState(prev);
+        const resolved = resolveTheme(prev);
+        setThemeState(resolved);
+        applyTheme(resolved);
       }
     },
-    [theme, applyTheme]
+    [preference]
   );
 
   // Initialize theme state from the early initialization
   useEffect(() => {
     if (initialThemePromise) {
       initialThemePromise
-        .then((initialTheme) => {
-          setThemeState(initialTheme);
+        .then((pref) => {
+          setPreferenceState(pref);
+          setThemeState(resolveTheme(pref));
         })
         .catch((error) => {
           console.error('Failed to initialize theme:', error);
@@ -78,7 +89,20 @@ const useTheme = (): [Theme, (theme: Theme) => Promise<void>] => {
     }
   }, []);
 
-  return [theme, setTheme];
+  // Listen for system color scheme changes when preference is 'system'
+  useEffect(() => {
+    if (preference !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => {
+      const resolved = resolveTheme('system');
+      setThemeState(resolved);
+      applyTheme(resolved);
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [preference]);
+
+  return [theme, preference, setPreference];
 };
 
 export default useTheme;

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -202,6 +202,7 @@
   "fontSizeReset": "Reset zoom",
   "lightMode": "Light",
   "darkMode": "Dark",
+  "systemMode": "System",
   "agent": "Agent",
   "tools": "Tools",
   "skill": "Skill Hub",

--- a/src/renderer/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/i18n/locales/ja-JP/settings.json
@@ -199,6 +199,7 @@
   "fontSizeReset": "ズームをリセット",
   "lightMode": "ライト",
   "darkMode": "ダーク",
+  "systemMode": "システム",
   "agent": "エージェント",
   "tools": "ツール",
   "webui": "リモート接続",

--- a/src/renderer/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/i18n/locales/ko-KR/settings.json
@@ -199,6 +199,7 @@
   "fontSizeReset": "확대/축소 초기화",
   "lightMode": "라이트",
   "darkMode": "다크",
+  "systemMode": "시스템",
   "agent": "에이전트",
   "tools": "도구",
   "webui": "원격 연결",

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -199,6 +199,7 @@
   "fontSizeReset": "Yakınlaştırmayı sıfırla",
   "lightMode": "Açık",
   "darkMode": "Koyu",
+  "systemMode": "Sistem",
   "agent": "Ajan",
   "tools": "Araçlar",
   "webui": "Uzak Bağlantı",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -202,6 +202,7 @@
   "fontSizeReset": "恢复默认缩放",
   "lightMode": "浅色",
   "darkMode": "深色",
+  "systemMode": "系统",
   "agent": "对话Agent",
   "tools": "工具",
   "skill": "技能",

--- a/src/renderer/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/i18n/locales/zh-TW/settings.json
@@ -199,6 +199,7 @@
   "fontSizeReset": "恢復預設縮放",
   "lightMode": "淺色",
   "darkMode": "深色",
+  "systemMode": "系統",
   "agent": "代理",
   "tools": "工具",
   "webui": "遠端連線",

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -8,6 +8,7 @@ import { resolveLocaleKey } from '@/common/utils';
 import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import { useConversationTabs } from '@/renderer/pages/conversation/context/ConversationTabsContext';
+import { ThemeSwitcher } from '@/renderer/components/ThemeSwitcher';
 import AgentPillBar from './components/AgentPillBar';
 import AssistantSelectionArea from './components/AssistantSelectionArea';
 import { AgentPillBarSkeleton, AssistantsSkeleton } from './components/GuidSkeleton';
@@ -263,6 +264,9 @@ const GuidPage: React.FC = () => {
   return (
     <ConfigProvider getPopupContainer={() => guidContainerRef.current || document.body}>
       <div ref={guidContainerRef} className={styles.guidContainer}>
+        <div className='absolute top-12px right-16px z-10'>
+          <ThemeSwitcher />
+        </div>
         {selectedMenu ? (
           /* 功能菜单内容区域 - 完全清空展示新内容 */
           <div className={styles.functionMenuContainer}>

--- a/src/renderer/sider.tsx
+++ b/src/renderer/sider.tsx
@@ -1,5 +1,5 @@
 import { ArrowCircleLeft, Down, Earth, Lightning, ListCheckbox, Logout, Plus, Robot, SettingTwo, Shield, Toolkit } from '@icon-park/react';
-import { IconHome, IconMoonFill, IconSunFill } from '@arco-design/web-react/icon';
+import { IconHome } from '@arco-design/web-react/icon';
 import classNames from 'classnames';
 import React, { Suspense, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,7 +9,6 @@ import { Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import { cleanupSiderTooltips, getSiderTooltipProps } from './utils/siderTooltip';
 import { useLayoutContext } from './context/LayoutContext';
 import { blurActiveElement } from './utils/focus';
-import { useThemeContext } from './context/ThemeContext';
 import { isElectronDesktop } from './utils/platform';
 
 const WorkspaceGroupedHistory = React.lazy(() => import('./pages/conversation/WorkspaceGroupedHistory'));
@@ -28,7 +27,6 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { theme, setTheme } = useThemeContext();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const isSettings = pathname.startsWith('/settings');
@@ -82,9 +80,6 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     setIsBatchMode((prev) => !prev);
   };
 
-  const handleQuickThemeToggle = () => {
-    void setTheme(theme === 'dark' ? 'light' : 'dark');
-  };
   const workspaceHistoryProps = {
     collapsed,
     tooltipEnabled: collapsed && !isMobile,
@@ -243,17 +238,6 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
         ) : (
           /* 设置页面 - 主题切换 + 返回按钮 */
           <div className='flex flex-col gap-2px'>
-            {/* 主题切换 */}
-            <Tooltip {...siderTooltipProps} content={theme === 'dark' ? t('settings.lightMode') : t('settings.darkMode')} position='right'>
-              <div onClick={handleQuickThemeToggle} className={classNames('flex items-center py-10px rd-8px cursor-pointer transition-colors hover:bg-hover active:bg-fill-2', collapsed ? 'justify-center px-4px w-40px h-40px' : 'justify-start gap-10px px-16px')}>
-                {theme === 'dark' ? <IconSunFill style={{ fontSize: 18, color: 'rgb(var(--primary-6))' }} /> : <IconMoonFill style={{ fontSize: 18, color: 'rgb(var(--primary-6))' }} />}
-                {!collapsed && (
-                  <span className='text-t-primary'>
-                    {t('settings.theme')} · {theme === 'dark' ? t('settings.darkMode') : t('settings.lightMode')}
-                  </span>
-                )}
-              </div>
-            </Tooltip>
             {/* 返回按钮 */}
             <div className={classNames('flex items-center gap-10px px-4px py-10px rd-8px cursor-pointer transition-colors hover:bg-hover active:bg-fill-2', collapsed ? 'justify-center mr-2px' : 'ml-2px')} onClick={handleSettingsClick}>
               <div className='w-32px h-32px rd-50% bg-[var(--color-fill-3)] flex items-center justify-center text-t-primary text-14px font-bold shrink-0'>


### PR DESCRIPTION
## Summary
- Add a **system theme mode** that follows the OS color scheme preference (light/dark), alongside the existing manual light and dark modes
- Replace the old 2-option toggle with a compact 3-icon switcher (sun / monitor / moon) placed on the main page top-right corner
- Remove the theme toggle from the sidebar settings panel to reduce clutter
- Listen for real-time OS color scheme changes when system mode is active

## Test plan
- [ ] Verify light mode works as before
- [ ] Verify dark mode works as before
- [ ] Verify system mode follows macOS appearance setting
- [ ] Toggle macOS appearance while system mode is active — app should update in real-time
- [ ] Check theme switcher renders correctly on the main (guid) page
- [ ] Confirm sidebar no longer shows theme toggle on settings pages
- [ ] Verify all 6 locale translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)