### PR TITLE
fix(openclaw): replace [LOAD_SKILL:] with direct SKILL.md read for openclaw-gateway

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -22,7 +22,7 @@ import { SUDOCLAW_DIR } from '../services/sudoclaw/SudoclawInstallService';
 import { checkSudoclawHealth } from '../services/sudoclaw/sudoclawHealth';
 import type AcpAgent from '../task/AcpAgent';
 import type OpenClawAgent from '../task/OpenClawAgent';
-import { prepareFirstMessage, prepareFirstMessageWithSkillsIndex, injectSkillsDirectoryHint } from '../task/agentUtils';
+import { prepareFirstMessage, prepareOpenClawFirstMessage, injectSkillsDirectoryHint } from '../task/agentUtils';
 import { resolveOpenClawConnectionStatus } from '../utils/connectionStatus';
 import { listWorkspaceSkillTargets, resolveConversationEnabledSkillNames } from '../utils/workspaceSkillTargets';
 import { areSkillSelectionsEqual, resolveLatestConversationEnabledSkills } from '../utils/conversationAssistantSkills';
@@ -896,7 +896,10 @@ export function initConversationBridge(): void {
         let agentContent = other.input;
 
         const skillsToInject = other.skills?.length ? other.skills : enabledSkills;
-        agentContent = await prepareFirstMessageWithSkillsIndex(agentContent, {
+        // Use prepareOpenClawFirstMessage — openclaw agents have a file read tool and must
+        // read SKILL.md directly. prepareFirstMessageWithSkillsIndex injects [LOAD_SKILL:]
+        // which is a Gemini-only protocol that openclaw doesn't support.
+        agentContent = await prepareOpenClawFirstMessage(agentContent, {
           presetContext,
           enabledSkills: skillsToInject,
         });

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -174,6 +174,51 @@ For example:
 }
 
 /**
+ * 为 OpenClaw (openclaw-gateway) 准备首条消息内容。
+ * Prepare first message content for OpenClaw (openclaw-gateway) agents.
+ *
+ * OpenClaw agents have a file read tool and can read SKILL.md files directly.
+ * Do NOT inject [LOAD_SKILL:] instructions — those are for Gemini ACP agents only.
+ * Only inject presetContext + builtin skills location hint (read-based, not tag-based).
+ * Workspace skills are handled separately by injectSkillsDirectoryHint.
+ *
+ * @param content - 原始消息内容 / Original message content
+ * @param config - 首次消息配置 / First message configuration
+ * @returns 注入系统指令后的消息内容 / Message content with system instructions injected
+ */
+export async function prepareOpenClawFirstMessage(content: string, config: FirstMessageConfig): Promise<string> {
+  const instructions: string[] = [];
+
+  // 1. 添加预设规则 / Add preset rules
+  if (config.presetContext) {
+    instructions.push(config.presetContext);
+  }
+
+  // 2. 加载内置 skills 索引 — 告诉 agent 直接读取 SKILL.md，不使用 [LOAD_SKILL:] 协议
+  // Load builtin skills index — tell agent to read SKILL.md directly, no [LOAD_SKILL:] protocol
+  const skillManager = AcpSkillManager.getInstance();
+  await skillManager.discoverBuiltinSkills();
+
+  const builtinSkillsIndex = skillManager.getBuiltinSkillsIndex();
+  if (builtinSkillsIndex.length > 0) {
+    const systemSkillsDir = getBuiltinSkillsDir();
+    const lines = builtinSkillsIndex.map((s) => `- ${s.name}: ${systemSkillsDir}/${s.name}/SKILL.md`);
+    const skillsInstruction = `[Builtin Skills]
+The following builtin skills are available. Read the SKILL.md file to get instructions for a skill.
+
+${lines.join('\n')}`;
+    instructions.push(skillsInstruction);
+  }
+
+  if (instructions.length === 0) {
+    return content;
+  }
+
+  const systemInstructions = instructions.join('\n\n');
+  return `[Assistant Rules - You MUST follow these instructions]\n${systemInstructions}\n\n[User Request]\n${content}`;
+}
+
+/**
  * 为首条消息补充 workspace skills 目录提示，供 OpenClaw 自行读取非 builtin skills。
  * Add workspace skills directory hint so OpenClaw can discover non-builtin skills by itself.
  *


### PR DESCRIPTION
## Summary

- openclaw-gateway agents have a file read tool and can read `SKILL.md` files directly
- Previous code called `prepareFirstMessageWithSkillsIndex` which injects a `[LOAD_SKILL: skill-name]` instruction — a Gemini-only protocol designed for agents with no file access
- When the openclaw agent saw this instruction, it output `[LOAD_SKILL: image-generation]` as literal text instead of actually using the skill
- Adds `prepareOpenClawFirstMessage` in `agentUtils.ts` that injects `presetContext` + builtin skill paths using "read the SKILL.md file" semantics (no `[LOAD_SKILL:]` tag)
- `conversationBridge.ts` now calls the new function for `openclaw-gateway` conversations; workspace skills continue to be enumerated by `injectSkillsDirectoryHint`

## Test plan

- [ ] Ask a sudoclaw (openclaw-gateway) conversation to use a skill (e.g. "draw a boy") — agent should read the `SKILL.md` file and execute the skill, not output `[LOAD_SKILL: image-generation]`
- [ ] Verify preset assistant context (presetContext rules) still appears in the first message
- [ ] Verify builtin skills (e.g. `cron`) are listed with their correct SKILL.md paths
- [ ] Verify workspace skills (image-generation etc.) are still listed via `[Skills Directory]` hint
- [ ] Verify ACP (non-openclaw) agents are unaffected — `AcpAgent.ts` still uses `prepareFirstMessageWithSkillsIndex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)