### PR TITLE
fix: channel plugins fail on startup due to secrets initialization race condition

### DIFF
--- a/src/channels/core/ChannelManager.ts
+++ b/src/channels/core/ChannelManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { getDatabase } from '@/process/database';
+import { serviceManager } from '@process/services/serviceManager';
 import { ExtensionRegistry } from '@/extensions';
 import { getChannelMessageService } from '../agent/ChannelMessageService';
 import { getChannelDefaultModel } from '../actions/SystemActions';
@@ -120,15 +121,37 @@ export class ChannelManager {
       });
 
       // Load and start enabled plugins from database
+      // Wait for secrets first to ensure credentials are available
+      this.initialized = true;
+      await this.waitForSecretsReady();
       await this.loadEnabledPlugins();
 
-      this.initialized = true;
       console.log('[ChannelManager] Initialized successfully');
+
     } catch (error) {
       console.error('[ChannelManager] Initialization failed:', error);
       throw error;
     }
   }
+
+  /**
+   * Wait for secrets to be available before loading plugins.
+   * This ensures credentials are populated in SecretCache before
+   * channel plugins attempt to read them via resolveSecret().
+   */
+  private async waitForSecretsReady(): Promise<boolean> {
+    try {
+      const secretsReady = await serviceManager.waitForSecrets();
+      if (!secretsReady) {
+        console.warn('[ChannelManager] Secrets not available, loading plugins with fallback credentials');
+      }
+      return secretsReady;
+    } catch (err) {
+      console.warn('[ChannelManager] Error waiting for secrets, proceeding with fallback:', err);
+      return false;
+    }
+  }
+
 
   /**
    * Shutdown the assistant subsystem

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -43,6 +43,10 @@ class ServiceManager {
   private gatewayReadyResolve: ((value: { host: string; port: number } | null) => void) | null = null;
   private gatewayReadyPromise: Promise<{ host: string; port: number } | null> | null = null;
 
+  // Deferred promise resolved when secrets are initialized (or failed).
+  private secretsReadyResolve: ((value: boolean) => void) | null = null;
+  private secretsReadyPromise: Promise<boolean> | null = null;
+
   private buildSudoclawStartDiagnostics(lastHealth: SudoclawHealthCheckResult): {
     launchCommand: ReturnType<OpenClawGateway['getLastLaunchCommand']>;
     lastHealth: SudoclawHealthCheckResult;
@@ -218,11 +222,18 @@ class ServiceManager {
 
       // Initialize secrets system after Nexus is healthy
       // This runs migration (if needed) and preloads the secret cache
-      this.initializeSecrets().catch((err) => {
-        mainWarn('ServiceManager', 'Secrets initialization failed (non-critical):', err);
+      this.secretsReadyPromise = new Promise<boolean>((resolve) => {
+        this.secretsReadyResolve = resolve;
       });
+      this.initializeSecrets()
+        .then(() => this.secretsReadyResolve?.(true))
+        .catch((err) => {
+          mainWarn('ServiceManager', 'Secrets initialization failed (non-critical):', err);
+          this.secretsReadyResolve?.(false);
+        });
     } catch (err) {
       mainError('ServiceManager', 'Failed to start Nexus', err);
+      this.secretsReadyResolve?.(false);
       throw err;
     }
   }
@@ -658,6 +669,27 @@ class ServiceManager {
       return null;
     }
     return this.gatewayReadyPromise;
+  }
+
+  /**
+   * Wait for the secrets system to be initialized.
+   * Channel plugins call this before loading to ensure credentials are available.
+   * Polls until the promise is created (Nexus may still be starting),
+   * then awaits its resolution.
+   */
+  async waitForSecrets(): Promise<boolean> {
+    // Poll until the promise is created by startNexusOnce()
+    const POLL_INTERVAL_MS = 200;
+    const MAX_POLL_MS = 120_000;
+    const deadline = Date.now() + MAX_POLL_MS;
+    while (!this.secretsReadyPromise && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+    if (!this.secretsReadyPromise) {
+      // Timeout or startup never reached secrets initialization.
+      return false;
+    }
+    return this.secretsReadyPromise;
   }
 
   /** Send SIGUSR1 to the gateway for hot-reload (skills/config). */


### PR DESCRIPTION
## Summary
- 修复钉钉、飞书、Telegram 等 Channel 插件在应用启动时因凭证未就绪而全部失败的 bug
- 在 ServiceManager 中新增 `waitForSecrets()` 延迟 Promise（复用 `waitForGateway()` 模式），ChannelManager 在加载插件前等待凭证系统初始化完成

## Problem
应用启动时存在双重 fire-and-forget 时序竞争：
1. `index.ts` 中 `serviceManager.startup()` 是 fire-and-forget，ChannelManager 与之并行执行
2. `ServiceManager.startNexusOnce()` 中 `initializeSecrets()` 也是 fire-and-forget

导致 ChannelManager 在 Nexus 启动之前、SecretCache preload 之前就加载插件，`resolveSecret()` 返回空字符串，所有插件凭证校验失败。

## Fix
- **ServiceManager.ts**: 新增 `secretsReadyPromise`/`secretsReadyResolve` 字段和 `waitForSecrets()` 方法（带轮询等待），`startNexusOnce()` 中将 `initializeSecrets()` 改为解析延迟 Promise
- **ChannelManager.ts**: 在 `loadEnabledPlugins()` 前调用 `waitForSecretsReady()` 等待凭证就绪，`initialized = true` 提前确保等待期间 `enablePlugin()` 可用

## Test plan
- [x] `bun run start` 启动应用，确认钉钉和飞书插件状态从 `created → initializing → ready → starting → running`
- [x] 确认日志中 `[SecretCache] listSecrets returned` 出现在插件启动之前
- [x] 确认不再出现 `Failed to start plugin dingtalk_default` / `lark_default` 错误
- [ ] 确认 Nexus 启动失败时 ChannelManager 在超时后正常降级

🤖 Generated with [Claude Code](https://claude.com/claude-code)