### PR TITLE
fix: resolve add button hover flicker and incomplete display in Guide assistant area

### DIFF
--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -134,9 +134,9 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ isPrese
               </div>
             );
           })}
-        <div className='group flex items-center justify-center h-28px w-max min-w-28px max-w-28px rd-50% bg-fill-0 cursor-pointer overflow-hidden whitespace-nowrap b-1 b-dashed select-none transition-all duration-500 ease-out hover:min-w-0 hover:max-w-320px hover:rd-100px hover:px-16px hover:justify-start hover:gap-8px hover:bg-fill-2' style={{ borderWidth: '1px', borderColor: 'var(--bg-3)' }} onClick={() => navigate('/settings/agent')}>
+        <div className='group flex items-center justify-center h-28px min-w-28px px-8px gap-4px rd-100px bg-fill-0 cursor-pointer whitespace-nowrap b-1 b-dashed select-none transition-colors duration-300 hover:bg-fill-2' style={{ borderWidth: '1px', borderColor: 'var(--bg-3)' }} onClick={() => navigate('/settings/agent')}>
           <Plus theme='outline' size={14} className='flex-shrink-0 line-height-0 text-[var(--color-text-3)] group-hover:text-[var(--color-text-2)] transition-colors duration-300' />
-          <span className='opacity-0 max-w-0 overflow-hidden text-14px text-2 group-hover:opacity-100 group-hover:max-w-none transition-[opacity,max-width] duration-400 ease-out delay-75'>{t('settings.createAssistant', { defaultValue: 'Add Assistant' })}</span>
+          <span className='text-14px text-2 group-hover:text-1 transition-colors duration-300'>{t('settings.createAssistant', { defaultValue: 'Add Assistant' })}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes the add button hover flickering and incomplete display issue in the Guide page assistant area when there are 5+ assistants.

- Replace width-expanding hover animation with stable pill-shaped layout
- Use `transition-colors` instead of `transition-all` to prevent layout reflow
- Button text always visible, matching other assistant pills

Closes #207

Generated with [Claude Code](https://claude.ai/code)