### PR TITLE
fix(channels): remove startup timeout in waitForSecrets to handle slow Nexus

### DIFF
--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -43,15 +43,10 @@ export const initializeProcess = async () => {
   }
   perfLog('initBridge', Date.now() - bridgeStart);
 
-  // 3. Start ServiceManager — installs missing runtimes & starts services
+  // 3. Start ServiceManager — installs missing runtimes & starts services (non-blocking)
   //    Handles: Node.js, Sudoclaw, Nexus install + OpenClaw gateway + Nexus + SafetyPollingService
-  //    Must complete before ChannelManager to ensure secrets are ready
   const { serviceManager } = await import('./services/serviceManager');
-  try {
-    await serviceManager.startup();
-  } catch (error) {
-    mainError('Process', 'ServiceManager startup failed', error);
-  }
+  void serviceManager.startup();
 
   // Initialize Extension Registry and Channel subsystem in parallel (they are independent)
   const parallelStart = Date.now();

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -666,14 +666,13 @@ class ServiceManager {
   async waitForSecrets(): Promise<boolean> {
     // Poll until the promise is created by startNexusOnce()
     const POLL_INTERVAL_MS = 200;
-    const MAX_POLL_MS = 120_000;
-    const deadline = Date.now() + MAX_POLL_MS;
-    while (!this.secretsReadyPromise && Date.now() < deadline) {
+    while (!this.secretsReadyPromise) {
       await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-    }
-    if (!this.secretsReadyPromise) {
-      // Timeout or startup never reached secrets initialization.
-      return false;
+      // startup 已结束但未创建 secretsReadyPromise → startup 在到达 startNexusOnce 之前失败
+      if (!this.startupInProgress) {
+        mainWarn('ServiceManager', 'waitForSecrets: startup completed without creating secretsReadyPromise');
+        return false;
+      }
     }
     return this.secretsReadyPromise;
   }


### PR DESCRIPTION
## Summary
- Revert the `await serviceManager.startup()` from PR #291 which unnecessarily blocked ExtensionRegistry initialization
- Remove the 120s hard timeout in `waitForSecrets()` and replace it with startup failure detection via `startupInProgress` flag
- ChannelManager already has internal `waitForSecretsReady()` that precisely waits for Nexus + secrets, no need to block all initialization behind `serviceManager.startup()`

## Test plan
- [ ] Build passes (`electron-vite build`)
- [ ] Normal startup: ExtensionRegistry not blocked by ServiceManager, ChannelManager correctly gets secrets
- [ ] Slow Nexus startup (>120s): no longer times out, ChannelManager waits until secrets are ready
- [ ] Startup failure: `waitForSecrets()` detects startup ended, returns false, ChannelManager continues with fallback credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)