### PR TITLE
feat: migrate Convert to Word to turn actions and make buttons permanent

### DIFF
--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -48,7 +48,7 @@ type IMessageVO =
       id: string;
       messages: Array<IMessageToolGroup | IMessageAcpToolCall>;
     }
-  | { type: 'turn_actions'; id: string; turnTexts: string[] };
+  | { type: 'turn_actions'; id: string; turnTexts: string[]; conversationId?: string };
 
 // Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
@@ -182,7 +182,7 @@ const MessageList: React.FC<{ className?: string }> = () => {
 
     const flushTurnActions = () => {
       if (turnTexts.length > 0) {
-        result.push({ type: 'turn_actions', id: `turn-actions-${lastAiTextId}`, turnTexts });
+        result.push({ type: 'turn_actions', id: `turn-actions-${lastAiTextId}`, turnTexts, conversationId: conversationContext?.conversationId });
         turnTexts = [];
         lastAiTextId = '';
       }
@@ -327,8 +327,8 @@ const MessageList: React.FC<{ className?: string }> = () => {
     }
     if ('type' in item && item.type === 'turn_actions') {
       return (
-        <div key={item.id} className='min-w-0 message-item px-8px max-w-full md:max-w-780px mx-auto'>
-          <TurnActions turnTexts={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTexts} />
+        <div key={item.id} className='group min-w-0 message-item px-8px max-w-full md:max-w-780px mx-auto'>
+          <TurnActions turnTexts={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTexts} conversationId={(item as Extract<IMessageVO, { type: 'turn_actions' }>).conversationId} />
         </div>
       );
     }

--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -6,16 +6,14 @@
 
 import type { IMessageText } from '@/common/chatLib';
 import { NEXUS_FILES_MARKER } from '@/common/constants';
-import { ipcBridge } from '@/common';
 import { iconColors } from '@/renderer/theme/colors';
-import { Alert, Message, Tooltip, Tag } from '@arco-design/web-react';
-import { Copy, FileWord, Lightning, CloseSmall } from '@icon-park/react';
+import { Alert, Tag, Tooltip } from '@arco-design/web-react';
+import { Copy, Lightning } from '@icon-park/react';
 import classNames from 'classnames';
-import React, { useMemo, useState, useCallback, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { copyText } from '@/renderer/utils/clipboard';
 import { filterUserVisibleFiles } from '@/renderer/utils/messageFiles';
-import { emitter } from '@/renderer/utils/emitter';
 import { getInstalledSkillDisplay } from '@/renderer/utils/skillDisplay';
 import { skillHub } from '@/common/ipcBridge';
 import { isElectronDesktop } from '@/renderer/utils/platform';
@@ -74,7 +72,6 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
   const { data, json } = useFormatContent(text);
   const { t } = useTranslation();
   const [showCopyAlert, setShowCopyAlert] = useState(false);
-  const [converting, setConverting] = useState(false);
   const isUserMessage = message.position === 'right';
   const skills = message.content.skills || [];
 
@@ -94,32 +91,6 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
     };
     void fetchInstalledSkills();
   }, [skills.length]);
-
-  const handleConvertToWord = useCallback(async () => {
-    if (converting) return;
-    setConverting(true);
-    try {
-      const res = await ipcBridge.document.saveAsDocx.invoke({
-        markdown: text,
-        conversationId: message.conversation_id,
-      });
-
-      if (res?.success && res.data) {
-        Message.success(t('messages.convertSuccess', { defaultValue: 'Converted to Word successfully' }));
-        // 自动刷新工作区 (通过 emitter)
-        emitter.emit('chat.history.refresh');
-        // 可选：打开文件夹定位文件
-        void ipcBridge.shell.showItemInFolder.invoke(res.data);
-      } else {
-        Message.error(res?.msg || t('messages.convertFailed', { defaultValue: 'Failed to convert to Word' }));
-      }
-    } catch (error) {
-      console.error('Failed to convert to Word:', error);
-      Message.error(t('messages.convertFailed', { defaultValue: 'Failed to convert to Word' }));
-    } finally {
-      setConverting(false);
-    }
-  }, [text, message.conversation_id, t, converting]);
 
   // 过滤空内容，避免渲染空DOM
   if (!message.content.content || (typeof message.content.content === 'string' && !message.content.content.trim())) {
@@ -142,16 +113,8 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
 
   const copyButton = (
     <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
-      <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto' onClick={handleCopy} style={{ lineHeight: 0 }}>
+      <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors' onClick={handleCopy} style={{ lineHeight: 0 }}>
         <Copy theme='outline' size='16' fill={iconColors.secondary} />
-      </div>
-    </Tooltip>
-  );
-
-  const transToWordButton = (
-    <Tooltip content={t('messages.convertToWord', { defaultValue: 'Convert to Word' })}>
-      <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto' onClick={handleConvertToWord} style={{ lineHeight: 0 }}>
-        <FileWord theme='outline' size='16' fill={converting ? iconColors.disabled : iconColors.secondary} />
       </div>
     </Tooltip>
   );
@@ -231,8 +194,7 @@ const MessageText: React.FC<{ message: IMessageText }> = ({ message }) => {
             'justify-start': !isUserMessage,
           })}
         >
-          {copyButton}
-          {transToWordButton}
+          {isUserMessage && copyButton}
         </div>
       </div>
       {showCopyAlert && <Alert type='success' content={t('messages.copySuccess')} showIcon className='fixed top-20px left-50% transform -translate-x-50% z-9999 w-max max-w-[80%]' style={{ boxShadow: '0px 2px 12px rgba(0,0,0,0.12)' }} closable={false} />}

--- a/src/renderer/messages/TurnActions.tsx
+++ b/src/renderer/messages/TurnActions.tsx
@@ -6,14 +6,17 @@
 
 import { iconColors } from '@/renderer/theme/colors';
 import { copyText } from '@/renderer/utils/clipboard';
+import { ipcBridge } from '@/common';
+import { emitter } from '@/renderer/utils/emitter';
 import { Alert, Message, Tooltip } from '@arco-design/web-react';
-import { Copy } from '@icon-park/react';
-import React, { useState } from 'react';
+import { Copy, FileWord } from '@icon-park/react';
+import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const TurnActions: React.FC<{ turnTexts: string[] }> = ({ turnTexts }) => {
+const TurnActions: React.FC<{ turnTexts: string[]; conversationId?: string }> = ({ turnTexts, conversationId }) => {
   const { t } = useTranslation();
   const [showCopyAlert, setShowCopyAlert] = useState(false);
+  const [converting, setConverting] = useState(false);
 
   const handleCopy = () => {
     const textToCopy = turnTexts.join('\n\n');
@@ -27,12 +30,41 @@ const TurnActions: React.FC<{ turnTexts: string[] }> = ({ turnTexts }) => {
       });
   };
 
+  const handleConvertToWord = useCallback(async () => {
+    if (converting || !conversationId) return;
+    setConverting(true);
+    try {
+      const res = await ipcBridge.document.saveAsDocx.invoke({
+        markdown: turnTexts.join('\n\n'),
+        conversationId,
+      });
+
+      if (res?.success && res.data) {
+        Message.success(t('messages.convertSuccess', { defaultValue: 'Converted to Word successfully' }));
+        emitter.emit('chat.history.refresh');
+        void ipcBridge.shell.showItemInFolder.invoke(res.data);
+      } else {
+        Message.error(res?.msg || t('messages.convertFailed', { defaultValue: 'Failed to convert to Word' }));
+      }
+    } catch (error) {
+      console.error('Failed to convert to Word:', error);
+      Message.error(t('messages.convertFailed', { defaultValue: 'Failed to convert to Word' }));
+    } finally {
+      setConverting(false);
+    }
+  }, [turnTexts, conversationId, t, converting]);
+
   return (
     <>
-      <div className='flex items-center h-28px'>
+      <div className='flex items-center h-28px gap-4px'>
         <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
           <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors' onClick={handleCopy} style={{ lineHeight: 0 }}>
             <Copy theme='outline' size='16' fill={iconColors.secondary} />
+          </div>
+        </Tooltip>
+        <Tooltip content={t('messages.convertToWord', { defaultValue: 'Convert to Word' })}>
+          <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors' onClick={handleConvertToWord} style={{ lineHeight: 0 }}>
+            <FileWord theme='outline' size='16' fill={converting ? iconColors.disabled : iconColors.secondary} />
           </div>
         </Tooltip>
       </div>


### PR DESCRIPTION
## Summary
- Migrated "Convert to Word" feature from individual message bubbles to turn-level action group.
- Unified data logic: Word export now uses the entire turn's AI response content (consistent with Copy).
- Changed action buttons from hover-visible to permanently visible for better accessibility.
- Cleaned up redundant UI elements in message bubbles.

## Test plan
- Verify AI turns show both [Copy] and [Convert to Word] buttons permanently at the bottom.
- Verify User messages show the [Copy] button permanently.
- Confirm Word export generates a document containing the full AI response for the turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)