### PR TITLE
fix(channels): await ServiceManager startup before initializing ChannelManager

### DIFF
--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -43,10 +43,15 @@ export const initializeProcess = async () => {
   }
   perfLog('initBridge', Date.now() - bridgeStart);
 
-  // 3. Start ServiceManager — installs missing runtimes & starts services (non-blocking)
+  // 3. Start ServiceManager — installs missing runtimes & starts services
   //    Handles: Node.js, Sudoclaw, Nexus install + OpenClaw gateway + Nexus + SafetyPollingService
+  //    Must complete before ChannelManager to ensure secrets are ready
   const { serviceManager } = await import('./services/serviceManager');
-  void serviceManager.startup();
+  try {
+    await serviceManager.startup();
+  } catch (error) {
+    mainError('Process', 'ServiceManager startup failed', error);
+  }
 
   // Initialize Extension Registry and Channel subsystem in parallel (they are independent)
   const parallelStart = Date.now();


### PR DESCRIPTION
## Summary
- Fixed channel plugins (DingTalk, Lark, etc.) failing to start when Nexus takes longer than 120s to initialize during first-time setup
- Changed `void serviceManager.startup()` to `await` with try-catch in `src/process/index.ts`, ensuring secrets are migrated and preloaded before ChannelManager reads credentials

## Root Cause
`ServiceManager.startup()` was non-blocking (`void`), running in parallel with `ChannelManager.initialize()`. When Nexus startup (download + install + health check) exceeds the 120s `waitForSecrets()` timeout, `resolveSecret()` returns empty strings, causing channel plugins to fail with missing credentials (e.g., `clientSecret=MISSING`).

## Test plan
- [ ] Restore .nexus to old version → launch app → DingTalk plugin starts normally
- [ ] Normal startup (Nexus already installed) → channel plugins work correctly
- [ ] Delete Nexus binary → launch app → app doesn't crash, plugins fail gracefully with logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)