### PR TITLE
fix: 确保 USER.md 安全规则在 Sudoclaw 启动后写入

### DIFF
--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -5,7 +5,9 @@
  */
 
 import { app } from 'electron';
+import * as fs from 'node:fs';
 import * as http from 'node:http';
+import * as path from 'node:path';
 import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
 import { initStatusManager } from '../initStatus';
 import { isSudoclawHealthPayload, type SudoclawHealthPayload } from '../sudoclaw/sudoclawHealth';
@@ -293,7 +295,7 @@ class ServiceManager {
     try {
       mainLog('ServiceManager', 'Starting Sudoclaw gateway...');
       const { OpenClawGatewayManager } = await import('@/agent/openclaw');
-      const { SUDOCLAW_DIR, SUDOCLAW_DEFAULT_PORT, SUDOCLAW_CONFIG_PATH, repairOpenClawConfig, getSudoclawVersionState, ensureSudoclawInstalled } = await import('../sudoclaw/SudoclawInstallService');
+      const { SUDOCLAW_DIR, SUDOCLAW_DEFAULT_PORT, SUDOCLAW_CONFIG_PATH, repairOpenClawConfig, getSudoclawVersionState, ensureSudoclawInstalled, ensureUserMdSafetyRules } = await import('../sudoclaw/SudoclawInstallService');
       await this.ensureNodeReadyForSudoclawStart();
 
       const versionState = getSudoclawVersionState();
@@ -325,6 +327,16 @@ class ServiceManager {
       initStatusManager.setStepProgress('sudoclaw', 100, 'Sudoclaw 服务已就绪');
       mainLog('ServiceManager', 'Sudoclaw gateway started successfully');
       this.gatewayReadyResolve?.({ host: 'localhost', port: SUDOCLAW_DEFAULT_PORT });
+
+      // Ensure USER.md safety rules after Sudoclaw starts.
+      // Sudoclaw may create a default USER.md template on first run, which could
+      // overwrite rules written before startup. Run again after gateway is healthy.
+      try {
+        fs.mkdirSync(path.join(SUDOCLAW_DIR, 'workspace'), { recursive: true });
+        ensureUserMdSafetyRules();
+      } catch (err) {
+        mainWarn('ServiceManager', 'Failed to ensure USER.md safety rules after Sudoclaw start', err);
+      }
 
       // Sync image model from sudowork config to sudoclaw.json on every startup.
       // Covers first-time (no prior user interaction) and ensures sudoclaw.json stays in sync.

--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -565,7 +565,7 @@ const USER_MD_SAFETY_MARKER = '<!-- SUDOCLAW_DELETE_SAFETY_RULES -->';
  *
  * This guarantees that fresh installs *and* upgrades always carry the prompt.
  */
-function ensureUserMdSafetyRules(): void {
+export function ensureUserMdSafetyRules(): void {
   const userMdPath = path.join(SUDOCLAW_WORKSPACE_DIR, 'USER.md');
   const safetyRulesBlock = `
 ${USER_MD_SAFETY_MARKER}


### PR DESCRIPTION
## Summary
- 导出 `ensureUserMdSafetyRules` 函数供外部调用
- 在 ServiceManager 中 Sudoclaw 启动完成后再次调用确保规则存在

问题原因：`repairOpenClawConfig()` 在 Sudoclaw 启动前调用 `ensureUserMdSafetyRules()`，但 Sudoclaw 启动后会创建默认的 USER.md 模板，覆盖了安全规则。

## Test plan
- [x] `npm run build && npm run start` 启动应用
- [x] 检查 `~/.nexus/sudoclaw/workspace/USER.md` 包含 `<!-- SUDOCLAW_DELETE_SAFETY_RULES -->` 标记

🤖 Generated with [Claude Code](https://claude.ai/code)