### PR TITLE
fix(guid): 新建会话时全面清除 Guide 页面所有用户输入状态

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -38,6 +38,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ipcBridge } from '@/common';
 import { skillHub } from '@/common/ipcBridge';
+import { useAddEventListener } from '@/renderer/utils/emitter';
 import styles from './index.module.css';
 
 const GuidPage: React.FC = () => {
@@ -222,12 +223,36 @@ const GuidPage: React.FC = () => {
     setMentionSelectorOpen: mention.setMentionSelectorOpen,
     setMentionActiveIndex: mention.setMentionActiveIndex,
 
+    // Agent/skills reset
+    resetAgentSelection: agentSelection.resetSelection,
+    setSelectedSkills,
+
     // Navigation & tabs
     navigate,
     closeAllTabs,
     openTab,
     t,
   });
+
+  // 监听 guid.reset 事件，重置所有用户输入状态（新建会话时触发）
+  const handleGuidReset = useCallback(() => {
+    // 重置输入内容
+    guidInput.setInput('');
+    guidInput.setFiles([]);
+    guidInput.setDir('');
+    // 重置助手选择
+    agentSelection.resetSelection();
+    // 重置技能选择
+    setSelectedSkills([]);
+    // 重置 mention 状态
+    mention.setMentionOpen(false);
+    mention.setMentionQuery(null);
+    mention.setMentionSelectorVisible(false);
+    mention.setMentionSelectorOpen(false);
+    mention.setMentionActiveIndex(0);
+  }, [guidInput, agentSelection, mention]);
+
+  useAddEventListener('guid.reset', handleGuidReset, [handleGuidReset]);
 
   // 通过 @ 按钮触发技能选择器
   const handleTriggerSkillSelector = useCallback(() => {

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -68,6 +68,8 @@ export type GuidAgentSelectionResult = {
   getEffectiveAgentType: (agentInfo: { backend: AcpBackend; customAgentId?: string } | undefined) => EffectiveAgentInfo;
   refreshCustomAgents: () => Promise<void>;
   customAgentAvatarMap: Map<string, string | undefined>;
+  /** Reset agent selection to default state and clear persisted storage */
+  resetSelection: () => void;
 };
 
 type UseGuidAgentSelectionOptions = {
@@ -598,6 +600,17 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey }: Us
     void refreshCustomAgents();
   }, [refreshCustomAgents]);
 
+  // Reset agent selection to default state (no assistant selected)
+  const resetSelection = useCallback(() => {
+    _setSelectedAgentKey('openclaw-gateway');
+    _setSelectedMode('default');
+    _setSelectedAcpModel(null);
+    // Clear persisted agent key so it won't be restored on next mount
+    ConfigStorage.set('guid.lastSelectedAgent', '').catch((error) => {
+      console.error('Failed to clear saved agent:', error);
+    });
+  }, []);
+
   return {
     selectedAgentKey,
     setSelectedAgentKey,
@@ -624,5 +637,6 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey }: Us
     getEffectiveAgentType,
     refreshCustomAgents,
     customAgentAvatarMap,
+    resetSelection,
   };
 };

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -52,6 +52,10 @@ export type GuidSendDeps = {
   setMentionSelectorOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setMentionActiveIndex: React.Dispatch<React.SetStateAction<number>>;
 
+  // Agent/skills reset
+  resetAgentSelection: () => void;
+  setSelectedSkills: React.Dispatch<React.SetStateAction<string[]>>;
+
   // Navigation & tabs
   navigate: NavigateFunction;
   closeAllTabs: () => void;
@@ -69,7 +73,7 @@ export type GuidSendResult = {
  * Hook that manages the send logic for all conversation types (acp/openclaw-gateway).
  */
 export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
-  const { input, setInput, files, setFiles, dir, setDir, setLoading, selectedSkills, selectedAgent, selectedAgentKey, selectedAgentInfo, isPresetAgent, selectedMode, selectedAcpModel, currentModel, findAgentByKey, getEffectiveAgentType, resolvePresetRulesAndSkills, resolveEnabledSkills, isMainAgentAvailable, getAvailableFallbackAgent, currentEffectiveAgentInfo, isGoogleAuth, setMentionOpen, setMentionQuery, setMentionSelectorOpen, setMentionActiveIndex, navigate, closeAllTabs, openTab, t } = deps;
+  const { input, setInput, files, setFiles, dir, setDir, setLoading, selectedSkills, selectedAgent, selectedAgentKey, selectedAgentInfo, isPresetAgent, selectedMode, selectedAcpModel, currentModel, findAgentByKey, getEffectiveAgentType, resolvePresetRulesAndSkills, resolveEnabledSkills, isMainAgentAvailable, getAvailableFallbackAgent, currentEffectiveAgentInfo, isGoogleAuth, setMentionOpen, setMentionQuery, setMentionSelectorOpen, setMentionActiveIndex, resetAgentSelection, setSelectedSkills, navigate, closeAllTabs, openTab, t } = deps;
 
   const handleSend = useCallback(async () => {
     const isCustomWorkspace = !!dir;
@@ -246,6 +250,9 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
         setMentionActiveIndex(0);
         setFiles([]);
         setDir('');
+        // 重置助手选择和技能，确保返回 Guide 页面时为初始状态
+        resetAgentSelection();
+        setSelectedSkills([]);
       })
       .catch((error) => {
         console.error('Failed to send message:', error);
@@ -253,7 +260,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
       .finally(() => {
         setLoading(false);
       });
-  }, [handleSend, setLoading, setInput, setMentionOpen, setMentionQuery, setMentionSelectorOpen, setMentionActiveIndex, setFiles, setDir]);
+  }, [handleSend, setLoading, setInput, setMentionOpen, setMentionQuery, setMentionSelectorOpen, setMentionActiveIndex, setFiles, setDir, resetAgentSelection, setSelectedSkills]);
 
   // Calculate button disabled state
   const isButtonDisabled = !input.trim();

--- a/src/renderer/sider.tsx
+++ b/src/renderer/sider.tsx
@@ -11,6 +11,8 @@ import { useLayoutContext } from './context/LayoutContext';
 import { blurActiveElement } from './utils/focus';
 import { isElectronDesktop } from './utils/platform';
 import { useAuth } from './context/AuthContext';
+import { emitter } from './utils/emitter';
+import { ConfigStorage } from '@/common/storage';
 
 const WorkspaceGroupedHistory = React.lazy(() => import('./pages/conversation/WorkspaceGroupedHistory'));
 const SettingsSider = React.lazy(() => import('./pages/settings/SettingsSider'));
@@ -116,6 +118,10 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                     cleanupSiderTooltips();
                     blurActiveElement();
                     setIsBatchMode(false);
+                    // 清除持久化的 agent 选择，确保新会话时不恢复之前的助手
+                    void ConfigStorage.set('guid.lastSelectedAgent', '');
+                    // 触发 Guide 页面重置所有用户输入状态
+                    emitter.emit('guid.reset');
                     void navigate('/guid');
                     if (onSessionClick) {
                       onSessionClick();
@@ -133,6 +139,10 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                     cleanupSiderTooltips();
                     blurActiveElement();
                     setIsBatchMode(false);
+                    // 清除持久化的 agent 选择，确保新会话时不恢复之前的助手
+                    void ConfigStorage.set('guid.lastSelectedAgent', '');
+                    // 触发 Guide 页面重置所有用户输入状态
+                    emitter.emit('guid.reset');
                     void navigate('/guid');
                     if (onSessionClick) {
                       onSessionClick();

--- a/src/renderer/utils/emitter.ts
+++ b/src/renderer/utils/emitter.ts
@@ -41,6 +41,8 @@ interface EventTypes {
   'agent.connection.status': [string, string]; // [conversationId, status]
   'staroffice.install.request': [{ conversationId: string; text: string; detectedUrl?: string | null }];
   'staroffice.install.finished': [{ conversationId: string }];
+  // Guide 页面重置事件 / Guide page reset event (triggered by "New Conversation")
+  'guid.reset': void;
 }
 
 export const emitter = new EventEmitter<EventTypes>();


### PR DESCRIPTION
Closes #200

## Summary

- 新建会话时通过 `guid.reset` 事件机制全面重置 Guide 页面状态
- 清除助手选择、输入内容、上传文件、技能选择、权限模式、mention 状态等
- 同时清除 ConfigStorage 中的持久化值，防止页面重新挂载时恢复旧状态

## Test Plan

- [ ] 在 Guide 页面选择助手、添加文件、选择技能，点击“新建会话”——所有状态应重置
- [ ] 发送消息后返回 Guide 页面——无预选助手、无残留文件和技能
- [ ] 验证助手选择在单次会话内仍然正常工作

Generated with [Claude Code](https://claude.ai/code)