### PR TITLE
fix(image): remove nexus timestamp regex from file display path

### DIFF
--- a/src/renderer/utils/messageFiles.ts
+++ b/src/renderer/utils/messageFiles.ts
@@ -1,4 +1,4 @@
-import { NEXUS_FILES_MARKER, NEXUS_TIMESTAMP_REGEX } from '@/common/constants';
+import { NEXUS_FILES_MARKER } from '@/common/constants';
 import type { FileOrFolderItem } from '@/renderer/types/files';
 import { isTemporaryWorkspace } from '@/renderer/utils/workspace';
 
@@ -33,7 +33,6 @@ export const buildDisplayMessage = (input: string, files: string[], workspacePat
     if (isAbsolute) {
       const parts = filePath.split(/[\\/]/);
       let fileName = parts[parts.length - 1] || filePath;
-      fileName = fileName.replace(NEXUS_TIMESTAMP_REGEX, '$1');
       return `${workspacePath}/${fileName}`;
     }
     return `${workspacePath}/${filePath}`;

--- a/tests/unit/messageFiles.test.ts
+++ b/tests/unit/messageFiles.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { buildDisplayMessage } from '@/renderer/utils/messageFiles';
+
+const WORKSPACE = '/Users/test/.nexus/sudoclaw/workspace/proj-123';
+
+describe('buildDisplayMessage', () => {
+  it('preserves _nexus_ timestamp suffix in pasted file names', () => {
+    // This is the core bug fix: paste-uploaded files have _nexus_<timestamp> suffix.
+    // buildDisplayMessage must preserve the full filename so it matches the actual
+    // file path created by copyFilesToDirectory.
+    const result = buildDisplayMessage(
+      'analyze this image',
+      ['C:\\Users\\test\\.nexus\\config\\temp\\image_nexus_1775876155151.png'],
+      WORKSPACE,
+    );
+    expect(result).toContain(`${WORKSPACE}/image_nexus_1775876155151.png`);
+    // Must NOT contain the stripped version
+    expect(result).not.toContain(`${WORKSPACE}/image.png`);
+  });
+
+  it('handles file-picker uploads without _nexus_ suffix', () => {
+    const result = buildDisplayMessage(
+      'analyze this',
+      ['C:\\Users\\test\\Pictures\\a4ac618e1abdfa9f0a0f9cce37c97746.jpeg'],
+      WORKSPACE,
+    );
+    expect(result).toContain(`${WORKSPACE}/a4ac618e1abdfa9f0a0f9cce37c97746.jpeg`);
+  });
+
+  it('handles bdpan:// remote paths', () => {
+    const result = buildDisplayMessage(
+      'check this file',
+      ['bdpan://bucket/path/to/report.pdf?token=abc'],
+      WORKSPACE,
+    );
+    expect(result).toContain(`${WORKSPACE}/report.pdf`);
+    expect(result).not.toContain('?token=abc');
+  });
+
+  it('handles relative file paths by joining with workspace', () => {
+    const result = buildDisplayMessage(
+      'see attached',
+      ['docs/spec.md'],
+      WORKSPACE,
+    );
+    expect(result).toContain(`${WORKSPACE}/docs/spec.md`);
+  });
+
+  it('returns original input when no workspace is provided', () => {
+    const result = buildDisplayMessage(
+      'no workspace',
+      ['/tmp/file.txt'],
+      '',
+    );
+    expect(result).toBe('no workspace\n\n[[NEXUS_FILES]]\n/tmp/file.txt');
+  });
+
+  it('returns input unchanged when files list is empty', () => {
+    const result = buildDisplayMessage('just text', [], WORKSPACE);
+    expect(result).toBe('just text');
+  });
+
+  it('handles multiple files including both paste and picker uploads', () => {
+    const result = buildDisplayMessage(
+      'analyze both',
+      [
+        'C:\\Users\\test\\.nexus\\config\\temp\\screenshot_nexus_1775876200000.png',
+        'C:\\Users\\test\\Downloads\\photo.jpeg',
+      ],
+      WORKSPACE,
+    );
+    expect(result).toContain(`${WORKSPACE}/screenshot_nexus_1775876200000.png`);
+    expect(result).toContain(`${WORKSPACE}/photo.jpeg`);
+  });
+});


### PR DESCRIPTION
## Summary
- Remove `NEXUS_TIMESTAMP_REGEX` replacement in `buildDisplayMessage` that stripped `_nexus_` timestamp suffix from pasted file names
- This caused a path mismatch: display path showed `workspace/image.png` while actual file was `workspace/image_nexus_1775876155151.png`, leading to "Image not found" in preview
- File-picker uploads (without `_nexus_` suffix) were unaffected, which is why only some users experienced the issue

## Root Cause
`PasteService` generates temp filenames with `_nexus_` suffix (e.g., `image_nexus_1775876155151.png`). `buildDisplayMessage` stripped this suffix via regex, but `copyFilesToDirectory` preserved the original filename. The resulting path mismatch caused `getImageBase64` to fail.

## Test plan
- [x] Unit tests for `buildDisplayMessage` (7 cases covering paste upload, file picker, bdpan, relative path, empty files, multiple files)
- [ ] Manual: paste image upload → send → verify preview works
- [ ] Manual: file picker upload → send → verify preview works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)