### PR TITLE
fix(skill-hub): gate store rendering on installed-skill load and filter to hub-only comparison

### DIFF
--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -493,6 +493,9 @@ const SkillModalContent: React.FC = () => {
   const latestVersionsRef = useRef(latestVersions);
   latestVersionsRef.current = latestVersions;
 
+  // Track whether the installed-skill comparison map has been loaded at least once
+  const [installedSkillsReady, setInstalledSkillsReady] = useState(false);
+
   // ---- Fetch installed skills ----
   const fetchInstalledSkills = useCallback(async () => {
     if (!isElectronDesktop()) return;
@@ -500,11 +503,18 @@ const SkillModalContent: React.FC = () => {
       const res = await skillHub.getInstalledSkills.invoke();
       if (res.success && res.data) {
         const map = new Map<string, string>();
-        for (const s of res.data) map.set(s.name, s.version);
+        // Only hub-installed skills should participate in the store comparison
+        for (const s of res.data) {
+          if (s.meta?.source_type === 'hub' || (!s.meta?.source_type && s.isHubInstalled)) {
+            map.set(s.name, s.version);
+          }
+        }
         setInstalledSkills(map);
       }
     } catch (err) {
       console.error('Failed to fetch installed skills:', err);
+    } finally {
+      setInstalledSkillsReady(true);
     }
   }, []);
 
@@ -1030,7 +1040,7 @@ const SkillModalContent: React.FC = () => {
 
           {/* Skill grid */}
           <AionScrollArea className='flex-1 min-h-0' disableOverflow={isPageMode} onScroll={handleScroll}>
-            {loading ? (
+            {loading || !installedSkillsReady ? (
               <div className='flex justify-center items-center py-48px'>
                 <Spin size={28} />
               </div>


### PR DESCRIPTION
Fixes #232

**Changes:**
- Add `installedSkillsReady` state to gate store list rendering until installed-skill comparison data is loaded
- Filter `fetchInstalledSkills` to only include hub-installed skills in the comparison map

Generated with [Claude Code](https://claude.ai/code)