### PR TITLE
fix(guid): refresh agent list after Claude Code install/uninstall

### DIFF
--- a/src/agent/acp/AcpDetector.ts
+++ b/src/agent/acp/AcpDetector.ts
@@ -320,6 +320,16 @@ class AcpDetector {
     // Re-add custom agents with current config
     await this.addCustomAgentsToList(this.detectedAgents);
   }
+
+  /**
+   * Re-run full agent detection (e.g. after CLI install/uninstall).
+   * Resets the detection flag and re-initializes so that newly installed
+   * or removed CLI agents are picked up immediately.
+   */
+  async rescanCliAgents(): Promise<void> {
+    this.isDetected = false;
+    await this.initialize();
+  }
 }
 
 // 单例实例

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -302,6 +302,8 @@ export const acpConversation = {
   >('acp.get-available-agents'),
   checkEnv: bridge.buildProvider<{ env: Record<string, string> }, void>('acp.check.env'),
   refreshCustomAgents: bridge.buildProvider<IBridgeResponse, void>('acp.refresh-custom-agents'),
+  /** Re-run full CLI agent detection (after install/uninstall) */
+  rescanAgents: bridge.buildProvider<IBridgeResponse, void>('acp.rescan-agents'),
   checkAgentHealth: bridge.buildProvider<IBridgeResponse<{ available: boolean; latency?: number; error?: string }>, { backend: AcpBackend }>('acp.check-agent-health'),
   // Set session mode for ACP agents (claude, qwen, etc.)
   // 设置 ACP 代理的会话模式（claude、qwen 等）

--- a/src/process/bridge/acpConversationBridge.ts
+++ b/src/process/bridge/acpConversationBridge.ts
@@ -70,6 +70,19 @@ export function initAcpConversationBridge(): void {
     }
   });
 
+  // Re-run full CLI agent detection - called after CLI install/uninstall
+  ipcBridge.acpConversation.rescanAgents.provider(async () => {
+    try {
+      await acpDetector.rescanCliAgents();
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  });
+
   // Check agent health by sending a real test message
   // This is the most reliable way to verify an agent can actually respond
   ipcBridge.acpConversation.checkAgentHealth.provider(async ({ backend }) => {

--- a/src/renderer/components/SettingsModal/contents/RuntimeModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/RuntimeModalContent.tsx
@@ -10,7 +10,8 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { useSettingsViewMode } from '../settingsViewContext';
-import { nexus as nexusIpc, claudeCli as claudeCliIpc, libreOffice as libreOfficeIpc, sudoclaw as sudoclawIpc, nodeRuntime as nodeRuntimeIpc } from '@/common/ipcBridge';
+import { nexus as nexusIpc, claudeCli as claudeCliIpc, libreOffice as libreOfficeIpc, sudoclaw as sudoclawIpc, nodeRuntime as nodeRuntimeIpc, acpConversation } from '@/common/ipcBridge';
+import { mutate } from 'swr';
 import type { ICliStatus, ILibreOfficeInstallPhase, ISudoclawInstallPhase, NexusInstallPhase } from '@/common/ipcBridge';
 import { getRuntimeActions, getStatusInfo, isInstalled, type LoadState, type ToolRow } from './runtimeStatus';
 
@@ -123,6 +124,16 @@ const RuntimeModalContent: React.FC = () => {
     }
   }, []);
 
+  /** Refresh the Guid homepage agent list (best-effort). */
+  const refreshAvailableAgents = useCallback(async () => {
+    try {
+      await acpConversation.refreshCustomAgents.invoke();
+      await mutate('acp.agents.available');
+    } catch {
+      /* silent – agent list refresh is best-effort */
+    }
+  }, []);
+
   const installClaude = useCallback(async () => {
     setClaudeLoad('installing');
     setClaudePhase(undefined);
@@ -131,6 +142,8 @@ const RuntimeModalContent: React.FC = () => {
       if (res?.success) {
         Message.success(t('settings.runtimeSettings.installSuccess', { name: 'Claude Code' }));
         await refreshClaude();
+        // Refresh the Guid homepage agent list so Claude Code appears immediately
+        void refreshAvailableAgents();
       } else {
         Message.error(res?.msg || t('settings.runtimeSettings.installFailed', { name: 'Claude Code' }));
       }
@@ -140,7 +153,7 @@ const RuntimeModalContent: React.FC = () => {
       setClaudeLoad('idle');
       setClaudePhase(undefined);
     }
-  }, [refreshClaude, t]);
+  }, [refreshClaude, refreshAvailableAgents, t]);
 
   const uninstallClaude = useCallback(async () => {
     setClaudeLoad('loading');
@@ -149,6 +162,8 @@ const RuntimeModalContent: React.FC = () => {
       if (res?.success) {
         Message.success(t('settings.runtimeSettings.uninstallSuccess', { name: 'Claude Code' }));
         await refreshClaude();
+        // Refresh the Guid homepage agent list so Claude Code is removed immediately
+        void refreshAvailableAgents();
       } else {
         Message.error(res?.msg || t('settings.runtimeSettings.uninstallFailed', { name: 'Claude Code' }));
       }
@@ -157,7 +172,7 @@ const RuntimeModalContent: React.FC = () => {
     } finally {
       setClaudeLoad('idle');
     }
-  }, [refreshClaude, t]);
+  }, [refreshClaude, refreshAvailableAgents, t]);
 
   const refreshLibreOffice = useCallback(async (options?: RefreshOptions) => {
     if (!options?.silent) {
@@ -398,6 +413,8 @@ const RuntimeModalContent: React.FC = () => {
     const unsubClaude = claudeCliIpc.installResult.on(() => {
       setClaudePhase(undefined);
       void refreshClaude();
+      // Also refresh the Guid homepage agent list for background installs
+      void refreshAvailableAgents();
     });
     const unsubClaudeProgress = claudeCliIpc.installProgress.on(({ phase }) => {
       setClaudePhase(phase);
@@ -432,7 +449,7 @@ const RuntimeModalContent: React.FC = () => {
       unsubLoProgress();
       unsubLoResult();
     };
-  }, [refreshNode, refreshClaude, refreshNexus, refreshSudoclaw, refreshLibreOffice]);
+  }, [refreshNode, refreshClaude, refreshAvailableAgents, refreshNexus, refreshSudoclaw, refreshLibreOffice]);
 
   const tableData: ToolRow[] = [
     {

--- a/src/renderer/components/SettingsModal/contents/RuntimeModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/RuntimeModalContent.tsx
@@ -124,10 +124,12 @@ const RuntimeModalContent: React.FC = () => {
     }
   }, []);
 
-  /** Refresh the Guid homepage agent list (best-effort). */
+  /** Refresh the Guid homepage agent list (best-effort).
+   *  Uses rescanAgents to re-run full CLI detection so that newly
+   *  installed / uninstalled CLI agents (e.g. Claude Code) are picked up. */
   const refreshAvailableAgents = useCallback(async () => {
     try {
-      await acpConversation.refreshCustomAgents.invoke();
+      await acpConversation.rescanAgents.invoke();
       await mutate('acp.agents.available');
     } catch {
       /* silent – agent list refresh is best-effort */

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -14,6 +14,7 @@ import type { AcpBackend, AcpBackendConfig, AcpModelInfo, AvailableAgent, Effect
 import { getAgentModes } from '@/renderer/constants/agentModes';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR, { mutate } from 'swr';
+import { emitter } from '@/renderer/utils/emitter';
 
 /** Save preferred mode to the agent's own config key */
 async function savePreferredMode(agentKey: string, mode: string): Promise<void> {
@@ -599,6 +600,19 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey }: Us
   useEffect(() => {
     void refreshCustomAgents();
   }, [refreshCustomAgents]);
+
+  // Defensive: re-scan available agents whenever the user clicks "New Chat"
+  // so that newly installed agents (e.g. Claude Code) appear even if the
+  // Guid page was never unmounted and the mount-only effect didn't re-run.
+  useEffect(() => {
+    const handler = () => {
+      void mutate('acp.agents.available');
+    };
+    emitter.on('guid.reset', handler);
+    return () => {
+      emitter.off('guid.reset', handler);
+    };
+  }, []);
 
   // Reset agent selection to default state (no assistant selected)
   const resetSelection = useCallback(() => {

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -604,9 +604,13 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey }: Us
   // Defensive: re-scan available agents whenever the user clicks "New Chat"
   // so that newly installed agents (e.g. Claude Code) appear even if the
   // Guid page was never unmounted and the mount-only effect didn't re-run.
+  // Uses rescanAgents to re-run full CLI detection on the main process,
+  // then revalidates the SWR cache so the UI picks up the change.
   useEffect(() => {
     const handler = () => {
-      void mutate('acp.agents.available');
+      void ipcBridge.acpConversation.rescanAgents.invoke().then(() => {
+        void mutate('acp.agents.available');
+      });
     };
     emitter.on('guid.reset', handler);
     return () => {


### PR DESCRIPTION
Closes #233

## Summary
- After Claude Code install/uninstall, refresh the Guid homepage agent list immediately via IPC + SWR revalidation
- Handle background installs (first-launch prompt) by also refreshing agents in the installResult listener
- Defensive fallback: revalidate agents on "New Chat" click (guid.reset event)

Generated with [Claude Code](https://claude.ai/code)