### PR TITLE
feat: add login/register tabs to login page

### DIFF
--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -218,7 +218,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ phone, code }),
+        body: JSON.stringify({ phone, code, enterprise_code }),
       });
 
       const data = (await response.json()) as any;

--- a/src/renderer/pages/login/LoginPage.css
+++ b/src/renderer/pages/login/LoginPage.css
@@ -158,9 +158,56 @@ body.login-page-active {
   color: var(--text-primary);
 }
 
+/* ========================================
+   Tab Switcher
+   ======================================== */
+
+.login-tabs {
+  display: flex;
+  gap: 0;
+  margin-top: 24px;
+  border-bottom: 1px solid var(--border-base);
+}
+
+.login-tab {
+  flex: 1;
+  padding: 10px 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+  -webkit-app-region: no-drag;
+}
+
+.login-tab:hover {
+  color: var(--text-primary);
+}
+
+.login-tab--active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+}
+
+[data-theme='dark'] .login-tab {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+[data-theme='dark'] .login-tab:hover {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+[data-theme='dark'] .login-tab--active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+}
+
 .login-page__header {
   text-align: center;
-  margin-bottom: 32px;
+  margin-bottom: 0;
 }
 
 .login-page__logo {

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import AppLoader from '../../components/AppLoader';
 import { useAuth } from '../../context/AuthContext';
 import { Button, Input, Message, Space } from '@arco-design/web-react';
-import { Phone, Protect, Key } from '@icon-park/react';
+import { Phone, Protect, Key, User } from '@icon-park/react';
 import { ipcBridge } from '@/common';
 import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import './LoginPage.css';
@@ -27,10 +27,13 @@ const AionLogoMark: React.FC = () => <img src={SudoworkIcon} alt='Sudowork' clas
 const LoginPage: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { status, login } = useAuth();
+  const { status, login, register } = useAuth();
 
+  const [mode, setMode] = useState<'login' | 'register'>('login');
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [invitationCode, setInvitationCode] = useState('');
   const [loading, setLoading] = useState(false);
   const [countdown, setCountdown] = useState(0);
 
@@ -107,19 +110,52 @@ const LoginPage: React.FC = () => {
       return;
     }
 
+    if (mode === 'register') {
+      if (!nickname.trim()) {
+        Message.warning('请输入昵称');
+        return;
+      }
+      if (!invitationCode.trim()) {
+        Message.warning('请输入邀请码');
+        return;
+      }
+    }
+
     setLoading(true);
     const result = await login({ phone, code, enterprise_code: ENTERPRISE_CODE });
 
     if (result.success) {
+      if (mode === 'register') {
+        Message.info('该手机号已注册，已直接登录');
+      }
       setTimeout(() => navigate('/guid', { replace: true }), 300);
+      setLoading(false);
+      return;
     } else {
       const statusCode = (result as any).status;
       const needRegister = (result as any).need_register;
       const registerToken = (result as any).register_token;
 
-      // 处理需要注册的情况
       if (needRegister && registerToken) {
-        navigate(`/register?token=${registerToken}&phone=${encodeURIComponent(phone)}`, { replace: true });
+        if (mode === 'register') {
+          // In register mode: proceed with registration inline
+          const regResult = await register({
+            register_token: registerToken,
+            nickname: nickname.trim(),
+            invitation_code: invitationCode.trim(),
+          });
+
+          if (regResult.success) {
+            setTimeout(() => navigate('/guid', { replace: true }), 300);
+          } else {
+            Message.error(regResult.message || '注册失败');
+          }
+        } else {
+          // In login mode: prompt user to switch to register tab
+          Message.info('该手机号未注册，请切换到注册标签完成注册');
+          setMode('register');
+        }
+        setLoading(false);
         return;
       }
 
@@ -205,7 +241,17 @@ const LoginPage: React.FC = () => {
           <p className='text-13px text-t-secondary'>企业级 Agent 协同指挥中心</p>
         </div>
 
-        <div className='flex flex-col gap-20px mt-32px'>
+        {/* Tab switcher */}
+        <div className='login-tabs'>
+          <button type='button' className={`login-tab ${mode === 'login' ? 'login-tab--active' : ''}`} onClick={() => setMode('login')}>
+            登录
+          </button>
+          <button type='button' className={`login-tab ${mode === 'register' ? 'login-tab--active' : ''}`} onClick={() => setMode('register')}>
+            注册
+          </button>
+        </div>
+
+        <div className='flex flex-col gap-20px mt-24px'>
           <div className='flex flex-col gap-8px'>
             <div className='text-12px font-600 text-t-secondary ml-4px'>手机号码</div>
             <Input size='large' prefix={<Phone className='text-t-tertiary' />} placeholder='11 位手机号' value={phone} onChange={setPhone} className='login-input !rd-12px h-48px' />
@@ -221,8 +267,22 @@ const LoginPage: React.FC = () => {
             </Space>
           </div>
 
+          {mode === 'register' && (
+            <>
+              <div className='flex flex-col gap-8px'>
+                <div className='text-12px font-600 text-t-secondary ml-4px'>昵称</div>
+                <Input size='large' prefix={<User className='text-t-tertiary' />} placeholder='请输入您的昵称' value={nickname} onChange={setNickname} className='login-input !rd-12px h-48px' maxLength={20} />
+              </div>
+
+              <div className='flex flex-col gap-8px'>
+                <div className='text-12px font-600 text-t-secondary ml-4px'>邀请码</div>
+                <Input size='large' prefix={<Protect className='text-t-tertiary' />} placeholder='请输入 6 位邀请码' value={invitationCode} onChange={setInvitationCode} className='login-input !rd-12px h-48px' maxLength={6} />
+              </div>
+            </>
+          )}
+
           <Button type='primary' size='large' loading={loading} onClick={() => handleSubmit()} className='login-btn-primary !rd-12px h-52px mt-12px font-700 text-16px'>
-            登录
+            {mode === 'login' ? '登录' : '注册'}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add "登录"/"注册" tab switcher to the login page so users can register directly without navigating to a separate `/register` page
- Register mode shows additional nickname and invitation code fields; switching tabs preserves phone number and SMS code
- Fix bug in `AuthContext.tsx` where `enterprise_code` was accepted as a param but not included in the login request body

## Test plan
- [ ] Open the app → login page shows login/register tabs
- [ ] Login tab: phone + SMS code fields only (existing behavior)
- [ ] Register tab: phone + SMS code + nickname + invitation code fields
- [ ] Switching tabs preserves phone number and SMS code values
- [ ] Register flow works end-to-end (login → get register_token → register)
- [ ] If user tries to register with an already-registered phone, shows info message and logs in directly
- [ ] Dark mode: tabs render correctly with proper colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)