### PR TITLE
fix(win-installer): 修正安装包文件属性中的公司名称

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sudowork",
   "productName": "sudowork",
   "version": "0.1.3",
-  "description": "新一代企业AI应用平台—AgentOPS|办公专家",
+  "description": "新一代企业AI应用平台--AgentOPS|办公专家",
   "main": "./out/main/index.js",
   "engines": {
     "node": ">=22 <26"
@@ -67,7 +67,7 @@
   },
   "keywords": [],
   "author": {
-    "name": "Sudowork",
+    "name": "北京数牍科技有限公司",
     "email": "service@sudoprivacy.com"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- 将 `package.json` 中 `author.name` 从 "Sudowork" 更改为 "北京数牍科技有限公司"
- 确保 Windows 安装包文件属性中的"公司"字段显示正确的公司名称

## Test plan
- [ ] 重新构建 Windows 安装包 (`bun run build:win`)
- [ ] 检查生成的 .exe 文件属性：右键 → 属性 → 详细信息 → 公司字段应显示"北京数牍科技有限公司"

🤖 Generated with [Claude Code](https://claude.com/claude-code)