### PR TITLE
feat: [#283] 导入自定义 Skill 后增加安全审计功能

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1120,6 +1120,10 @@ export const skillHub = {
   setSkillEnabled: bridge.buildProvider<IBridgeResponse<void>, { skillName: string; enabled: boolean }>('skill-hub.set-skill-enabled'),
   /** Uninstall a hub-installed skill by directory name (builtin skills are rejected) */
   uninstallSkill: bridge.buildProvider<IBridgeResponse<void>, { skillName: string }>('skill-hub.uninstall-skill'),
+  /** Get security audit report for a skill */
+  getSkillAuditReport: bridge.buildProvider<IBridgeResponse<import('@/common/skillAuditTypes').SkillAuditReport>, { skillName: string }>('skill-hub.get-skill-audit-report'),
+  /** Run security audit for a skill (re-scan) */
+  runSkillAudit: bridge.buildProvider<IBridgeResponse<import('@/common/skillAuditTypes').SkillAuditReport>, { skillName: string }>('skill-hub.run-skill-audit'),
 };
 
 // ==================== Channel API ====================

--- a/src/common/skillAuditTypes.ts
+++ b/src/common/skillAuditTypes.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Skill Security Audit Types
+ *
+ * Types for the skill security audit feature that analyzes what operations
+ * a custom skill performs (network calls, file access, command execution, etc.)
+ */
+
+/** Audit operation categories */
+export type AuditCategory = 'external_api' | 'network' | 'sensitive_data' | 'filesystem' | 'executable';
+
+/** Supported languages for audit scanning */
+export type AuditLanguage = 'javascript' | 'typescript' | 'python' | 'shell';
+
+/** Single audit finding — a specific operation detected in code */
+export interface AuditFinding {
+  /** Unique identifier */
+  id: string;
+  /** Operation category */
+  category: AuditCategory;
+  /** Source file (relative path) */
+  file: string;
+  /** Line number (1-based) */
+  line: number;
+  /** Column number (0-based, optional) */
+  column?: number;
+  /** Matched code snippet */
+  code: string;
+  /** Rule pattern name */
+  pattern: string;
+  /** Human-readable description */
+  description: string;
+  /** Detected language */
+  language: AuditLanguage;
+  /** Extra info: e.g. detected URL for network calls, file path for fs ops */
+  detail?: string;
+}
+
+/** Category summary — how many findings per category */
+export interface AuditCategorySummary {
+  /** Operation category */
+  category: AuditCategory;
+  /** Human-readable label */
+  label: string;
+  /** Number of findings in this category */
+  count: number;
+  /** Whether any findings exist in this category */
+  found: boolean;
+  /** Short description when no findings */
+  safeDescription: string;
+  /** Short description when findings exist */
+  foundDescription: string;
+}
+
+/** Complete audit report for a skill */
+export interface SkillAuditReport {
+  /** Skill name */
+  skillName: string;
+  /** Audit timestamp (ISO 8601) */
+  auditTime: string;
+  /** Total number of files in the skill directory */
+  totalFiles: number;
+  /** Number of files actually scanned (code files only) */
+  scannedFiles: number;
+  /** All findings */
+  findings: AuditFinding[];
+  /** Summary per category */
+  categorySummaries: AuditCategorySummary[];
+  /** Whether any findings were detected */
+  hasFindings: boolean;
+  /** Pre-rendered Markdown report */
+  markdownReport: string;
+  /** Path to the saved Markdown report file */
+  reportPath?: string;
+}
+
+/** Audit category display configuration */
+export const AUDIT_CATEGORY_CONFIG: Record<AuditCategory, { label: string; labelEn: string; safeDescription: string; safeDescriptionEn: string; foundDescription: string; foundDescriptionEn: string }> = {
+  external_api: {
+    label: '外部API调用',
+    labelEn: 'External API Calls',
+    safeDescription: '纯本地处理',
+    safeDescriptionEn: 'Pure local processing',
+    foundDescription: '检测到外部API调用',
+    foundDescriptionEn: 'External API calls detected',
+  },
+  network: {
+    label: '网络连接需求',
+    labelEn: 'Network Connections',
+    safeDescription: '不连接外部服务',
+    safeDescriptionEn: 'No external service connections',
+    foundDescription: '存在网络连接操作',
+    foundDescriptionEn: 'Network connection operations detected',
+  },
+  sensitive_data: {
+    label: '敏感数据收集',
+    labelEn: 'Sensitive Data Collection',
+    safeDescription: '仅处理用户提供的文档',
+    safeDescriptionEn: 'Only processes user-provided documents',
+    foundDescription: '检测到敏感数据访问',
+    foundDescriptionEn: 'Sensitive data access detected',
+  },
+  filesystem: {
+    label: '系统文件访问',
+    labelEn: 'System File Access',
+    safeDescription: '工作范围受限',
+    safeDescriptionEn: 'Limited working scope',
+    foundDescription: '存在文件系统操作',
+    foundDescriptionEn: 'File system operations detected',
+  },
+  executable: {
+    label: '可执行脚本',
+    labelEn: 'Executable Scripts',
+    safeDescription: '所有文件为纯文档',
+    safeDescriptionEn: 'All files are plain documents',
+    foundDescription: '检测到命令执行操作',
+    foundDescriptionEn: 'Command execution operations detected',
+  },
+};

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -21,6 +21,7 @@ import { toAssetUrl } from '@/extensions/assetProtocol';
 import { AcpSkillManager } from '@/process/task/AcpSkillManager';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { buildSkillDisplayName, canonicalizeSkillMarkdownPath, findRootSkillMarkdownFileName, isSkillMarkdownFileName, parseSkillFrontmatter, resolveSkillIconFromFiles } from '@/process/utils/skillPackage';
+import { scanSkillDirectory, readAuditReport } from '@/process/services/safety/SkillAuditScanner';
 
 const SKILL_HUB_BASE_URL = 'https://sudoclawhub.sudoprivacy.com/api/skills';
 const SKILL_HUB_CURSOR_URL = 'https://sudoclawhub.sudoprivacy.com/api/skills/cursor';
@@ -478,6 +479,15 @@ async function installImportedSkillFromPreparedDirectory(
   };
   await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
 
+  // Run security audit asynchronously (non-blocking)
+  void (async () => {
+    try {
+      await scanSkillDirectory(customDir, skillName);
+    } catch (err) {
+      mainWarn('SkillHub', 'Security audit after import failed:', err);
+    }
+  })();
+
   void (async () => {
     try {
       await reloadSkillRuntime();
@@ -858,6 +868,47 @@ export function initSkillHubBridge(): void {
       return result;
     } catch (error) {
       mainError('SkillHub', 'Failed to update skill enabled state:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  // Get security audit report for an installed skill
+  ipcBridge.skillHub.getSkillAuditReport.provider(async ({ skillName }) => {
+    try {
+      const userSkillsDir = getUserSkillsDir();
+      const skillDir = await resolveInstalledSkillDirAllSubdirs(userSkillsDir, skillName);
+      if (!skillDir) {
+        return { success: false, msg: `Skill "${skillName}" not found` };
+      }
+
+      // Try reading existing report first
+      const existingReport = await readAuditReport(skillDir);
+      if (existingReport) {
+        return { success: true, data: existingReport };
+      }
+
+      // No existing report, run audit now
+      const report = await scanSkillDirectory(skillDir, skillName);
+      return { success: true, data: report };
+    } catch (error) {
+      mainError('SkillHub', 'Failed to get audit report:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  // Run (or re-run) security audit for an installed skill
+  ipcBridge.skillHub.runSkillAudit.provider(async ({ skillName }) => {
+    try {
+      const userSkillsDir = getUserSkillsDir();
+      const skillDir = await resolveInstalledSkillDirAllSubdirs(userSkillsDir, skillName);
+      if (!skillDir) {
+        return { success: false, msg: `Skill "${skillName}" not found` };
+      }
+
+      const report = await scanSkillDirectory(skillDir, skillName);
+      return { success: true, data: report };
+    } catch (error) {
+      mainError('SkillHub', 'Failed to run audit:', error);
       return { success: false, msg: error instanceof Error ? error.message : String(error) };
     }
   });

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -479,14 +479,12 @@ async function installImportedSkillFromPreparedDirectory(
   };
   await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
 
-  // Run security audit asynchronously (non-blocking)
-  void (async () => {
-    try {
-      await scanSkillDirectory(customDir, skillName);
-    } catch (err) {
-      mainWarn('SkillHub', 'Security audit after import failed:', err);
-    }
-  })();
+  // Run security audit synchronously so the report is ready when the frontend opens the audit modal
+  try {
+    await scanSkillDirectory(customDir, skillName);
+  } catch (err) {
+    mainWarn('SkillHub', 'Security audit after import failed:', err);
+  }
 
   void (async () => {
     try {

--- a/src/process/services/safety/SkillAuditScanner.ts
+++ b/src/process/services/safety/SkillAuditScanner.ts
@@ -1,0 +1,382 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Skill Audit Scanner
+ *
+ * Scans a skill directory to detect what operations the skill performs:
+ * - External API calls (HTTP requests, REST endpoints)
+ * - Network connections (sockets, WebSockets, SSH)
+ * - Sensitive data collection (env vars, passwords, tokens)
+ * - File system access (read/write/delete files)
+ * - Executable scripts (command execution, eval, subprocess)
+ *
+ * Results are presented as operation counts per category, not risk levels.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import type { AuditCategory, AuditCategorySummary, AuditFinding, AuditLanguage, SkillAuditReport } from '@/common/skillAuditTypes';
+import { AUDIT_CATEGORY_CONFIG } from '@/common/skillAuditTypes';
+import { getRulesForLanguage } from './auditRules';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+
+/** Directories to skip during scanning */
+const EXCLUDED_DIRS = new Set(['node_modules', '.git', '.vscode', '__pycache__', '.env', 'venv', '.venv', '.idea', 'dist', 'build', '.next', '.cache']);
+
+/** Files to skip during scanning */
+const EXCLUDED_FILES = new Set(['_sudowork_meta.json', '_sudowork_audit.json', '_sudowork_audit.md', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml']);
+
+/** File extension to language mapping */
+const EXTENSION_LANGUAGE_MAP: Record<string, AuditLanguage> = {
+  '.js': 'javascript',
+  '.mjs': 'javascript',
+  '.cjs': 'javascript',
+  '.jsx': 'javascript',
+  '.ts': 'typescript',
+  '.tsx': 'typescript',
+  '.mts': 'typescript',
+  '.cts': 'typescript',
+  '.py': 'python',
+  '.pyw': 'python',
+  '.sh': 'shell',
+  '.bash': 'shell',
+  '.zsh': 'shell',
+  '.fish': 'shell',
+};
+
+/** Maximum file size to scan (1MB) */
+const MAX_FILE_SIZE = 1024 * 1024;
+
+let findingIdCounter = 0;
+
+function generateFindingId(): string {
+  findingIdCounter += 1;
+  return `finding-${Date.now()}-${findingIdCounter}`;
+}
+
+/**
+ * Check if a line is a comment in the given language.
+ * Simple heuristic — does not handle multi-line comments fully.
+ */
+function isCommentLine(line: string, language: AuditLanguage): boolean {
+  const trimmed = line.trim();
+  switch (language) {
+    case 'python':
+      return trimmed.startsWith('#');
+    case 'shell':
+      return trimmed.startsWith('#');
+    case 'javascript':
+    case 'typescript':
+      return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+    default:
+      return false;
+  }
+}
+
+/**
+ * Detect language from file extension
+ */
+function detectLanguage(filePath: string): AuditLanguage | null {
+  const ext = path.extname(filePath).toLowerCase();
+  return EXTENSION_LANGUAGE_MAP[ext] || null;
+}
+
+/**
+ * Recursively collect files from a directory, excluding certain directories and files.
+ */
+async function collectFiles(dir: string, baseDir: string): Promise<{ absolutePath: string; relativePath: string }[]> {
+  const results: { absolutePath: string; relativePath: string }[] = [];
+
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const absolutePath = path.join(dir, entry.name);
+      const relativePath = path.relative(baseDir, absolutePath);
+
+      if (entry.isDirectory()) {
+        if (EXCLUDED_DIRS.has(entry.name) || entry.name.startsWith('.')) {
+          continue;
+        }
+        const subResults = await collectFiles(absolutePath, baseDir);
+        results.push(...subResults);
+      } else if (entry.isFile()) {
+        if (EXCLUDED_FILES.has(entry.name)) {
+          continue;
+        }
+        results.push({ absolutePath, relativePath });
+      }
+    }
+  } catch (err) {
+    mainWarn('SkillAudit', `Failed to read directory: ${dir}`, err);
+  }
+
+  return results;
+}
+
+/**
+ * Scan a single file for pattern matches.
+ */
+async function scanFile(filePath: string, relativePath: string, language: AuditLanguage): Promise<AuditFinding[]> {
+  const findings: AuditFinding[] = [];
+
+  try {
+    const stat = await fs.stat(filePath);
+    if (stat.size > MAX_FILE_SIZE) {
+      mainWarn('SkillAudit', `Skipping large file: ${relativePath} (${stat.size} bytes)`);
+      return findings;
+    }
+
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.split('\n');
+    const rules = getRulesForLanguage(language);
+
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const line = lines[lineIndex];
+
+      // Skip empty lines
+      if (!line.trim()) continue;
+
+      // Skip comment lines (simple heuristic)
+      if (isCommentLine(line, language)) continue;
+
+      for (const rule of rules) {
+        const match = rule.pattern.exec(line);
+        if (match) {
+          findings.push({
+            id: generateFindingId(),
+            category: rule.category,
+            file: relativePath,
+            line: lineIndex + 1,
+            column: match.index,
+            code: line.trim(),
+            pattern: rule.id,
+            description: rule.description,
+            language,
+            detail: extractDetail(line, rule.category),
+          });
+        }
+      }
+    }
+  } catch (err) {
+    mainWarn('SkillAudit', `Failed to scan file: ${relativePath}`, err);
+  }
+
+  return findings;
+}
+
+/**
+ * Try to extract a URL or path from a code line, based on the category.
+ */
+function extractDetail(line: string, category: AuditCategory): string | undefined {
+  if (category === 'external_api' || category === 'network') {
+    // Try to extract URL
+    const urlMatch = line.match(/['"`](https?:\/\/[^'"`\s]+)['"`]/);
+    if (urlMatch) {
+      return urlMatch[1];
+    }
+    // Try to extract domain/IP
+    const domainMatch = line.match(/['"`]([a-zA-Z0-9][-a-zA-Z0-9]*(?:\.[a-zA-Z0-9][-a-zA-Z0-9]*)+(?::\d+)?)['"`]/);
+    if (domainMatch) {
+      return domainMatch[1];
+    }
+  }
+
+  if (category === 'filesystem') {
+    // Try to extract file path
+    const pathMatch = line.match(/['"`]((?:\/|\.\/|\.\.\/|~\/)[^'"`\s]+)['"`]/);
+    if (pathMatch) {
+      return pathMatch[1];
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Build category summaries from findings.
+ */
+function buildCategorySummaries(findings: AuditFinding[]): AuditCategorySummary[] {
+  const categories: AuditCategory[] = ['external_api', 'network', 'sensitive_data', 'filesystem', 'executable'];
+
+  return categories.map((category) => {
+    const config = AUDIT_CATEGORY_CONFIG[category];
+    const categoryFindings = findings.filter((f) => f.category === category);
+    return {
+      category,
+      label: config.label,
+      count: categoryFindings.length,
+      found: categoryFindings.length > 0,
+      safeDescription: config.safeDescription,
+      foundDescription: config.foundDescription,
+    };
+  });
+}
+
+/**
+ * Generate a Markdown audit report.
+ */
+function generateMarkdownReport(report: Omit<SkillAuditReport, 'markdownReport' | 'reportPath'>): string {
+  const lines: string[] = [];
+
+  lines.push('# 安全审计报告');
+  lines.push('');
+  lines.push('## 基本信息');
+  lines.push(`- **Skill**: ${report.skillName}`);
+  lines.push(`- **审计时间**: ${report.auditTime}`);
+  lines.push(`- **扫描文件数**: ${report.scannedFiles}/${report.totalFiles}`);
+  lines.push('');
+
+  // Category summary
+  lines.push('## 审计总览');
+  lines.push('');
+  lines.push('| 检测维度 | 状态 | 详情 |');
+  lines.push('|----------|------|------|');
+
+  for (const summary of report.categorySummaries) {
+    const status = summary.found ? `\u26A0\uFE0F 检测到 ${summary.count} 处` : '\u2705 未检测到';
+    const description = summary.found ? summary.foundDescription : summary.safeDescription;
+    lines.push(`| ${summary.label} | ${status} | ${description} |`);
+  }
+
+  lines.push('');
+
+  // Detailed findings grouped by category
+  if (report.hasFindings) {
+    lines.push('## 详细发现');
+    lines.push('');
+
+    const categories: AuditCategory[] = ['external_api', 'network', 'sensitive_data', 'filesystem', 'executable'];
+    for (const category of categories) {
+      const categoryFindings = report.findings.filter((f) => f.category === category);
+      if (categoryFindings.length === 0) continue;
+
+      const config = AUDIT_CATEGORY_CONFIG[category];
+      lines.push(`### ${config.label} (${categoryFindings.length} 处)`);
+      lines.push('');
+
+      for (const finding of categoryFindings) {
+        lines.push(`- **${finding.file}:${finding.line}**`);
+        lines.push(`  - \`${finding.code}\``);
+        lines.push(`  - ${finding.description}`);
+        if (finding.detail) {
+          lines.push(`  - 目标: \`${finding.detail}\``);
+        }
+        lines.push('');
+      }
+    }
+  } else {
+    lines.push('## 结论');
+    lines.push('');
+    lines.push('经过审计，该技能未检测到外部API调用、网络连接、敏感数据收集、系统文件操作或命令执行等操作。');
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('> 由 Sudowork 安全审计引擎自动生成');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Deduplicate findings: same file + same line + same rule → keep only one.
+ */
+function deduplicateFindings(findings: AuditFinding[]): AuditFinding[] {
+  const seen = new Set<string>();
+  return findings.filter((f) => {
+    const key = `${f.file}:${f.line}:${f.pattern}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Scan a skill directory and produce an audit report.
+ *
+ * @param skillDir  Absolute path to the skill installation directory
+ * @param skillName Skill name for the report
+ * @returns Complete audit report with findings, summaries, and Markdown
+ */
+export async function scanSkillDirectory(skillDir: string, skillName: string): Promise<SkillAuditReport> {
+  mainLog('SkillAudit', `Starting audit for skill "${skillName}" at ${skillDir}`);
+
+  // Collect all files
+  const allFiles = await collectFiles(skillDir, skillDir);
+  const totalFiles = allFiles.length;
+
+  // Filter to scannable files (known extensions)
+  const scannableFiles = allFiles.filter((f) => detectLanguage(f.absolutePath) !== null);
+  const scannedFiles = scannableFiles.length;
+
+  // Scan each file
+  let allFindings: AuditFinding[] = [];
+  for (const file of scannableFiles) {
+    const language = detectLanguage(file.absolutePath)!;
+    const fileFindings = await scanFile(file.absolutePath, file.relativePath, language);
+    allFindings.push(...fileFindings);
+  }
+
+  // Deduplicate
+  allFindings = deduplicateFindings(allFindings);
+
+  // Build summaries
+  const categorySummaries = buildCategorySummaries(allFindings);
+  const hasFindings = allFindings.length > 0;
+
+  // Generate Markdown
+  const partialReport = {
+    skillName,
+    auditTime: new Date().toISOString(),
+    totalFiles,
+    scannedFiles,
+    findings: allFindings,
+    categorySummaries,
+    hasFindings,
+  };
+
+  const markdownReport = generateMarkdownReport(partialReport);
+
+  // Save audit results
+  const auditJsonPath = path.join(skillDir, '_sudowork_audit.json');
+  const auditMdPath = path.join(skillDir, '_sudowork_audit.md');
+
+  const report: SkillAuditReport = {
+    ...partialReport,
+    markdownReport,
+    reportPath: auditMdPath,
+  };
+
+  try {
+    await fs.writeFile(auditJsonPath, JSON.stringify(report, null, 2), 'utf-8');
+    await fs.writeFile(auditMdPath, markdownReport, 'utf-8');
+    mainLog('SkillAudit', `Audit report saved to ${auditMdPath}`);
+  } catch (err) {
+    mainWarn('SkillAudit', 'Failed to save audit report:', err);
+  }
+
+  mainLog('SkillAudit', `Audit complete: ${allFindings.length} findings across ${scannedFiles} files`);
+
+  return report;
+}
+
+/**
+ * Read a previously saved audit report from a skill directory.
+ *
+ * @param skillDir Absolute path to the skill directory
+ * @returns The saved audit report, or null if not found
+ */
+export async function readAuditReport(skillDir: string): Promise<SkillAuditReport | null> {
+  try {
+    const auditJsonPath = path.join(skillDir, '_sudowork_audit.json');
+    const raw = await fs.readFile(auditJsonPath, 'utf-8');
+    return JSON.parse(raw) as SkillAuditReport;
+  } catch {
+    return null;
+  }
+}

--- a/src/process/services/safety/SkillAuditScanner.ts
+++ b/src/process/services/safety/SkillAuditScanner.ts
@@ -59,6 +59,22 @@ function generateFindingId(): string {
 }
 
 /**
+ * Check if a line is primarily an output/print/log statement.
+ * Matches inside such lines are almost always false positives
+ * (e.g. `echo "使用 curl 下载"` is not a real curl invocation).
+ */
+function isOutputStatement(line: string, language: AuditLanguage): boolean {
+  const trimmed = line.trim();
+  if (language === 'shell') {
+    return /^(echo|printf|log_\w+|print)\s/.test(trimmed);
+  }
+  if (language === 'python') {
+    return /^(print|logging\.\w+|logger\.\w+)\s*\(/.test(trimmed);
+  }
+  return false;
+}
+
+/**
  * Check if a line is a comment in the given language.
  * Simple heuristic — does not handle multi-line comments fully.
  */
@@ -143,6 +159,9 @@ async function scanFile(filePath: string, relativePath: string, language: AuditL
 
       // Skip comment lines (simple heuristic)
       if (isCommentLine(line, language)) continue;
+
+      // Skip output/print/log statements (high false-positive source)
+      if (isOutputStatement(line, language)) continue;
 
       for (const rule of rules) {
         const match = rule.pattern.exec(line);

--- a/src/process/services/safety/auditRules.ts
+++ b/src/process/services/safety/auditRules.ts
@@ -196,14 +196,14 @@ export const SHELL_RULES: AuditRule[] = [
     id: 'sh-api-curl',
     language: 'shell',
     category: 'external_api',
-    pattern: /\bcurl\s+/,
+    pattern: /\bcurl\s+(-[a-zA-Z]|--[a-zA-Z]|['"`]?https?:\/\/|\$[{(a-zA-Z_])/,
     description: 'curl HTTP 请求',
   },
   {
     id: 'sh-api-wget',
     language: 'shell',
     category: 'external_api',
-    pattern: /\bwget\s+/,
+    pattern: /\bwget\s+(-[a-zA-Z]|--[a-zA-Z]|['"`]?https?:\/\/|\$[{(a-zA-Z_])/,
     description: 'wget 下载请求',
   },
   {
@@ -316,8 +316,15 @@ export const SHELL_RULES: AuditRule[] = [
     id: 'sh-exec-source',
     language: 'shell',
     category: 'executable',
-    pattern: /\b(source|\.)\s+[^\s]+/,
+    pattern: /\bsource\s+[^\s]+/,
     description: 'source 脚本执行',
+  },
+  {
+    id: 'sh-exec-dot-source',
+    language: 'shell',
+    category: 'executable',
+    pattern: /(?:^|[;&|]\s*)\.\s+(\/[^\s;|&]+|\.\.?\/[^\s;|&]+|~\/[^\s;|&]+|\$[^\s;|&]+)/,
+    description: '. (dot) 脚本执行',
   },
   {
     id: 'sh-exec-install',

--- a/src/process/services/safety/auditRules.ts
+++ b/src/process/services/safety/auditRules.ts
@@ -1,0 +1,531 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Skill Audit Detection Rules
+ *
+ * Pattern-based rules for detecting operations performed by custom skills.
+ * Each rule maps a regex pattern to an audit category (network, filesystem, etc.)
+ */
+
+import type { AuditCategory, AuditLanguage } from '@/common/skillAuditTypes';
+
+/** A single audit detection rule */
+export interface AuditRule {
+  /** Unique rule identifier */
+  id: string;
+  /** Target language */
+  language: AuditLanguage;
+  /** Audit category */
+  category: AuditCategory;
+  /** Regex pattern to match */
+  pattern: RegExp;
+  /** Human-readable description */
+  description: string;
+}
+
+// ==================== Python Rules ====================
+
+export const PYTHON_RULES: AuditRule[] = [
+  // External API calls
+  {
+    id: 'py-api-requests',
+    language: 'python',
+    category: 'external_api',
+    pattern: /\brequests\.(get|post|put|delete|patch|head|options|request)\s*\(/,
+    description: 'requests HTTP 库调用',
+  },
+  {
+    id: 'py-api-httpx',
+    language: 'python',
+    category: 'external_api',
+    pattern: /\bhttpx\.(get|post|put|delete|patch|head|options|request|AsyncClient|Client)\s*\(/,
+    description: 'httpx HTTP 库调用',
+  },
+  {
+    id: 'py-api-aiohttp',
+    language: 'python',
+    category: 'external_api',
+    pattern: /\baiohttp\.(ClientSession|request)\b/,
+    description: 'aiohttp HTTP 库调用',
+  },
+  {
+    id: 'py-api-urllib',
+    language: 'python',
+    category: 'external_api',
+    pattern: /\burllib\.(request\.urlopen|request\.Request|parse\.urlencode)\b/,
+    description: 'urllib 库调用',
+  },
+
+  // Network connections
+  {
+    id: 'py-net-socket',
+    language: 'python',
+    category: 'network',
+    pattern: /\bsocket\.(socket|create_connection|connect)\b/,
+    description: 'socket 网络连接',
+  },
+  {
+    id: 'py-net-import-socket',
+    language: 'python',
+    category: 'network',
+    pattern: /^\s*import\s+socket\b/,
+    description: '导入 socket 模块',
+  },
+  {
+    id: 'py-net-import-requests',
+    language: 'python',
+    category: 'network',
+    pattern: /^\s*import\s+(requests|httpx|aiohttp)\b/,
+    description: '导入网络请求库',
+  },
+  {
+    id: 'py-net-from-import',
+    language: 'python',
+    category: 'network',
+    pattern: /^\s*from\s+(requests|httpx|aiohttp|urllib)\s+import\b/,
+    description: '导入网络请求库组件',
+  },
+
+  // Sensitive data collection
+  {
+    id: 'py-sens-environ',
+    language: 'python',
+    category: 'sensitive_data',
+    pattern: /\bos\.environ\b/,
+    description: '访问环境变量',
+  },
+  {
+    id: 'py-sens-getenv',
+    language: 'python',
+    category: 'sensitive_data',
+    pattern: /\bos\.getenv\s*\(/,
+    description: '读取环境变量',
+  },
+  {
+    id: 'py-sens-getpass',
+    language: 'python',
+    category: 'sensitive_data',
+    pattern: /\bgetpass\.(getpass|getuser)\s*\(/,
+    description: '获取密码/用户信息',
+  },
+  {
+    id: 'py-sens-keyring',
+    language: 'python',
+    category: 'sensitive_data',
+    pattern: /\bkeyring\.(get_password|set_password|get_credential)\s*\(/,
+    description: '访问系统密钥链',
+  },
+
+  // File system access
+  {
+    id: 'py-fs-open',
+    language: 'python',
+    category: 'filesystem',
+    pattern: /\bopen\s*\([^)]*(['"][waxr+b]+['"]|mode\s*=)/,
+    description: '文件打开操作',
+  },
+  {
+    id: 'py-fs-pathlib',
+    language: 'python',
+    category: 'filesystem',
+    pattern: /\bpathlib\.Path\b/,
+    description: 'pathlib 路径操作',
+  },
+  {
+    id: 'py-fs-shutil',
+    language: 'python',
+    category: 'filesystem',
+    pattern: /\bshutil\.(copy|copy2|copytree|move|rmtree|disk_usage)\s*\(/,
+    description: 'shutil 文件操作',
+  },
+  {
+    id: 'py-fs-os-path',
+    language: 'python',
+    category: 'filesystem',
+    pattern: /\bos\.(remove|unlink|rmdir|makedirs|mkdir|rename|listdir|walk|scandir)\s*\(/,
+    description: 'os 文件系统操作',
+  },
+  {
+    id: 'py-fs-glob',
+    language: 'python',
+    category: 'filesystem',
+    pattern: /\bglob\.(glob|iglob)\s*\(/,
+    description: 'glob 文件搜索',
+  },
+
+  // Executable/command execution
+  {
+    id: 'py-exec-subprocess',
+    language: 'python',
+    category: 'executable',
+    pattern: /\bsubprocess\.(run|call|check_output|check_call|Popen)\s*\(/,
+    description: 'subprocess 命令执行',
+  },
+  {
+    id: 'py-exec-os-system',
+    language: 'python',
+    category: 'executable',
+    pattern: /\bos\.(system|popen|exec[lv]p?e?)\s*\(/,
+    description: 'os.system 命令执行',
+  },
+  {
+    id: 'py-exec-eval',
+    language: 'python',
+    category: 'executable',
+    pattern: /\b(eval|exec)\s*\(/,
+    description: '动态代码执行 (eval/exec)',
+  },
+  {
+    id: 'py-exec-compile',
+    language: 'python',
+    category: 'executable',
+    pattern: /\bcompile\s*\([^)]*['"]exec['"]/,
+    description: '动态代码编译执行',
+  },
+];
+
+// ==================== Shell Rules ====================
+
+export const SHELL_RULES: AuditRule[] = [
+  // External API calls
+  {
+    id: 'sh-api-curl',
+    language: 'shell',
+    category: 'external_api',
+    pattern: /\bcurl\s+/,
+    description: 'curl HTTP 请求',
+  },
+  {
+    id: 'sh-api-wget',
+    language: 'shell',
+    category: 'external_api',
+    pattern: /\bwget\s+/,
+    description: 'wget 下载请求',
+  },
+  {
+    id: 'sh-api-httpie',
+    language: 'shell',
+    category: 'external_api',
+    pattern: /\b(http|https)\s+(GET|POST|PUT|DELETE|PATCH|HEAD)\s+/,
+    description: 'HTTPie 请求',
+  },
+
+  // Network connections
+  {
+    id: 'sh-net-nc',
+    language: 'shell',
+    category: 'network',
+    pattern: /\b(nc|netcat|ncat)\s+/,
+    description: 'netcat 网络连接',
+  },
+  {
+    id: 'sh-net-ssh',
+    language: 'shell',
+    category: 'network',
+    pattern: /\bssh\s+/,
+    description: 'SSH 远程连接',
+  },
+  {
+    id: 'sh-net-scp',
+    language: 'shell',
+    category: 'network',
+    pattern: /\b(scp|rsync)\s+/,
+    description: '远程文件传输',
+  },
+  {
+    id: 'sh-net-ping',
+    language: 'shell',
+    category: 'network',
+    pattern: /\bping\s+/,
+    description: 'ping 网络探测',
+  },
+
+  // Sensitive data
+  {
+    id: 'sh-sens-password',
+    language: 'shell',
+    category: 'sensitive_data',
+    pattern: /\$\{?(PASSWORD|PASSWD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|ACCESS_KEY|SECRET_KEY)\}?/i,
+    description: '引用敏感环境变量',
+  },
+  {
+    id: 'sh-sens-env-read',
+    language: 'shell',
+    category: 'sensitive_data',
+    pattern: /\bprintenv\b|\benv\s/,
+    description: '读取环境变量',
+  },
+
+  // File system — dangerous operations
+  {
+    id: 'sh-fs-rm',
+    language: 'shell',
+    category: 'filesystem',
+    pattern: /\brm\s+(-[rfidv]+\s+|)(?!.*\.(log|tmp|cache)\b)/,
+    description: '文件删除操作',
+  },
+  {
+    id: 'sh-fs-chmod',
+    language: 'shell',
+    category: 'filesystem',
+    pattern: /\bchmod\s+/,
+    description: '文件权限修改',
+  },
+  {
+    id: 'sh-fs-chown',
+    language: 'shell',
+    category: 'filesystem',
+    pattern: /\bchown\s+/,
+    description: '文件所有者修改',
+  },
+  {
+    id: 'sh-fs-dd',
+    language: 'shell',
+    category: 'filesystem',
+    pattern: /\bdd\s+/,
+    description: 'dd 磁盘操作',
+  },
+  {
+    id: 'sh-fs-mktemp',
+    language: 'shell',
+    category: 'filesystem',
+    pattern: /\bmktemp\b/,
+    description: '创建临时文件',
+  },
+
+  // Executable — dynamic command execution
+  {
+    id: 'sh-exec-eval',
+    language: 'shell',
+    category: 'executable',
+    pattern: /\beval\s+/,
+    description: 'eval 动态命令执行',
+  },
+  {
+    id: 'sh-exec-bash-c',
+    language: 'shell',
+    category: 'executable',
+    pattern: /\b(bash|sh|zsh)\s+-c\s+/,
+    description: 'shell -c 命令执行',
+  },
+  {
+    id: 'sh-exec-source',
+    language: 'shell',
+    category: 'executable',
+    pattern: /\b(source|\.)\s+[^\s]+/,
+    description: 'source 脚本执行',
+  },
+  {
+    id: 'sh-exec-install',
+    language: 'shell',
+    category: 'executable',
+    pattern: /\b(pip|pip3|npm|yarn|pnpm|brew|apt-get|yum|dnf)\s+(install|add)\s+/,
+    description: '包管理器安装',
+  },
+];
+
+// ==================== JavaScript/TypeScript Rules ====================
+
+export const JS_TS_RULES: AuditRule[] = [
+  // External API calls
+  {
+    id: 'js-api-fetch',
+    language: 'javascript',
+    category: 'external_api',
+    pattern: /\bfetch\s*\(/,
+    description: 'fetch API 调用',
+  },
+  {
+    id: 'js-api-axios',
+    language: 'javascript',
+    category: 'external_api',
+    pattern: /\baxios\.(get|post|put|delete|patch|head|request|create)\s*\(/,
+    description: 'axios HTTP 请求',
+  },
+  {
+    id: 'js-api-xhr',
+    language: 'javascript',
+    category: 'external_api',
+    pattern: /\bnew\s+XMLHttpRequest\s*\(/,
+    description: 'XMLHttpRequest 请求',
+  },
+  {
+    id: 'js-api-http-request',
+    language: 'javascript',
+    category: 'external_api',
+    pattern: /\b(https?)\.(request|get)\s*\(/,
+    description: 'Node.js http/https 请求',
+  },
+  {
+    id: 'js-api-got',
+    language: 'javascript',
+    category: 'external_api',
+    pattern: /\bgot\.(get|post|put|delete|patch|head)\s*\(/,
+    description: 'got HTTP 请求',
+  },
+  {
+    id: 'js-api-node-fetch',
+    language: 'javascript',
+    category: 'external_api',
+    pattern: /\brequire\s*\(\s*['"]node-fetch['"]\s*\)/,
+    description: 'node-fetch 导入',
+  },
+
+  // Network connections
+  {
+    id: 'js-net-import',
+    language: 'javascript',
+    category: 'network',
+    pattern: /\brequire\s*\(\s*['"](axios|got|node-fetch|request|superagent|undici)['"]\s*\)/,
+    description: '导入网络请求库',
+  },
+  {
+    id: 'js-net-import-es',
+    language: 'javascript',
+    category: 'network',
+    pattern: /\bimport\s+.*\s+from\s+['"](axios|got|node-fetch|request|superagent|undici)['"]/,
+    description: '导入网络请求库 (ES)',
+  },
+  {
+    id: 'js-net-websocket',
+    language: 'javascript',
+    category: 'network',
+    pattern: /\bnew\s+WebSocket\s*\(/,
+    description: 'WebSocket 连接',
+  },
+  {
+    id: 'js-net-socket',
+    language: 'javascript',
+    category: 'network',
+    pattern: /\brequire\s*\(\s*['"]net['"]\s*\)/,
+    description: 'Node.js net 模块',
+  },
+
+  // Sensitive data
+  {
+    id: 'js-sens-env',
+    language: 'javascript',
+    category: 'sensitive_data',
+    pattern: /\bprocess\.env\b/,
+    description: '访问环境变量',
+  },
+  {
+    id: 'js-sens-dotenv',
+    language: 'javascript',
+    category: 'sensitive_data',
+    pattern: /\brequire\s*\(\s*['"]dotenv['"]\s*\)/,
+    description: '导入 dotenv 环境变量',
+  },
+  {
+    id: 'js-sens-localstorage',
+    language: 'javascript',
+    category: 'sensitive_data',
+    pattern: /\blocalStorage\.(getItem|setItem)\s*\(/,
+    description: 'localStorage 数据存储',
+  },
+  {
+    id: 'js-sens-cookie',
+    language: 'javascript',
+    category: 'sensitive_data',
+    pattern: /\bdocument\.cookie\b/,
+    description: '访问 Cookie',
+  },
+
+  // File system
+  {
+    id: 'js-fs-read',
+    language: 'javascript',
+    category: 'filesystem',
+    pattern: /\bfs\w*\.(readFile|readFileSync|readdir|readdirSync|createReadStream)\s*\(/,
+    description: '文件读取操作',
+  },
+  {
+    id: 'js-fs-write',
+    language: 'javascript',
+    category: 'filesystem',
+    pattern: /\bfs\w*\.(writeFile|writeFileSync|appendFile|appendFileSync|createWriteStream)\s*\(/,
+    description: '文件写入操作',
+  },
+  {
+    id: 'js-fs-delete',
+    language: 'javascript',
+    category: 'filesystem',
+    pattern: /\bfs\w*\.(unlink|unlinkSync|rmSync|rm|rmdir|rmdirSync)\s*\(/,
+    description: '文件删除操作',
+  },
+  {
+    id: 'js-fs-import',
+    language: 'javascript',
+    category: 'filesystem',
+    pattern: /\brequire\s*\(\s*['"]fs['"]\s*\)|import\s+.*\s+from\s+['"]fs['"]/,
+    description: '导入 fs 模块',
+  },
+  {
+    id: 'js-fs-path',
+    language: 'javascript',
+    category: 'filesystem',
+    pattern: /\bpath\.(join|resolve|dirname|basename|normalize)\s*\(/,
+    description: 'path 路径操作',
+  },
+
+  // Executable — command execution
+  {
+    id: 'js-exec-child-process',
+    language: 'javascript',
+    category: 'executable',
+    pattern: /\b(child_process|cp)\.(exec|execSync|execFile|execFileSync|spawn|spawnSync|fork)\s*\(/,
+    description: 'child_process 命令执行',
+  },
+  {
+    id: 'js-exec-import-cp',
+    language: 'javascript',
+    category: 'executable',
+    pattern: /\brequire\s*\(\s*['"]child_process['"]\s*\)|import\s+.*\s+from\s+['"]child_process['"]/,
+    description: '导入 child_process 模块',
+  },
+  {
+    id: 'js-exec-eval',
+    language: 'javascript',
+    category: 'executable',
+    pattern: /\beval\s*\(/,
+    description: 'eval 动态代码执行',
+  },
+  {
+    id: 'js-exec-new-function',
+    language: 'javascript',
+    category: 'executable',
+    pattern: /\bnew\s+Function\s*\(/,
+    description: 'new Function 动态代码执行',
+  },
+  {
+    id: 'js-exec-shell',
+    language: 'javascript',
+    category: 'executable',
+    pattern: /\brequire\s*\(\s*['"]shelljs['"]\s*\)/,
+    description: 'ShellJS 命令执行',
+  },
+];
+
+/** Get all rules for a given language */
+export function getRulesForLanguage(language: AuditLanguage): AuditRule[] {
+  switch (language) {
+    case 'python':
+      return PYTHON_RULES;
+    case 'shell':
+      return SHELL_RULES;
+    case 'javascript':
+    case 'typescript':
+      return JS_TS_RULES;
+    default:
+      return [];
+  }
+}
+
+/** Get all rules across all languages */
+export function getAllRules(): AuditRule[] {
+  return [...PYTHON_RULES, ...SHELL_RULES, ...JS_TS_RULES];
+}

--- a/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
@@ -434,6 +434,62 @@ const FindingRow: React.FC<{ finding: AuditFinding }> = ({ finding }) => {
   );
 };
 
+// ==================== Standalone Audit Report Modal ====================
+
+/**
+ * Standalone modal that shows ONLY the audit summary card.
+ * Used after importing a custom skill — avoids showing the full skill detail page.
+ * Includes a "View Details" button to open the full audit detail modal.
+ */
+export const SkillAuditReportModal: React.FC<{
+  skillName: string;
+  visible: boolean;
+  onClose: () => void;
+  /** Called when user clicks "View Audit Details" to open the detailed findings modal */
+  onViewAuditDetails?: (skillName: string) => void;
+}> = ({ skillName, visible, onClose, onViewAuditDetails }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={onClose}
+      footer={null}
+      closable={false}
+      maskClosable
+      style={{ width: 480 }}
+      className='skill-audit-report-modal'
+      wrapStyle={{ zIndex: 1050 }}
+      maskStyle={{ zIndex: 1050 }}
+    >
+      <div className='flex flex-col'>
+        {/* Header */}
+        <div className='flex items-center justify-between mb-12px'>
+          <div className='flex items-center gap-8px'>
+            <Shield size='16' className='text-success' />
+            <span className='font-semibold text-15px text-t-primary'>
+              {t('settings.skill.audit.reportTitle', { defaultValue: '安全审计报告' })}
+            </span>
+            <span className='text-12px text-t-tertiary'>— {skillName}</span>
+          </div>
+          <div
+            className='w-28px h-28px flex items-center justify-center rd-full bg-fill-2 hover:bg-fill-3 cursor-pointer transition-colors text-t-secondary'
+            onClick={onClose}
+          >
+            <Close size='14' />
+          </div>
+        </div>
+
+        {/* Audit summary card */}
+        <SkillAuditSummary
+          skillName={skillName}
+          onViewDetails={onViewAuditDetails ? () => onViewAuditDetails(skillName) : undefined}
+        />
+      </div>
+    </Modal>
+  );
+};
+
 function getCategoryEmoji(category: AuditCategory): string {
   switch (category) {
     case 'external_api':

--- a/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
@@ -14,9 +14,9 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { Modal, Spin, Message } from '@arco-design/web-react';
-import { Close, Shield } from '@icon-park/react';
+import { Close, Shield, FolderOpen } from '@icon-park/react';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
-import { skillHub } from '@/common/ipcBridge';
+import { skillHub, shell } from '@/common/ipcBridge';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import type { SkillAuditReport, AuditFinding, AuditCategorySummary, AuditCategory } from '@/common/skillAuditTypes';
 import { AUDIT_CATEGORY_CONFIG } from '@/common/skillAuditTypes';
@@ -114,15 +114,29 @@ export const SkillAuditSummary: React.FC<{
             {t('settings.skill.audit.reportPath', { defaultValue: '安全审计报告' })}：{report.reportPath}
           </div>
         )}
-        {onViewDetails && (
-          <button
-            type='button'
-            className='text-11px text-primary hover:text-primary-dark cursor-pointer bg-transparent border-none outline-none whitespace-nowrap flex-shrink-0'
-            onClick={onViewDetails}
-          >
-            {t('settings.skill.audit.viewDetails', { defaultValue: '查看详情' })}
-          </button>
-        )}
+        <div className='flex items-center gap-8px flex-shrink-0'>
+          {report.reportPath && isElectronDesktop() && (
+            <button
+              type='button'
+              className='text-11px text-t-secondary hover:text-primary cursor-pointer bg-transparent border-none outline-none whitespace-nowrap flex items-center gap-3px'
+              onClick={() => {
+                void shell.showItemInFolder.invoke(report.reportPath!);
+              }}
+            >
+              <FolderOpen size='12' />
+              {t('settings.skill.audit.openFilePath', { defaultValue: '打开路径' })}
+            </button>
+          )}
+          {onViewDetails && (
+            <button
+              type='button'
+              className='text-11px text-primary hover:text-primary-dark cursor-pointer bg-transparent border-none outline-none whitespace-nowrap flex-shrink-0'
+              onClick={onViewDetails}
+            >
+              {t('settings.skill.audit.viewDetails', { defaultValue: '查看详情' })}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -239,6 +253,8 @@ export const SkillAuditDetailModal: React.FC<{
       maskClosable
       style={{ width: 560 }}
       className='skill-audit-detail-modal'
+      wrapStyle={{ zIndex: 1100 }}
+      maskStyle={{ zIndex: 1100 }}
     >
       <div className='flex flex-col max-h-80vh'>
         {/* Header */}

--- a/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
@@ -1,0 +1,436 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Skill Security Audit Report Components
+ *
+ * Displays audit results in two views:
+ * 1. SkillAuditSummary — Summary card showing operation categories with ✅/⚠️ indicators
+ * 2. SkillAuditDetailModal — Detailed findings modal with code snippets and locations
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Modal, Spin, Message } from '@arco-design/web-react';
+import { Close, Shield } from '@icon-park/react';
+import AionScrollArea from '@/renderer/components/base/AionScrollArea';
+import { skillHub } from '@/common/ipcBridge';
+import { isElectronDesktop } from '@/renderer/utils/platform';
+import type { SkillAuditReport, AuditFinding, AuditCategorySummary, AuditCategory } from '@/common/skillAuditTypes';
+import { AUDIT_CATEGORY_CONFIG } from '@/common/skillAuditTypes';
+import { useTranslation } from 'react-i18next';
+
+// ==================== Audit Summary Component ====================
+
+/**
+ * Displays a summary of the audit results, similar to the screenshot:
+ * - Shield icon + title
+ * - List of categories with ✅ (safe) or ⚠️ (found N places) indicators
+ * - Link to the full report file
+ */
+export const SkillAuditSummary: React.FC<{
+  skillName: string;
+  /** Called when user clicks "View Details" */
+  onViewDetails?: () => void;
+}> = ({ skillName, onViewDetails }) => {
+  const [report, setReport] = useState<SkillAuditReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!isElectronDesktop() || !skillName) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchReport = async () => {
+      try {
+        const res = await skillHub.getSkillAuditReport.invoke({ skillName });
+        if (!cancelled && res.success && res.data) {
+          setReport(res.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch audit report:', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void fetchReport();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [skillName]);
+
+  if (loading) {
+    return (
+      <div className='bg-fill-1 rd-10px p-14px'>
+        <div className='flex items-center gap-6px mb-8px'>
+          <Shield size='14' className='text-success' />
+          <span className='font-medium text-13px text-t-primary'>
+            {t('settings.skill.audit.title', { defaultValue: '安全审查结果' })}
+          </span>
+        </div>
+        <div className='flex justify-center py-12px'>
+          <Spin size={16} />
+        </div>
+      </div>
+    );
+  }
+
+  if (!report) return null;
+
+  return (
+    <div className='bg-fill-1 rd-10px p-14px'>
+      {/* Header */}
+      <div className='flex items-center gap-6px mb-8px'>
+        <Shield size='14' className='text-success' />
+        <span className='font-medium text-13px text-t-primary'>
+          {t('settings.skill.audit.title', { defaultValue: '安全审查结果' })}
+        </span>
+      </div>
+
+      {/* Summary description */}
+      <div className='text-12px text-t-secondary mb-10px'>
+        {report.hasFindings
+          ? t('settings.skill.audit.summaryWithFindings', { defaultValue: '经过安全审查，该技能包存在以下操作：' })
+          : t('settings.skill.audit.summaryNoFindings', { defaultValue: '经过严格的安全审查，确认该技能包：' })}
+      </div>
+
+      {/* Category list */}
+      <div className='space-y-6px'>
+        {report.categorySummaries.map((summary) => (
+          <CategoryRow key={summary.category} summary={summary} />
+        ))}
+      </div>
+
+      {/* Report path and view details */}
+      <div className='mt-10px pt-8px border-t border-line flex items-center justify-between'>
+        {report.reportPath && (
+          <div className='text-11px text-t-tertiary truncate flex-1 min-w-0 mr-8px'>
+            {t('settings.skill.audit.reportPath', { defaultValue: '安全审计报告' })}：{report.reportPath}
+          </div>
+        )}
+        {onViewDetails && (
+          <button
+            type='button'
+            className='text-11px text-primary hover:text-primary-dark cursor-pointer bg-transparent border-none outline-none whitespace-nowrap flex-shrink-0'
+            onClick={onViewDetails}
+          >
+            {t('settings.skill.audit.viewDetails', { defaultValue: '查看详情' })}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Single category row in the audit summary.
+ * Shows ✅ for safe categories or ⚠️ N处调用 for found categories.
+ */
+const CategoryRow: React.FC<{ summary: AuditCategorySummary }> = ({ summary }) => {
+  const { t } = useTranslation();
+
+  if (!summary.found) {
+    return (
+      <div className='flex items-start gap-6px'>
+        <span className='text-14px flex-shrink-0 leading-18px'>✅</span>
+        <span className='text-12px text-t-secondary leading-18px'>
+          {t(`settings.skill.audit.no_${summary.category}` as any, { defaultValue: `无${summary.label}` })}
+          <span className='text-t-tertiary'> – {summary.safeDescription}</span>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex items-start gap-6px'>
+      <span className='text-14px flex-shrink-0 leading-18px'>⚠️</span>
+      <span className='text-12px text-t-secondary leading-18px'>
+        {summary.label}
+        <span className='text-warning font-medium'>
+          {' '}({summary.count} {t('settings.skill.audit.places', { defaultValue: '处调用' })})
+        </span>
+        <span className='text-t-tertiary'> – {summary.foundDescription}</span>
+      </span>
+    </div>
+  );
+};
+
+// ==================== Audit Detail Modal ====================
+
+/**
+ * Modal showing detailed audit findings, grouped by category.
+ * Each finding shows file path, line number, code snippet, and extracted details.
+ */
+export const SkillAuditDetailModal: React.FC<{
+  skillName: string;
+  visible: boolean;
+  onClose: () => void;
+}> = ({ skillName, visible, onClose }) => {
+  const [report, setReport] = useState<SkillAuditReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<AuditCategory | 'all'>('all');
+  const { t } = useTranslation();
+
+  const fetchReport = useCallback(async () => {
+    if (!isElectronDesktop() || !skillName) return;
+    setLoading(true);
+    try {
+      const res = await skillHub.getSkillAuditReport.invoke({ skillName });
+      if (res.success && res.data) {
+        setReport(res.data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch audit report:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [skillName]);
+
+  const handleRerunAudit = useCallback(async () => {
+    if (!isElectronDesktop() || !skillName) return;
+    setLoading(true);
+    try {
+      const res = await skillHub.runSkillAudit.invoke({ skillName });
+      if (res.success && res.data) {
+        setReport(res.data);
+        Message.success(t('settings.skill.audit.rerunSuccess', { defaultValue: '重新审计完成' }));
+      } else {
+        Message.error(res.msg || t('settings.skill.audit.rerunFailed', { defaultValue: '重新审计失败' }));
+      }
+    } catch (err) {
+      console.error('Failed to rerun audit:', err);
+      Message.error(t('settings.skill.audit.rerunFailed', { defaultValue: '重新审计失败' }));
+    } finally {
+      setLoading(false);
+    }
+  }, [skillName, t]);
+
+  useEffect(() => {
+    if (visible) {
+      void fetchReport();
+      setSelectedCategory('all');
+    } else {
+      setReport(null);
+    }
+  }, [visible, fetchReport]);
+
+  const filteredFindings = report?.findings.filter((f) => selectedCategory === 'all' || f.category === selectedCategory) || [];
+
+  // Group findings by file
+  const groupedByFile = new Map<string, AuditFinding[]>();
+  for (const finding of filteredFindings) {
+    const existing = groupedByFile.get(finding.file) || [];
+    existing.push(finding);
+    groupedByFile.set(finding.file, existing);
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={onClose}
+      footer={null}
+      closable={false}
+      maskClosable
+      style={{ width: 560 }}
+      className='skill-audit-detail-modal'
+    >
+      <div className='flex flex-col max-h-80vh'>
+        {/* Header */}
+        <div className='flex items-center justify-between mb-12px'>
+          <div className='flex items-center gap-8px'>
+            <Shield size='16' className='text-success' />
+            <span className='font-semibold text-15px text-t-primary'>
+              {t('settings.skill.audit.detailTitle', { defaultValue: '安全审计详情' })}
+            </span>
+            <span className='text-12px text-t-tertiary'>— {skillName}</span>
+          </div>
+          <div className='flex items-center gap-8px'>
+            <button
+              type='button'
+              className='text-11px px-8px py-3px rd-4px bg-fill-2 hover:bg-fill-3 text-t-secondary cursor-pointer border-none outline-none transition-colors'
+              onClick={() => void handleRerunAudit()}
+              disabled={loading}
+            >
+              {t('settings.skill.audit.rerun', { defaultValue: '重新审计' })}
+            </button>
+            <div
+              className='w-28px h-28px flex items-center justify-center rd-full bg-fill-2 hover:bg-fill-3 cursor-pointer transition-colors text-t-secondary'
+              onClick={onClose}
+            >
+              <Close size='14' />
+            </div>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className='flex justify-center py-48px'>
+            <Spin size={24} />
+          </div>
+        ) : !report ? (
+          <div className='flex flex-col items-center justify-center py-48px text-t-secondary'>
+            <span className='text-13px'>{t('settings.skill.audit.noReport', { defaultValue: '暂无审计报告' })}</span>
+          </div>
+        ) : (
+          <>
+            {/* Info bar */}
+            <div className='flex items-center gap-12px mb-12px text-11px text-t-tertiary'>
+              <span>
+                {t('settings.skill.audit.scannedFiles', { defaultValue: '扫描文件' })}：{report.scannedFiles}/{report.totalFiles}
+              </span>
+              <span>
+                {t('settings.skill.audit.totalFindings', { defaultValue: '发现' })}：{report.findings.length} {t('settings.skill.audit.places', { defaultValue: '处调用' })}
+              </span>
+              <span>
+                {t('settings.skill.audit.auditTime', { defaultValue: '审计时间' })}：{new Date(report.auditTime).toLocaleString()}
+              </span>
+            </div>
+
+            {/* Category filter tabs */}
+            <div className='flex gap-4px mb-12px overflow-x-auto pb-2px scrollbar-hide flex-shrink-0'>
+              <CategoryFilterTab
+                label={t('settings.skill.audit.all', { defaultValue: '全部' })}
+                count={report.findings.length}
+                active={selectedCategory === 'all'}
+                onClick={() => setSelectedCategory('all')}
+              />
+              {report.categorySummaries
+                .filter((s) => s.found)
+                .map((s) => (
+                  <CategoryFilterTab
+                    key={s.category}
+                    label={s.label}
+                    count={s.count}
+                    active={selectedCategory === s.category}
+                    onClick={() => setSelectedCategory(s.category)}
+                  />
+                ))}
+            </div>
+
+            {/* Findings list */}
+            <AionScrollArea className='flex-1 min-h-0'>
+              {filteredFindings.length === 0 ? (
+                <div className='flex flex-col items-center justify-center py-32px text-t-tertiary'>
+                  <span className='text-12px'>{t('settings.skill.audit.noFindings', { defaultValue: '该类别下无发现' })}</span>
+                </div>
+              ) : (
+                <div className='space-y-12px pb-16px'>
+                  {Array.from(groupedByFile.entries()).map(([file, findings]) => (
+                    <FileFindings key={file} file={file} findings={findings} />
+                  ))}
+                </div>
+              )}
+            </AionScrollArea>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+// ==================== Sub-components ====================
+
+const CategoryFilterTab: React.FC<{
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}> = ({ label, count, active, onClick }) => (
+  <button
+    type='button'
+    className={`px-10px py-4px rd-16px text-11px cursor-pointer transition-colors whitespace-nowrap flex-shrink-0 border-none outline-none flex items-center gap-4px ${
+      active
+        ? 'bg-primary text-white'
+        : 'bg-fill-2 text-t-secondary hover:bg-fill-3 hover:text-t-primary'
+    }`}
+    onClick={onClick}
+  >
+    {label}
+    <span className={`text-10px ${active ? 'text-white/70' : 'text-t-tertiary'}`}>
+      {count}
+    </span>
+  </button>
+);
+
+/**
+ * Group of findings for a single file.
+ */
+const FileFindings: React.FC<{
+  file: string;
+  findings: AuditFinding[];
+}> = ({ file, findings }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className='bg-fill-1 rd-8px overflow-hidden'>
+      {/* File header */}
+      <div className='px-12px py-8px bg-fill-2 border-b border-line'>
+        <span className='text-12px font-medium text-t-primary font-mono'>{file}</span>
+        <span className='text-11px text-t-tertiary ml-8px'>
+          ({findings.length} {t('settings.skill.audit.places', { defaultValue: '处调用' })})
+        </span>
+      </div>
+
+      {/* Findings */}
+      <div className='divide-y divide-line'>
+        {findings.map((finding) => (
+          <FindingRow key={finding.id} finding={finding} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Single finding row showing line number, code, and description.
+ */
+const FindingRow: React.FC<{ finding: AuditFinding }> = ({ finding }) => {
+  const config = AUDIT_CATEGORY_CONFIG[finding.category];
+  const categoryEmoji = getCategoryEmoji(finding.category);
+
+  return (
+    <div className='px-12px py-8px hover:bg-fill-2/50 transition-colors'>
+      <div className='flex items-center gap-6px mb-3px'>
+        <span className='text-12px'>{categoryEmoji}</span>
+        <span className='text-11px text-t-secondary'>{config.label}</span>
+        <span className='text-11px text-t-tertiary'>·</span>
+        <span className='text-11px text-t-tertiary font-mono'>
+          L{finding.line}
+        </span>
+      </div>
+      <div className='bg-fill-2 rd-4px px-8px py-4px mb-3px'>
+        <code className='text-11px text-t-primary font-mono break-all leading-relaxed'>
+          {finding.code}
+        </code>
+      </div>
+      <div className='text-11px text-t-tertiary'>
+        {finding.description}
+        {finding.detail && (
+          <span className='text-primary ml-4px'>→ {finding.detail}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+function getCategoryEmoji(category: AuditCategory): string {
+  switch (category) {
+    case 'external_api':
+      return '🌐';
+    case 'network':
+      return '🔗';
+    case 'sensitive_data':
+      return '🔑';
+    case 'filesystem':
+      return '📁';
+    case 'executable':
+      return '⚡';
+    default:
+      return '📋';
+  }
+}

--- a/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillAuditReport.tsx
@@ -81,7 +81,21 @@ export const SkillAuditSummary: React.FC<{
     );
   }
 
-  if (!report) return null;
+  if (!report) {
+    return (
+      <div className='bg-fill-1 rd-10px p-14px'>
+        <div className='flex items-center gap-6px mb-8px'>
+          <Shield size='14' className='text-success' />
+          <span className='font-medium text-13px text-t-primary'>
+            {t('settings.skill.audit.title', { defaultValue: '安全审查结果' })}
+          </span>
+        </div>
+        <div className='text-12px text-t-tertiary text-center py-12px'>
+          {t('settings.skill.audit.noReport', { defaultValue: '暂无审计报告' })}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className='bg-fill-1 rd-10px p-14px'>
@@ -459,8 +473,9 @@ export const SkillAuditReportModal: React.FC<{
       maskClosable
       style={{ width: 480 }}
       className='skill-audit-report-modal'
-      wrapStyle={{ zIndex: 1050 }}
-      maskStyle={{ zIndex: 1050 }}
+      wrapStyle={{ zIndex: 2000 }}
+      maskStyle={{ zIndex: 2000 }}
+      getPopupContainer={() => document.body}
     >
       <div className='flex flex-col'>
         {/* Header */}

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -18,6 +18,7 @@ import type { ISkillHubSkill, ISkillHubDetail, ISkillHubListResponse, IInstalled
 import { useAuth } from '@/renderer/context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { SkillAuditSummary, SkillAuditDetailModal } from './SkillAuditReport';
 
 // ==================== Helpers ====================
 
@@ -307,7 +308,11 @@ const SkillDetailModal: React.FC<{
   skipApiFetch?: boolean;
   /** When true, hide the action buttons area entirely (e.g. when opened from installed tab) */
   hideActions?: boolean;
-}> = ({ skill, visible, onClose, isInstalled, isHubInstalled, hasVersion, latestVersionInfo, installing, downloading, installProgress, onInstall, onDownload, onUninstall, uninstalling, onGoUse, onUpdate, updating = false, installedVersion, skipApiFetch = false, hideActions = false }) => {
+  /** Skill directory name for audit report display */
+  auditSkillName?: string;
+  /** Callback when "View Audit Details" is clicked */
+  onViewAuditDetails?: (skillName: string) => void;
+}> = ({ skill, visible, onClose, isInstalled, isHubInstalled, hasVersion, latestVersionInfo, installing, downloading, installProgress, onInstall, onDownload, onUninstall, uninstalling, onGoUse, onUpdate, updating = false, installedVersion, skipApiFetch = false, hideActions = false, auditSkillName, onViewAuditDetails }) => {
   const canUninstall = isInstalled && isHubInstalled;
   const [detail, setDetail] = useState<ISkillHubDetail | null>(null);
   const [loading, setLoading] = useState(false);
@@ -420,6 +425,14 @@ const SkillDetailModal: React.FC<{
                     </div>
                   </div>
                 )}
+
+                {/* Security audit section — shown for installed skills */}
+                {isInstalled && auditSkillName && (
+                  <SkillAuditSummary
+                    skillName={auditSkillName}
+                    onViewDetails={onViewAuditDetails ? () => onViewAuditDetails(auditSkillName) : undefined}
+                  />
+                )}
               </div>
             )}
           </div>
@@ -531,6 +544,10 @@ const SkillModalContent: React.FC = () => {
   // Installed skill detail modal state (separate from store detail modal)
   const [installedDetailInfo, setInstalledDetailInfo] = useState<IInstalledSkillInfo | null>(null);
   const [installedDetailVisible, setInstalledDetailVisible] = useState(false);
+
+  // Audit detail modal state
+  const [auditDetailSkillName, setAuditDetailSkillName] = useState<string | null>(null);
+  const [auditDetailVisible, setAuditDetailVisible] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
   // Sentinel element for IntersectionObserver-based infinite scroll
@@ -1332,6 +1349,11 @@ const SkillModalContent: React.FC = () => {
         onUpdate={() => detailSkill && void handleUpdate(detailSkill.id)}
         updating={detailSkill ? updatingSkillId === detailSkill.id : false}
         installedVersion={detailSkill ? normalizeSkillVersion(installedSkills.get(detailSkill.name)) : undefined}
+        auditSkillName={detailSkill && detailIsInstalled ? detailSkill.name : undefined}
+        onViewAuditDetails={(name) => {
+          setAuditDetailSkillName(name);
+          setAuditDetailVisible(true);
+        }}
       />
 
       {/* Installed skill detail modal — data from local _sudowork_meta.json */}
@@ -1372,9 +1394,24 @@ const SkillModalContent: React.FC = () => {
             installedVersion={installedDetailInstalledVer}
             skipApiFetch
             hideActions={!installedDetailHasUpdate && !installedDetailInfo?.isHubInstalled}
+            auditSkillName={installedDetailInfo?.name}
+            onViewAuditDetails={(name) => {
+              setAuditDetailSkillName(name);
+              setAuditDetailVisible(true);
+            }}
           />
         );
       })()}
+
+      {/* Audit detail modal */}
+      <SkillAuditDetailModal
+        skillName={auditDetailSkillName || ''}
+        visible={auditDetailVisible}
+        onClose={() => {
+          setAuditDetailVisible(false);
+          setAuditDetailSkillName(null);
+        }}
+      />
     </div>
   );
 };

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -619,14 +619,25 @@ const SkillModalContent: React.FC = () => {
 
       const res = await skillHub.importLocalSkill.invoke({ sourcePath: dialogResult.data.filePaths[0] });
       if (res.success && res.data) {
+        const importedSkillName = res.data.skillName;
         Message.success(
           t('settings.skill.importSuccess', {
-            name: res.data.skillName,
-            defaultValue: `已导入技能：${res.data.skillName}`,
+            name: importedSkillName,
+            defaultValue: `已导入技能：${importedSkillName}`,
           })
         );
         await fetchInstalledSkills();
-        await fetchInstalledList();
+        // Refresh installed list and then open the detail modal for the imported skill
+        const listRes = await skillHub.getInstalledSkills.invoke();
+        if (listRes.success && listRes.data) {
+          setInstalledList(listRes.data);
+          // Find the newly imported skill and open its detail modal (which includes the audit summary)
+          const importedSkill = listRes.data.find((s) => s.name === importedSkillName);
+          if (importedSkill?.meta) {
+            setInstalledDetailInfo(importedSkill);
+            setInstalledDetailVisible(true);
+          }
+        }
       } else {
         Message.error(
           t('settings.skill.importFailed', {
@@ -644,7 +655,7 @@ const SkillModalContent: React.FC = () => {
         })
       );
     }
-  }, [fetchInstalledList, fetchInstalledSkills, t]);
+  }, [fetchInstalledSkills, t]);
 
   // ---- Fetch latest versions ----
   const fetchLatestVersions = useCallback(async (skillList: ISkillHubSkill[], existingMap?: Map<string, SkillLatestVersion>) => {

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -18,7 +18,7 @@ import type { ISkillHubSkill, ISkillHubDetail, ISkillHubListResponse, IInstalled
 import { useAuth } from '@/renderer/context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { SkillAuditSummary, SkillAuditDetailModal } from './SkillAuditReport';
+import { SkillAuditSummary, SkillAuditDetailModal, SkillAuditReportModal } from './SkillAuditReport';
 
 // ==================== Helpers ====================
 
@@ -549,6 +549,10 @@ const SkillModalContent: React.FC = () => {
   const [auditDetailSkillName, setAuditDetailSkillName] = useState<string | null>(null);
   const [auditDetailVisible, setAuditDetailVisible] = useState(false);
 
+  // Standalone audit report modal state (shown after importing a custom skill)
+  const [auditReportSkillName, setAuditReportSkillName] = useState<string | null>(null);
+  const [auditReportVisible, setAuditReportVisible] = useState(false);
+
   const containerRef = useRef<HTMLDivElement>(null);
   // Sentinel element for IntersectionObserver-based infinite scroll
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -627,17 +631,14 @@ const SkillModalContent: React.FC = () => {
           })
         );
         await fetchInstalledSkills();
-        // Refresh installed list and then open the detail modal for the imported skill
+        // Refresh installed list
         const listRes = await skillHub.getInstalledSkills.invoke();
         if (listRes.success && listRes.data) {
           setInstalledList(listRes.data);
-          // Find the newly imported skill and open its detail modal (which includes the audit summary)
-          const importedSkill = listRes.data.find((s) => s.name === importedSkillName);
-          if (importedSkill?.meta) {
-            setInstalledDetailInfo(importedSkill);
-            setInstalledDetailVisible(true);
-          }
         }
+        // Open standalone audit report modal (just the audit summary, not the full detail page)
+        setAuditReportSkillName(importedSkillName);
+        setAuditReportVisible(true);
       } else {
         Message.error(
           t('settings.skill.importFailed', {
@@ -1413,6 +1414,20 @@ const SkillModalContent: React.FC = () => {
           />
         );
       })()}
+
+      {/* Standalone audit report modal — shown after importing a custom skill */}
+      <SkillAuditReportModal
+        skillName={auditReportSkillName || ''}
+        visible={auditReportVisible}
+        onClose={() => {
+          setAuditReportVisible(false);
+          setAuditReportSkillName(null);
+        }}
+        onViewAuditDetails={(name) => {
+          setAuditDetailSkillName(name);
+          setAuditDetailVisible(true);
+        }}
+      />
 
       {/* Audit detail modal */}
       <SkillAuditDetailModal


### PR DESCRIPTION
## Summary

- 导入自定义 Skill 后自动进行安全审计，分析技能做了哪些操作
- 支持 5 个检测维度：外部API调用、网络连接、敏感数据、文件系统、命令执行
- 前端展示审计总结卡片 + 详细发现弹窗

Closes #283

Generated with [Claude Code](https://claude.ai/code)