### PR TITLE
fix(auth): add token refresh mechanism and 401 auto-retry

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -6,6 +6,16 @@
 ; - Keeps Cancel button enabled during installation
 
 !include "x64.nsh"
+; MUI2.nsh and nsDialogs.nsh must be included here because electron-builder
+; includes this file in the NSIS script header, BEFORE the main installer.nsi
+; template loads MUI2.nsh. Macros (customHeader, customInstall, etc.) are
+; unaffected because they are only defined at include time and expanded later.
+; However, file-scope functions (tosPageCreate, etc.) are compiled immediately
+; and need these headers available. All headers have include guards, so the
+; later !include in installer.nsi is safely a no-op.
+!include "MUI2.nsh"
+!include "nsDialogs.nsh"
+!include "LogicLib.nsh"
 
 ; ========================================
 ; Language overrides: Standardize Simplified Chinese uninstall terminology

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -25,6 +25,15 @@ export interface AuthUser {
   };
 }
 
+// 新的存储结构
+interface AuthStorage {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number; // 过期时间戳（毫秒）
+  user: AuthUser;
+  device_id: string;
+}
+
 interface LoginParams {
   phone: string;
   code: string;
@@ -64,13 +73,27 @@ interface AuthContextValue {
   register: (params: RegisterParams) => Promise<RegisterResult>;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
+  ensureValidToken: (forceRefresh?: boolean) => Promise<string | null>;
+  forceRefreshToken: () => Promise<string | null>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const AUTH_USER_ENDPOINT = '/api/auth/user';
+const AUTH_STORAGE_KEY = 'sudowork_auth_v2';
+const DEVICE_ID_KEY = 'sudowork_device_id';
 
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
+
+// 获取或创建设备 ID
+function getDeviceId(): string {
+  let deviceId = localStorage.getItem(DEVICE_ID_KEY);
+  if (!deviceId) {
+    deviceId = crypto.randomUUID();
+    localStorage.setItem(DEVICE_ID_KEY, deviceId);
+  }
+  return deviceId;
+}
 
 async function fetchCurrentUser(signal?: AbortSignal): Promise<AuthUser | null> {
   try {
@@ -100,10 +123,25 @@ async function fetchCurrentUser(signal?: AbortSignal): Promise<AuthUser | null> 
 
 // 处理登录成功后的通用逻辑
 async function handleLoginSuccess(data: any, setUser: (user: AuthUser) => void, setStatus: (status: AuthStatus) => void, setReady: (ready: boolean) => void) {
-  const authData = { ...data.data.user, token: data.data.token };
+  const deviceId = getDeviceId();
+
+  // 新的存储结构
+  const authStorage: AuthStorage = {
+    access_token: data.data.access_token,
+    refresh_token: data.data.refresh_token,
+    expires_at: Date.now() + data.data.expires_in * 1000,
+    user: data.data.user,
+    device_id: deviceId,
+  };
+
+  // 兼容旧代码：user 对象也包含 token
+  const authData = { ...data.data.user, token: data.data.access_token };
+
   setUser(authData);
   setStatus('authenticated');
-  localStorage.setItem('sudowork_auth_v1', JSON.stringify(authData));
+  localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authStorage));
+  // 清理旧的存储
+  localStorage.removeItem('sudowork_auth_v1');
   setReady(true);
 
   // 保存用户手机号到配置文件供 skill 读取
@@ -176,17 +214,149 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const [ready, setReady] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
-  const refresh = useCallback(async () => {
-    const stored = localStorage.getItem('sudowork_auth_v1');
+  // Token 刷新函数
+  const refreshTokens = useCallback(async (): Promise<boolean> => {
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!stored) return false;
+
+    try {
+      const authStorage: AuthStorage = JSON.parse(stored);
+      const { refresh_token, device_id } = authStorage;
+
+      const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token, device_id }),
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        const newStorage: AuthStorage = {
+          access_token: data.access_token,
+          refresh_token: data.refresh_token,
+          expires_at: Date.now() + data.expires_in * 1000,
+          user: authStorage.user,
+          device_id: device_id || getDeviceId(),
+        };
+
+        localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(newStorage));
+        setUser({ ...authStorage.user, token: data.access_token });
+        console.log('[Auth] Token refreshed successfully');
+        return true;
+      }
+    } catch (error) {
+      console.error('[Auth] Token refresh failed:', error);
+    }
+
+    return false;
+  }, []);
+
+  // 确保有效 Token（在请求前调用）
+  const ensureValidToken = useCallback(
+    async (forceRefresh = false): Promise<string | null> => {
+      // 优先检查新版本存储
+      const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+      if (stored) {
+        try {
+          const authStorage: AuthStorage = JSON.parse(stored);
+          const { access_token, expires_at } = authStorage;
+
+          // 强制刷新 或 提前 5 分钟刷新
+          if (forceRefresh || (expires_at && Date.now() > expires_at - 5 * 60 * 1000)) {
+            const refreshed = await refreshTokens();
+            if (!refreshed) {
+              // refresh_token 也过期，需要重新登录
+              return null;
+            }
+            // 返回新的 access_token
+            const newStorage = JSON.parse(localStorage.getItem(AUTH_STORAGE_KEY) || '{}');
+            return newStorage.access_token || null;
+          }
+
+          return access_token;
+        } catch (error) {
+          console.error('[Auth] Failed to ensure valid token:', error);
+        }
+      }
+
+      // 兼容旧版本存储（sudowork_auth_v1）
+      const oldStored = localStorage.getItem('sudowork_auth_v1');
+      if (oldStored) {
+        try {
+          const oldAuthData = JSON.parse(oldStored);
+          // 旧版本没有 refresh_token，直接返回 token
+          // 如果 token 失效，用户需要重新登录才能获得新机制
+          return oldAuthData.token || null;
+        } catch (error) {
+          console.error('[Auth] Failed to parse old auth storage:', error);
+        }
+      }
+
+      return null;
+    },
+    [refreshTokens]
+  );
+
+  // 强制刷新 Token（当服务器返回 401 时调用）
+  const forceRefreshToken = useCallback(async (): Promise<string | null> => {
+    console.log('[Auth] Force refreshing token...');
+
+    // 检查是否有新版本存储（有 refresh_token）
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
     if (stored) {
       try {
-        const parsed = JSON.parse(stored);
-        setUser(parsed);
+        const authStorage: AuthStorage = JSON.parse(stored);
+        if (authStorage.refresh_token) {
+          // 有 refresh_token，可以刷新
+          return ensureValidToken(true);
+        }
+      } catch (error) {
+        console.error('[Auth] Failed to check auth storage:', error);
+      }
+    }
+
+    // 旧版本用户没有 refresh_token，返回 null 让用户重新登录
+    console.warn('[Auth] No refresh_token available, user needs to re-login');
+    return null;
+  }, [ensureValidToken]);
+
+  const refresh = useCallback(async () => {
+    // 优先检查新版本存储
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (stored) {
+      try {
+        const authStorage: AuthStorage = JSON.parse(stored);
+        setUser({ ...authStorage.user, token: authStorage.access_token });
         setStatus('authenticated');
         setReady(true);
 
         // 从 localStorage 恢复登录状态时，也保存手机号到文件
-        // Save phone to file when restoring auth from localStorage
+        if (isDesktopRuntime && authStorage.user.phone) {
+          ipcBridge.sudoworkAuth.saveUserPhone.invoke({ phone: authStorage.user.phone }).catch((error) => {
+            console.error('[Auth] Failed to save user phone on restore:', error);
+          });
+        }
+
+        // 检查 token 是否需要刷新
+        if (authStorage.expires_at && Date.now() > authStorage.expires_at - 5 * 60 * 1000) {
+          await refreshTokens();
+        }
+        return;
+      } catch (e) {
+        localStorage.removeItem(AUTH_STORAGE_KEY);
+      }
+    }
+
+    // 兼容旧版本存储
+    const oldStored = localStorage.getItem('sudowork_auth_v1');
+    if (oldStored) {
+      try {
+        const parsed = JSON.parse(oldStored);
+        // 旧 token 没有 refresh_token，用户需要重新登录才能获得新机制
+        setUser(parsed);
+        setStatus('authenticated');
+        setReady(true);
+
         if (isDesktopRuntime && parsed.phone) {
           ipcBridge.sudoworkAuth.saveUserPhone.invoke({ phone: parsed.phone }).catch((error) => {
             console.error('[Auth] Failed to save user phone on restore:', error);
@@ -220,7 +390,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setStatus('unauthenticated');
     }
     setReady(true);
-  }, []);
+  }, [refreshTokens]);
 
   useEffect(() => {
     void refresh();
@@ -230,11 +400,14 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   }, [refresh]);
 
   const login = useCallback(async ({ phone, code, enterprise_code, invitation_code, remember }: LoginParams): Promise<LoginResult> => {
+    const deviceId = getDeviceId();
+
     try {
       const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Device-Id': deviceId,
         },
         body: JSON.stringify({ phone, code, enterprise_code }),
       });
@@ -273,11 +446,14 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   }, []);
 
   const register = useCallback(async ({ register_token, nickname, invitation_code }: RegisterParams): Promise<RegisterResult> => {
+    const deviceId = getDeviceId();
+
     try {
       const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Device-Id': deviceId,
         },
         body: JSON.stringify({ register_token, nickname, invitation_code }),
       });
@@ -305,10 +481,29 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   }, []);
 
   const logout = useCallback(async () => {
-    localStorage.removeItem('sudowork_auth_v1');
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+
+    if (stored) {
+      try {
+        const authStorage: AuthStorage = JSON.parse(stored);
+        const { refresh_token, device_id } = authStorage;
+
+        // 调用服务端注销接口
+        await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/logout`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh_token, device_id }),
+        });
+      } catch (error) {
+        console.error('[Auth] Logout request failed:', error);
+      }
+    }
+
+    // 清除本地存储
+    localStorage.removeItem(AUTH_STORAGE_KEY);
+    localStorage.removeItem('sudowork_auth_v1'); // 也清理旧版本
 
     // 清除用户手机号文件
-    // Clear user phone file on logout
     if (isDesktopRuntime) {
       try {
         await ipcBridge.sudoworkAuth.clearUserPhone.invoke();
@@ -325,7 +520,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     try {
       await fetch('/logout', {
         method: 'POST',
-        // Logout also needs CSRF token / 登出同样需要 CSRF Token
         headers: {
           'Content-Type': 'application/json',
         },
@@ -349,8 +543,10 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       register,
       logout,
       refresh,
+      ensureValidToken,
+      forceRefreshToken,
     }),
-    [login, register, logout, ready, refresh, status, user]
+    [login, register, logout, ready, refresh, status, user, ensureValidToken, forceRefreshToken]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/renderer/pages/settings/UserProfile.tsx
+++ b/src/renderer/pages/settings/UserProfile.tsx
@@ -1,5 +1,5 @@
 import { ipcBridge } from '@/common';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Avatar, Progress, Table, Tag, Button, Input, Modal, Message } from '@arco-design/web-react';
 import { User, Phone, Wechat, Edit } from '@icon-park/react';
 import SettingsPageWrapper from './components/SettingsPageWrapper';
@@ -9,7 +9,7 @@ import { useAuth } from '../../context/AuthContext';
 
 const UserProfile: React.FC = () => {
   const { t } = useTranslation();
-  const { user: currentUser, refresh } = useAuth();
+  const { user: currentUser, refresh, ensureValidToken, forceRefreshToken } = useAuth();
   const [profile, setProfile] = useState<any>(null);
   const [stats, setStats] = useState<any>(null);
   const [ledger, setLedger] = useState<any[]>([]);
@@ -18,14 +18,54 @@ const UserProfile: React.FC = () => {
   const [editModalVisible, setEditModalVisible] = useState(false);
   const [rechargeModalVisible, setRechargeModalVisible] = useState(false);
 
+  // 带自动刷新的 fetch 封装
+  const fetchWithAuth = useCallback(
+    async (url: string, options: RequestInit = {}, retry = true): Promise<Response> => {
+      const token = await ensureValidToken();
+      if (!token) {
+        throw new Error('NO_TOKEN');
+      }
+
+      const headers = {
+        ...options.headers,
+        Authorization: `Bearer ${token}`,
+      };
+
+      const response = await fetch(url, { ...options, headers });
+
+      // 如果返回 401，尝试强制刷新 token 后重试一次
+      if (response.status === 401 && retry) {
+        console.log('[UserProfile] Got 401, attempting force token refresh...');
+        const newToken = await forceRefreshToken();
+        if (newToken) {
+          // 用新 token 重试
+          const retryHeaders = {
+            ...options.headers,
+            Authorization: `Bearer ${newToken}`,
+          };
+          return fetch(url, { ...options, headers: retryHeaders });
+        }
+      }
+
+      return response;
+    },
+    [ensureValidToken, forceRefreshToken]
+  );
+
   const fetchProfile = async () => {
     setLoading(true);
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const headers = { Authorization: `Bearer ${currentUser?.token}` };
 
       // 并行调用：用户信息 + 仪表盘数据（积分、今日统计、使用流水）
-      const [profileRes, dashboardRes] = await Promise.all([fetch(`${serverConfig.baseUrl}/api/v1/user/profile`, { headers }), fetch(`${serverConfig.baseUrl}/api/v1/user/dashboard`, { headers })]);
+      const [profileRes, dashboardRes] = await Promise.all([fetchWithAuth(`${serverConfig.baseUrl}/api/v1/user/profile`), fetchWithAuth(`${serverConfig.baseUrl}/api/v1/user/dashboard`)]);
+
+      // 检查是否有 401 响应
+      if (profileRes.status === 401 || dashboardRes.status === 401) {
+        console.warn('[UserProfile] Unauthorized after retry, user may need to re-login');
+        setLoading(false);
+        return;
+      }
 
       const profileData = await profileRes.json();
       const dashboardData = await dashboardRes.json();
@@ -49,10 +89,10 @@ const UserProfile: React.FC = () => {
     if (currentUser?.token) void fetchProfile();
   }, [currentUser]);
 
-  const usedPoints = stats?.used || 0;
-  const totalPoints = stats?.total || 100;
-  const remainingPoints = stats?.remaining || 0;
-  const bonusPoints = stats?.bonus || 1000;
+  const usedPoints = stats?.used ?? 0;
+  const totalPoints = stats?.total ?? 0;
+  const remainingPoints = stats?.remaining ?? 0;
+  const bonusPoints = stats?.bonus ?? 0;
   const usedPercent = totalPoints > 0 ? Math.round((usedPoints / totalPoints) * 100) : 0;
 
   const handleEditNickname = () => {
@@ -68,27 +108,29 @@ const UserProfile: React.FC = () => {
 
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const headers = {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${currentUser?.token}`,
-      };
 
-      const res = await fetch(`${serverConfig.baseUrl}/api/v1/user/update-profile`, {
+      const res = await fetchWithAuth(`${serverConfig.baseUrl}/api/v1/user/update-profile`, {
         method: 'POST',
-        headers,
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nickname: editingNickname.trim() }),
       });
+
+      // 检查 401
+      if (res.status === 401) {
+        Message.error('登录状态已过期，请重新登录');
+        return;
+      }
 
       const data = await res.json();
       if (data.success) {
         Message.success('昵称已更新');
         setEditModalVisible(false);
         // 更新本地存储的用户信息
-        const stored = localStorage.getItem('sudowork_auth_v1');
+        const stored = localStorage.getItem('sudowork_auth_v2');
         if (stored) {
           const authData = JSON.parse(stored);
-          authData.nickname = editingNickname.trim();
-          localStorage.setItem('sudowork_auth_v1', JSON.stringify(authData));
+          authData.user.nickname = editingNickname.trim();
+          localStorage.setItem('sudowork_auth_v2', JSON.stringify(authData));
         }
         // 刷新页面数据
         await fetchProfile();


### PR DESCRIPTION
- Add `ensureValidToken` with forceRefresh support
- Add `forceRefreshToken` for 401 auto-retry scenario
- Add `fetchWithAuth` wrapper in UserProfile for auto token refresh
- Support legacy auth storage (sudowork_auth_v1) compatibility
- Call server logout API on logout to invalidate tokens
- Fix points display showing 0 when token expired

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
