### PR TITLE
WIP: inject plugin credentials into agent subprocess env

### DIFF
--- a/skills/chandao-api/SKILL.md
+++ b/skills/chandao-api/SKILL.md
@@ -23,20 +23,12 @@ description: >
 
 脚本按以下顺序查找凭证：
 
-1. **环境变量**（优先）：`CHANDAO_BASE_URL`、`CHANDAO_ACCOUNT`、`CHANDAO_PASSWORD`
+1. **环境变量**（优先）：`CHANDAO_BASE_URL`、`CHANDAO_ACCOUNT`、`CHANDAO_PASSWORD` — 如果用户已在 SudoClaw 设置中配置禅道插件，这些环境变量会自动注入，无需手动配置。
 2. **`.env` 文件**（回退）：`skills/chandao-api/.env`
 
-**推荐方式：** 在技能目录下创建 `.env` 文件：
+### 重要：先检查凭证，不要直接向用户索取
 
-```
-CHANDAO_BASE_URL=https://your-site.chandao.net
-CHANDAO_ACCOUNT=your_username
-CHANDAO_PASSWORD=your_password
-```
-
-**如果凭证缺失：** 脚本会报错并提示。此时应向用户索取禅道实例地址、用户名和密码。
-
-### 检查凭证是否可用
+**在使用禅道 API 之前，必须先运行 `python scripts/chandao.py --check` 检查凭证是否已配置。** 凭证通常已通过环境变量自动注入。只有在检查失败时才向用户索取凭证。
 
 ```bash
 python scripts/chandao.py --check

--- a/src/agent/openclaw/OpenClawGatewayManager.ts
+++ b/src/agent/openclaw/OpenClawGatewayManager.ts
@@ -14,6 +14,7 @@ import { pathToFileURL } from 'node:url';
 import { getNodeBinaryPath } from '@process/services/claudeCli/NodeRuntimeService';
 import { app } from 'electron';
 import { mainError, mainLog, mainWarn } from '@process/utils/mainLogger';
+import { getDatabase } from '@process/database';
 
 interface GatewayManagerConfig {
   /** Gateway port (default: 17863 for Sudoclaw) */
@@ -176,6 +177,25 @@ export class OpenClawGatewayManager extends EventEmitter {
     }
   }
 
+  /** Inject enabled plugin credentials (e.g. Chandao) into gateway env */
+  private injectPluginCredentials(env: Record<string, string>): void {
+    try {
+      const pluginsResult = getDatabase().getPluginCredentialsDirect('zentao');
+      if (pluginsResult) {
+        if (pluginsResult.serverUrl) env.CHANDAO_BASE_URL = pluginsResult.serverUrl;
+        if (pluginsResult.zentaoUsername) env.CHANDAO_ACCOUNT = pluginsResult.zentaoUsername;
+        if (pluginsResult.zentaoPassword) env.CHANDAO_PASSWORD = pluginsResult.zentaoPassword;
+        console.log('[OpenClawGatewayManager] Injected Zentao credentials:', {
+          hasUrl: !!pluginsResult.serverUrl,
+          hasUser: !!pluginsResult.zentaoUsername,
+          hasPass: !!pluginsResult.zentaoPassword,
+        });
+      }
+    } catch (error) {
+      console.error('[OpenClawGatewayManager] Failed to inject plugin credentials:', error);
+    }
+  }
+
   private canUseInProcess(): boolean {
     // Always use subprocess mode for safety hook to work properly.
     // In-process mode runs gateway in Electron main process, where
@@ -200,6 +220,7 @@ export class OpenClawGatewayManager extends EventEmitter {
     process.argv = ['node', entryPath, ...buildGatewayArgs(this.port)];
     process.env.OPENCLAW_STATE_DIR = this.stateDir!;
     process.env.SUDOCLAW_CONFIG_PATH = path.join(this.stateDir!, 'sudoclaw.json');
+    this.injectPluginCredentials(process.env as Record<string, string>);
     process.chdir(pkgRoot);
 
     // Load safety hook before gateway entry (for in-process mode)
@@ -271,6 +292,9 @@ export class OpenClawGatewayManager extends EventEmitter {
       // Skills (e.g. image-analysis) read SUDOROUTER credentials and CHAT_MODEL
       // directly from sudoclaw.json via SUDOCLAW_CONFIG_PATH at each invocation,
       // so no env var injection is needed here.
+      // However, plugin credentials (e.g. Chandao) are stored in the app database
+      // and need to be injected as env vars for skills that read them.
+      this.injectPluginCredentials(env);
       console.log('[OpenClawGatewayManager] Using bundled Node.js:', bundledNode);
       mainLog('OpenClawGatewayManager', 'Using bundled Node.js', { path: bundledNode });
 

--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -891,6 +891,33 @@ export class AionUIDatabase {
   }
 
   /**
+   * Get plugin credentials directly from SQLite (bypasses Nexus secret cache).
+   * Used for injecting credentials into agent subprocess environments where
+   * Nexus migration may not have completed.
+   */
+  getPluginCredentialsDirect(pluginType: string): Record<string, string> | null {
+    try {
+      const row = this.db.prepare(
+        'SELECT config FROM assistant_plugins WHERE type = ? LIMIT 1',
+      ).get(pluginType) as { config: string } | undefined;
+      if (!row) return null;
+      const storedConfig = JSON.parse(row.config || '{}');
+      const creds = storedConfig.credentials;
+      if (!creds || typeof creds !== 'object') return null;
+      // Return all credential fields as strings
+      const result: Record<string, string> = {};
+      for (const [key, value] of Object.entries(creds)) {
+        if (typeof value === 'string' && value) {
+          result[key] = value;
+        }
+      }
+      return Object.keys(result).length > 0 ? result : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Get assistant plugin by ID
    *
    * After migration:
@@ -983,20 +1010,19 @@ export class AionUIDatabase {
           updated_at = excluded.updated_at
       `);
 
-      // Store non-credential config in SQLite
-      // Also store ID fields (not in credentialFields) that should be preserved but not stored in Nexus
-      const credentialFields = SecretMigrationCoordinator.getChannelCredentialFields(plugin.type);
-      const idFields: Record<string, string> = {};
+      // Store all credential fields in SQLite config for direct access
+      // (needed by gateway env injection which runs before Nexus secret cache is populated)
+      const allCredFields: Record<string, string> = {};
       if (plugin.credentials) {
         for (const [key, value] of Object.entries(plugin.credentials)) {
-          if (!credentialFields.includes(key) && typeof value === 'string' && value) {
-            idFields[key] = value;
+          if (typeof value === 'string' && value) {
+            allCredFields[key] = value;
           }
         }
       }
       const storedConfig = {
         config: plugin.config,
-        credentials: idFields, // Store ID fields that are not in Nexus
+        credentials: allCredFields,
       };
 
       stmt.run(plugin.id, plugin.type, plugin.name, plugin.enabled ? 1 : 0, JSON.stringify(storedConfig), plugin.status, plugin.lastConnected ?? null, plugin.createdAt || now, now);

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -272,6 +272,19 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
         cdpPort,
       });
       customEnv = { ...customEnv, ...presetResult.envOverrides };
+
+      // Inject plugin credentials (e.g. Chandao) into agent subprocess environment
+      try {
+        const zentaoCreds = getDatabase().getPluginCredentialsDirect('zentao');
+        if (zentaoCreds) {
+          if (zentaoCreds.serverUrl) customEnv.CHANDAO_BASE_URL = zentaoCreds.serverUrl;
+          if (zentaoCreds.zentaoUsername) customEnv.CHANDAO_ACCOUNT = zentaoCreds.zentaoUsername;
+          if (zentaoCreds.zentaoPassword) customEnv.CHANDAO_PASSWORD = zentaoCreds.zentaoPassword;
+        }
+      } catch (error) {
+        mainWarn('[AcpAgent]', 'Failed to inject plugin credentials:', error);
+      }
+
       if (presetResult.contextAppendix && this.options.presetContext) {
         this.options.presetContext += presetResult.contextAppendix;
       }


### PR DESCRIPTION
> ⚠️ **This PR is NOT ready for merge.** It is a WIP proof-of-concept that needs review and further work. See #253 for full context.

## Summary

- Inject Chandao plugin credentials (`CHANDAO_BASE_URL`, `CHANDAO_ACCOUNT`, `CHANDAO_PASSWORD`) from SQLite into agent subprocess environment variables
- Covers both **OpenClaw gateway** (`OpenClawGatewayManager.ts`) and **ACP agent** (`AcpAgent.ts`) paths
- Adds `getPluginCredentialsDirect()` to read credentials directly from SQLite, bypassing Nexus secret cache (which may not be initialized at gateway spawn time)
- Stores all credential fields (including secrets) in SQLite's `config.credentials` so they survive the Nexus cache timing gap
- Updates `chandao-api` SKILL.md to instruct agents to check credentials first before asking the user

## Known Issues / TODOs

- [ ] Hardcoded `zentao` type and `CHANDAO_*` env names — should be generalized
- [ ] Storing password plaintext in SQLite may have security implications — needs review
- [ ] Contains debug `console.log` statements — should be cleaned up
- [ ] Missing unit tests
- [ ] Gateway spawns before Nexus secret cache preload — fundamental timing issue needs architectural decision

## Test Plan

- [ ] Configure Chandao credentials in Settings → test connection
- [ ] Start new OpenClaw conversation → invoke chandao-api skill → verify credentials auto-detected
- [ ] Start new ACP conversation → invoke chandao-api skill → verify credentials auto-detected
- [ ] Restart app → verify credentials persist and inject correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)