### PR TITLE
fix(ui): rebrand about page to SudoClaw and add theme switcher

### DIFF
--- a/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useSettingsViewMode } from '../settingsViewContext';
 import { buildVersion, buildDate, buildCommit, isNightlyBuild } from '@/common/buildInfo';
 import OpsModal from '@/renderer/components/OpsModal';
+import sudoIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 
 const AboutModalContent: React.FC = () => {
   const viewMode = useSettingsViewMode();
@@ -24,24 +25,28 @@ const AboutModalContent: React.FC = () => {
       <div className={classNames('flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-24px', isPageMode && 'px-0 overflow-visible')}>
         <div className='flex flex-col max-w-540px mx-auto'>
           <div className='flex flex-col items-center py-28px'>
-            <div className='w-56px h-56px rd-16px bg-gradient-to-br from-orange-4 to-orange-6 flex items-center justify-center mb-12px shadow-md'>
-              <span className='text-white text-20px font-800'>S</span>
+            <div className='w-48px h-48px flex items-center justify-center mb-12px'>
+              <img src={sudoIcon} alt='SudoClaw' className='w-42px h-42px' />
             </div>
             <Typography.Title heading={4} className='text-18px font-700 text-t-primary mb-4px mt-0'>
-              Sudowork
+              SudoClaw
             </Typography.Title>
-            <div className='text-12px text-t-tertiary mb-10px'>北京数牍科技有限公司</div>
-            <span className='px-10px py-3px rd-20px text-12px bg-fill-2 text-t-secondary font-mono font-500'>{buildVersion}</span>
-            {isNightlyBuild && <span className='mt-6px px-8px py-2px rd-10px text-11px bg-orange-1 text-orange-6 font-500 dark:bg-orange-9/20'>{t('update.nightlyBadge', { defaultValue: 'Nightly Preview' })}</span>}
+            <div className='text-12px text-t-tertiary mb-8px'>北京数牍科技有限公司</div>
+            <div className='flex items-center gap-6px'>
+              <span className='px-10px py-3px rd-20px text-12px bg-fill-2 text-t-secondary font-mono font-500'>{buildVersion}</span>
+              {isNightlyBuild && <span className='px-8px py-2px rd-10px text-11px bg-orange-1 text-orange-6 font-500 dark:bg-orange-9/20'>{t('update.nightlyBadge', { defaultValue: 'Nightly Preview' })}</span>}
+            </div>
             {isNightlyBuild && buildDate !== 'unknown' && (
-              <div className='mt-6px text-11px text-t-quaternary font-mono'>
+              <div className='mt-6px text-11px text-t-tertiary font-mono'>
                 {t('update.buildDate', { defaultValue: 'Build date' })}: {buildDate} · {buildCommit}
               </div>
             )}
-            <Button size='small' type='outline' className='mt-12px' onClick={() => window.dispatchEvent(new Event('aionui-open-update-modal'))}>
-              {t('settings.checkForUpdates')}
-            </Button>
-            <Button size='small' type='text' className='mt-12px ml-8px opacity-50 hover:opacity-100 transition-opacity' onClick={() => setOpsVisible(true)} icon={<Setting theme='outline' size='14' />} />
+            <div className='flex items-center gap-4px mt-14px'>
+              <Button size='small' type='outline' onClick={() => window.dispatchEvent(new Event('aionui-open-update-modal'))}>
+                {t('settings.checkForUpdates')}
+              </Button>
+              <Button size='small' type='text' className='opacity-50 hover:opacity-100 transition-opacity' onClick={() => setOpsVisible(true)} icon={<Setting theme='outline' size='14' />} />
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
+import { ThemeSwitcher } from '@/renderer/components/ThemeSwitcher';
 import { useSettingsViewMode } from '../settingsViewContext';
 
 /**
@@ -144,6 +145,7 @@ const SystemModalContent: React.FC = () => {
   // 偏好设置项配置 / Preference items configuration
   const preferenceItems = [
     { key: 'language', label: t('settings.language'), component: <LanguageSwitcher /> },
+    { key: 'theme', label: t('settings.theme'), component: <ThemeSwitcher /> },
     { key: 'closeToTray', label: t('settings.closeToTray'), component: <Switch checked={closeToTray} onChange={handleCloseToTrayChange} /> },
   ];
 


### PR DESCRIPTION
## Summary
- Replace "Sudowork" with "SudoClaw" and use sudo logo in the about page
- Improve about page layout: compact logo, inline version + nightly badge, grouped action buttons
- Fix dark mode build date text visibility
- Add ThemeSwitcher (light/system/dark) to system settings for easier access

## Test plan
- [ ] Open Settings → 关于, verify logo shows sudo cube icon and title reads "SudoClaw"
- [ ] Verify nightly badge and version appear on the same row
- [ ] Check build date text is readable in dark mode
- [ ] Open Settings → 系统, verify theme switcher (light/system/dark) appears between language and close-to-tray
- [ ] Toggle theme modes and confirm they apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)