### PR TITLE
fix(assistant): preserve empty skill selection as explicit empty array

### DIFF
--- a/src/process/task/AcpSkillManager.ts
+++ b/src/process/task/AcpSkillManager.ts
@@ -125,7 +125,9 @@ export class AcpSkillManager {
    * @returns AcpSkillManager 实例 / AcpSkillManager instance
    */
   static getInstance(enabledSkills?: string[]): AcpSkillManager {
-    const cacheKey = enabledSkills?.sort().join(',') || 'all';
+    // Distinguish between undefined (non-preset → load all) and [] (preset with
+    // no skills → load none).  An empty array must NOT map to 'all'.
+    const cacheKey = enabledSkills ? (enabledSkills.length > 0 ? [...enabledSkills].sort().join(',') : '__none__') : 'all';
 
     // 如果缓存键变化，需要重新创建实例
     // If cache key changed, need to recreate instance
@@ -219,8 +221,9 @@ export class AcpSkillManager {
 
       for (const extSkill of extSkills) {
         // 如果指定了 enabledSkills，只加载被启用的扩展 skills
-        // If enabledSkills is specified, only load enabled extension skills
-        if (enabledSkills && enabledSkills.length > 0 && !enabledSkills.includes(extSkill.name)) {
+        // If enabledSkills is specified, only load enabled extension skills.
+        // An empty array means "no skills" (preset assistant with none selected).
+        if (enabledSkills && !enabledSkills.includes(extSkill.name)) {
           continue;
         }
 
@@ -266,7 +269,8 @@ export class AcpSkillManager {
         if (!entry.isDirectory()) continue;
         const skillName = entry.name;
 
-        if (enabledSkills && enabledSkills.length > 0 && !enabledSkills.includes(skillName)) {
+        // An empty array means "no skills" (preset assistant with none selected).
+        if (enabledSkills && !enabledSkills.includes(skillName)) {
           continue;
         }
 
@@ -350,7 +354,8 @@ export class AcpSkillManager {
         // Skip if already found in subdirectories
         if (this.skills.has(skillName)) continue;
 
-        if (enabledSkills && enabledSkills.length > 0 && !enabledSkills.includes(skillName)) {
+        // An empty array means "no skills" (preset assistant with none selected).
+        if (enabledSkills && !enabledSkills.includes(skillName)) {
           continue;
         }
 

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -517,7 +517,10 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey }: Us
       if (!agentInfo) return undefined;
       if (agentInfo.backend !== 'custom') return undefined;
       const customAgent = customAgents.find((agent) => agent.id === agentInfo.customAgentId);
-      return customAgent?.enabledSkills;
+      // For preset assistants (custom backend), treat missing enabledSkills as
+      // an explicit empty array so that downstream consumers do not fall back to
+      // loading *all* skills.
+      return customAgent?.enabledSkills ?? [];
     },
     [customAgents]
   );

--- a/src/renderer/shared/agents/presetAssistantResources.ts
+++ b/src/renderer/shared/agents/presetAssistantResources.ts
@@ -37,7 +37,10 @@ const defaultDeps: PresetAssistantResourceDeps = {
   getEnabledSkills: async (customAgentId) => {
     const customAgents = await ConfigStorage.get('acp.customAgents');
     const assistant = customAgents?.find((agent) => agent.id === customAgentId);
-    return assistant?.enabledSkills;
+    // For preset assistants, treat missing enabledSkills as an explicit empty
+    // array so that downstream consumers (workspace sync, AcpSkillManager) do
+    // not fall back to loading *all* skills.
+    return assistant?.enabledSkills ?? [];
   },
   warn: (message, error) => {
     console.warn(message, error);


### PR DESCRIPTION
Fixes #234

## Summary
- When a Digital Assistant has no skills selected, `enabledSkills` was stored as `undefined` causing all skills to be synced into the workspace
- Fixed upstream data sources to return `[]` (explicit empty array) instead of `undefined` for preset assistants
- Fixed `AcpSkillManager` to properly treat empty arrays as "no optional skills"

## Test plan
- [ ] Create a Digital Assistant with no skills selected → start conversation → verify temp workspace has no skills
- [ ] Create a Digital Assistant with specific skills selected → start conversation → verify only those skills are synced
- [ ] Use a non-preset standalone agent → verify all skills are still available

Generated with [Claude Code](https://claude.ai/code)