### PR TITLE
fix(wecom): handle non-standard PKCS#7 padding and auto-detect file extensions

### DIFF
--- a/src/channels/plugins/wecom/WeComCrypto.ts
+++ b/src/channels/plugins/wecom/WeComCrypto.ts
@@ -83,14 +83,74 @@ export function parseWeComAesKey(aeskey: string): { key: Buffer; iv: Buffer; alg
  * @returns The decrypted plaintext buffer
  */
 export function decryptWeComMedia(ciphertext: Buffer, key: Buffer, iv: Buffer, algorithm: 'aes-256-cbc' | 'aes-128-ecb'): Buffer {
+  let decipher;
   if (algorithm === 'aes-256-cbc') {
-    const decipher = createDecipheriv('aes-256-cbc', key, iv);
-    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    decipher = createDecipheriv('aes-256-cbc', key, iv);
+  } else {
+    decipher = createDecipheriv('aes-128-ecb', key, null);
   }
 
-  // AES-128-ECB (null IV for ECB mode)
-  const decipher = createDecipheriv('aes-128-ecb', key, null);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  // WeCom media encryption uses non-standard PKCS#7 padding
+  // Disable auto-padding and manually strip padding after decryption
+  decipher.setAutoPadding(false);
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+
+  // Strip padding: check last byte and remove trailing bytes if they match
+  // Standard PKCS#7: last N bytes all equal N (padding length)
+  // WeCom variant: padding bytes may have different values but form a valid block
+  return stripPkcs7Padding(decrypted);
+}
+
+/**
+ * Strip PKCS#7 padding from decrypted data.
+ *
+ * Handles both standard PKCS#7 (padding value equals padding length)
+ * and WeCom's variant where padding bytes may differ.
+ *
+ * @param data - Decrypted data with potential padding
+ * @returns Data with padding stripped, or original data if no valid padding found
+ */
+function stripPkcs7Padding(data: Buffer): Buffer {
+  if (data.length === 0) return data;
+
+  const lastByte = data[data.length - 1];
+
+  // Valid padding range: 1-32 bytes
+  if (lastByte < 1 || lastByte > 32) return data;
+
+  // Standard PKCS#7: last N bytes all equal N
+  const paddingLength = lastByte;
+  if (data.length >= paddingLength) {
+    const paddingBytes = data.slice(-paddingLength);
+    const allMatch = paddingBytes.every((byte) => byte === paddingLength);
+    if (allMatch) {
+      return data.slice(0, -paddingLength);
+    }
+  }
+
+  // WeCom variant: check if trailing bytes are uniform padding
+  // WeCom may use padding value that differs from padding length
+  // Common case: 16 bytes of uniform value (AES block size)
+  for (const checkLen of [32, 16]) {
+    if (data.length >= checkLen) {
+      const trailing = data.slice(-checkLen);
+      const uniformValue = trailing[0];
+      // All bytes in trailing block should be the same
+      const allSame = trailing.every((byte) => byte === uniformValue);
+      if (allSame && uniformValue > 0) {
+        // Verify remaining data has valid content
+        const stripped = data.slice(0, -checkLen);
+        const signature = stripped.slice(0, 4).toString('hex');
+        const validSignatures = ['ffd8ffe0', 'ffd8ffe1', '89504e47', '25504446', '47494638'];
+        if (validSignatures.includes(signature)) {
+          return stripped;
+        }
+      }
+    }
+  }
+
+  // No valid padding pattern found, return original
+  return data;
 }
 
 /**
@@ -129,12 +189,15 @@ export async function downloadAndDecryptMedia(url: string, aeskey: string, timeo
       if (parsed) {
         try {
           data = decryptWeComMedia(data, parsed.key, parsed.iv, parsed.algorithm);
+          console.log(`[WeComCrypto] Decrypted: ${data.length} bytes, signature=${data.slice(0, 4).toString('hex')}`);
         } catch (decryptError) {
-          console.warn('[WeComCrypto] AES decryption failed, returning raw data:', decryptError);
-          // Return raw data as fallback - some media may not actually be encrypted
+          console.error('[WeComCrypto] AES decryption failed:', decryptError);
+          console.error(`[WeComCrypto] Failed: url=${url.slice(0, 100)}, aeskey=${aeskey.slice(0, 20)}..., dataSize=${data.length}`);
+          throw decryptError;
         }
       } else {
-        console.warn('[WeComCrypto] Invalid AES key format, returning raw data');
+        console.error('[WeComCrypto] Invalid AES key format');
+        throw new Error('Invalid AES key format - cannot decrypt media');
       }
     }
 

--- a/src/channels/plugins/wecom/WeComPlugin.ts
+++ b/src/channels/plugins/wecom/WeComPlugin.ts
@@ -15,6 +15,52 @@ import type { WeComMsgCallback, WeComEventCallback } from './WeComAdapter';
 import { downloadAndDecryptMedia } from './WeComCrypto';
 
 /**
+ * Detect Office document type from ZIP content.
+ *
+ * DOCX/XLSX/PPTX files are ZIP archives. We check for characteristic file paths:
+ * - PPTX: contains "ppt/presentation.xml" (check first, most specific)
+ * - XLSX: contains "xl/workbook.xml"
+ * - DOCX: contains "word/document.xml"
+ *
+ * @param buffer - ZIP file buffer
+ * @returns Extension string (.docx/.xlsx/.pptx) or .docx as fallback
+ */
+function detectOfficeDocumentType(buffer: Buffer): string {
+  try {
+    // Search for characteristic paths in ZIP content
+    // Use more specific paths to avoid false matches
+    const content = buffer.toString('binary');
+
+    // Check in order of specificity (most specific first)
+    if (content.includes('ppt/presentation.xml')) {
+      return '.pptx';
+    }
+    if (content.includes('xl/workbook.xml')) {
+      return '.xlsx';
+    }
+    if (content.includes('word/document.xml')) {
+      return '.docx';
+    }
+
+    // Fallback: check for directory names (less reliable)
+    if (content.includes('ppt/')) {
+      return '.pptx';
+    }
+    if (content.includes('xl/')) {
+      return '.xlsx';
+    }
+    if (content.includes('word/')) {
+      return '.docx';
+    }
+
+    // Default to docx for unknown Office files
+    return '.docx';
+  } catch {
+    return '.docx';
+  }
+}
+
+/**
  * WeComPlugin - WeCom (WeChat Work) Bot integration via WebSocket long connection
  *
  * Uses the official WeCom AI Bot WebSocket protocol.
@@ -349,12 +395,41 @@ export class WeComPlugin extends BasePlugin {
     // Download and decrypt each media item
     for (const item of mediaItems) {
       try {
-        const ext = item.filename ? path.extname(item.filename) : getDefaultExtension(item.msgtype);
+        const buffer = await downloadAndDecryptMedia(item.url, item.aeskey);
+
+        // Detect file format from signature and determine extension
+        const signature = buffer.slice(0, 4).toString('hex');
+        const formatMap: Record<string, { format: string; ext: string }> = {
+          ffd8ffe0: { format: 'JPEG', ext: '.jpg' },
+          ffd8ffe1: { format: 'JPEG', ext: '.jpg' },
+          '89504e47': { format: 'PNG', ext: '.png' },
+          '25504446': { format: 'PDF', ext: '.pdf' },
+          '47494638': { format: 'GIF', ext: '.gif' },
+          '504b0304': { format: 'ZIP/Office', ext: '' }, // DOCX/XLSX/PPTX are ZIP archives
+        };
+        const detected = formatMap[signature];
+
+        // Determine extension: prefer detected format, then filename, then default
+        let ext: string;
+        if (detected) {
+          // For ZIP format, try to detect specific Office document type
+          if (signature === '504b0304') {
+            const officeType = detectOfficeDocumentType(buffer);
+            ext = officeType || (item.filename ? path.extname(item.filename) : '.docx');
+          } else {
+            ext = detected.ext;
+          }
+        } else if (item.filename) {
+          ext = path.extname(item.filename);
+        } else {
+          ext = getDefaultExtension(item.msgtype);
+        }
+
         const baseName = item.filename || `wecom_${Date.now()}_${Math.random().toString(36).slice(2, 8)}${ext}`;
         const filePath = path.join(this.mediaDir, baseName);
 
-        const buffer = await downloadAndDecryptMedia(item.url, item.aeskey);
         fs.writeFileSync(filePath, buffer);
+        console.log(`[WeComPlugin] Downloaded: type=${item.msgtype}, size=${buffer.length}, format=${detected?.format || 'unknown'}, ext=${ext}, path=${filePath}`);
 
         // Write local path back to the message body
         const mixedItemsRef = body.mixed?.msg_item || body.mixed?.items || body.mixed?.item;
@@ -373,8 +448,6 @@ export class WeComPlugin extends BasePlugin {
               break;
           }
         }
-
-        console.log(`[WeComPlugin] Downloaded media: type=${item.msgtype}, size=${buffer.length}, encrypted=${!!item.aeskey}, path=${filePath}`);
       } catch (error) {
         console.error(`[WeComPlugin] Failed to download media for type=${item.msgtype}:`, error);
       }


### PR DESCRIPTION
## Summary

- 修复企业微信媒体文件解密失败的问题（BAD_DECRYPT 错误）
- 企业微信使用非标准 PKCS#7 padding（padding 值为 17 而非 16）
- 添加文件签名自动检测，为解密后的文件设置正确扩展名

## Changes

- `WeComCrypto.ts`: 使用 `setAutoPadding(false)` 绕过 Node.js padding 验证，手动去除 padding
- `WeComPlugin.ts`: 添加文件格式检测（JPEG、PNG、PDF、GIF、DOCX、XLSX、PPTX）

## Test plan

- [x] 通过企业微信发送图片，验证图片正常解密且扩展名正确
- [x] 通过企业微信发送 PDF 文档，验证解密正常且扩展名为 .pdf
- [x] 通过企业微信发送 Word 文档，验证解密正常且扩展名为 .docx
- [x] 通过企业微信发送 PPT 文档，验证解密正常且扩展名为 .pptx

🤖 Generated with [Claude Code](https://claude.com/claude-code)