### PR TITLE
fix: change “运行Sudowork” checkbox text to white on installer finish page

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -373,6 +373,39 @@ $\r$\n\
 !macroend
 
 ; ========================================
+; Custom Finish Page: Fix "Run Sudowork" checkbox color on dark background
+; ========================================
+; The MUI2 finish page uses MUI_BGCOLOR ("161C2D") as background and
+; MUI_TEXTCOLOR ("FFFFFF") for labels, but the "Run" checkbox inherits the
+; default system text colour (black / dark), making it nearly invisible.
+; We define a customFinishPage macro so electron-builder uses our version
+; instead of the default one, allowing us to attach a SHOW callback that
+; forces the checkbox text to white.
+!macro customFinishPage
+  !ifndef HIDE_RUN_AFTER_FINISH
+    Function StartApp
+      ${if} ${isUpdated}
+        StrCpy $1 "--updated"
+      ${else}
+        StrCpy $1 ""
+      ${endif}
+      ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
+    FunctionEnd
+
+    !define MUI_FINISHPAGE_RUN
+    !define MUI_FINISHPAGE_RUN_FUNCTION "StartApp"
+  !endif
+
+  !define MUI_PAGE_CUSTOMFUNCTION_SHOW finishPageShow
+  !insertmacro MUI_PAGE_FINISH
+
+  Function finishPageShow
+    ; Make the "Run" checkbox readable on the dark finish page background
+    SetCtlColors $mui.FinishPage.Run "FFFFFF" "161C2D"
+  FunctionEnd
+!macroend
+
+; ========================================
 ; Install: Record installed files into a manifest
 ; ========================================
 !macro customInstall


### PR DESCRIPTION
The MUI2 finish page “Run” checkbox inherited default dark text color, making it nearly invisible against the dark background. Added a customFinishPage macro with a SHOW callback that sets the checkbox text color to white for proper contrast.

Closes #182

Generated with [Claude Code](https://claude.ai/code)