### PR TITLE
fix: 会话重命名后右侧标题即时刷新

### DIFF
--- a/src/renderer/pages/conversation/index.tsx
+++ b/src/renderer/pages/conversation/index.tsx
@@ -7,6 +7,7 @@ import useSWR from 'swr';
 import ChatConversation from './ChatConversation';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { useConversationTabs } from './context/ConversationTabsContext';
+import { addEventListener } from '@/renderer/utils/emitter';
 
 const ChatConversationIndex: React.FC = () => {
   const { id } = useParams();
@@ -27,9 +28,18 @@ const ChatConversationIndex: React.FC = () => {
     previousConversationIdRef.current = id;
   }, [id, closePreview]);
 
-  const { data, isLoading } = useSWR(`conversation/${id}`, () => {
+  const { data, isLoading, mutate } = useSWR(`conversation/${id}`, () => {
     return ipcBridge.conversation.get.invoke({ id });
   });
+
+  // 监听会话历史刷新事件，同步刷新当前会话数据（解决重命名后标题不更新的问题）
+  // Listen to history refresh event to sync current conversation data (fixes rename title not updating)
+  useEffect(() => {
+    if (!id) return;
+    return addEventListener('chat.history.refresh', () => {
+      mutate();
+    });
+  }, [id, mutate]);
 
   // 当会话数据加载完成后，自动打开 tab
   // Automatically open tab when conversation data is loaded


### PR DESCRIPTION
## Summary
- 修复会话重命名后，右侧会话框上方标题不即时刷新的问题
- 添加监听 `chat.history.refresh` 事件，触发 SWR mutate() 刷新当前会话数据

## 问题描述
从左侧侧边栏重命名会话后，右侧会话框上方的标题不会立即更新，需要切换到其他会话再切回来才能看到新名称。

## 解决方案
在 `src/renderer/pages/conversation/index.tsx` 中监听 `chat.history.refresh` 事件，当重命名操作触发该事件时，调用 SWR 的 `mutate()` 方法重新获取会话数据，使标题即时刷新。

## Test plan
- [ ] 从左侧侧边栏重命名一个会话
- [ ] 验证右侧会话框上方的标题立即显示新名称
- [ ] 验证切换会话功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)