### PR TITLE
fix(messages): auto-scroll during ToolCall streaming

### DIFF
--- a/src/renderer/messages/useAutoScroll.ts
+++ b/src/renderer/messages/useAutoScroll.ts
@@ -5,13 +5,16 @@
  */
 
 /**
- * useAutoScroll - Auto-scroll hook with user scroll detection
- * Uses Virtuoso's native followOutput for streaming auto-scroll,
- * only calls scrollToIndex for user-initiated actions (send message, click button).
+ * useAutoScroll - Auto-scroll hook with user scroll detection.
  *
- * Tool Call Optimization:
- * - Scrolls to top when user sends a message to show tool execution steps
- * - Auto-scrolls to bottom when task completes
+ * Behavior:
+ * - When the user sends a message, scrolls the prompt to the top of the viewport.
+ * - When the AI streams output (text or ToolCall), auto-scrolls to the bottom
+ *   so the latest content stays visible. This covers both new messages AND
+ *   in-place content updates (e.g. long-running tool output that streams into
+ *   an existing message), which Virtuoso's native `followOutput` does not handle.
+ * - When the user manually scrolls up, auto-follow pauses to preserve their
+ *   reading position, and resumes once they scroll back to the bottom.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { VirtuosoHandle } from 'react-virtuoso';
@@ -119,7 +122,9 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     lastScrollTopRef.current = currentScrollTop;
   }, []);
 
-  // Force scroll when user sends a message or task completes
+  // Force scroll when user sends a message, or auto-follow AI output (including
+  // ToolCall streaming content updates) unless the user has manually scrolled up.
+  // 处理用户发送消息 / 跟随 AI 输出（包含 ToolCall 运行时内容更新）
   useEffect(() => {
     const currentListLength = messages.length;
     const prevLength = previousListLengthRef.current;
@@ -127,42 +132,50 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
 
     previousListLengthRef.current = currentListLength;
 
-    if (!isNewMessage) return;
+    if (!messages.length || itemCount <= 0) return;
 
     const lastMessage = messages[messages.length - 1];
 
-    // User sent a message - scroll to show the message at top of viewport
-    // 用户发送消息后滚动到合适位置，保持能看到用户输入，同时展示更多工具执行步骤空间
-    if (lastMessage?.position === 'right') {
+    // User sent a new message - scroll to show the message at top of viewport.
+    // 用户发送消息后将其滚动到视口顶部，方便用户对照自己的输入
+    if (isNewMessage && lastMessage?.position === 'right') {
       userScrolledRef.current = false;
       // Use double RAF to ensure DOM is updated before scrolling
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           if (virtuosoRef.current) {
             lastProgrammaticScrollTimeRef.current = Date.now();
-            // Scroll to show user message at top, keeping it visible
-            // 滚动到用户消息位置，使其位于视口顶部但仍可见
             virtuosoRef.current.scrollToIndex({
               index: itemCount - 1,
               align: 'start',
               behavior: 'auto', // Use auto for immediate positioning
             });
-
-            // Set userScrolledRef to true to prevent further auto-scrolling
-            // and pin the user prompt at the top
-            userScrolledRef.current = true;
           }
         });
       });
-    } else if (lastMessage?.position === 'left' && lastMessage.type !== 'tool_group' && lastMessage.type !== 'acp_tool_call' && lastMessage.type !== 'codex_tool_call') {
-      // Assistant final response - scroll to bottom to show completion
-      // 助手完成回复后滚动到底部，展示完成状态
-      userScrolledRef.current = false;
+      return;
+    }
+
+    // AI output (new message or in-place content update, including ToolCall streaming).
+    // Auto-scroll to bottom to keep the latest content visible, unless the user has
+    // manually scrolled up — in which case we respect their reading position.
+    // 自动滚动到底部以跟随 AI 输出（含 ToolCall 运行时内容更新）；
+    // 若用户已手动向上滚动，则保留其阅读位置，不干扰阅读。
+    //
+    // Note: we intentionally do NOT update lastProgrammaticScrollTimeRef here.
+    // Auto-follow always scrolls DOWN (scrollTop increases → delta > 0), so it
+    // cannot be misdetected as a user scroll-up in handleScroll. Skipping the
+    // guard update keeps user scroll-up detection responsive during high-frequency
+    // streaming updates where the guard window would otherwise never close.
+    if (!userScrolledRef.current && lastMessage?.position === 'left') {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           if (virtuosoRef.current) {
-            lastProgrammaticScrollTimeRef.current = Date.now();
-            scrollToBottom('auto');
+            virtuosoRef.current.scrollToIndex({
+              index: itemCount - 1,
+              align: 'end',
+              behavior: 'auto',
+            });
           }
         });
       });

--- a/tests/unit/useAutoScroll.dom.test.ts
+++ b/tests/unit/useAutoScroll.dom.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useAutoScroll } from '../../src/renderer/messages/useAutoScroll';
-import type { TMessage, IMessageText } from '../../src/common/chatLib';
+import type { TMessage, IMessageText, IMessageToolGroup } from '../../src/common/chatLib';
 
 // Mock VirtuosoHandle
 const createMockVirtuosoHandle = () => ({
@@ -177,5 +177,181 @@ describe('useAutoScroll - scroll to bottom on message send (#977)', () => {
 
     // When not at bottom, should return false
     expect(result.current.handleFollowOutput(false)).toBe(false);
+  });
+});
+
+describe('useAutoScroll - tool call auto-follow (#306)', () => {
+  let mockVirtuosoHandle: ReturnType<typeof createMockVirtuosoHandle>;
+
+  beforeEach(() => {
+    mockVirtuosoHandle = createMockVirtuosoHandle();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const createTextMessage = (position: 'left' | 'right', id: string): IMessageText => ({
+    id,
+    msg_id: id,
+    type: 'text',
+    position,
+    conversation_id: 'test-conv',
+    content: { content: 'test message' },
+    createdAt: Date.now(),
+  });
+
+  const createToolGroupMessage = (id: string, description = 'running'): IMessageToolGroup => ({
+    id,
+    msg_id: id,
+    type: 'tool_group',
+    position: 'left',
+    conversation_id: 'test-conv',
+    content: [
+      {
+        callId: `call-${id}`,
+        description,
+        name: 'run_shell_command',
+        renderOutputAsMarkdown: false,
+        status: 'Executing',
+      },
+    ],
+    createdAt: Date.now(),
+  });
+
+  it('should auto-scroll to bottom when a tool_group message is appended', async () => {
+    const initial: TMessage[] = [createTextMessage('right', 'u1')];
+
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), { initialProps: { messages: initial, itemCount: 1 } });
+
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    // Flush the scroll-to-top that happens on user send so we can assert on the
+    // tool-call scroll independently.
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    mockVirtuosoHandle.scrollToIndex.mockClear();
+
+    // AI now starts a tool call — this is a NEW left-position message.
+    const withTool: TMessage[] = [...initial, createToolGroupMessage('t1')];
+    rerender({ messages: withTool, itemCount: 2 });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(mockVirtuosoHandle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: 1,
+        align: 'end',
+        behavior: 'auto',
+      })
+    );
+  });
+
+  it('should auto-scroll on in-place tool_group content updates (streaming output)', async () => {
+    const userMsg = createTextMessage('right', 'u1');
+    const initial: TMessage[] = [userMsg, createToolGroupMessage('t1', 'step 1')];
+
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), { initialProps: { messages: initial, itemCount: 2 } });
+
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    mockVirtuosoHandle.scrollToIndex.mockClear();
+
+    // Tool call content grows in place (same length, same id, new reference).
+    // This simulates streaming stdout where only the last message's content updates.
+    const updated: TMessage[] = [userMsg, createToolGroupMessage('t1', 'step 1\nstep 2\nstep 3')];
+    rerender({ messages: updated, itemCount: 2 });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // Should still scroll even though list length did not change — this is the
+    // key behavior that was missing before the fix.
+    expect(mockVirtuosoHandle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: 1,
+        align: 'end',
+        behavior: 'auto',
+      })
+    );
+  });
+
+  it('should NOT auto-scroll during tool call streaming if user scrolled up', async () => {
+    const userMsg = createTextMessage('right', 'u1');
+    const initial: TMessage[] = [userMsg, createToolGroupMessage('t1', 'step 1')];
+
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), { initialProps: { messages: initial, itemCount: 2 } });
+
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    mockVirtuosoHandle.scrollToIndex.mockClear();
+
+    // Simulate user scrolling up: first establish a high scrollTop, then scroll up by > 10px.
+    // The programmatic-scroll guard is 150ms; advance past it first.
+    act(() => {
+      vi.advanceTimersByTime(200);
+      result.current.handleScroll({ target: { scrollTop: 500 } } as unknown as React.UIEvent<HTMLDivElement>);
+      result.current.handleScroll({ target: { scrollTop: 100 } } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    // Tool output streams in — should NOT auto-scroll because user is reading history
+    const updated: TMessage[] = [userMsg, createToolGroupMessage('t1', 'step 1\nstep 2')];
+    rerender({ messages: updated, itemCount: 2 });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(mockVirtuosoHandle.scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('should resume auto-scroll after user scrolls back to bottom', async () => {
+    const userMsg = createTextMessage('right', 'u1');
+    const initial: TMessage[] = [userMsg, createToolGroupMessage('t1', 'step 1')];
+
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), { initialProps: { messages: initial, itemCount: 2 } });
+
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // User scrolls up
+    act(() => {
+      vi.advanceTimersByTime(200);
+      result.current.handleScroll({ target: { scrollTop: 500 } } as unknown as React.UIEvent<HTMLDivElement>);
+      result.current.handleScroll({ target: { scrollTop: 100 } } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    // User scrolls back to bottom (Virtuoso reports atBottom)
+    act(() => {
+      result.current.handleAtBottomStateChange(true);
+    });
+
+    mockVirtuosoHandle.scrollToIndex.mockClear();
+
+    // More streaming content arrives
+    const updated: TMessage[] = [userMsg, createToolGroupMessage('t1', 'step 1\nstep 2')];
+    rerender({ messages: updated, itemCount: 2 });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // Auto-scroll should have resumed
+    expect(mockVirtuosoHandle.scrollToIndex).toHaveBeenCalledWith(expect.objectContaining({ align: 'end' }));
   });
 });


### PR DESCRIPTION
Closes #306

## Summary

Fixes the auto-scroll bug where the scrollbar did not follow ToolCall output while a tool was running.

## Root Cause

1. After the user sent a message, `userScrolledRef.current` was set to `true` to pin the prompt at the viewport top. This flag also made `handleFollowOutput` return `false`, which suppressed auto-scroll for every subsequent AI message — including tool calls.
2. Virtuoso's `followOutput` only fires on list length changes, so in-place content updates to an existing `tool_group` / `acp_tool_call` / `codex_tool_call` message never triggered any scroll. The existing `useEffect` also explicitly excluded those types from its auto-scroll branch.

## Fix

- User messages still scroll to the top of the viewport but no longer pin `userScrolledRef`.
- Any `left`-position message (text or any tool call type) auto-scrolls to bottom on both new messages and in-place content updates, unless the user has manually scrolled up.
- Auto-follow scrolls no longer update `lastProgrammaticScrollTimeRef`: they only scroll down (delta > 0), so they can't be misdetected as user scroll-up, and skipping the update keeps user scroll-up detection responsive during high-frequency streaming.

## Acceptance Criteria

- [x] ToolCall 运行时滚动条自动保持在底部
- [x] 新增输出内容时自动滚动显示
- [x] 用户手动向上滚动后，暂停自动滚动

## Test Plan

- [x] `bun run test tests/unit/useAutoScroll.dom.test.ts` — 10 / 10 pass (added 4 regression tests covering tool call streaming)
- [x] `bun run lint` on modified files — no new errors
- [x] `bun run type:check` — no new type errors in modified files
- [ ] Manual verification: send a message that triggers a long-running shell tool call; confirm viewport follows streaming output
- [ ] Manual verification: scroll up during a tool call; confirm auto-scroll pauses and resumes after scrolling back to bottom