### PR TITLE
fix(download): reduce progress log frequency to every 5%

### DIFF
--- a/scripts/download-bdpan.js
+++ b/scripts/download-bdpan.js
@@ -80,11 +80,16 @@ function downloadFile(url, dest) {
         }
         const totalSize = parseInt(response.headers['content-length'] || '0', 10);
         let downloaded = 0;
+        let lastPrintedPercent = -1;
         response.on('data', (chunk) => {
           downloaded += chunk.length;
           if (totalSize > 0) {
             const percent = Math.round((downloaded / totalSize) * 100);
-            process.stdout.write(`\rDownloading: ${percent}%`);
+            // Only print every 5%
+            if (percent - lastPrintedPercent >= 5 || percent === 100) {
+              lastPrintedPercent = percent;
+              process.stdout.write(`\rDownloading: ${percent}%`);
+            }
           }
         });
         response.pipe(file);

--- a/scripts/download-nexus.js
+++ b/scripts/download-nexus.js
@@ -105,12 +105,17 @@ function downloadFile(url, dest) {
 
           const totalSize = parseInt(response.headers['content-length'] || '0', 10);
           let downloaded = 0;
+          let lastPrintedPercent = -1;
 
           response.on('data', (chunk) => {
             downloaded += chunk.length;
             if (totalSize > 0) {
               const percent = Math.round((downloaded / totalSize) * 100);
-              process.stdout.write(`\rDownloading: ${percent}%`);
+              // Only print every 5%
+              if (percent - lastPrintedPercent >= 5 || percent === 100) {
+                lastPrintedPercent = percent;
+                process.stdout.write(`\rDownloading: ${percent}%`);
+              }
             }
           });
 

--- a/scripts/download-node.js
+++ b/scripts/download-node.js
@@ -68,12 +68,17 @@ function downloadFile(url, dest) {
 
           const totalSize = parseInt(response.headers['content-length'] || '0', 10);
           let downloaded = 0;
+          let lastPrintedPercent = -1;
 
           response.on('data', (chunk) => {
             downloaded += chunk.length;
             if (totalSize > 0) {
               const percent = Math.round((downloaded / totalSize) * 100);
-              process.stdout.write(`\rDownloading: ${percent}%`);
+              // Only print every 5%
+              if (percent - lastPrintedPercent >= 5 || percent === 100) {
+                lastPrintedPercent = percent;
+                process.stdout.write(`\rDownloading: ${percent}%`);
+              }
             }
           });
 


### PR DESCRIPTION
Previously the download progress was printed on every chunk, causing excessive log output. Now only prints when percent increases by 5% or reaches 100%.

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
