### PR TITLE
feat(mention): support @ file references from workspace in input

### DIFF
--- a/src/renderer/components/SkillSelectorMenu.tsx
+++ b/src/renderer/components/SkillSelectorMenu.tsx
@@ -6,6 +6,8 @@
 
 import classNames from 'classnames';
 import React, { useEffect, useRef } from 'react';
+import type { AtMentionTab } from '@/renderer/hooks/useSkillSelectorController';
+import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 
 export interface SkillSelectorMenuItem {
   key: string;
@@ -28,9 +30,25 @@ interface SkillSelectorMenuProps {
   onHoverItem: (index: number) => void;
   onSelectItem: (item: SkillSelectorMenuItem) => void;
   emptyText: string;
+  /** Whether to show tabs (skills/files) */
+  showTabs?: boolean;
+  /** Current active tab */
+  activeTab?: AtMentionTab;
+  /** Callback when tab changes */
+  onTabChange?: (tab: AtMentionTab) => void;
+  /** File items for the files tab */
+  fileItems?: WorkspaceFileItem[];
+  /** Callback when a file item is selected */
+  onSelectFile?: (file: WorkspaceFileItem) => void;
+  /** Text for files tab title */
+  filesTabTitle?: string;
+  /** Text for skills tab title */
+  skillsTabTitle?: string;
+  /** Empty text for files tab */
+  filesEmptyText?: string;
 }
 
-const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, items, selectedKeys, activeIndex, loading = false, loadingText = 'Loading...', onHoverItem, onSelectItem, emptyText }) => {
+const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, items, selectedKeys, activeIndex, loading = false, loadingText = 'Loading...', onHoverItem, onSelectItem, emptyText, showTabs = false, activeTab = 'skills', onTabChange, fileItems = [], onSelectFile, filesTabTitle = 'Files', skillsTabTitle = 'Skills', filesEmptyText = 'No files' }) => {
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
@@ -38,7 +56,7 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
     if (current) {
       current.scrollIntoView({ block: 'nearest' });
     }
-  }, [activeIndex, items.length]);
+  }, [activeIndex, items.length, fileItems.length, activeTab]);
 
   return (
     <div
@@ -53,6 +71,7 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
         minWidth: '240px',
       }}
     >
+      {/* Header with optional tabs */}
       <div
         className='px-12px py-8px border-b border-solid flex items-center justify-between gap-8px'
         style={{
@@ -60,21 +79,97 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
           background: 'color-mix(in srgb, var(--color-bg-1) 84%, transparent)',
         }}
       >
-        <div className='text-13px font-semibold text-t-primary'>{title}</div>
-        {hint && <div className='text-13px text-t-secondary truncate'>{hint}</div>}
+        {showTabs ? (
+          <div className='flex items-center gap-2px'>
+            <button
+              type='button'
+              className={classNames('px-10px py-4px rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
+                'bg-primary text-white': activeTab === 'skills',
+                'bg-transparent text-t-secondary hover:text-t-primary hover:bg-fill-2': activeTab !== 'skills',
+              })}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => onTabChange?.('skills')}
+            >
+              {skillsTabTitle}
+            </button>
+            <button
+              type='button'
+              className={classNames('px-10px py-4px rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
+                'bg-primary text-white': activeTab === 'files',
+                'bg-transparent text-t-secondary hover:text-t-primary hover:bg-fill-2': activeTab !== 'files',
+              })}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => onTabChange?.('files')}
+            >
+              {filesTabTitle}
+            </button>
+          </div>
+        ) : (
+          <div className='text-13px font-semibold text-t-primary'>{title}</div>
+        )}
+        {hint && !showTabs && <div className='text-13px text-t-secondary truncate'>{hint}</div>}
+        {showTabs && <div className='text-11px text-t-secondary truncate'>Tab to switch</div>}
       </div>
+
+      {/* Content area */}
       <div role='listbox' aria-busy={loading} className='overflow-y-auto p-6px' style={{ maxHeight: 'min(34vh, 260px)' }}>
-        {loading && <div className='px-10px py-12px text-13px text-t-secondary'>{loadingText}</div>}
-        {!loading && items.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{emptyText}</div>}
-        {!loading &&
-          items.map((item, index) => {
-            const isSelected = selectedKeys.includes(item.key);
-            return (
+        {/* Skills tab content */}
+        {activeTab === 'skills' && (
+          <>
+            {loading && <div className='px-10px py-12px text-13px text-t-secondary'>{loadingText}</div>}
+            {!loading && items.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{emptyText}</div>}
+            {!loading &&
+              items.map((item, index) => {
+                const isSelected = selectedKeys.includes(item.key);
+                return (
+                  <button
+                    key={item.key}
+                    type='button'
+                    role='option'
+                    aria-selected={isSelected}
+                    ref={(node) => {
+                      itemRefs.current[index] = node;
+                    }}
+                    className={classNames('w-full text-left px-10px py-6px rounded-8px transition-all border border-solid outline-none cursor-pointer mb-2px last:mb-0', {
+                      'border-[var(--color-border-2)]': index === activeIndex,
+                      'border-transparent hover:bg-[var(--color-fill-1)]': index !== activeIndex,
+                    })}
+                    style={{
+                      minHeight: '42px',
+                      background: index === activeIndex ? 'color-mix(in srgb, var(--aou-2) 88%, transparent)' : isSelected ? 'color-mix(in srgb, var(--color-primary-light-1) 50%, transparent)' : 'transparent',
+                      boxShadow: undefined,
+                    }}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onMouseEnter={() => onHoverItem(index)}
+                    onClick={() => onSelectItem(item)}
+                  >
+                    <div className='flex items-center gap-8px'>
+                      {/* Icon / Emoji */}
+                      <div className='w-28px h-28px flex-shrink-0 rd-6px overflow-hidden bg-fill-2 flex items-center justify-center text-16px'>{item.icon ? <img src={item.icon} alt={item.displayName} className='w-full h-full object-cover' /> : <span>{item.emoji || '⚡'}</span>}</div>
+                      {/* Content */}
+                      <div className='min-w-0 flex-1'>
+                        <div className='flex items-center gap-6px min-w-0'>
+                          <span className={classNames('text-14px truncate', index === activeIndex ? 'text-t-primary font-semibold' : 'text-t-primary font-medium')}>{item.displayName}</span>
+                          {isSelected && <span className='px-4px py-0px bg-primary text-white text-9px rd-3px whitespace-nowrap flex-shrink-0 leading-14px'>已添加</span>}
+                        </div>
+                        {item.description && <div className='text-11px text-t-secondary truncate mt-1px'>{item.description}</div>}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+          </>
+        )}
+
+        {/* Files tab content */}
+        {activeTab === 'files' && (
+          <>
+            {fileItems.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{filesEmptyText}</div>}
+            {fileItems.map((file, index) => (
               <button
-                key={item.key}
+                key={file.fullPath}
                 type='button'
                 role='option'
-                aria-selected={isSelected}
                 ref={(node) => {
                   itemRefs.current[index] = node;
                 }}
@@ -83,28 +178,26 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
                   'border-transparent hover:bg-[var(--color-fill-1)]': index !== activeIndex,
                 })}
                 style={{
-                  minHeight: '42px',
-                  background: index === activeIndex ? 'color-mix(in srgb, var(--aou-2) 88%, transparent)' : isSelected ? 'color-mix(in srgb, var(--color-primary-light-1) 50%, transparent)' : 'transparent',
-                  boxShadow: undefined,
+                  minHeight: '38px',
+                  background: index === activeIndex ? 'color-mix(in srgb, var(--aou-2) 88%, transparent)' : 'transparent',
                 }}
+                onMouseDown={(e) => e.preventDefault()}
                 onMouseEnter={() => onHoverItem(index)}
-                onClick={() => onSelectItem(item)}
+                onClick={() => onSelectFile?.(file)}
               >
                 <div className='flex items-center gap-8px'>
-                  {/* Icon / Emoji */}
-                  <div className='w-28px h-28px flex-shrink-0 rd-6px overflow-hidden bg-fill-2 flex items-center justify-center text-16px'>{item.icon ? <img src={item.icon} alt={item.displayName} className='w-full h-full object-cover' /> : <span>{item.emoji || '⚡'}</span>}</div>
-                  {/* Content */}
+                  <div className='w-24px h-24px flex-shrink-0 rd-4px bg-fill-2 flex items-center justify-center text-14px'>
+                    <span>📄</span>
+                  </div>
                   <div className='min-w-0 flex-1'>
-                    <div className='flex items-center gap-6px min-w-0'>
-                      <span className={classNames('text-14px truncate', index === activeIndex ? 'text-t-primary font-semibold' : 'text-t-primary font-medium')}>{item.displayName}</span>
-                      {isSelected && <span className='px-4px py-0px bg-primary text-white text-9px rd-3px whitespace-nowrap flex-shrink-0 leading-14px'>已添加</span>}
-                    </div>
-                    {item.description && <div className='text-11px text-t-secondary truncate mt-1px'>{item.description}</div>}
+                    <div className={classNames('text-13px truncate', index === activeIndex ? 'text-t-primary font-semibold' : 'text-t-primary font-medium')}>{file.name}</div>
+                    <div className='text-11px text-t-secondary truncate mt-1px'>{file.relativePath}</div>
                   </div>
                 </div>
               </button>
-            );
-          })}
+            ))}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -8,7 +8,8 @@ import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
 import SlashCommandMenu, { type SlashCommandMenuItem } from '@/renderer/components/SlashCommandMenu';
 import { useSlashCommandController } from '@/renderer/hooks/useSlashCommandController';
 import SkillSelectorMenu, { type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorMenu';
-import { useSkillSelectorController, type SkillSelectorItem } from '@/renderer/hooks/useSkillSelectorController';
+import { useSkillSelectorController, type SkillSelectorItem, stripAtQuery, replaceAtQuery } from '@/renderer/hooks/useSkillSelectorController';
+import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 import { useLayoutContext } from '@/renderer/context/LayoutContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { blurActiveElement, shouldBlockMobileInputFocus } from '@/renderer/utils/focus';
@@ -54,7 +55,9 @@ const SendBox: React.FC<{
   slashCommands?: SlashCommandItem[];
   onSlashBuiltinCommand?: (name: string) => void;
   onSkillsChange?: (skills: string[]) => void;
-}> = ({ onSend, onStop, prefix, className, loading, tools, disabled, placeholder, value: input = '', onChange: setInput = constVoid, onFilesAdded, supportedExts = allSupportedExts, defaultMultiLine = false, lockMultiLine = false, sendButtonPrefix, slashCommands = [], onSlashBuiltinCommand, onSkillsChange }) => {
+  /** Workspace files for @ file references */
+  workspaceFiles?: WorkspaceFileItem[];
+}> = ({ onSend, onStop, prefix, className, loading, tools, disabled, placeholder, value: input = '', onChange: setInput = constVoid, onFilesAdded, supportedExts = allSupportedExts, defaultMultiLine = false, lockMultiLine = false, sendButtonPrefix, slashCommands = [], onSlashBuiltinCommand, onSkillsChange, workspaceFiles }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const { t } = useTranslation();
@@ -334,10 +337,17 @@ const SendBox: React.FC<{
       if (!selectedSkills.includes(skillName)) {
         setSelectedSkills([...selectedSkills, skillName]);
       }
-      setInput('');
+      // Strip the @query from input when selecting a skill
+      setInput(stripAtQuery(input));
     },
     onRemoveSkill: (skillName) => {
       setSelectedSkills(selectedSkills.filter((s) => s !== skillName));
+    },
+    workspaceFiles,
+    onSelectFile: (file) => {
+      // Replace @query with @relativePath in input
+      const newInput = replaceAtQuery(input, `@${file.relativePath}`);
+      setInput(newInput);
     },
   });
 
@@ -513,7 +523,7 @@ const SendBox: React.FC<{
             />
           </div>
         )}
-        {/* Skill Selector Menu */}
+        {/* Skill Selector Menu (with optional file tabs) */}
         {skillSelectorController.isOpen && (
           <div className='absolute left-12px right-12px bottom-[calc(100%+8px)] z-70'>
             <SkillSelectorMenu
@@ -532,6 +542,19 @@ const SendBox: React.FC<{
                 }
               }}
               emptyText={t('messages.skills.empty', { defaultValue: 'No skills found' })}
+              showTabs={skillSelectorController.showTabs}
+              activeTab={skillSelectorController.activeTab}
+              onTabChange={skillSelectorController.setActiveTab}
+              fileItems={skillSelectorController.filteredFiles}
+              onSelectFile={(file) => {
+                const fileIndex = skillSelectorController.filteredFiles.findIndex((f) => f.fullPath === file.fullPath);
+                if (fileIndex >= 0) {
+                  skillSelectorController.onSelectByIndex(fileIndex);
+                }
+              }}
+              skillsTabTitle={t('messages.skills.tabSkills', { defaultValue: 'Skills' })}
+              filesTabTitle={t('messages.skills.tabFiles', { defaultValue: 'Files' })}
+              filesEmptyText={t('messages.skills.filesEmpty', { defaultValue: 'No files in workspace' })}
             />
           </div>
         )}

--- a/src/renderer/hooks/useSkillSelectorController.ts
+++ b/src/renderer/hooks/useSkillSelectorController.ts
@@ -4,17 +4,54 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type { WorkspaceFileItem } from './useWorkspaceFiles';
 
-// Match @ followed by skill name (alphanumeric, underscore, hyphen, Chinese characters)
-// 匹配 @ 后跟技能名（允许字母数字、下划线、连字符、中文）
-const SKILL_QUERY_RE = /^@([a-zA-Z0-9_\u4e00-\u9fa5-]*)$/;
+// Match @ at start of input or after whitespace, followed by query text
+// Supports @ at any position in input (not just start)
+const AT_QUERY_RE = /(?:^|\s)@([^\s@]*)$/;
 
+/**
+ * Extract the @ query from input text.
+ * Returns the query string after @, or null if no @ trigger found.
+ */
 export function matchSkillQuery(input: string): string | null {
-  const match = input.match(SKILL_QUERY_RE);
+  const match = input.match(AT_QUERY_RE);
   return match ? match[1] : null;
 }
+
+/**
+ * Strip the @query portion from input text, keeping everything before @.
+ */
+export function stripAtQuery(input: string): string {
+  const match = input.match(/(?:^|\s)@[^\s@]*$/);
+  if (!match) return input;
+  const matchStart = match.index ?? 0;
+  // Keep everything before the @ (including the leading space if any)
+  const prefix = input.slice(0, matchStart);
+  // If the match started with a space, keep it
+  if (match[0].startsWith(' ') || match[0].startsWith('\t') || match[0].startsWith('\n')) {
+    return prefix + match[0][0];
+  }
+  return prefix;
+}
+
+/**
+ * Replace the @query portion in input text with a new value.
+ */
+export function replaceAtQuery(input: string, replacement: string): string {
+  const match = input.match(/(?:^|\s)@[^\s@]*$/);
+  if (!match) return input + replacement;
+  const matchStart = match.index ?? 0;
+  const prefix = input.slice(0, matchStart);
+  if (match[0].startsWith(' ') || match[0].startsWith('\t') || match[0].startsWith('\n')) {
+    return prefix + match[0][0] + replacement + ' ';
+  }
+  return prefix + replacement + ' ';
+}
+
+export type AtMentionTab = 'skills' | 'files';
 
 export interface SkillSelectorItem {
   name: string;
@@ -31,18 +68,31 @@ interface UseSkillSelectorControllerOptions {
   selectedSkills: string[];
   onSelectSkill: (skillName: string) => void;
   onRemoveSkill?: (skillName: string) => void;
+  /** Workspace files for @ file references */
+  workspaceFiles?: WorkspaceFileItem[];
+  /** Callback when a file is selected */
+  onSelectFile?: (file: WorkspaceFileItem) => void;
 }
 
 export function useSkillSelectorController(options: UseSkillSelectorControllerOptions) {
-  const { input, skills, selectedSkills, onSelectSkill, onRemoveSkill } = options;
+  const { input, skills, selectedSkills, onSelectSkill, onRemoveSkill, workspaceFiles = [], onSelectFile } = options;
   const query = useMemo(() => matchSkillQuery(input), [input]);
   const [activeIndex, setActiveIndex] = useState(0);
   const [dismissed, setDismissed] = useState(false);
+  const [activeTab, setActiveTab] = useState<AtMentionTab>('skills');
+  const prevQueryRef = useRef<string | null>(null);
 
-  // Reset state only when query changes
+  // Determine if tabs should be shown (always show when in conversation with workspace)
+  // Per user request: remove workspaceFiles.length > 0 condition
+  const showTabs = workspaceFiles !== undefined && workspaceFiles !== null;
+
+  // Reset state when query changes
   useEffect(() => {
-    setActiveIndex((prev) => (prev !== 0 ? 0 : prev));
-    setDismissed((prev) => (prev !== false ? false : prev));
+    if (query !== prevQueryRef.current) {
+      setActiveIndex(0);
+      setDismissed(false);
+      prevQueryRef.current = query;
+    }
   }, [query]);
 
   const filteredSkills = useMemo(() => {
@@ -64,20 +114,52 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
     });
   }, [skills, query]);
 
-  const isOpen = query !== null && !dismissed && filteredSkills.length > 0;
+  const filteredFiles = useMemo(() => {
+    if (query === null) {
+      return [];
+    }
+    const keyword = query.trim().toLowerCase();
+    if (!keyword) {
+      return workspaceFiles;
+    }
+    return workspaceFiles.filter((file) => {
+      const nameMatch = file.name.toLowerCase().includes(keyword);
+      const pathMatch = file.relativePath.toLowerCase().includes(keyword);
+      return nameMatch || pathMatch;
+    });
+  }, [workspaceFiles, query]);
+
+  // Get items for current tab
+  const currentTabItems = activeTab === 'skills' ? filteredSkills : filteredFiles;
+
+  // Menu is open when query is detected and not dismissed, and either tab has content or tabs are shown
+  const hasAnyContent = filteredSkills.length > 0 || filteredFiles.length > 0;
+  const isOpen = query !== null && !dismissed && (hasAnyContent || showTabs);
 
   const executeSkill = useCallback(
     (index: number) => {
-      const skill = filteredSkills[index];
-      if (!skill) {
-        return false;
+      if (activeTab === 'skills') {
+        const skill = filteredSkills[index];
+        if (!skill) return false;
+        onSelectSkill(skill.name);
+        setDismissed(true);
+        return true;
+      } else {
+        const file = filteredFiles[index];
+        if (!file) return false;
+        onSelectFile?.(file);
+        setDismissed(true);
+        return true;
       }
-      onSelectSkill(skill.name);
-      setDismissed(true);
-      return true;
     },
-    [filteredSkills, onSelectSkill]
+    [activeTab, filteredSkills, filteredFiles, onSelectSkill, onSelectFile]
   );
+
+  const switchTab = useCallback(() => {
+    if (!showTabs) return;
+    setActiveTab((prev) => (prev === 'skills' ? 'files' : 'skills'));
+    setActiveIndex(0);
+  }, [showTabs]);
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {
@@ -91,15 +173,22 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
         return true;
       }
 
+      // Tab key switches between tabs
+      if (event.key === 'Tab' && showTabs) {
+        event.preventDefault();
+        switchTab();
+        return true;
+      }
+
       if (event.key === 'ArrowDown') {
         event.preventDefault();
-        setActiveIndex((prev) => (prev + 1) % filteredSkills.length);
+        setActiveIndex((prev) => Math.min(prev + 1, currentTabItems.length - 1));
         return true;
       }
 
       if (event.key === 'ArrowUp') {
         event.preventDefault();
-        setActiveIndex((prev) => (prev - 1 + filteredSkills.length) % filteredSkills.length);
+        setActiveIndex((prev) => Math.max(prev - 1, 0));
         return true;
       }
 
@@ -118,13 +207,20 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
 
       return false;
     },
-    [activeIndex, executeSkill, filteredSkills.length, isOpen, query, selectedSkills, onRemoveSkill]
+    [activeIndex, executeSkill, currentTabItems.length, isOpen, query, selectedSkills, onRemoveSkill, showTabs, switchTab]
   );
 
   return {
     isOpen,
     activeIndex,
     filteredSkills,
+    filteredFiles,
+    activeTab,
+    showTabs,
+    setActiveTab: (tab: AtMentionTab) => {
+      setActiveTab(tab);
+      setActiveIndex(0);
+    },
     onKeyDown,
     onSelectByIndex: executeSkill,
     setDismissed,

--- a/src/renderer/hooks/useWorkspaceFiles.ts
+++ b/src/renderer/hooks/useWorkspaceFiles.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ipcBridge } from '@/common';
+import type { IDirOrFile } from '@/common/ipcBridge';
+import { useConversationContextSafe } from '@/renderer/context/ConversationContext';
+import { useAddEventListener } from '@/renderer/utils/emitter';
+
+/**
+ * Flattened workspace file item for @ mention selection
+ */
+export interface WorkspaceFileItem {
+  /** File name (e.g. "main.py") */
+  name: string;
+  /** Full absolute path */
+  fullPath: string;
+  /** Relative path from workspace root (e.g. "src/main.py") */
+  relativePath: string;
+  /** Whether this is a file (true) or directory (false) */
+  isFile: boolean;
+}
+
+/**
+ * Recursively flatten IDirOrFile tree into a flat list of file items
+ */
+function flattenFileTree(nodes: IDirOrFile[], result: WorkspaceFileItem[] = []): WorkspaceFileItem[] {
+  for (const node of nodes) {
+    if (node.isFile) {
+      result.push({
+        name: node.name,
+        fullPath: node.fullPath,
+        relativePath: node.relativePath,
+        isFile: true,
+      });
+    }
+    if (node.children && node.children.length > 0) {
+      flattenFileTree(node.children, result);
+    }
+  }
+  return result;
+}
+
+/**
+ * Hook to fetch workspace files for @ mention file references.
+ * Uses ipcBridge.fs.getFilesByDir (more reliable than conversation.getWorkspace).
+ * Listens for workspace refresh events to auto-update.
+ */
+export function useWorkspaceFiles(): WorkspaceFileItem[] {
+  const conversationContext = useConversationContextSafe();
+  const workspace = conversationContext?.workspace;
+  const conversationType = conversationContext?.type;
+  const [files, setFiles] = useState<WorkspaceFileItem[]>([]);
+  const loadingRef = useRef(false);
+
+  const loadFiles = useCallback(async () => {
+    if (!workspace || loadingRef.current) return;
+    loadingRef.current = true;
+    try {
+      const result = await ipcBridge.fs.getFilesByDir.invoke({ dir: workspace, root: workspace });
+      const flatList = result && result.length > 0 && result[0].children ? flattenFileTree(result[0].children) : [];
+      flatList.sort((a, b) => a.name.localeCompare(b.name));
+      setFiles(flatList);
+    } catch (error) {
+      console.error('[useWorkspaceFiles] Failed to load workspace files:', error);
+    } finally {
+      loadingRef.current = false;
+    }
+  }, [workspace]);
+
+  // Initial load
+  useEffect(() => {
+    void loadFiles();
+  }, [loadFiles]);
+
+  // Listen for workspace refresh events (when agent creates/modifies files)
+  useAddEventListener(
+    'acp.workspace.refresh',
+    () => {
+      if (conversationType === 'acp') {
+        void loadFiles();
+      }
+    },
+    [conversationType, loadFiles]
+  );
+
+  useAddEventListener(
+    'openclaw-gateway.workspace.refresh',
+    () => {
+      if (conversationType === 'openclaw-gateway') {
+        void loadFiles();
+      }
+    },
+    [conversationType, loadFiles]
+  );
+
+  return files;
+}

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -30,6 +30,7 @@ import AgentModeSelector from '@/renderer/components/AgentModeSelector';
 import AcpConfigSelector from '@/renderer/components/AcpConfigSelector';
 import { useSlashCommands } from '@/renderer/hooks/useSlashCommands';
 import { filterUserVisibleAtPath, filterUserVisibleFiles } from '@/renderer/utils/messageFiles';
+import { useWorkspaceFiles } from '@/renderer/hooks/useWorkspaceFiles';
 
 const useAcpSendBoxDraft = getSendBoxDraftHook('acp', {
   _type: 'acp',
@@ -410,6 +411,7 @@ const AcpSendBox: React.FC<{
 }> = ({ conversation_id, backend, sessionMode, agentName }) => {
   const { thought, running, acpStatus, aiProcessing, setAiProcessing, resetState, tokenUsage, contextLimit } = useAcpMessage(conversation_id);
   const { t } = useTranslation();
+  const workspaceFiles = useWorkspaceFiles();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slashCommands = useSlashCommands(conversation_id, { agentStatus: acpStatus });
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
@@ -781,6 +783,7 @@ const AcpSendBox: React.FC<{
           // For now, they're passed directly to onSend
         }}
         sendButtonPrefix={tokenUsage ? <ContextUsageIndicator tokenUsage={tokenUsage} contextLimit={contextLimit > 0 ? contextLimit : undefined} size={24} /> : undefined}
+        workspaceFiles={workspaceFiles}
       ></SendBox>
       <BdpanFileSelector
         visible={bdpanSelectorVisible}

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -31,6 +31,7 @@ import { useLatestRef } from '@/renderer/hooks/useLatestRef';
 import { useOpenFileSelector } from '@/renderer/hooks/useOpenFileSelector';
 import { useAutoTitle } from '@/renderer/hooks/useAutoTitle';
 import { useSlashCommands } from '@/renderer/hooks/useSlashCommands';
+import { useWorkspaceFiles } from '@/renderer/hooks/useWorkspaceFiles';
 import { AIProcessingContext } from './OpenClawChat';
 
 interface OpenClawDraftData {
@@ -100,6 +101,7 @@ const OpenClawSendBox: React.FC<{
   const aiProcessingContext = React.useContext(AIProcessingContext);
   const [workspacePath, setWorkspacePath] = useState('');
   const { t } = useTranslation();
+  const workspaceFiles = useWorkspaceFiles();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slashCommands = useSlashCommands(conversation_id);
   const addOrUpdateMessage = useAddOrUpdateMessage();
@@ -714,6 +716,7 @@ const OpenClawSendBox: React.FC<{
           // Store skills in ref or state if needed for session management
           // For now, they're passed directly to onSend
         }}
+        workspaceFiles={workspaceFiles}
       ></SendBox>
       <BdpanFileSelector
         visible={bdpanSelectorVisible}


### PR DESCRIPTION
## Summary

- Add tabbed @ mention dropdown with Skills and Files tabs
- Use ipcBridge.fs.getFilesByDir instead of conversation.getWorkspace for reliable file fetching
- Files tab always visible in conversation (removed length > 0 condition)
- Support @ at any position in input (not just start)
- Tab key or click switches between tabs
- Arrow key navigation clamps to boundaries
- Prevent focus loss with onMouseDown preventDefault
- GuidPage unaffected (no workspace at that stage)
- Backend AcpAtFileProcessor already resolves @filepath to file content

Closes #241

Generated with [Claude Code](https://claude.ai/code)