### PR TITLE
feat(mcp): 集成 mcporter 实现 MCP 配置统一管理

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -339,6 +339,25 @@ export const mcpService = {
   getAuthenticatedServers: bridge.buildProvider<IBridgeResponse<string[]>, void>('mcp.get-authenticated-servers'),
 };
 
+// mcporter 服务相关接口
+export interface IMcporterDaemonStatus {
+  running: boolean;
+  pid?: number;
+  socketPath?: string;
+  uptime?: number;
+}
+
+export const mcporterService = {
+  isAvailable: bridge.buildProvider<IBridgeResponse<boolean>, void>('mcporter.is-available'),
+  install: bridge.buildProvider<IBridgeResponse<void>, void>('mcporter.install'),
+  syncConfig: bridge.buildProvider<IBridgeResponse<void>, IMcpServer[]>('mcporter.sync-config'),
+  startDaemon: bridge.buildProvider<IBridgeResponse<void>, void>('mcporter.start-daemon'),
+  stopDaemon: bridge.buildProvider<IBridgeResponse<void>, void>('mcporter.stop-daemon'),
+  getDaemonStatus: bridge.buildProvider<IBridgeResponse<IMcporterDaemonStatus>, void>('mcporter.get-daemon-status'),
+  getConfigPath: bridge.buildProvider<IBridgeResponse<string>, void>('mcporter.get-config-path'),
+  initialize: bridge.buildProvider<IBridgeResponse<void>, IMcpServer[]>('mcporter.initialize'),
+};
+
 // OpenClaw 对话相关接口 - 复用统一的conversation接口
 export const openclawConversation = {
   sendMessage: conversation.sendMessage,

--- a/src/process/bridge/index.ts
+++ b/src/process/bridge/index.ts
@@ -20,6 +20,7 @@ import { initFileWatchBridge } from './fileWatchBridge';
 import { initFsBridge } from './fsBridge';
 import { initGeminiBridge } from './geminiBridge';
 import { initMcpBridge } from './mcpBridge';
+import { initMcporterBridge } from './mcporterBridge';
 import { initModelBridge } from './modelBridge';
 import { initPreviewHistoryBridge } from './previewHistoryBridge';
 import { initShellBridge } from './shellBridge';
@@ -64,6 +65,7 @@ export function initAllBridges(): void {
   initAuthBridge();
   initModelBridge();
   initMcpBridge();
+  initMcporterBridge();
   initDatabaseBridge();
   initPreviewHistoryBridge();
   initDocumentBridge();

--- a/src/process/bridge/mcporterBridge.ts
+++ b/src/process/bridge/mcporterBridge.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '../../common';
+import { mcporterService } from '@process/services/mcporter';
+
+export function initMcporterBridge(): void {
+  // mcporter 服务相关 IPC 处理程序
+  ipcBridge.mcporterService.isAvailable.provider(async () => {
+    try {
+      const result = await mcporterService.isAvailable();
+      return { success: true, data: result };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error checking mcporter availability',
+      };
+    }
+  });
+
+  ipcBridge.mcporterService.install.provider(async () => {
+    try {
+      await mcporterService.install();
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error installing mcporter',
+      };
+    }
+  });
+
+  ipcBridge.mcporterService.syncConfig.provider(async (servers) => {
+    try {
+      await mcporterService.syncConfig(servers);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error syncing mcporter config',
+      };
+    }
+  });
+
+  ipcBridge.mcporterService.startDaemon.provider(async () => {
+    try {
+      await mcporterService.startDaemon();
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error starting mcporter daemon',
+      };
+    }
+  });
+
+  ipcBridge.mcporterService.stopDaemon.provider(async () => {
+    try {
+      await mcporterService.stopDaemon();
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error stopping mcporter daemon',
+      };
+    }
+  });
+
+  ipcBridge.mcporterService.getDaemonStatus.provider(async () => {
+    try {
+      const result = await mcporterService.getDaemonStatus();
+      return { success: true, data: result };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error getting mcporter daemon status',
+      };
+    }
+  });
+
+  ipcBridge.mcporterService.getConfigPath.provider(async () => {
+    try {
+      const result = mcporterService.getConfigPath();
+      return { success: true, data: result };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error getting mcporter config path',
+      };
+    }
+  });
+
+  ipcBridge.mcporterService.initialize.provider(async (servers) => {
+    try {
+      await mcporterService.initialize(servers);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error initializing mcporter',
+      };
+    }
+  });
+}

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -789,9 +789,26 @@ const initStorage = async () => {
   } catch (error) {
     mainError('Sudowork', 'Failed to initialize default MCP servers:', error);
   }
+
   // 4.5 异步迁移旧技能目录结构到分目录结构
   // Async migrate legacy skill directory structure to categorized subdirectories
   await migrateSkillsToSubdirectories();
+
+  // 4.6 初始化 mcporter（后台执行，不阻塞启动）
+  void (async () => {
+    try {
+      const mcpConfig = await configFile.get('mcp.config').catch((): undefined => undefined);
+      if (mcpConfig && Array.isArray(mcpConfig) && mcpConfig.length > 0) {
+        // 动态导入避免循环依赖
+        const { mcporterService } = await import('./services/mcporter');
+        await mcporterService.initialize(mcpConfig);
+        mainLog('Sudowork', 'mcporter initialized');
+      }
+    } catch (error) {
+      // mcporter 初始化失败不影响应用启动
+      mainWarn('Sudowork', 'Failed to initialize mcporter (non-critical):', error);
+    }
+  })();
 
   // 5. 初始化内置助手（Assistants）— runs in parallel with database init (step 6)
   // PERF: Assistant config + database init are independent; run them concurrently

--- a/src/process/services/mcporter/McporterService.ts
+++ b/src/process/services/mcporter/McporterService.ts
@@ -1,0 +1,345 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { exec, spawn, ChildProcess } from 'child_process';
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import path from 'path';
+import os from 'os';
+import type { IMcpServer } from '@/common/storage';
+import { convertToMcporterConfig, type McporterConfig } from './mcporterConfig';
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { safeExec } from '@process/utils/safeExec';
+
+/**
+ * mcporter daemon 状态
+ */
+export interface DaemonStatus {
+  running: boolean;
+  pid?: number;
+  socketPath?: string;
+  uptime?: number;
+}
+
+/**
+ * mcporter 服务 - 管理 MCP 配置和 daemon
+ */
+class McporterService {
+  private configPath: string;
+  private configDir: string;
+  private daemonProcess: ChildProcess | null = null;
+  private readonly TIMEOUT = 30000;
+
+  constructor() {
+    // 配置路径: ~/.nexus/mcporter/mcporter.json
+    this.configDir = path.join(os.homedir(), '.nexus', 'mcporter');
+    this.configPath = path.join(this.configDir, 'mcporter.json');
+  }
+
+  /**
+   * 获取 mcporter 配置文件路径
+   */
+  getConfigPath(): string {
+    return this.configPath;
+  }
+
+  /**
+   * 获取 mcporter 配置目录路径
+   */
+  getConfigDir(): string {
+    return this.configDir;
+  }
+
+  /**
+   * 检查 mcporter 是否可用
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      const result = await safeExec('npx mcporter --version', {
+        timeout: 10000,
+      });
+      return result.stdout.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 安装 mcporter (全局安装)
+   */
+  async install(): Promise<void> {
+    mainLog('McporterService', 'Installing mcporter globally...');
+
+    try {
+      await safeExec('npm install -g mcporter', {
+        timeout: 60000,
+      });
+      mainLog('McporterService', 'mcporter installed successfully');
+    } catch (error) {
+      mainError('McporterService', 'Failed to install mcporter:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 确保配置目录存在
+   */
+  private ensureConfigDir(): void {
+    if (!existsSync(this.configDir)) {
+      mkdirSync(this.configDir, { recursive: true });
+      mainLog('McporterService', `Created config directory: ${this.configDir}`);
+    }
+  }
+
+  /**
+   * 同步 MCP 配置到 mcporter
+   */
+  async syncConfig(servers: IMcpServer[]): Promise<void> {
+    this.ensureConfigDir();
+
+    const config = convertToMcporterConfig(servers);
+    const configJson = JSON.stringify(config, null, 2);
+
+    try {
+      // 1. 同步到 mcporter 配置
+      writeFileSync(this.configPath, configJson, 'utf-8');
+      mainLog('McporterService', `Synced ${Object.keys(config.mcpServers).length} MCP servers to ${this.configPath}`);
+
+      // 2. 同步到 Claude Code 配置 (~/.claude.json)
+      await this.syncToClaudeCode(config.mcpServers);
+
+      // 如果 daemon 正在运行，发送重新加载信号
+      if (this.daemonProcess) {
+        await this.reloadDaemon();
+      }
+    } catch (error) {
+      mainError('McporterService', 'Failed to sync config:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 同步 MCP 配置到 Claude Code (~/.claude.json)
+   */
+  private async syncToClaudeCode(mcpServers: McporterConfig['mcpServers']): Promise<void> {
+    const claudeConfigPath = path.join(os.homedir(), '.claude.json');
+
+    try {
+      // 读取现有配置
+      let claudeConfig: Record<string, unknown> = {};
+      if (existsSync(claudeConfigPath)) {
+        const content = readFileSync(claudeConfigPath, 'utf-8');
+        claudeConfig = JSON.parse(content);
+      }
+
+      // 转换为 Claude Code 格式
+      const claudeMcpServers: Record<string, { type?: string; url?: string; command?: string; args?: string[]; env?: Record<string, string> }> = {};
+
+      for (const [name, server] of Object.entries(mcpServers)) {
+        if (server.baseUrl) {
+          // HTTP/SSE 类型
+          claudeMcpServers[name] = {
+            type: 'sse',
+            url: server.baseUrl,
+          };
+          if (server.headers) {
+            // Claude Code 不直接支持 headers，但 mcporter 可以处理
+            claudeMcpServers[name].url = server.baseUrl;
+          }
+        } else if (server.command) {
+          // Stdio 类型
+          claudeMcpServers[name] = {
+            command: server.command,
+            args: server.args,
+            env: server.env,
+          };
+        }
+      }
+
+      // 更新配置
+      claudeConfig['mcpServers'] = claudeMcpServers;
+
+      // 写回文件
+      writeFileSync(claudeConfigPath, JSON.stringify(claudeConfig, null, 2), 'utf-8');
+      mainLog('McporterService', `Synced ${Object.keys(claudeMcpServers).length} MCP servers to Claude Code`);
+    } catch (error) {
+      mainWarn('McporterService', 'Failed to sync to Claude Code:', error);
+      // 不抛出错误，因为这不是关键操作
+    }
+  }
+
+  /**
+   * 读取当前 mcporter 配置
+   */
+  readConfig(): McporterConfig | null {
+    try {
+      if (!existsSync(this.configPath)) {
+        return null;
+      }
+      const content = readFileSync(this.configPath, 'utf-8');
+      return JSON.parse(content) as McporterConfig;
+    } catch (error) {
+      mainWarn('McporterService', 'Failed to read config:', error);
+      return null;
+    }
+  }
+
+  /**
+   * 启动 mcporter daemon
+   */
+  async startDaemon(): Promise<void> {
+    if (this.daemonProcess) {
+      mainLog('McporterService', 'Daemon already running');
+      return;
+    }
+
+    this.ensureConfigDir();
+
+    mainLog('McporterService', 'Starting mcporter daemon...');
+
+    try {
+      // 使用环境变量指定配置路径
+      const env = {
+        ...process.env,
+        MCPORTER_CONFIG: this.configPath,
+      };
+
+      // 启动 daemon 进程
+      this.daemonProcess = spawn('npx', ['mcporter', 'daemon', 'start', '--detach'], {
+        env,
+        stdio: 'ignore',
+        detached: true,
+      });
+
+      this.daemonProcess.on('error', (error) => {
+        mainError('McporterService', 'Daemon process error:', error);
+        this.daemonProcess = null;
+      });
+
+      this.daemonProcess.on('exit', (code, signal) => {
+        mainLog('McporterService', `Daemon process exited with code ${code}, signal ${signal}`);
+        this.daemonProcess = null;
+      });
+
+      // 等待 daemon 启动
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      mainLog('McporterService', 'mcporter daemon started');
+    } catch (error) {
+      mainError('McporterService', 'Failed to start daemon:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 停止 mcporter daemon
+   */
+  async stopDaemon(): Promise<void> {
+    if (!this.daemonProcess) {
+      mainLog('McporterService', 'Daemon not running');
+      return;
+    }
+
+    mainLog('McporterService', 'Stopping mcporter daemon...');
+
+    try {
+      // 使用 mcporter CLI 停止 daemon
+      const env = {
+        ...process.env,
+        MCPORTER_CONFIG: this.configPath,
+      };
+
+      await safeExec('npx mcporter daemon stop', {
+        timeout: 10000,
+        env,
+      });
+
+      this.daemonProcess = null;
+      mainLog('McporterService', 'mcporter daemon stopped');
+    } catch (error) {
+      mainWarn('McporterService', 'Failed to stop daemon:', error);
+      // 强制清理
+      if (this.daemonProcess) {
+        this.daemonProcess.kill();
+        this.daemonProcess = null;
+      }
+    }
+  }
+
+  /**
+   * 重新加载 daemon 配置
+   */
+  private async reloadDaemon(): Promise<void> {
+    try {
+      const env = {
+        ...process.env,
+        MCPORTER_CONFIG: this.configPath,
+      };
+
+      await safeExec('npx mcporter daemon restart', {
+        timeout: 10000,
+        env,
+      });
+
+      mainLog('McporterService', 'Daemon reloaded');
+    } catch (error) {
+      mainWarn('McporterService', 'Failed to reload daemon:', error);
+    }
+  }
+
+  /**
+   * 获取 daemon 状态
+   */
+  async getDaemonStatus(): Promise<DaemonStatus> {
+    try {
+      const env = {
+        ...process.env,
+        MCPORTER_CONFIG: this.configPath,
+      };
+
+      const result = await safeExec('npx mcporter daemon status --json', {
+        timeout: 5000,
+        env,
+      });
+
+      const status = JSON.parse(result.stdout) as DaemonStatus;
+      return status;
+    } catch {
+      return { running: false };
+    }
+  }
+
+  /**
+   * 初始化 mcporter（检查安装、同步配置、启动 daemon）
+   */
+  async initialize(servers: IMcpServer[]): Promise<void> {
+    mainLog('McporterService', 'Initializing mcporter...');
+
+    // 检查 mcporter 是否可用
+    const available = await this.isAvailable();
+    if (!available) {
+      mainLog('McporterService', 'mcporter not available, installing...');
+      await this.install();
+    }
+
+    // 同步配置
+    await this.syncConfig(servers);
+
+    // 启动 daemon
+    await this.startDaemon();
+
+    mainLog('McporterService', 'mcporter initialized');
+  }
+
+  /**
+   * 清理资源
+   */
+  async cleanup(): Promise<void> {
+    await this.stopDaemon();
+  }
+}
+
+// 单例导出
+export const mcporterService = new McporterService();

--- a/src/process/services/mcporter/index.ts
+++ b/src/process/services/mcporter/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { mcporterService, type DaemonStatus } from './McporterService';
+export { convertToMcporterConfig, convertFromMcporterConfig, type McporterConfig, type McporterServerConfig } from './mcporterConfig';

--- a/src/process/services/mcporter/mcporterConfig.ts
+++ b/src/process/services/mcporter/mcporterConfig.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IMcpServer } from '@/common/storage';
+
+/**
+ * mcporter 配置格式
+ * @see https://github.com/steipete/mcporter
+ */
+export interface McporterConfig {
+  mcpServers: {
+    [name: string]: McporterServerConfig;
+  };
+  imports?: string[];
+}
+
+export interface McporterServerConfig {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  baseUrl?: string; // for HTTP/SSE
+  headers?: Record<string, string>;
+  lifecycle?: 'ephemeral' | { mode: 'keep-alive'; idleTimeoutMs?: number };
+  description?: string;
+}
+
+/**
+ * 将 Sudowork MCP 服务器配置转换为 mcporter 格式
+ * Convert Sudowork MCP server config to mcporter format
+ */
+export function convertToMcporterConfig(servers: IMcpServer[]): McporterConfig {
+  const mcpServers: McporterConfig['mcpServers'] = {};
+
+  for (const server of servers) {
+    // 只同步启用的服务器
+    if (!server.enabled) continue;
+
+    const config: McporterServerConfig = {};
+
+    switch (server.transport.type) {
+      case 'stdio':
+        config.command = server.transport.command;
+        if (server.transport.args && server.transport.args.length > 0) {
+          config.args = server.transport.args;
+        }
+        if (server.transport.env && Object.keys(server.transport.env).length > 0) {
+          config.env = server.transport.env;
+        }
+        break;
+
+      case 'sse':
+      case 'http':
+      case 'streamable_http':
+        config.baseUrl = server.transport.url;
+        if (server.transport.headers && Object.keys(server.transport.headers).length > 0) {
+          config.headers = server.transport.headers;
+        }
+        break;
+    }
+
+    if (server.description) {
+      config.description = server.description;
+    }
+
+    // 对于需要持久连接的 MCP server（如 chrome-devtools），启用 keep-alive
+    if (isKeepAliveServer(server)) {
+      config.lifecycle = { mode: 'keep-alive' };
+    }
+
+    mcpServers[server.name] = config;
+  }
+
+  return { mcpServers };
+}
+
+/**
+ * 判断是否是需要 keep-alive 的服务器
+ * Check if server needs keep-alive lifecycle
+ */
+function isKeepAliveServer(server: IMcpServer): boolean {
+  const keepAlivePatterns = [
+    'chrome-devtools',
+    'playwright',
+    'mobile-mcp',
+    'puppeteer',
+    'browser',
+  ];
+
+  const name = server.name.toLowerCase();
+  const command = server.transport.type === 'stdio' ? server.transport.command.toLowerCase() : '';
+
+  return keepAlivePatterns.some(
+    (pattern) => name.includes(pattern) || command.includes(pattern)
+  );
+}
+
+/**
+ * 从 mcporter 配置转换为 Sudowork 格式
+ * Convert mcporter config to Sudowork format
+ */
+export function convertFromMcporterConfig(config: McporterConfig): Partial<IMcpServer>[] {
+  const servers: Partial<IMcpServer>[] = [];
+
+  for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
+    const server: Partial<IMcpServer> = {
+      id: `mcporter_${name}`,
+      name,
+      description: serverConfig.description,
+      enabled: true,
+    };
+
+    if (serverConfig.command) {
+      server.transport = {
+        type: 'stdio',
+        command: serverConfig.command,
+        args: serverConfig.args,
+        env: serverConfig.env,
+      };
+    } else if (serverConfig.baseUrl) {
+      // 根据 URL 判断是 SSE 还是 HTTP
+      const url = serverConfig.baseUrl.toLowerCase();
+      const isSse = url.includes('/sse') || url.endsWith('/mcp');
+
+      server.transport = {
+        type: isSse ? 'sse' : 'http',
+        url: serverConfig.baseUrl,
+        headers: serverConfig.headers,
+      };
+    }
+
+    servers.push(server);
+  }
+
+  return servers;
+}

--- a/src/renderer/hooks/mcp/useMcpServers.ts
+++ b/src/renderer/hooks/mcp/useMcpServers.ts
@@ -62,7 +62,13 @@ export const useMcpServers = () => {
         // 异步保存到存储（在微任务中执行）
         queueMicrotask(() => {
           ConfigStorage.set('mcp.config', newServers)
-            .then(() => resolve())
+            .then(() => {
+              // 同步到 mcporter（静默失败，不影响主流程）
+              ipcBridge.mcporterService.syncConfig.invoke(newServers).catch((error) => {
+                console.warn('[useMcpServers] Failed to sync to mcporter:', error);
+              });
+              resolve();
+            })
             .catch((error) => {
               console.error('Failed to save MCP servers:', error);
               reject(error);


### PR DESCRIPTION
## Summary

- 新增 `McporterService` 服务，管理 mcporter 的安装和配置
- 实现 MCP 配置自动同步到 `~/.nexus/mcporter/mcporter.json` (sudoclaw 使用) 和 `~/.claude.json` (Claude Code 使用)
- 在 Sudowork 应用中添加/修改/删除 MCP server 时自动同步配置
- 支持自动识别 chrome-devtools、playwright 等需要 keep-alive 的服务器
- 应用启动时自动初始化 mcporter（非阻塞）

## 配置同步流程

```
Sudowork 应用 (设置 → 工具 → MCP 管理)
    ↓ 自动同步
├── ~/.nexus/mcporter/mcporter.json → sudoclaw 使用
└── ~/.claude.json → Claude Code 使用
```

## 测试计划

- [ ] 在 Sudowork 应用中添加 MCP server
- [ ] 验证配置同步到 `~/.nexus/mcporter/mcporter.json`
- [ ] 验证配置同步到 `~/.claude.json`
- [ ] 在 sudoclaw 中使用配置的 MCP 工具
- [ ] 在 Claude Code 中使用配置的 MCP 工具
- [ ] 删除 MCP server 后验证配置同步移除

🤖 Generated with [Claude Code](https://claude.com/claude-code)