### PR TITLE
fix: prepend bundled Node.js directory to PATH when using bundled npx

### DIFF
--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -433,9 +433,17 @@ export function resolveNpxPath(env: Record<string, string | undefined>): string 
   try {
     if (isNodeInstalled()) {
       const bundledNodePath = getNodeBinaryPath();
-      const bundledNpx = path.join(path.dirname(bundledNodePath), npxName);
+      const bundledNodeDir = path.dirname(bundledNodePath);
+      const bundledNpx = path.join(bundledNodeDir, npxName);
       if (existsSync(bundledNpx)) {
         mainLog('ShellEnv', `Using bundled npx: ${bundledNpx}`);
+        // Prepend the bundled node directory to PATH so that npx.cmd (and any
+        // child processes it spawns) can find `node` without requiring a
+        // system-wide Node.js installation.  This mirrors how
+        // ensureMinNodeVersion() mutates env.PATH.
+        const sep = isWindows ? ';' : ':';
+        env.PATH = bundledNodeDir + sep + (env.PATH || '');
+        mainLog('ShellEnv', `Prepended bundled node dir to PATH: ${bundledNodeDir}`);
         return bundledNpx;
       }
     }


### PR DESCRIPTION
Fixes #81

When `resolveNpxPath()` finds bundled npx.cmd, the directory containing `node.exe` was not added to PATH. This caused `npx.cmd` to fail with `'"node"' is not recognized` because npx internally invokes node via PATH.

Now the bundled node directory is prepended to `env.PATH` so npx.cmd and its child processes can locate `node` without a system-wide Node.js installation.

Generated with [Claude Code](https://claude.ai/code)