### PR TITLE
fix: remove unconditional auto-launch after install on Windows

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -390,13 +390,6 @@ $\r$\n\
 !macroend
 
 ; ========================================
-; Auto-launch after installation
-; ========================================
-Function .onInstSuccess
-  Exec '"$INSTDIR\Sudowork.exe"'
-FunctionEnd
-
-; ========================================
 ; Uninstall: Prompt user about deleting user data before removal begins
 ; ========================================
 ; This macro runs BEFORE customRemoveFiles in the uninstall section.


### PR DESCRIPTION
Fixes #168

## Summary

- Removed the `.onInstSuccess` function in `scripts/installer.nsh` that unconditionally launched the app after installation
- electron-builder's assisted installer already provides a finish page with a "Run application" checkbox that respects user preference

Generated with [Claude Code](https://claude.ai/code)