### PR TITLE
fix: show doctor assistant in 数字助手 page

### DIFF
--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -345,12 +345,20 @@ const initBuiltinAssistantRules = async (): Promise<void> => {
   // 需要复制的情况：
   // 1. 版本更新了
   // 2. 目标目录不存在（用户手动删除了）
+  // 3. 有助手规则文件缺失（新增了预设助手）
   // Conditions that require copy:
   // 1. Version updated
   // 2. Target directories don't exist (user manually deleted)
+  // 3. Some assistant rule files are missing (new preset added)
   const skillsDirExists = existsSync(skillsDir);
   const assistantsDirExists = existsSync(assistantsDir);
-  const needsCopy = lastCopiedVersion !== currentVersion || !skillsDirExists || !assistantsDirExists;
+  const hasAllAssistantRules = assistantsDirExists && ASSISTANT_PRESETS.every((preset) => {
+    if (Object.keys(preset.ruleFiles).length === 0) return true;
+    const firstLocale = Object.keys(preset.ruleFiles)[0];
+    const targetFileName = `builtin-${preset.id}.${firstLocale}.md`;
+    return existsSync(path.join(assistantsDir, targetFileName));
+  });
+  const needsCopy = lastCopiedVersion !== currentVersion || !skillsDirExists || !assistantsDirExists || !hasAllAssistantRules;
 
   if (!needsCopy) {
     console.log(`[Sudowork] Builtin resources already up-to-date (v${currentVersion}), skipping copy`);

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -30,7 +30,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ isPrese
 
   // Only render if there are preset agents
   if (!customAgents || !customAgents.some((a) => a.isPreset)) return null;
-  const allowedPresetIds = ['builtin-ui-ux-pro-max', 'builtin-planning-with-files', 'builtin-beautiful-mermaid', 'builtin-moltbook', 'builtin-copilot'];
+  const allowedPresetIds = ['builtin-ui-ux-pro-max', 'builtin-planning-with-files', 'builtin-beautiful-mermaid', 'builtin-moltbook', 'builtin-copilot', 'builtin-doctor'];
   const nobuildin = customAgents.filter((a) => a.isPreset).filter((_) => !_.id.startsWith('builtin-'));
   customAgents = customAgents
     .filter((a) => a.isPreset)

--- a/src/renderer/pages/settings/AssistantManagement.tsx
+++ b/src/renderer/pages/settings/AssistantManagement.tsx
@@ -273,9 +273,9 @@ const AssistantManagement: React.FC<AssistantManagementProps> = ({ message }) =>
         }
       }
 
-      // 仅保留指定的 4 个内置助手：UI 专业设计师、文件规划助手、Beautiful Mermaid、moltbook
-      // Keep only 4 builtin assistants: UI 专业设计师，文件规划助手，Beautiful Mermaid, moltbook
-      let allowedPresetIds = ['builtin-ui-ux-pro-max', 'builtin-planning-with-files', 'builtin-beautiful-mermaid', 'builtin-moltbook', 'builtin-copilot'];
+      // 仅保留指定的内置助手
+      // Keep only allowed builtin assistants
+      let allowedPresetIds = ['builtin-ui-ux-pro-max', 'builtin-planning-with-files', 'builtin-beautiful-mermaid', 'builtin-moltbook', 'builtin-copilot', 'builtin-doctor'];
       const filteredAgents = mergedAgents.filter((agent) => {
         const otherAgents = mergedAgents.filter((_) => !_.id.startsWith('builtin-'));
         allowedPresetIds = allowedPresetIds.concat(otherAgents.map((_) => _.id));


### PR DESCRIPTION
## Summary
- Add `builtin-doctor` to the allowlist in AssistantManagement and AssistantSelectionArea so the doctor preset appears in both the settings page and chat assistant chips
- Fix initStorage to re-copy rule files when a new preset is added but the app version hasn't changed, ensuring newly added presets get their rules materialized

## Test plan
- [ ] Open 数字助手 settings page and verify 诊断医生 (Doctor) assistant appears in the list
- [ ] Open chat page and verify Doctor assistant chip appears at the bottom
- [ ] Click Doctor assistant and verify it starts without ENOENT errors for rule files

🤖 Generated with [Claude Code](https://claude.com/claude-code)