### PR TITLE
fix(win-installer): 修复 tosPage 变量未引用导致的编译失败

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -17,9 +17,15 @@
   Var /GLOBAL deleteNexusData
 
   ; Variables for the Terms of Service / Privacy Policy agreement page
+  ; Guard with !ifndef BUILD_UNINSTALLER because these variables are only used
+  ; in the installer's custom ToS page (also guarded by !ifndef BUILD_UNINSTALLER).
+  ; Without this guard, the uninstaller pass triggers NSIS warning 6001
+  ; ("Variable not referenced or never set") which is treated as a build error.
+  !ifndef BUILD_UNINSTALLER
   Var /GLOBAL tosPage.Dialog
   Var /GLOBAL tosPage.Checkbox
   Var /GLOBAL tosPage.TextBox
+  !endif
 
   ; Override MUI2 uninstaller page strings for Simplified Chinese (LANG_SIMPCHINESE)
   ; Suppress warning 6030 (LangString set multiple times) since we intentionally


### PR DESCRIPTION
## Summary

- 将 `tosPage.Dialog`、`tosPage.Checkbox`、`tosPage.TextBox` 变量声明用 `!ifndef BUILD_UNINSTALLER` 包裹
- 修复卸载器构建阶段的 NSIS warning 6001 导致的编译失败

Closes #138

Generated with [Claude Code](https://claude.ai/code)