### PR TITLE
fix(skill-store): 技能商店已安装技能状态显示改用滑动开关

### DIFF
--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -9,7 +9,7 @@ import { ipcBridge } from '@/common';
 import { resolveSkillIcon, getInstalledSkillDisplay, normalizeSkillVersion } from '@/renderer/utils/skillDisplay';
 import { useSettingsViewMode } from '../settingsViewContext';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, Spin, Message, Input, Progress, Modal, Popconfirm } from '@arco-design/web-react';
+import { Button, Spin, Message, Input, Progress, Modal, Popconfirm, Switch } from '@arco-design/web-react';
 import { Download, Search, Delete, Close, Shield, Lightning, UploadOne, Install } from '@icon-park/react';
 import classNames from 'classnames';
 import { isElectronDesktop } from '@/renderer/utils/platform';
@@ -195,16 +195,12 @@ const InstalledSkillCard: React.FC<{
               e.stopPropagation();
             }}
           >
-            <button type='button' className={classNames('h-20px min-w-48px px-6px rd-full border-none flex items-center justify-center gap-4px text-10px font-medium transition-colors cursor-pointer', isEnabled ? 'bg-primary text-white shadow-sm' : 'bg-fill-3 text-t-secondary')} onClick={() => onToggleEnabled?.(!isEnabled)} disabled={togglingEnabled}>
-              {togglingEnabled ? (
-                <Spin size={10} />
-              ) : (
-                <>
-                  <span className={classNames('w-5px h-5px rd-full flex-shrink-0', isEnabled ? 'bg-white/90' : 'bg-t-secondary')} />
-                  <span>{isEnabled ? t('settings.skill.enableToggle', { defaultValue: '启用' }) : t('settings.agentDisabled', { defaultValue: '已禁用' })}</span>
-                </>
-              )}
-            </button>
+            <Switch
+              size='small'
+              checked={isEnabled}
+              loading={togglingEnabled}
+              onChange={(checked) => onToggleEnabled?.(checked)}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
将技能商店中已安装技能的启用/禁用状态显示从文字按钮样式改为 Arco Design Switch 组件， 启用状态为绿色，禁用状态为灰色，消除文字歧义。

Closes #144

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
