### PR TITLE
feat(guid): add prompt templates on Guide page

### DIFF
--- a/src/renderer/i18n/locales/en-US/guid.json
+++ b/src/renderer/i18n/locales/en-US/guid.json
@@ -1,4 +1,57 @@
 {
+  "promptTemplates": {
+    "title": "Prompt Templates",
+    "categories": {
+      "coding": "Coding",
+      "writing": "Writing",
+      "translation": "Translation",
+      "analysis": "Analysis",
+      "creative": "Creative",
+      "learning": "Learning"
+    },
+    "coding": {
+      "writeScript": "Write a script",
+      "writeScriptContent": "Help me write a Python script to...",
+      "codeReview": "Code review",
+      "codeReviewContent": "Please review the following code, identify potential issues and suggest improvements:\n\n```\n// Paste code here\n```",
+      "debug": "Debug an error",
+      "debugContent": "I encountered the following error, please help me analyze the cause and provide a solution:\n\nError message:",
+      "explain": "Explain code",
+      "explainContent": "Please explain how the following code works in a clear and simple way:\n\n```\n// Paste code here\n```"
+    },
+    "writing": {
+      "article": "Write an article",
+      "articleContent": "Please help me write an article about..., requirements...",
+      "polish": "Polish text",
+      "polishContent": "Please help me polish the following text to make it more professional and fluent:\n\n",
+      "email": "Write an email",
+      "emailContent": "Please help me write an email, subject is..., recipient is..."
+    },
+    "translation": {
+      "toEnglish": "Translate to English",
+      "toEnglishContent": "Please translate the following content to English, maintaining the original style:\n\n",
+      "toChinese": "Translate to Chinese",
+      "toChineseContent": "Please translate the following content to Chinese with faithfulness, expressiveness, and elegance:\n\n"
+    },
+    "analysis": {
+      "data": "Analyze data trends",
+      "dataContent": "Please analyze the following data and identify key trends and insights:\n\n",
+      "summarize": "Summarize key points",
+      "summarizeContent": "Please summarize the key points of the following content using concise bullet points:\n\n"
+    },
+    "creative": {
+      "brainstorm": "Brainstorm",
+      "brainstormContent": "Please brainstorm on the topic of... and give me 10 creative ideas",
+      "naming": "Name something",
+      "namingContent": "Please help me come up with a meaningful name for..., provide 5 options"
+    },
+    "learning": {
+      "explain": "Explain a concept",
+      "explainContent": "Please explain the concept of... in simple terms with examples",
+      "compare": "Compare two things",
+      "compareContent": "Please compare... and..., analyzing their principles, pros/cons, and use cases"
+    }
+  },
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "No Main Agent is available. Please login to Google or install Claude/Codex CLI. Go to settings?",
   "noAgentAvailableShort": "No Main Agent available. Click to configure.",

--- a/src/renderer/i18n/locales/ja-JP/guid.json
+++ b/src/renderer/i18n/locales/ja-JP/guid.json
@@ -1,4 +1,57 @@
 {
+  "promptTemplates": {
+    "title": "プロンプトテンプレート",
+    "categories": {
+      "coding": "プログラミング",
+      "writing": "文章作成",
+      "translation": "翻訳",
+      "analysis": "分析",
+      "creative": "クリエイティブ",
+      "learning": "学習"
+    },
+    "coding": {
+      "writeScript": "スクリプトを書く",
+      "writeScriptContent": "Pythonスクリプトを書いてください。用途は...",
+      "codeReview": "コードレビュー",
+      "codeReviewContent": "以下のコードをレビューして、潜在的な問題を指摘し、改善案を提案してください：\n\n```\n// コードをここに貼り付け\n```",
+      "debug": "エラーのデバッグ",
+      "debugContent": "以下のエラーが発生しました。原因を分析し、解決策を教えてください：\n\nエラーメッセージ：",
+      "explain": "コードを解説",
+      "explainContent": "以下のコードの動作原理を分かりやすく説明してください：\n\n```\n// コードをここに貼り付け\n```"
+    },
+    "writing": {
+      "article": "記事を書く",
+      "articleContent": "...に関する記事を書いてください。要件は...",
+      "polish": "文章を推敲",
+      "polishContent": "以下の文章をより専門的で流暢になるように推敲してください：\n\n",
+      "email": "メールを書く",
+      "emailContent": "メールを書いてください。件名は...、宛先は..."
+    },
+    "translation": {
+      "toEnglish": "英語に翻訳",
+      "toEnglishContent": "以下の内容を英語に翻訳してください。原文のスタイルを維持してください：\n\n",
+      "toChinese": "中国語に翻訳",
+      "toChineseContent": "以下の内容を中国語に翻訳してください：\n\n"
+    },
+    "analysis": {
+      "data": "データ分析",
+      "dataContent": "以下のデータを分析し、主要なトレンドとインサイトを見つけてください：\n\n",
+      "summarize": "要点をまとめる",
+      "summarizeContent": "以下の内容の要点を簡潔な箇条書きでまとめてください：\n\n"
+    },
+    "creative": {
+      "brainstorm": "ブレインストーミング",
+      "brainstormContent": "...というテーマでブレインストーミングを行い、10個のクリエイティブなアイデアを出してください",
+      "naming": "ネーミング",
+      "namingContent": "...に良い名前を考えてください。5つの候補を挙げてください"
+    },
+    "learning": {
+      "explain": "概念を解説",
+      "explainContent": "...という概念を分かりやすく、例を挙げて説明してください",
+      "compare": "二つを比較",
+      "compareContent": "...と...の違いを、原理、メリット・デメリット、適用場面などの観点から分析してください"
+    }
+  },
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "メインエージェントが利用できません。Google にログインするか、Claude/Codex CLI をインストールしてください。設定へ移動しますか？",
   "noAgentAvailableShort": "No Main Agent available. Click to configure.",

--- a/src/renderer/i18n/locales/ko-KR/guid.json
+++ b/src/renderer/i18n/locales/ko-KR/guid.json
@@ -1,4 +1,57 @@
 {
+  "promptTemplates": {
+    "title": "프롬프트 템플릿",
+    "categories": {
+      "coding": "프로그래밍",
+      "writing": "글쓰기",
+      "translation": "번역",
+      "analysis": "분석",
+      "creative": "창작",
+      "learning": "학습"
+    },
+    "coding": {
+      "writeScript": "스크립트 작성",
+      "writeScriptContent": "Python 스크립트를 작성해 주세요. 용도는...",
+      "codeReview": "코드 리뷰",
+      "codeReviewContent": "다음 코드를 리뷰하고 잠재적 문제를 지적하며 개선안을 제안해 주세요:\n\n```\n// 코드를 여기에 붙여넣기\n```",
+      "debug": "오류 디버깅",
+      "debugContent": "다음 오류가 발생했습니다. 원인을 분석하고 해결 방법을 알려주세요:\n\n오류 메시지:",
+      "explain": "코드 설명",
+      "explainContent": "다음 코드의 동작 원리를 이해하기 쉽게 설명해 주세요:\n\n```\n// 코드를 여기에 붙여넣기\n```"
+    },
+    "writing": {
+      "article": "글 작성",
+      "articleContent": "...에 대한 글을 작성해 주세요. 요구사항은...",
+      "polish": "문장 다듬기",
+      "polishContent": "다음 문장을 더 전문적이고 매끄럽게 다듬어 주세요:\n\n",
+      "email": "이메일 작성",
+      "emailContent": "이메일을 작성해 주세요. 제목은..., 수신자는..."
+    },
+    "translation": {
+      "toEnglish": "영어로 번역",
+      "toEnglishContent": "다음 내용을 영어로 번역해 주세요. 원문 스타일을 유지해 주세요:\n\n",
+      "toChinese": "중국어로 번역",
+      "toChineseContent": "다음 내용을 중국어로 번역해 주세요:\n\n"
+    },
+    "analysis": {
+      "data": "데이터 분석",
+      "dataContent": "다음 데이터를 분석하고 주요 트렌드와 인사이트를 찾아주세요:\n\n",
+      "summarize": "요점 정리",
+      "summarizeContent": "다음 내용의 요점을 간결한 글머리 기호로 정리해 주세요:\n\n"
+    },
+    "creative": {
+      "brainstorm": "브레인스토밍",
+      "brainstormContent": "...라는 주제로 브레인스토밍을 하고 10가지 창의적인 아이디어를 제시해 주세요",
+      "naming": "이름 짓기",
+      "namingContent": "...에 좋은 이름을 지어주세요. 5가지 후보를 제시해 주세요"
+    },
+    "learning": {
+      "explain": "개념 설명",
+      "explainContent": "...라는 개념을 알기 쉽게 예시와 함께 설명해 주세요",
+      "compare": "두 가지 비교",
+      "compareContent": "...와 ...의 차이점을 원리, 장단점, 적용 사례 등의 관점에서 분석해 주세요"
+    }
+  },
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "사용 가능한 메인 에이전트가 없습니다. Google에 로그인하거나 Claude/Codex CLI를 설치해 주세요. 설정으로 이동하시겠습니까?",
   "noAgentAvailableShort": "No Main Agent available. Click to configure.",

--- a/src/renderer/i18n/locales/tr-TR/guid.json
+++ b/src/renderer/i18n/locales/tr-TR/guid.json
@@ -1,4 +1,57 @@
 {
+  "promptTemplates": {
+    "title": "Bilgi İstemi Şablonları",
+    "categories": {
+      "coding": "Programlama",
+      "writing": "Yazarlık",
+      "translation": "Çeviri",
+      "analysis": "Analiz",
+      "creative": "Yaratıcılık",
+      "learning": "Öğrenme"
+    },
+    "coding": {
+      "writeScript": "Bir betik yaz",
+      "writeScriptContent": "Bana bir Python betiği yazın, amacı...",
+      "codeReview": "Kod incelemesi",
+      "codeReviewContent": "Lütfen aşağıdaki kodu inceleyin, olası sorunları belirtin ve iyileştirme önerileri sunun:\n\n```\n// Kodu buraya yapıştırın\n```",
+      "debug": "Hata ayıklama",
+      "debugContent": "Aşağıdaki hatayla karşılaştım, lütfen nedenini analiz edip çözüm sunun:\n\nHata mesajı:",
+      "explain": "Kodu açıkla",
+      "explainContent": "Lütfen aşağıdaki kodun nasıl çalıştığını basit ve anlaşılır bir şekilde açıklayın:\n\n```\n// Kodu buraya yapıştırın\n```"
+    },
+    "writing": {
+      "article": "Makale yaz",
+      "articleContent": "Lütfen ... hakkında bir makale yazın, gereksinimler...",
+      "polish": "Metni düzenle",
+      "polishContent": "Lütfen aşağıdaki metni daha profesyonel ve akıcı hale getirin:\n\n",
+      "email": "E-posta yaz",
+      "emailContent": "Lütfen bir e-posta yazın, konu..., alıcı..."
+    },
+    "translation": {
+      "toEnglish": "İngilizceye çevir",
+      "toEnglishContent": "Lütfen aşağıdaki içeriği İngilizceye çevirin, orijinal tarzı koruyun:\n\n",
+      "toChinese": "Çinceye çevir",
+      "toChineseContent": "Lütfen aşağıdaki içeriği Çinceye çevirin:\n\n"
+    },
+    "analysis": {
+      "data": "Veri analizi",
+      "dataContent": "Lütfen aşağıdaki verileri analiz edin ve temel eğilimleri ve içgörüleri belirleyin:\n\n",
+      "summarize": "Özetleme",
+      "summarizeContent": "Lütfen aşağıdaki içeriğin önemli noktalarını kısa madde işaretleri halinde özetleyin:\n\n"
+    },
+    "creative": {
+      "brainstorm": "Beyin fırtınası",
+      "brainstormContent": "Lütfen ... konusunda beyin fırtınası yapın ve 10 yaratıcı fikir verin",
+      "naming": "İsim bul",
+      "namingContent": "Lütfen ... için güzel ve anlamlı bir isim bulun, 5 seçenek sunun"
+    },
+    "learning": {
+      "explain": "Bir kavramı açıkla",
+      "explainContent": "Lütfen ... kavramını basit bir dille ve örneklerle açıklayın",
+      "compare": "İki şeyi karşılaştır",
+      "compareContent": "Lütfen ... ve ... arasındaki farkları ilkeler, artılar/eksiler ve kullanım alanları açısından analiz edin"
+    }
+  },
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "Kullanılabilir bir Ana Ajan yok. Lütfen Google'a giriş yapın veya Claude/Codex CLI kurun. Ayarlara gitmek ister misiniz?",
   "noAgentAvailableShort": "No Main Agent available. Click to configure.",

--- a/src/renderer/i18n/locales/zh-CN/guid.json
+++ b/src/renderer/i18n/locales/zh-CN/guid.json
@@ -1,4 +1,57 @@
 {
+  "promptTemplates": {
+    "title": "常用提示词",
+    "categories": {
+      "coding": "编程",
+      "writing": "写作",
+      "translation": "翻译",
+      "analysis": "分析",
+      "creative": "创意",
+      "learning": "学习"
+    },
+    "coding": {
+      "writeScript": "帮我写一个脚本",
+      "writeScriptContent": "帮我写一个 Python 脚本，用于...",
+      "codeReview": "帮我 Review 代码",
+      "codeReviewContent": "请帮我 review 以下代码，指出潜在问题并给出优化建议：\n\n```\n// 粘贴代码\n```",
+      "debug": "帮我调试报错",
+      "debugContent": "我遇到了以下报错，请帮我分析原因并给出解决方案：\n\n错误信息：",
+      "explain": "解释这段代码",
+      "explainContent": "请解释以下代码的工作原理，用简单易懂的方式说明：\n\n```\n// 粘贴代码\n```"
+    },
+    "writing": {
+      "article": "帮我撰写文章",
+      "articleContent": "请帮我撰写一篇关于...的文章，要求...",
+      "polish": "润色一段文字",
+      "polishContent": "请帮我润色以下文字，使其更加专业流畅：\n\n",
+      "email": "帮我写封邮件",
+      "emailContent": "请帮我写一封邮件，主题是...，收件人是..."
+    },
+    "translation": {
+      "toEnglish": "翻译为英文",
+      "toEnglishContent": "请将以下内容翻译为英文，保持原文风格：\n\n",
+      "toChinese": "翻译为中文",
+      "toChineseContent": "请将以下内容翻译为中文，要求信达雅：\n\n"
+    },
+    "analysis": {
+      "data": "分析数据趋势",
+      "dataContent": "请分析以下数据，找出关键趋势和洞察：\n\n",
+      "summarize": "总结要点",
+      "summarizeContent": "请总结以下内容的要点，用简洁的 bullet points 列出：\n\n"
+    },
+    "creative": {
+      "brainstorm": "头脑风暴",
+      "brainstormContent": "请帮我就...这个主题进行头脑风暴，给出 10 个创意想法",
+      "naming": "取名字",
+      "namingContent": "请帮我为...取一个好听且有意义的名字，给出 5 个备选"
+    },
+    "learning": {
+      "explain": "解释一个概念",
+      "explainContent": "请用通俗易懂的方式解释...这个概念，并举例说明",
+      "compare": "对比两个事物",
+      "compareContent": "请对比...和...的区别，从原理、优缺点、适用场景等方面分析"
+    }
+  },
   "agentFallbackNotice": "{{original}} 不可用，已自动切换到 {{fallback}}。",
   "noAgentAvailable": "没有可用的 Main Agent。请登录 Google 或安装 Claude/Codex CLI。是否前往设置？",
   "noAgentAvailableShort": "没有可用的 Main Agent。点击配置。",

--- a/src/renderer/i18n/locales/zh-TW/guid.json
+++ b/src/renderer/i18n/locales/zh-TW/guid.json
@@ -1,4 +1,57 @@
 {
+  "promptTemplates": {
+    "title": "常用提示詞",
+    "categories": {
+      "coding": "程式設計",
+      "writing": "寫作",
+      "translation": "翻譯",
+      "analysis": "分析",
+      "creative": "創意",
+      "learning": "學習"
+    },
+    "coding": {
+      "writeScript": "幫我寫一個腳本",
+      "writeScriptContent": "幫我寫一個 Python 腳本，用於...",
+      "codeReview": "幫我 Review 程式碼",
+      "codeReviewContent": "請幫我 review 以下程式碼，指出潛在問題並給出優化建議：\n\n```\n// 貼上程式碼\n```",
+      "debug": "幫我除錯",
+      "debugContent": "我遇到了以下錯誤，請幫我分析原因並給出解決方案：\n\n錯誤訊息：",
+      "explain": "解釋這段程式碼",
+      "explainContent": "請解釋以下程式碼的工作原理，用簡單易懂的方式說明：\n\n```\n// 貼上程式碼\n```"
+    },
+    "writing": {
+      "article": "幫我撰寫文章",
+      "articleContent": "請幫我撰寫一篇關於...的文章，要求...",
+      "polish": "潤飾一段文字",
+      "polishContent": "請幫我潤飾以下文字，使其更加專業流暢：\n\n",
+      "email": "幫我寫封郵件",
+      "emailContent": "請幫我寫一封郵件，主題是...，收件人是..."
+    },
+    "translation": {
+      "toEnglish": "翻譯為英文",
+      "toEnglishContent": "請將以下內容翻譯為英文，保持原文風格：\n\n",
+      "toChinese": "翻譯為中文",
+      "toChineseContent": "請將以下內容翻譯為中文，要求信達雅：\n\n"
+    },
+    "analysis": {
+      "data": "分析數據趨勢",
+      "dataContent": "請分析以下數據，找出關鍵趨勢和洞察：\n\n",
+      "summarize": "總結要點",
+      "summarizeContent": "請總結以下內容的要點，用簡潔的 bullet points 列出：\n\n"
+    },
+    "creative": {
+      "brainstorm": "腦力激盪",
+      "brainstormContent": "請幫我就...這個主題進行腦力激盪，給出 10 個創意想法",
+      "naming": "取名字",
+      "namingContent": "請幫我為...取一個好聽且有意義的名字，給出 5 個備選"
+    },
+    "learning": {
+      "explain": "解釋一個概念",
+      "explainContent": "請用通俗易懂的方式解釋...這個概念，並舉例說明",
+      "compare": "對比兩個事物",
+      "compareContent": "請對比...和...的區別，從原理、優缺點、適用場景等方面分析"
+    }
+  },
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "目前沒有可用的主代理。請登入 Google 或安裝 Claude/Codex CLI。要前往設定嗎？",
   "noAgentAvailableShort": "No Main Agent available. Click to configure.",

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -24,6 +24,7 @@ import GuidInputCard from './components/GuidInputCard';
 import GuidModelSelector from './components/GuidModelSelector';
 import MentionDropdown from './components/MentionDropdown';
 import MentionSelectorBadge from './components/MentionSelectorBadge';
+import PromptTemplates from './components/PromptTemplates';
 import QuickActionButtons from './components/QuickActionButtons';
 import { useGuidAgentSelection } from './hooks/useGuidAgentSelection';
 import { useGuidInput } from './hooks/useGuidInput';
@@ -385,6 +386,14 @@ const GuidPage: React.FC = () => {
             </p>
 
             {agentSelection.availableAgents === undefined ? <AgentPillBarSkeleton /> : agentSelection.availableAgents.length > 0 ? <AgentPillBar availableAgents={agentSelection.availableAgents} selectedAgentKey={agentSelection.selectedAgentKey} getAgentKey={agentSelection.getAgentKey} onSelectAgent={handleSelectAgentFromPillBar} /> : null}
+
+            <PromptTemplates
+              visible={!agentSelection.isPresetAgent && !guidInput.input.trim()}
+              onSelectPrompt={(content) => {
+                guidInput.setInput(content);
+                guidInput.handleTextareaFocus();
+              }}
+            />
 
             <GuidInputCard
               input={guidInput.input}

--- a/src/renderer/pages/guid/components/PromptTemplates.tsx
+++ b/src/renderer/pages/guid/components/PromptTemplates.tsx
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_PROMPT_CATEGORIES } from '../constants';
+import styles from '../index.module.css';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type PromptTemplatesProps = {
+  /** Whether the component should be visible */
+  visible: boolean;
+  /** Callback when a prompt template is selected */
+  onSelectPrompt: (content: string) => void;
+};
+
+/**
+ * Displays categorized prompt templates above the input card.
+ * Users can click a category to expand its prompts, then click a prompt to fill the input.
+ */
+const PromptTemplates: React.FC<PromptTemplatesProps> = ({ visible, onSelectPrompt }) => {
+  const { t } = useTranslation();
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+
+  if (!visible) return null;
+
+  const currentCategory = DEFAULT_PROMPT_CATEGORIES.find((c) => c.key === activeCategory);
+
+  return (
+    <div className={styles.promptTemplatesContainer}>
+      {/* Title */}
+      <div className='flex items-center gap-6px mb-10px'>
+        <span className='text-13px' style={{ color: 'var(--color-text-3)' }}>
+          💡 {t('guid.promptTemplates.title', { defaultValue: 'Prompt Templates' })}
+        </span>
+      </div>
+
+      {/* Category tags */}
+      <div className='flex flex-wrap gap-8px mb-4px'>
+        {DEFAULT_PROMPT_CATEGORIES.map((category) => (
+          <div key={category.key} className={`${styles.promptCategoryTag} ${activeCategory === category.key ? styles.promptCategoryTagActive : ''}`} onClick={() => setActiveCategory(activeCategory === category.key ? null : category.key)}>
+            {category.icon} {t(category.labelKey)}
+          </div>
+        ))}
+      </div>
+
+      {/* Expanded prompt list */}
+      {activeCategory && currentCategory && (
+        <div className={styles.promptListContainer}>
+          {currentCategory.prompts.map((prompt) => (
+            <div key={prompt.labelKey} className={styles.promptItem} onClick={() => onSelectPrompt(t(prompt.contentKey))}>
+              {t(prompt.labelKey)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PromptTemplates;

--- a/src/renderer/pages/guid/constants.ts
+++ b/src/renderer/pages/guid/constants.ts
@@ -5,6 +5,7 @@
  */
 
 import coworkSvg from '@/renderer/assets/cowork.svg';
+import type { PromptCategory } from './types';
 
 /**
  * Map custom avatar identifiers to their resolved image URLs.
@@ -13,3 +14,66 @@ export const CUSTOM_AVATAR_IMAGE_MAP: Record<string, string> = {
   'cowork.svg': coworkSvg,
   '\u{1F6E0}\u{FE0F}': coworkSvg,
 };
+
+/**
+ * Default prompt template categories shown on the Guide page.
+ */
+export const DEFAULT_PROMPT_CATEGORIES: PromptCategory[] = [
+  {
+    key: 'coding',
+    labelKey: 'guid.promptTemplates.categories.coding',
+    icon: '💻',
+    prompts: [
+      { labelKey: 'guid.promptTemplates.coding.writeScript', contentKey: 'guid.promptTemplates.coding.writeScriptContent' },
+      { labelKey: 'guid.promptTemplates.coding.codeReview', contentKey: 'guid.promptTemplates.coding.codeReviewContent' },
+      { labelKey: 'guid.promptTemplates.coding.debug', contentKey: 'guid.promptTemplates.coding.debugContent' },
+      { labelKey: 'guid.promptTemplates.coding.explain', contentKey: 'guid.promptTemplates.coding.explainContent' },
+    ],
+  },
+  {
+    key: 'writing',
+    labelKey: 'guid.promptTemplates.categories.writing',
+    icon: '✍️',
+    prompts: [
+      { labelKey: 'guid.promptTemplates.writing.article', contentKey: 'guid.promptTemplates.writing.articleContent' },
+      { labelKey: 'guid.promptTemplates.writing.polish', contentKey: 'guid.promptTemplates.writing.polishContent' },
+      { labelKey: 'guid.promptTemplates.writing.email', contentKey: 'guid.promptTemplates.writing.emailContent' },
+    ],
+  },
+  {
+    key: 'translation',
+    labelKey: 'guid.promptTemplates.categories.translation',
+    icon: '🌐',
+    prompts: [
+      { labelKey: 'guid.promptTemplates.translation.toEnglish', contentKey: 'guid.promptTemplates.translation.toEnglishContent' },
+      { labelKey: 'guid.promptTemplates.translation.toChinese', contentKey: 'guid.promptTemplates.translation.toChineseContent' },
+    ],
+  },
+  {
+    key: 'analysis',
+    labelKey: 'guid.promptTemplates.categories.analysis',
+    icon: '📊',
+    prompts: [
+      { labelKey: 'guid.promptTemplates.analysis.data', contentKey: 'guid.promptTemplates.analysis.dataContent' },
+      { labelKey: 'guid.promptTemplates.analysis.summarize', contentKey: 'guid.promptTemplates.analysis.summarizeContent' },
+    ],
+  },
+  {
+    key: 'creative',
+    labelKey: 'guid.promptTemplates.categories.creative',
+    icon: '🎨',
+    prompts: [
+      { labelKey: 'guid.promptTemplates.creative.brainstorm', contentKey: 'guid.promptTemplates.creative.brainstormContent' },
+      { labelKey: 'guid.promptTemplates.creative.naming', contentKey: 'guid.promptTemplates.creative.namingContent' },
+    ],
+  },
+  {
+    key: 'learning',
+    labelKey: 'guid.promptTemplates.categories.learning',
+    icon: '📚',
+    prompts: [
+      { labelKey: 'guid.promptTemplates.learning.explain', contentKey: 'guid.promptTemplates.learning.explainContent' },
+      { labelKey: 'guid.promptTemplates.learning.compare', contentKey: 'guid.promptTemplates.learning.compareContent' },
+    ],
+  },
+];

--- a/src/renderer/pages/guid/index.module.css
+++ b/src/renderer/pages/guid/index.module.css
@@ -347,3 +347,65 @@
 .functionPanelContent {
   max-width: 600px;
 }
+
+/* Prompt Templates */
+.promptTemplatesContainer {
+  width: 100%;
+  margin-bottom: 16px;
+  animation: fade-in 0.3s ease-out;
+}
+
+.promptCategoryTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  font-size: 13px;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: var(--color-fill-1);
+  color: var(--color-text-2);
+  border: 1px solid var(--color-border-2);
+  user-select: none;
+}
+
+.promptCategoryTag:hover {
+  background: var(--color-fill-2);
+  color: var(--color-text-1);
+}
+
+.promptCategoryTagActive {
+  background: var(--color-primary-light-1);
+  color: rgb(var(--primary-6));
+  border-color: rgb(var(--primary-6));
+}
+
+.promptCategoryTagActive:hover {
+  background: var(--color-primary-light-1);
+  color: rgb(var(--primary-6));
+}
+
+.promptListContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+  animation: panel-slide-in 0.25s ease-out;
+}
+
+.promptItem {
+  padding: 8px 14px;
+  font-size: 13px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: var(--color-fill-1);
+  color: var(--color-text-2);
+  border: 1px solid var(--color-border-2);
+}
+
+.promptItem:hover {
+  background: var(--color-fill-2);
+  color: var(--color-text-1);
+  border-color: var(--color-border-3);
+}

--- a/src/renderer/pages/guid/types.ts
+++ b/src/renderer/pages/guid/types.ts
@@ -48,6 +48,30 @@ export type EffectiveAgentInfo = {
 };
 
 /**
+ * A single prompt template entry.
+ */
+export type PromptTemplate = {
+  /** i18n key for the display label */
+  labelKey: string;
+  /** i18n key for the prompt content to fill into the input */
+  contentKey: string;
+};
+
+/**
+ * A category of prompt templates.
+ */
+export type PromptCategory = {
+  /** Unique key for the category */
+  key: string;
+  /** i18n key for the category name */
+  labelKey: string;
+  /** Emoji icon */
+  icon: string;
+  /** List of prompts in this category */
+  prompts: PromptTemplate[];
+};
+
+/**
  * Re-export commonly used ACP types for convenience.
  */
 export type { AcpBackend, AcpBackendConfig, AcpModelInfo, PresetAgentType };


### PR DESCRIPTION
## Summary

Add categorized prompt template selector on the Guide page (above input card) with 6 categories: coding, writing, translation, analysis, creative, learning.

- Templates appear above the input card, separated from the assistant area below
- Click a category to expand prompts, click a prompt to fill the input
- Auto-hides when preset agent selected or input has content
- Full i18n support for 6 locales (zh-CN, en-US, zh-TW, ja-JP, ko-KR, tr-TR)

Closes #191