### PR TITLE
fix: improve dark mode text contrast and readability

### DIFF
--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -62,8 +62,8 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ isPrese
           )}
           <div className='w-full'>
             <div className='flex items-center justify-between py-8px cursor-pointer select-none' onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}>
-              <span className='text-13px text-[rgb(var(--primary-6))] opacity-80'>{t('settings.assistantDescription', { defaultValue: 'Assistant Description' })}</span>
-              <Down theme='outline' size={14} fill='rgb(var(--primary-6))' className={`transition-transform duration-300 ${isDescriptionExpanded ? 'rotate-180' : ''}`} />
+              <span className='text-13px' style={{ color: 'var(--text-secondary)' }}>{t('settings.assistantDescription', { defaultValue: 'Assistant Description' })}</span>
+              <Down theme='outline' size={14} style={{ color: 'var(--text-secondary)' }} className={`transition-transform duration-300 ${isDescriptionExpanded ? 'rotate-180' : ''}`} />
             </div>
             <div className={`overflow-hidden transition-all duration-300 ${isDescriptionExpanded ? 'max-h-240px mt-4px opacity-100' : 'max-h-0 opacity-0'}`}>
               <div
@@ -88,7 +88,8 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ isPrese
                   {prompts.map((prompt: string, index: number) => (
                     <div
                       key={index}
-                      className='px-12px py-6px bg-fill-2 hover:bg-fill-3 text-[rgb(var(--primary-6))] text-13px rd-16px cursor-pointer transition-colors shadow-sm'
+                      className='px-12px py-6px text-13px rd-16px cursor-pointer transition-colors shadow-sm'
+                      style={{ background: 'var(--bg-2)', color: 'var(--text-primary)', border: '1px solid var(--bg-3)' }}
                       onClick={() => {
                         onSetInput(prompt);
                         onFocusInput();

--- a/src/renderer/styles/themes/color-schemes/default.css
+++ b/src/renderer/styles/themes/color-schemes/default.css
@@ -93,19 +93,19 @@
   --bg-3: #333333; /* 边框/分隔 */
   --bg-4: #404040;
   --bg-5: #4d4d4d;
-  --bg-6: #5a5a5a; /* 禁用/次要文字 */
-  --bg-8: #737373;
-  --bg-9: #a6a6a6;
-  --bg-10: #d9d9d9;
+  --bg-6: #6e6e6e; /* 禁用/次要文字 */
+  --bg-8: #909090;
+  --bg-9: #b8b8b8;
+  --bg-10: #e0e0e0;
 
   /* Interactive State Colors - Dark Mode */
   --bg-hover: #1f1f1f; /* 悬停背景 */
   --bg-active: #2d2d2d; /* 激活/按下背景 */
 
   /* Text Colors - Dark Mode */
-  --text-primary: #e5e5e5; /* 主要文字 */
-  --text-secondary: #a6a6a6; /* 次要文字 */
-  --text-disabled: #737373; /* 禁用文字 */
+  --text-primary: #f0f0f0; /* 主要文字 */
+  --text-secondary: #c0c0c0; /* 次要文字 */
+  --text-disabled: #8a8a8a; /* 禁用文字 */
 
   /* Semantic Colors - Dark Mode */
   --primary: #4d9fff;


### PR DESCRIPTION
## Summary

- Brighten dark mode text color variables (`--text-primary`, `--text-secondary`, `--text-disabled`) for better legibility
- Raise the `--bg-6/8/9/10` scale values which double as text colors in Arco Design components
- Fix `AssistantSelectionArea` prompt chips and "助手描述" label to use explicit theme variables instead of dim Arco `primary-6` color

## Test plan

- [ ] Switch app to dark mode and verify sidebar text, conversation list, and secondary labels are clearly readable
- [ ] Open a preset agent (e.g. Doctor) on the home page and verify the "助手描述" label and prompt chips are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)