### PR TITLE
fix: reduce excessive spacing between chat messages and copy button

### DIFF
--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -65,7 +65,8 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
     return rawContent;
   }, [message.content.content]);
 
-  const { text, files } = parseFileMarker(contentToRender);
+  const { text: rawText, files } = parseFileMarker(contentToRender);
+  const text = rawText.trimEnd();
   const visibleFiles = useMemo(() => filterUserVisibleFiles(files), [files]);
   const { data, json } = useFormatContent(text);
   const { t } = useTranslation();
@@ -172,7 +173,7 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
           )}
         </div>
         <div
-          className={classNames('h-32px flex items-center mt-4px', {
+          className={classNames('h-24px flex items-center mt-4px', {
             'justify-end': isUserMessage,
             'justify-start': !isUserMessage,
           })}


### PR DESCRIPTION
Fixes #29

**Changes:**
- Trim trailing whitespace from message text before rendering to prevent `remarkBreaks` from converting trailing newlines into phantom `<br>` blank lines
- Reduce copy button container from `h-32px` to `h-24px` to match actual button size (16px icon + 4px padding × 2 = 24px)

Generated with [Claude Code](https://claude.ai/code)