### PR TITLE
fix(workspace): auto-expand all folders when searching files

### DIFF
--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
@@ -9,6 +9,7 @@ import type { IDirOrFile } from '@/common/ipcBridge';
 import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { useEffect } from 'react';
 import type { ContextMenuState } from '../types';
+import { getAllDirKeys } from '../utils/treeHelpers';
 
 interface UseWorkspaceEventsOptions {
   conversation_id: string;
@@ -134,10 +135,16 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
    */
   useEffect(() => {
     return ipcBridge.conversation.responseSearchWorkSpace.provider((data) => {
-      if (data.match) setFiles([data.match]);
+      if (data.match) {
+        const matchData = [data.match];
+        setFiles(matchData);
+        // 搜索时自动展开所有文件夹，让用户直接看到匹配结果
+        // Auto-expand all folders on search so users can see matches directly
+        setExpandedKeys(getAllDirKeys(matchData));
+      }
       return Promise.resolve();
     });
-  }, [setFiles]);
+  }, [setFiles, setExpandedKeys]);
 
   /**
    * 监听右键菜单外部点击 - 关闭菜单

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
@@ -10,7 +10,7 @@ import { emitter } from '@/renderer/utils/emitter';
 import { dispatchWorkspaceHasFilesEvent } from '@/renderer/utils/workspaceEvents';
 import { useCallback, useRef, useState } from 'react';
 import type { SelectedNodeRef } from '../types';
-import { getFirstLevelKeys } from '../utils/treeHelpers';
+import { getAllDirKeys, getFirstLevelKeys } from '../utils/treeHelpers';
 
 interface UseWorkspaceTreeOptions {
   workspace: string;
@@ -94,9 +94,13 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
             setTreeKey(Math.random());
           }
 
-          // 只展开第一层文件夹（根节点）
-          // Only expand first level folders (root node)
-          setExpandedKeys(getFirstLevelKeys(res));
+          // 搜索时展开所有包含匹配结果的文件夹，否则只展开第一层
+          // When searching, expand all folders containing matches; otherwise only expand first level
+          if (search) {
+            setExpandedKeys(getAllDirKeys(res));
+          } else {
+            setExpandedKeys(getFirstLevelKeys(res));
+          }
 
           // 根据是否有文件决定工作空间面板的展开/折叠状态
           // Determine workspace panel expand/collapse state based on files

--- a/src/renderer/pages/conversation/workspace/utils/treeHelpers.ts
+++ b/src/renderer/pages/conversation/workspace/utils/treeHelpers.ts
@@ -68,6 +68,23 @@ export function getFirstLevelKeys(nodes: IDirOrFile[]): string[] {
 }
 
 /**
+ * 递归收集树中所有文件夹节点的 key（用于搜索时全部展开）
+ * Recursively collect all directory node keys in the tree (for expanding all on search)
+ */
+export function getAllDirKeys(nodes: IDirOrFile[]): string[] {
+  const keys: string[] = [];
+  for (const node of nodes) {
+    if (node.isDir) {
+      keys.push(node.relativePath);
+      if (node.children && node.children.length > 0) {
+        keys.push(...getAllDirKeys(node.children));
+      }
+    }
+  }
+  return keys;
+}
+
+/**
  * 替换路径列表中的旧路径为新路径
  * Replace old path with new path in path list
  */


### PR DESCRIPTION
Auto-expand all directory nodes when searching workspace files, so matching results are immediately visible without manual folder expansion.

Closes #160

Generated with [Claude Code](https://claude.ai/code)