### PR TITLE
feat(acp): add Nexus agent backend

### DIFF
--- a/.github/workflows/no-merge-commits.yml
+++ b/.github/workflows/no-merge-commits.yml
@@ -1,0 +1,55 @@
+name: No Merge Commits
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  check:
+    name: Block Merge Commits in PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject merge commits in PR branch
+        run: |
+          HEAD_REF="${{ github.head_ref }}"
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          BASE_REF=${{ github.event.pull_request.base.ref }}
+
+          # dev→main merges naturally contain merge commits from merged PRs.
+          if [ "$HEAD_REF" = "dev" ] && [ "$BASE_REF" = "main" ] && [ "$HEAD_REPO" = "${{ github.repository }}" ]; then
+            echo "✅ dev → main merge (same repo) — skipping merge commit check"
+            exit 0
+          fi
+
+          HEAD_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA=$(git merge-base "origin/${BASE_REF}" "$HEAD_SHA" 2>/dev/null || echo "")
+          if [ -z "$BASE_SHA" ]; then
+            echo "⚠️ Could not compute merge-base for origin/${BASE_REF}..${HEAD_SHA}, skipping"
+            exit 0
+          fi
+
+          echo "Checking commits between $BASE_SHA and $HEAD_SHA for merge commits..."
+
+          MERGE_COMMITS=$(git rev-list --merges "$BASE_SHA".."$HEAD_SHA" 2>/dev/null || true)
+
+          if [ -n "$MERGE_COMMITS" ]; then
+            echo ""
+            echo "❌ ERROR: PR branch contains merge commit(s)!"
+            echo ""
+            echo "Found merge commits:"
+            for mc in $MERGE_COMMITS; do
+              echo "  - $(git log --format='%h %s' -1 $mc)"
+            done
+            echo ""
+            echo "Fix: rebase your branch instead of merging:"
+            echo "  git rebase origin/dev"
+            echo ""
+            exit 1
+          fi
+
+          echo "✅ No merge commits found in PR branch"

--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -201,6 +201,8 @@ export class AcpConnection {
       case 'copilot':
       case 'qoder':
       case 'vibe':
+      case 'nexus':
+      case 'nanobot':
         if (!cliPath) {
           throw new Error(`CLI path is required for ${backend} backend`);
         }

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -63,6 +63,7 @@ export type AcpBackendAll =
   | 'openclaw-gateway' // OpenClaw Gateway WebSocket
   | 'vibe' // Mistral Vibe CLI
   | 'nanobot' // nanobot CLI (via ACP)
+  | 'nexus' // Nexus AI filesystem agent (via `nexus chat --acp`)
   | 'custom'; // User-configured custom ACP agent
 
 /**
@@ -454,6 +455,15 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     authRequired: false,
     enabled: false,
     supportsStreaming: false,
+  },
+  nexus: {
+    id: 'nexus',
+    name: 'Nexus',
+    cliCommand: 'nexus',
+    acpArgs: ['chat', '--acp'],
+    authRequired: false,
+    enabled: true,
+    supportsStreaming: true,
   },
   custom: {
     id: 'custom',


### PR DESCRIPTION
## Summary

Register Nexus as an ACP-compatible agent in sudowork, alongside Claude Code, Codex, Goose, etc.

## Changes

- Add `'nexus'` to `AcpBackendAll` type union
- Add nexus config to `ACP_BACKENDS_ALL`:
  - CLI command: `nexus`
  - ACP args: `['chat', '--acp']`
  - Auto-detected via `which nexus`
  - Streaming: enabled

## How it works

Sudowork spawns `nexus chat --acp` as a child process. Nexus communicates via JSON-RPC 2.0 over stdio — same protocol as all other ACP agents.

Nexus side: [nexi-lab/nexus#3724](https://github.com/nexi-lab/nexus/pull/3724) implements the ACP protocol handler.

## Test plan

- [ ] Install nexus CLI (`pip install nexus-ai-fs`)
- [ ] Set `NEXUS_LLM_BASE_URL` + `NEXUS_LLM_API_KEY`
- [ ] Open sudowork → New Conversation → select "Nexus" from dropdown
- [ ] Send a prompt → verify streaming response + tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)