### PR TITLE
fix: workspace file tree spinner stuck on conversation open

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -691,10 +691,13 @@ export function initConversationBridge(): void {
         },
       }).then((res) => (res ? [res] : []));
     } catch (error) {
-      if (error instanceof Error && error.message.includes('aborted')) {
-        return [];
+      // Always return [] on error — throwing from a bridge provider
+      // leaves the renderer invoke() promise hanging forever because
+      // the bridge subscribe handler has no .catch() on the provider call.
+      if (error instanceof Error && !error.message.includes('aborted')) {
+        mainWarn('conversationBridge', 'getWorkspace failed:', error.message);
       }
-      throw error;
+      return [];
     }
   });
 

--- a/src/process/utils.ts
+++ b/src/process/utils.ts
@@ -155,7 +155,14 @@ export async function readDirectoryRecursive(
     const itemPath = path.join(dirPath, item);
     if (fileService && fileService.shouldIgnoreFile(itemPath)) continue;
 
-    const itemStats = await fs.stat(itemPath);
+    let itemStats: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      itemStats = await fs.stat(itemPath);
+    } catch {
+      // Item may have been deleted/recreated concurrently (e.g. skill symlink sync).
+      // Skip it rather than aborting the entire directory read.
+      continue;
+    }
     if (itemStats.isDirectory()) {
       process.dir += 1;
       const child = await readDirectoryRecursive(itemPath, {

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
@@ -157,7 +157,11 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix }: Us
           return res;
         })
         .finally(() => {
-          setLoadingHandler(false);
+          // Only clear loading for the latest request — stale/aborted requests
+          // must not prematurely cancel the spinner while a newer request is in flight.
+          if (seq === loadSeqRef.current) {
+            setLoadingHandler(false);
+          }
         });
     },
     [conversation_id, workspace, setLoadingHandler]


### PR DESCRIPTION
## Summary

Opening a conversation caused the workspace file browser (right sidebar) to spin indefinitely, never showing files. Manual refresh worked.

**Root cause**: `readDirectoryRecursive` races with `syncWorkspaceSkills` — the skill sync deletes/recreates symlinks while the directory tree is being scanned. `fs.stat()` on a vanished symlink throws ENOENT, which propagates to the `getWorkspace` IPC handler. That handler re-throws non-abort errors, but the IPC bridge's `subscribe` handler has no `.catch()` on the provider call — so the renderer's `invoke()` promise **hangs forever**, leaving `loading: true` and `files: []`.

The bug became consistently reproducible after PR #269 expanded `shouldSyncWorkspaceSkills` to more conversation types, making the concurrent race much more frequent.

**Fixes** (3 files, minimal changes):

- **`src/process/utils.ts`** — Wrap `fs.stat()` on child items in try/catch; skip vanished items instead of aborting the entire directory read
- **`src/process/bridge/conversationBridge.ts`** — Never re-throw from the `getWorkspace` provider (return `[]` + log warning), preventing the invoke promise from hanging
- **`src/renderer/.../useWorkspaceTree.ts`** — Guard `.finally()` with `loadSeqRef` check so stale/aborted requests don't prematurely clear the loading spinner

## Test plan

- [ ] Open a conversation with a workspace — files should load without stuck spinner
- [ ] Switch rapidly between conversations — no stuck spinner, files load each time
- [ ] Manual refresh button still works
- [ ] Agent tool calls still trigger workspace refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)