### PR TITLE
fix: 修复钉钉跟随教程超链接指向错误的地址

### DIFF
--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -57,7 +57,7 @@ interface DingTalkConfigFormProps {
   onStatusChange: (status: IChannelPluginStatus | null) => void;
 }
 
-const DINGTALK_DEV_DOCS_URL = 'https://github.com/sudoprivacy/Sudowork/wiki/DingTalk-Bot-Setup-Guide';
+const DINGTALK_DEV_DOCS_URL = 'https://open.dingtalk.com/document/dingstart/custom-bot-creation-and-installation';
 
 const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- 修复钉钉配置中"跟随教程"超链接指向错误地址的问题
- 将超链接指向正确的钉钉开发文档：https://open.dingtalk.com/document/dingstart/custom-bot-creation-and-installation

## Changes
- 修改钉钉配置表单中的教程链接地址

## Test plan
- [ ] 验证钉钉配置页面中的"跟随教程"链接指向正确地址

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)