### PR TITLE
fix(nexus): remove auth guard that prevents secret storage with local Nexus

### DIFF
--- a/src/common/nexus/secret-migration.ts
+++ b/src/common/nexus/secret-migration.ts
@@ -501,24 +501,8 @@ export function getMigrationCoordinator(): SecretMigrationCoordinator {
  * This should be called after Nexus is healthy.
  */
 export async function initializeSecrets(): Promise<void> {
-  const config = resolveConfig();
-
-  const hasIdentityHeaders = !!(config.subject || config.agentId || config.zoneId);
-  const hasApiKey = !!config.apiKey;
-
-  // Skip if neither apiKey nor identity headers are configured
-  if (!hasApiKey && !hasIdentityHeaders) {
-    console.warn('[SecretMigration] No Nexus credentials found (apiKey or identity headers). Skipping secret migration.');
-    return;
-  }
-
   const coordinator = getMigrationCoordinator();
-  coordinator.initialize({
-    apiKey: config.apiKey,
-    subject: config.subject,
-    agentId: config.agentId,
-    zoneId: config.zoneId,
-  });
+  coordinator.initialize();
 
   // Run migration if needed
   const migrationResult = await coordinator.migrateAll();


### PR DESCRIPTION
## Summary
- 修复 `initializeSecrets()` 中的认证守卫在本地 Nexus (`--auth-type=none`) 场景下跳过整个 secret 初始化的问题
- 移除后 secretCache 能正确初始化，channel 凭证可以正常存储到 Nexus 并在重启后持久化

## Root Cause
`secret-migration.ts` 的 `initializeSecrets()` 在检测不到 API key 或 identity headers 时直接返回，但 sudowork 本地启动 Nexus 使用 `--auth-type=none`，不会配置任何认证信息。这导致 `secretCache.client` 始终为 `null`，所有凭证写入 Nexus 被静默跳过，应用重启后凭证丢失。

## Test plan
- [ ] 启动 sudowork，配置 channel（如 Telegram）并填入 token
- [ ] 确认保存成功
- [ ] 重启 sudowork，确认 channel 凭证仍然存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)