### PR TITLE
feat: 修改登录/注册页 slogan 为 AgentOPS | 办公专家

### DIFF
--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -238,7 +238,7 @@ const LoginPage: React.FC = () => {
             <AionLogoMark />
           </div>
           <h1 className='text-28px font-800 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>SudoClaw</h1>
-          <p className='text-13px text-t-secondary'>企业级 Agent 协同指挥中心</p>
+          <p className='text-13px text-t-secondary'>AgentOPS | 办公专家</p>
         </div>
 
         {/* Tab switcher */}


### PR DESCRIPTION
## 修改说明

将登录/注册页的 slogan 从 `企业级 Agent 协同指挥中心` 修改为 `AgentOPS | 办公专家`

Closes #37

Generated with [Claude Code](https://claude.ai/code)