### PR TITLE
fix: 文件规则写入问题

### DIFF
--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -503,6 +503,16 @@ export function repairOpenClawConfig(): void {
   } catch {
     // ignore parse errors
   }
+
+  // Ensure workspace directory and USER.md safety rules exist on every startup.
+  // This covers scenarios where macOS upgrades or filesystem changes remove the
+  // workspace directory or USER.md file after the initial installation.
+  try {
+    fs.mkdirSync(SUDOCLAW_WORKSPACE_DIR, { recursive: true });
+    ensureUserMdSafetyRules();
+  } catch (err) {
+    mainWarn('Sudoclaw', `Failed to ensure workspace/USER.md during config repair: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 function ensureDefaultConfig(): void {


### PR DESCRIPTION
macOS 升级后可能导致 workspace 目录或 USER.md 文件丢失，将修复逻辑补全到 repairOpenClawConfig() 中确保每次启动都会检查并修复。

Closes #189

Generated with [Claude Code](https://claude.ai/code)