### PR TITLE
feat: support nightly version upgrade (#176)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,8 +1,58 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import { resolve } from 'path';
+import { execSync } from 'child_process';
 import UnoCSS from 'unocss/vite';
 import unoConfig from './uno.config.ts';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+/**
+ * Resolve build-time metadata from environment variables or git.
+ *
+ * CI can inject via env vars: BUILD_VERSION, BUILD_DATE, BUILD_COMMIT, BUILD_IS_NIGHTLY.
+ * When running locally, values are auto-detected from git and package.json.
+ */
+function resolveBuildMeta() {
+  const execGit = (cmd: string, fallback: string): string => {
+    try {
+      return execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    } catch {
+      return fallback;
+    }
+  };
+
+  // Version: env var > git tag > package.json
+  let version = process.env.BUILD_VERSION;
+  if (!version) {
+    const gitTag = execGit('git describe --tags --exact-match 2>/dev/null', '');
+    if (gitTag) {
+      // Strip leading 'v' and any nightly prefix to get a clean version
+      version = gitTag.replace(/^v/, '');
+    }
+  }
+  if (!version) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      version = require('./package.json').version;
+    } catch {
+      version = '0.0.0-dev';
+    }
+  }
+
+  // Commit date: env var > git log
+  const buildDate = process.env.BUILD_DATE || execGit('git log -1 --format=%cs', new Date().toISOString().slice(0, 10));
+
+  // Short commit hash: env var > git rev-parse
+  const buildCommit = process.env.BUILD_COMMIT || execGit('git rev-parse --short HEAD', 'unknown');
+
+  // Nightly flag: env var or auto-detect from git tag
+  let isNightly = process.env.BUILD_IS_NIGHTLY === 'true';
+  if (!isNightly && !process.env.BUILD_IS_NIGHTLY) {
+    const gitTag = execGit('git describe --tags --exact-match 2>/dev/null', '');
+    isNightly = gitTag.startsWith('nightly-');
+  }
+
+  return { version, buildDate, buildCommit, isNightly };
+}
 
 // Icon Park transform plugin (replaces webpack icon-park-loader)
 function iconParkPlugin() {
@@ -38,6 +88,15 @@ const mainAliases = {
 
 export default defineConfig(({ mode }) => {
   const isDevelopment = mode === 'development';
+  const buildMeta = resolveBuildMeta();
+
+  // Shared build-time defines injected into all processes (main, preload, renderer)
+  const buildDefines = {
+    __BUILD_VERSION__: JSON.stringify(buildMeta.version),
+    __BUILD_DATE__: JSON.stringify(buildMeta.buildDate),
+    __BUILD_COMMIT__: JSON.stringify(buildMeta.buildCommit),
+    __BUILD_IS_NIGHTLY__: JSON.stringify(buildMeta.isNightly),
+  };
 
   return {
     main: {
@@ -76,7 +135,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      define: { 'process.env.env': JSON.stringify(process.env.env) },
+      define: { 'process.env.env': JSON.stringify(process.env.env), ...buildDefines },
     },
 
     preload: {
@@ -149,6 +208,7 @@ export default defineConfig(({ mode }) => {
       define: {
         'process.env.env': JSON.stringify(process.env.env),
         global: 'globalThis',
+        ...buildDefines,
       },
       optimizeDeps: {
         exclude: ['electron'],

--- a/src/common/buildInfo.ts
+++ b/src/common/buildInfo.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Build-time metadata injected via Vite `define` in electron.vite.config.ts.
+ *
+ * Values are populated at build time from git / environment variables:
+ *   - __BUILD_VERSION__   : git tag (e.g. "0.1.3") or package.json version
+ *   - __BUILD_DATE__      : commit date in ISO-8601 format (e.g. "2026-04-07")
+ *   - __BUILD_COMMIT__    : short commit hash (e.g. "abc1234")
+ *   - __BUILD_IS_NIGHTLY__: whether this is a nightly (pre-release) build
+ *
+ * CI workflows can override these via environment variables:
+ *   BUILD_VERSION, BUILD_DATE, BUILD_COMMIT, BUILD_IS_NIGHTLY
+ */
+
+declare const __BUILD_VERSION__: string;
+declare const __BUILD_DATE__: string;
+declare const __BUILD_COMMIT__: string;
+declare const __BUILD_IS_NIGHTLY__: boolean;
+
+/** Application version (from git tag or package.json) */
+export const buildVersion: string = typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : '0.0.0-dev';
+
+/** Commit date in YYYY-MM-DD format */
+export const buildDate: string = typeof __BUILD_DATE__ !== 'undefined' ? __BUILD_DATE__ : 'unknown';
+
+/** Short commit hash */
+export const buildCommit: string = typeof __BUILD_COMMIT__ !== 'undefined' ? __BUILD_COMMIT__ : 'unknown';
+
+/** Whether this is a nightly (pre-release) build */
+export const isNightlyBuild: boolean = typeof __BUILD_IS_NIGHTLY__ !== 'undefined' ? __BUILD_IS_NIGHTLY__ : false;
+
+/**
+ * Parse a nightly tag to extract its date.
+ * Nightly tags follow the format: nightly-YYYY-MM-DD-SHORTHASH
+ * @returns The date string (YYYY-MM-DD) or null if not a valid nightly tag.
+ */
+export function parseNightlyDate(tag: string): string | null {
+  const match = tag.match(/^nightly-(\d{4}-\d{2}-\d{2})-[a-f0-9]+$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Compare two nightly tags by date.
+ * @returns Positive if a is newer, negative if b is newer, 0 if same date.
+ */
+export function compareNightlyTags(a: string, b: string): number {
+  const dateA = parseNightlyDate(a);
+  const dateB = parseNightlyDate(b);
+  if (!dateA || !dateB) return 0;
+  return dateA.localeCompare(dateB);
+}
+
+/**
+ * Check if a tag is a nightly tag.
+ */
+export function isNightlyTag(tag: string): boolean {
+  return /^nightly-\d{4}-\d{2}-\d{2}-[a-f0-9]+$/.test(tag);
+}
+
+/**
+ * Get a human-readable build description string.
+ */
+export function getBuildDescription(): string {
+  if (isNightlyBuild) {
+    return `nightly (${buildDate}, ${buildCommit})`;
+  }
+  return `v${buildVersion} (${buildDate})`;
+}

--- a/src/process/bridge/updateBridge.ts
+++ b/src/process/bridge/updateBridge.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import semver from 'semver';
 import { autoUpdaterService } from '../services/autoUpdaterService';
 import { mainLog, mainError } from '@process/utils/mainLogger';
+import { isNightlyBuild, buildDate, isNightlyTag, parseNightlyDate } from '@/common/buildInfo';
 
 type GitHubReleaseApiAsset = {
   name: string;
@@ -260,6 +261,37 @@ const mapRelease = (rel: GitHubReleaseApi): UpdateReleaseInfo | null => {
   };
 };
 
+/**
+ * Map a nightly GitHub release to UpdateReleaseInfo.
+ * Nightly tags (e.g. "nightly-2026-04-01-abc1234") are not valid semver,
+ * so we use the date from the tag as a pseudo-version for display purposes.
+ */
+const mapNightlyRelease = (rel: GitHubReleaseApi): UpdateReleaseInfo | null => {
+  if (!isNightlyTag(rel.tag_name)) return null;
+
+  const nightlyDate = parseNightlyDate(rel.tag_name);
+  if (!nightlyDate) return null;
+
+  const assets = (rel.assets || [])
+    .filter((asset) => asset && asset.name && asset.browser_download_url)
+    .filter((asset) => isAllowedAssetName(asset.name))
+    .map(mapAsset);
+
+  return {
+    tagName: rel.tag_name,
+    // Use the nightly tag as the "version" string for display
+    version: rel.tag_name,
+    name: rel.name,
+    body: rel.body,
+    htmlUrl: rel.html_url,
+    publishedAt: rel.published_at,
+    prerelease: true,
+    draft: Boolean(rel.draft),
+    assets,
+    recommendedAsset: pickRecommendedAsset(assets),
+  };
+};
+
 type DownloadState = {
   abortController: AbortController;
   filePath: string;
@@ -420,6 +452,54 @@ export function initUpdateBridge(): void {
       const includePrerelease = Boolean(params?.includePrerelease);
       const currentVersion = app.getVersion();
 
+      const releases = await fetchGitHubReleases(repo);
+
+      // ────────────────────────────────────────────────────────────
+      // Nightly-to-nightly update path
+      // 当前为 nightly 版本时，只允许更新到更新的 nightly 版本
+      // When the current build is nightly, only allow updating to a newer nightly.
+      // ────────────────────────────────────────────────────────────
+      if (isNightlyBuild) {
+        mainLog('Update', `Current build is nightly (date: ${buildDate}), checking for newer nightly releases...`);
+
+        const nightlyCandidates = releases
+          .filter((r) => r && !r.draft && r.prerelease)
+          .map(mapNightlyRelease)
+          .filter((r): r is UpdateReleaseInfo => Boolean(r));
+
+        // Sort nightly candidates by date (newest first)
+        nightlyCandidates.sort((a, b) => {
+          const dateA = parseNightlyDate(a.tagName) || '';
+          const dateB = parseNightlyDate(b.tagName) || '';
+          return dateB.localeCompare(dateA);
+        });
+
+        const latestNightly = nightlyCandidates[0];
+        if (!latestNightly) {
+          mainLog('Update', 'No nightly releases found');
+          return { success: true, data: { currentVersion: `nightly (${buildDate})`, updateAvailable: false } };
+        }
+
+        const latestNightlyDate = parseNightlyDate(latestNightly.tagName) || '';
+        const updateAvailable = latestNightlyDate > buildDate;
+
+        mainLog('Update', `Latest nightly: ${latestNightly.tagName} (${latestNightlyDate}), current: ${buildDate}, update available: ${updateAvailable}`);
+
+        return {
+          success: true,
+          data: {
+            currentVersion: `nightly (${buildDate})`,
+            updateAvailable,
+            latest: updateAvailable ? latestNightly : undefined,
+          },
+        };
+      }
+
+      // ────────────────────────────────────────────────────────────
+      // Standard semver update path (stable / RC releases)
+      // 标准 semver 更新路径（稳定版 / RC 版本）
+      // ────────────────────────────────────────────────────────────
+
       // EN: Versioning note
       // Update comparisons are pure semver: `app.getVersion()` (packaged app version) vs release `tag_name`.
       // If you want dev/prerelease updates to work reliably, CI must inject a prerelease semver into
@@ -430,9 +510,8 @@ export function initUpdateBridge(): void {
       // 更新比较严格使用 semver：`app.getVersion()`（应用自身版本号）对比 Release 的 `tag_name`。
       // 若要 dev/预发布版本更新可靠生效，需要 CI 在 dev 构建时把 `package.json#version`
       // 注入为带 prerelease 的 semver（如 `1.7.2-dev.1234+sha.abcdef0`），以保证比较顺序正确。
-      // 这里刻意不对“当前是稳定版版本号但用户勾选了 prerelease”做字符串猜测。
+      // 这里刻意不对”当前是稳定版版本号但用户勾选了 prerelease”做字符串猜测。
 
-      const releases = await fetchGitHubReleases(repo);
       const candidates = releases
         .filter((r) => r && !r.draft)
         .filter((r) => (includePrerelease ? true : !r.prerelease))

--- a/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useSettingsViewMode } from '../settingsViewContext';
 import packageJson from '../../../../../package.json';
 import OpsModal from '@/renderer/components/OpsModal';
+import { buildVersion, buildDate, buildCommit, isNightlyBuild } from '@/common/buildInfo';
 
 const AboutModalContent: React.FC = () => {
   const viewMode = useSettingsViewMode();
@@ -31,7 +32,19 @@ const AboutModalContent: React.FC = () => {
               Sudowork
             </Typography.Title>
             <div className='text-12px text-t-tertiary mb-10px'>北京数牍科技有限公司</div>
-            <span className='px-10px py-3px rd-20px text-12px bg-fill-2 text-t-secondary font-mono font-500'>v{packageJson.version}</span>
+            <span className='px-10px py-3px rd-20px text-12px bg-fill-2 text-t-secondary font-mono font-500'>
+              {isNightlyBuild ? `nightly (${buildDate})` : `v${buildVersion || packageJson.version}`}
+            </span>
+            {buildDate !== 'unknown' && (
+              <div className='text-11px text-t-quaternary mt-4px font-mono'>
+                {t('settings.buildDate', { date: buildDate })} · {buildCommit}
+              </div>
+            )}
+            {isNightlyBuild && (
+              <span className='mt-4px px-8px py-2px rd-10px text-11px bg-orange-1 text-orange-6 dark:bg-orange-9/20 dark:text-orange-5 font-500'>
+                {t('settings.nightlyBuild')}
+              </span>
+            )}
             <Button size='small' type='outline' className='mt-12px' onClick={() => window.dispatchEvent(new Event('aionui-open-update-modal'))}>
               {t('settings.checkForUpdates')}
             </Button>

--- a/src/renderer/components/UpdateModal/index.tsx
+++ b/src/renderer/components/UpdateModal/index.tsx
@@ -12,6 +12,7 @@ import AionModal from '@/renderer/components/base/AionModal';
 import MarkdownView from '@/renderer/components/Markdown';
 import type { UpdateDownloadProgressEvent, UpdateReleaseInfo, AutoUpdateStatus } from '@/common/updateTypes';
 import { useTranslation } from 'react-i18next';
+import { isNightlyBuild } from '@/common/buildInfo';
 
 type UpdateStatus = 'checking' | 'upToDate' | 'available' | 'downloading' | 'downloaded' | 'success' | 'error';
 
@@ -28,7 +29,9 @@ const UpdateModal: React.FC = () => {
   const [errorMsg, setErrorMsg] = useState('');
   const [downloadPath, setDownloadPath] = useState('');
   const [releasePageUrl, setReleasePageUrl] = useState('');
-  const [useAutoUpdate, setUseAutoUpdate] = useState(true); // 默认使用自动更新
+  // Nightly builds exclude auto-update metadata (*.yml, *.blockmap),
+  // so electron-updater cannot be used. Default to manual download mode.
+  const [useAutoUpdate, setUseAutoUpdate] = useState(!isNightlyBuild);
   const [autoUpdateInfo, setAutoUpdateInfo] = useState<{ version: string; releaseNotes?: string } | null>(null);
   const [autoUpdateDownloadedPath, setAutoUpdateDownloadedPath] = useState<string | null>(null);
 
@@ -45,7 +48,8 @@ const UpdateModal: React.FC = () => {
     setAutoUpdateDownloadedPath(null);
   };
 
-  const includePrerelease = useMemo(() => localStorage.getItem('update.includePrerelease') === 'true', [visible]);
+  // Nightly builds always check for prerelease updates; otherwise respect user preference
+  const includePrerelease = useMemo(() => isNightlyBuild || localStorage.getItem('update.includePrerelease') === 'true', [visible]);
   const hasCompatibleManualAsset = Boolean(updateInfo?.recommendedAsset);
 
   const openReleasePage = () => {
@@ -58,6 +62,31 @@ const UpdateModal: React.FC = () => {
   const checkForUpdates = async () => {
     setStatus('checking');
     try {
+      // Nightly builds: skip auto-updater, go straight to manual GitHub API check
+      // Nightly 版本：跳过 electron-updater，直接通过 GitHub API 检查更新
+      if (isNightlyBuild) {
+        const res = await ipcBridge.update.check.invoke({ includePrerelease: true });
+        if (!res?.success) {
+          throw new Error(res?.msg || t('update.checkFailed'));
+        }
+        setCurrentVersion(res.data?.currentVersion || '');
+
+        if (res.data?.updateAvailable && res.data.latest) {
+          setUpdateInfo(res.data.latest);
+          setReleasePageUrl(res.data.latest.htmlUrl || '');
+          if (!res.data.latest.recommendedAsset) {
+            setErrorMsg(t('update.noCompatibleAssetManual'));
+          }
+          setStatus('available');
+          return;
+        }
+
+        setUpdateInfo(res.data?.latest || null);
+        setReleasePageUrl(res.data?.latest?.htmlUrl || '');
+        setStatus('upToDate');
+        return;
+      }
+
       // 优先使用自动更新模式
       if (useAutoUpdate) {
         const res = await ipcBridge.autoUpdate.check.invoke({ includePrerelease });
@@ -336,6 +365,12 @@ const UpdateModal: React.FC = () => {
       case 'available':
         return (
           <div className='flex flex-col h-full'>
+            {/* Nightly 版本提示 / Nightly version notice */}
+            {isNightlyBuild && (
+              <div className='mx-24px mt-12px px-12px py-10px text-12px rounded-8px bg-orange-1 text-orange-6 dark:bg-orange-9/20 dark:text-orange-5'>
+                {t('update.nightlyNote')}
+              </div>
+            )}
             {/* 版本信息头部 / Version info header */}
             <div className='flex items-center justify-between px-24px py-16px border-b border-border-2 bg-fill-1'>
               <div className='flex items-center gap-12px'>
@@ -343,7 +378,7 @@ const UpdateModal: React.FC = () => {
                   <Download size='20' fill='rgb(var(--primary-6))' />
                 </div>
                 <div>
-                  <div className='text-15px font-600 text-t-primary'>{t('update.availableTitle')}</div>
+                  <div className='text-15px font-600 text-t-primary'>{isNightlyBuild ? t('update.nightlyUpdateTitle') : t('update.availableTitle')}</div>
                   <div className='text-12px text-t-tertiary mt-2px'>
                     {currentVersion} → <span className='text-[rgb(var(--primary-6))] font-500'>{updateInfo?.version || autoUpdateInfo?.version}</span>
                   </div>
@@ -371,11 +406,13 @@ const UpdateModal: React.FC = () => {
               </div>
             </div>
 
-            {/* 自动更新开关 / Auto update toggle */}
-            <div className='flex items-center justify-between px-24px py-12px bg-fill-1 border-b border-border-2'>
-              <div className='text-13px text-t-secondary'>{t('update.autoUpdateMode')}</div>
-              <Switch checked={useAutoUpdate} onChange={setUseAutoUpdate} size='small' disabled={!hasCompatibleManualAsset} />
-            </div>
+            {/* 自动更新开关 / Auto update toggle (hidden for nightly builds) */}
+            {!isNightlyBuild && (
+              <div className='flex items-center justify-between px-24px py-12px bg-fill-1 border-b border-border-2'>
+                <div className='text-13px text-t-secondary'>{t('update.autoUpdateMode')}</div>
+                <Switch checked={useAutoUpdate} onChange={setUseAutoUpdate} size='small' disabled={!hasCompatibleManualAsset} />
+              </div>
+            )}
 
             {!hasCompatibleManualAsset && <div className='mx-24px mt-12px px-12px py-10px text-12px rounded-8px bg-[rgb(var(--warning-6))]/10 text-[rgb(var(--warning-6))]'>{t('update.noCompatibleAssetManual')}</div>}
 

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -510,6 +510,8 @@
   "contactMe": "Contact Me",
   "officialWebsite": "Official Website",
   "checkForUpdates": "Check for updates",
+  "buildDate": "Build date: {{date}}",
+  "nightlyBuild": "Nightly build",
   "includePrereleaseUpdates": "Include prerelease/dev builds",
   "saveModelConfigFailed": "Failed to save model configuration",
   "healthCheck": "Health Check",

--- a/src/renderer/i18n/locales/en-US/update.json
+++ b/src/renderer/i18n/locales/en-US/update.json
@@ -21,5 +21,7 @@
   "autoUpdateMode": "Auto-update mode",
   "showInFolder": "Show in folder",
   "openFile": "Open file",
-  "errorTitle": "Update failed"
+  "errorTitle": "Update failed",
+  "nightlyUpdateTitle": "New nightly build available",
+  "nightlyNote": "You are running a nightly build. Updates are limited to newer nightly builds only."
 }

--- a/src/renderer/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/i18n/locales/ja-JP/settings.json
@@ -499,6 +499,8 @@
   "contactMe": "お問い合わせ",
   "officialWebsite": "公式サイト",
   "checkForUpdates": "更新を確認",
+  "buildDate": "ビルド日: {{date}}",
+  "nightlyBuild": "Nightly ビルド",
   "includePrereleaseUpdates": "プレリリース/dev ビルドを含める",
   "saveModelConfigFailed": "モデル設定の保存に失敗しました",
   "healthCheck": "ヘルスチェック",

--- a/src/renderer/i18n/locales/ja-JP/update.json
+++ b/src/renderer/i18n/locales/ja-JP/update.json
@@ -21,5 +21,7 @@
   "autoUpdateMode": "自動更新モード",
   "showInFolder": "フォルダーで表示",
   "openFile": "ファイルを開く",
-  "errorTitle": "更新に失敗しました"
+  "errorTitle": "更新に失敗しました",
+  "nightlyUpdateTitle": "新しい Nightly ビルドがあります",
+  "nightlyNote": "Nightly ビルドを使用中です。更新は新しい Nightly ビルドのみに制限されます。"
 }

--- a/src/renderer/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/i18n/locales/ko-KR/settings.json
@@ -499,6 +499,8 @@
   "contactMe": "연락처",
   "officialWebsite": "공식 웹사이트",
   "checkForUpdates": "업데이트 확인",
+  "buildDate": "빌드 날짜: {{date}}",
+  "nightlyBuild": "Nightly 빌드",
   "includePrereleaseUpdates": "프리릴리즈/dev 빌드 포함",
   "saveModelConfigFailed": "모델 구성 저장 실패",
   "healthCheck": "상태 확인",

--- a/src/renderer/i18n/locales/ko-KR/update.json
+++ b/src/renderer/i18n/locales/ko-KR/update.json
@@ -21,5 +21,7 @@
   "autoUpdateMode": "자동 업데이트 모드",
   "showInFolder": "폴더에서 보기",
   "openFile": "파일 열기",
-  "errorTitle": "업데이트 실패"
+  "errorTitle": "업데이트 실패",
+  "nightlyUpdateTitle": "새로운 Nightly 빌드 사용 가능",
+  "nightlyNote": "Nightly 빌드를 사용 중입니다. 새로운 Nightly 빌드로만 업데이트할 수 있습니다."
 }

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -499,6 +499,8 @@
   "contactMe": "Bana Ulaşın",
   "officialWebsite": "Resmi Web Sitesi",
   "checkForUpdates": "Güncellemeleri kontrol et",
+  "buildDate": "Derleme tarihi: {{date}}",
+  "nightlyBuild": "Nightly sürüm",
   "includePrereleaseUpdates": "Ön sürüm/geliştirici sürümlerini dahil et",
   "saveModelConfigFailed": "Model yapılandırması kaydedilemedi",
   "healthCheck": "Sağlık Kontrolü",

--- a/src/renderer/i18n/locales/tr-TR/update.json
+++ b/src/renderer/i18n/locales/tr-TR/update.json
@@ -21,5 +21,7 @@
   "autoUpdateMode": "Otomatik güncelleme modu",
   "showInFolder": "Klasörde göster",
   "openFile": "Dosyayı aç",
-  "errorTitle": "Güncelleme başarısız"
+  "errorTitle": "Güncelleme başarısız",
+  "nightlyUpdateTitle": "Yeni nightly sürüm mevcut",
+  "nightlyNote": "Nightly sürüm kullanıyorsunuz. Güncellemeler yalnızca daha yeni nightly sürümlerle sınırlıdır."
 }

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -510,6 +510,8 @@
   "contactMe": "联系我",
   "officialWebsite": "官网",
   "checkForUpdates": "检查更新",
+  "buildDate": "构建日期：{{date}}",
+  "nightlyBuild": "Nightly 预览版",
   "includePrereleaseUpdates": "包含预发布/dev 版本",
   "saveModelConfigFailed": "保存模型配置失败",
   "healthCheck": "健康检测",

--- a/src/renderer/i18n/locales/zh-CN/update.json
+++ b/src/renderer/i18n/locales/zh-CN/update.json
@@ -21,5 +21,7 @@
   "autoUpdateMode": "自动更新模式",
   "showInFolder": "在文件夹中显示",
   "openFile": "打开文件",
-  "errorTitle": "更新失败"
+  "errorTitle": "更新失败",
+  "nightlyUpdateTitle": "发现新的 Nightly 版本",
+  "nightlyNote": "当前为 Nightly 预览版，仅支持更新到更新的 Nightly 版本。"
 }

--- a/src/renderer/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/i18n/locales/zh-TW/settings.json
@@ -499,6 +499,8 @@
   "contactMe": "聯繫我",
   "officialWebsite": "官網",
   "checkForUpdates": "檢查更新",
+  "buildDate": "建構日期：{{date}}",
+  "nightlyBuild": "Nightly 預覽版",
   "includePrereleaseUpdates": "包含預發佈/dev 版本",
   "saveModelConfigFailed": "儲存模型設定失敗",
   "healthCheck": "健康檢測",

--- a/src/renderer/i18n/locales/zh-TW/update.json
+++ b/src/renderer/i18n/locales/zh-TW/update.json
@@ -21,5 +21,7 @@
   "autoUpdateMode": "自動更新模式",
   "showInFolder": "在資料夾中顯示",
   "openFile": "開啟檔案",
-  "errorTitle": "更新失敗"
+  "errorTitle": "更新失敗",
+  "nightlyUpdateTitle": "有新的 Nightly 版本可用",
+  "nightlyNote": "目前使用的是 Nightly 預覽版，僅支援更新到更新的 Nightly 版本。"
 }


### PR DESCRIPTION
## Summary

- Add build-time metadata injection (version, date, commit, nightly flag) via Vite define
- Support nightly-to-nightly update detection via GitHub API
- Show build date and nightly badge in About page
- Add i18n for 6 locales

Closes #176

Generated with [Claude Code](https://claude.ai/code)