### PR TITLE
fix: write GEMINI.md for doctor persona and suppress Nexus info logs

### DIFF
--- a/src/process/services/nexus/DynamicNexusService.ts
+++ b/src/process/services/nexus/DynamicNexusService.ts
@@ -292,7 +292,12 @@ class DynamicNexusService {
       mainLog('Nexus:stdout', d.toString().trim());
     });
     this.process.stderr?.on('data', (d: Buffer) => {
-      mainError('Nexus:stderr', d.toString().trim());
+      const msg = d.toString().trim();
+      if (!msg) return;
+      // Nexus (Python) writes info/debug logs to stderr; only escalate warnings and errors
+      if (/\[(warn|warning|error|critical)\s*\]/i.test(msg)) {
+        mainError('Nexus:stderr', msg);
+      }
     });
     this.process.on('exit', (code, signal) => {
       mainLog('Nexus', `Process exited — code=${code} signal=${signal} uptime=${Date.now() - spawnStart}ms`);

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -284,6 +284,17 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
         }
       }
 
+      // Write preset rules as GEMINI.md for Gemini backend system instruction
+      if (this.extra.backend === 'gemini' && this.extra.workspace && this.options.presetContext) {
+        try {
+          const geminiMdPath = nodePath.join(this.extra.workspace, 'GEMINI.md');
+          fs.writeFileSync(geminiMdPath, this.options.presetContext);
+          mainLog('[AcpAgent]', `Wrote GEMINI.md to ${geminiMdPath}`);
+        } catch (error) {
+          mainWarn('[AcpAgent]', 'Failed to write GEMINI.md:', error);
+        }
+      }
+
       // Connect
       await this.connect();
 


### PR DESCRIPTION
## Summary
- Write preset rules as `GEMINI.md` to Gemini workspace so the doctor assistant uses the correct persona from the first message (instead of defaulting to "Gemini CLI")
- Filter Nexus Python stderr output to only forward warnings and errors to the console, suppressing noisy info-level logs

## Test plan
- [ ] Start a new conversation with the Doctor (诊断医生) assistant
- [ ] Verify the first response uses the correct persona ("Sudoclaw's Doctor")
- [ ] Open dev console and confirm Nexus info-level logs no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)