### PR TITLE
feat(skill): add sudowork channel config as credential fallback for chandao-api

### DIFF
--- a/skills/chandao-api/SKILL.md
+++ b/skills/chandao-api/SKILL.md
@@ -19,22 +19,13 @@ description: >
 
 调用禅道 API 需要三个参数：**实例地址**、**账号**和**密码**。
 
-### 凭证在哪里配置
+### 凭证配置
 
-脚本按以下顺序查找凭证：
+用户需要在远程连接的渠道配置中完成禅道的连接设置。技能会自动从中读取服务器地址、账号和密码。
 
-1. **环境变量**（优先）：`CHANDAO_BASE_URL`、`CHANDAO_ACCOUNT`、`CHANDAO_PASSWORD`
-2. **`.env` 文件**（回退）：`skills/chandao-api/.env`
+如果用户尚未配置，提示用户：请在远程连接的渠道配置中完成禅道的连接设置。
 
-**推荐方式：** 在技能目录下创建 `.env` 文件：
-
-```
-CHANDAO_BASE_URL=https://your-site.chandao.net
-CHANDAO_ACCOUNT=your_username
-CHANDAO_PASSWORD=your_password
-```
-
-**如果凭证缺失：** 脚本会报错并提示。此时应向用户索取禅道实例地址、用户名和密码。
+> 以下为内部实现细节，不要告知用户：脚本还会依次尝试环境变量（CHANDAO_BASE_URL/CHANDAO_ACCOUNT/CHANDAO_PASSWORD）和 .env 文件（skills/chandao-api/.env）作为回退。
 
 ### 检查凭证是否可用
 

--- a/skills/chandao-api/scripts/chandao.py
+++ b/skills/chandao-api/scripts/chandao.py
@@ -18,6 +18,7 @@ Token 管理（获取、自动续期）已全部封装，调用者只需关注�
 
 import json
 import os
+import sqlite3
 import sys
 import time
 import urllib.request
@@ -35,9 +36,11 @@ class Chandao:
             self._load_env()
 
         if not all([self.base_url, self.account, self.password]):
+            self._load_from_sudowork()
+
+        if not all([self.base_url, self.account, self.password]):
             raise ValueError(
-                "缺少凭证。请设置环境变量 CHANDAO_BASE_URL/CHANDAO_ACCOUNT/CHANDAO_PASSWORD，"
-                "或在 skills/chandao-api/.env 中配置。"
+                "缺少禅道凭证。请在远程连接的渠道配置中完成禅道的连接设置。"
             )
 
         self._api = f"{self.base_url}/api.php/v1"
@@ -63,6 +66,84 @@ class Chandao:
                         elif key == "CHANDAO_PASSWORD" and not self.password:
                             self.password = val
                 break
+
+    def _load_from_sudowork(self):
+        """从 SudoClaw 本地数据库和 Secret Store 加载凭证。
+
+        serverUrl 和 username 从 ~/.nexus/sudowork.db 的 assistant_plugins 表读取，
+        password 从 Nexus Secret Store API 读取。
+        """
+        try:
+            home = Path.home()
+            db_path = home / ".nexus" / "sudowork.db"
+            if db_path.exists():
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                cursor = conn.cursor()
+
+                # 先按 name 精确匹配禅道插件
+                cursor.execute(
+                    "SELECT config FROM assistant_plugins WHERE name LIKE '%zentao%' LIMIT 1"
+                )
+                row = cursor.fetchone()
+
+                # 未找到则遍历所有行查找包含 serverUrl 的 config
+                if not row:
+                    cursor.execute("SELECT config FROM assistant_plugins")
+                    for r in cursor.fetchall():
+                        config_str = r["config"]
+                        if isinstance(config_str, (str, bytes, bytearray)):
+                            if isinstance(config_str, (bytes, bytearray)):
+                                config_str = config_str.decode("utf-8")
+                            if "serverUrl" in config_str or "zentao" in config_str.lower():
+                                row = r
+                                break
+
+                if row:
+                    config_str = row["config"]
+                    if isinstance(config_str, (bytes, bytearray)):
+                        config_str = config_str.decode("utf-8")
+                    config = json.loads(config_str) if isinstance(config_str, str) else config_str
+                    if isinstance(config, dict):
+                        server_url = config.get("serverUrl", "")
+                        username = config.get("zentaoUsername", "")
+                        if not server_url or not username:
+                            credentials = config.get("credentials", {})
+                            if isinstance(credentials, dict):
+                                server_url = server_url or credentials.get("serverUrl", "")
+                                username = username or credentials.get("zentaoUsername", "")
+                        if not self.base_url and server_url:
+                            self.base_url = server_url.rstrip("/")
+                        if not self.account and username:
+                            self.account = username
+
+                conn.close()
+        except Exception:
+            pass
+
+        # password 从 Nexus Secret Store 读取
+        if not self.password:
+            try:
+                api_key = os.environ.get("NEXUS_API_KEY", "")
+                if not api_key:
+                    config_yaml = Path.home() / ".nexus" / "config.yaml"
+                    if config_yaml.exists():
+                        import yaml
+                        with open(config_yaml, "r", encoding="utf-8") as f:
+                            api_key = (yaml.safe_load(f) or {}).get("apiKey", "")
+
+                nexus_url = os.environ.get("NEXUS_URL", "http://localhost:12012")
+                secret_url = (
+                    f"{nexus_url}/api/v2/secrets/"
+                    f"channel:zentao:zentao_default/zentaoPassword"
+                )
+                headers = {"Authorization": f"Bearer {api_key}"}
+                req = urllib.request.Request(secret_url, headers=headers, method="GET")
+                with urllib.request.urlopen(req, timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.password = data.get("value", "")
+            except Exception:
+                pass
 
     @property
     def token(self):


### PR DESCRIPTION
## Summary
- 为 chandao-api skill 新增凭据获取回退机制：当环境变量和 `.env` 文件未配置时，自动从 SudoClaw 远程连接的渠道配置中读取禅道服务器地址、账号和密码
- SDK 依次尝试：环境变量 → `.env` 文件 → sudowork.db + Nexus Secret Store
- SKILL.md 凭证说明优化：面向用户只展示渠道配置方式，内部回退机制作为实现细节隔离

## Test plan
- [ ] 验证未配置任何凭据时，脚本提示"请在远程连接的渠道配置中完成禅道的连接设置"
- [ ] 验证在 SudoClaw 渠道配置中配置禅道后，脚本能自动读取凭据并成功调用 API
- [ ] 验证环境变量和 `.env` 文件的优先级高于渠道配置（向后兼容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)