### PR TITLE
CI: enable Claude bot to take app screenshots

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,4 +58,6 @@ jobs:
             "Bash(pkill:*)"
             "Bash(sleep:*)"
             "Bash(ps:*)"
+            --system-prompt
+            "When working on a pull request, always update the PR description to include a clear summary of changes."
 


### PR DESCRIPTION
## Summary

- Upgrade GitHub Actions permissions to `write` for contents/PRs/issues so Claude can push branches and comment
- Pre-install system dependencies (`xvfb`, `python3-websockets`) and `bun` before Claude runs
- Allow Bash tools (`bun`, `python3`, `curl`, `xvfb-run`, `pkill`, `sleep`, `ps`) via `--allowedTools`

This enables Claude in CI to:
1. Start the Electron app headlessly via `xvfb-run bun run start`
2. Capture screenshots via Chrome DevTools Protocol (CDP port 9230)
3. Attach screenshots to issue/PR comments

Verified locally that CDP screenshot capture works — see [issue #33 comment](https://github.com/sudoprivacy/sudowork/issues/33#issuecomment-4148521725).

Refs #33

## Test plan

- [ ] Trigger Claude bot on an issue with `@claude` and ask it to start the app and take a screenshot
- [ ] Verify xvfb and bun are available in the CI environment
- [ ] Confirm Claude can execute allowed Bash commands without approval prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)