### PR TITLE
fix: preserve workspace directory expanded state across all refresh scenarios

### DIFF
--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
@@ -8,9 +8,9 @@ import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';
 import { emitter } from '@/renderer/utils/emitter';
 import { dispatchWorkspaceHasFilesEvent } from '@/renderer/utils/workspaceEvents';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SelectedNodeRef } from '../types';
-import { getAllDirKeys, getFirstLevelKeys } from '../utils/treeHelpers';
+import { filterValidExpandedKeys, getAllDirKeys, getFirstLevelKeys } from '../utils/treeHelpers';
 
 interface UseWorkspaceTreeOptions {
   workspace: string;
@@ -27,7 +27,26 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
   const [files, setFiles] = useState<IDirOrFile[]>([]);
   const [loading, setLoading] = useState(false);
   const [treeKey, setTreeKey] = useState(Math.random());
-  const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
+  const [expandedKeys, _setExpandedKeys] = useState<string[]>([]);
+
+  // 使用 ref 跟踪用户当前展开的 key，避免在刷新时丢失状态
+  // Use ref to track user's current expanded keys, preventing state loss during refreshes
+  const expandedKeysRef = useRef<string[]>([]);
+
+  // 包装 setExpandedKeys，自动同步 state 和 ref
+  // Wrap setExpandedKeys to auto-sync state and ref
+  const setExpandedKeys = useCallback((keys: string[] | ((prev: string[]) => string[])) => {
+    if (typeof keys === 'function') {
+      _setExpandedKeys((prev) => {
+        const newKeys = keys(prev);
+        expandedKeysRef.current = newKeys;
+        return newKeys;
+      });
+    } else {
+      expandedKeysRef.current = keys;
+      _setExpandedKeys(keys);
+    }
+  }, []);
 
   // Selection state / 选中状态
   const [selected, setSelected] = useState<string[]>([]);
@@ -35,6 +54,13 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
   // 标记是否为首次加载（用于区分初始化和后续刷新）
   // Track if this is the first load (to distinguish initialization from subsequent refreshes)
   const isFirstLoadRef = useRef(true);
+
+  // 会话切换时重置首次加载标记
+  // Reset first load flag when conversation switches
+  useEffect(() => {
+    isFirstLoadRef.current = true;
+  }, [conversation_id]);
+
   const selectedKeysRef = useRef<string[]>([]);
   const selectedNodeRef = useRef<SelectedNodeRef | null>(null);
 
@@ -94,12 +120,21 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
             setTreeKey(Math.random());
           }
 
-          // 搜索时展开所有包含匹配结果的文件夹，否则只展开第一层
-          // When searching, expand all folders containing matches; otherwise only expand first level
+          // 搜索时展开所有包含匹配结果的文件夹
+          // 首次加载只展开第一层
+          // 后续刷新保留用户展开状态，仅移除已删除目录的 key
+          // When searching: expand all folders containing matches
+          // First load: only expand first level
+          // Subsequent refreshes: preserve user's expanded keys, only remove deleted dirs
           if (search) {
             setExpandedKeys(getAllDirKeys(res));
-          } else {
+          } else if (isFirstLoadRef.current) {
             setExpandedKeys(getFirstLevelKeys(res));
+          } else {
+            // 保留用户展开状态，过滤掉已不存在的目录
+            // Preserve user's expanded keys, filter out deleted directories
+            const validKeys = filterValidExpandedKeys(expandedKeysRef.current, res);
+            setExpandedKeys(validKeys);
           }
 
           // 根据是否有文件决定工作空间面板的展开/折叠状态

--- a/src/renderer/pages/conversation/workspace/utils/treeHelpers.ts
+++ b/src/renderer/pages/conversation/workspace/utils/treeHelpers.ts
@@ -85,6 +85,36 @@ export function getAllDirKeys(nodes: IDirOrFile[]): string[] {
 }
 
 /**
+ * 收集树中所有目录节点的 key 到 Set（用于验证展开状态）
+ * Collect all directory node keys into a Set (for validating expanded state)
+ */
+export function getAllDirKeysSet(nodes: IDirOrFile[]): Set<string> {
+  const keys = new Set<string>();
+  const stack = [...nodes];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.isDir) {
+      keys.add(node.relativePath);
+      if (node.children && node.children.length > 0) {
+        for (const child of node.children) {
+          stack.push(child);
+        }
+      }
+    }
+  }
+  return keys;
+}
+
+/**
+ * 过滤出仍然有效的展开 key（移除已删除目录的 key）
+ * Filter expanded keys to only keep those that still exist in the new tree data
+ */
+export function filterValidExpandedKeys(expandedKeys: string[], newTreeData: IDirOrFile[]): string[] {
+  const validDirKeys = getAllDirKeysSet(newTreeData);
+  return expandedKeys.filter((key) => validDirKeys.has(key));
+}
+
+/**
  * 替换路径列表中的旧路径为新路径
  * Replace old path with new path in path list
  */


### PR DESCRIPTION
Fixes #206

## Summary

- Fix workspace directory tree auto-collapsing in all scenarios: user input, command running, refresh button, and file preview clicks
- Preserve user's expanded directory state across workspace refreshes using expandedKeysRef
- Only reset to first-level expansion on initial load or conversation switch
- Add filterValidExpandedKeys helper to clean up keys for deleted directories

## Test plan

- [ ] Open a conversation with a temporary workspace containing nested directories
- [ ] Expand subdirectories in the file tree
- [ ] Type in the input box — verify directories stay expanded
- [ ] Run a command — verify directories stay expanded
- [ ] Click refresh button — verify directories stay expanded
- [ ] Click a file to preview — verify directories stay expanded
- [ ] Switch conversations — verify new conversation shows proper first-level expansion

Generated with [Claude Code](https://claude.ai/code)