### PR TITLE
fix(channels): update channel config guide links to Sudoclaw official docs

### DIFF
--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -57,7 +57,7 @@ interface DingTalkConfigFormProps {
   onStatusChange: (status: IChannelPluginStatus | null) => void;
 }
 
-const DINGTALK_DEV_DOCS_URL = 'https://open.dingtalk.com/document/dingstart/custom-bot-creation-and-installation';
+const DINGTALK_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/dingtalk.html';
 const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -57,7 +57,7 @@ interface LarkConfigFormProps {
   onStatusChange: (status: IChannelPluginStatus | null) => void;
 }
 
-const LARK_DEV_DOCS_URL = 'https://open.feishu.cn/document/develop-an-echo-bot/introduction';
+const LARK_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/feishu.html';
 const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {

--- a/src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { IChannelPluginStatus } from '@/channels/types';
+import { openExternalUrl } from '@/renderer/utils/platform';
 import { acpConversation, channel } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
@@ -15,6 +16,8 @@ import { Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { QRCodeSVG } from 'qrcode.react';
+
+const WECHAT_GUIDE_URL = 'https://sudoclaw.sudoprivacy.com/guides/weixin-clawbot.html';
 
 /**
  * Preference row component (matches DingTalk pattern)
@@ -239,7 +242,19 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
 
     return (
       <div className='flex flex-col gap-12px'>
-        <div className='text-13px text-t-secondary leading-relaxed'>{t('settings.channels.wechat.installDesc', 'Scan the QR code with WeChat to connect your personal WeChat account.')}</div>
+        <div className='text-13px text-t-secondary leading-relaxed'>
+          {t('settings.channels.wechat.installDesc', 'Scan the QR code with WeChat to connect your personal WeChat account.')}{' '}
+          <a
+            className='text-primary hover:underline cursor-pointer text-12px'
+            href={WECHAT_GUIDE_URL}
+            onClick={(e) => {
+              e.preventDefault();
+              openExternalUrl(WECHAT_GUIDE_URL).catch(console.error);
+            }}
+          >
+            跟随教程
+          </a>
+        </div>
         <Button type='primary' onClick={handleStartLogin} className='self-start'>
           {t('settings.channels.wechat.install', 'Connect WeChat')}
         </Button>

--- a/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
@@ -58,7 +58,7 @@ interface WeComConfigFormProps {
   onCredentialsChange?: (credentials: { botId: string; secret: string }) => void;
 }
 
-const WECOM_DEV_DOCS_URL = 'https://developer.work.weixin.qq.com/document/path/101463';
+const WECOM_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/wecom.html';
 const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -645,7 +645,7 @@
   },
   "lark": {
     "appId": "App ID",
-    "devConsoleLink": "飞书开放平台开发者后台",
+    "devConsoleLink": "跟随教程",
     "appIdDescSuffix": "获取 App ID",
     "appSecret": "App Secret",
     "appSecretDescSuffix": "获取 App Secret",
@@ -708,7 +708,7 @@
   },
   "wecom": {
     "botId": "Bot ID",
-    "devConsoleLink": "企业微信开发文档",
+    "devConsoleLink": "跟随教程",
     "botIdDescSuffix": "获取 Bot ID",
     "secret": "Secret",
     "secretDescSuffix": "获取 Secret",


### PR DESCRIPTION
## Summary

- 飞书/Lark: 更新接入链接 URL，链接文案改为"跟随教程"
- 钉钉/DingTalk: 更新接入链接 URL
- 企业微信/WeCom: 更新接入链接 URL，链接文案改为"跟随教程"
- 个人微信/WeChat: 在安装描述后新增"跟随教程"接入指南链接

Closes #314

## Test plan

- [ ] 打开设置 > 渠道配置，检查飞书配置页链接指向 `sudoclaw.sudoprivacy.com/guides/feishu.html`，文案为"跟随教程"
- [ ] 检查钉钉配置页链接指向 `sudoclaw.sudoprivacy.com/guides/dingtalk.html`
- [ ] 检查企业微信配置页链接指向 `sudoclaw.sudoprivacy.com/guides/wecom.html`，文案为"跟随教程"
- [ ] 检查个人微信配置页"跟随教程"链接存在且可点击

🤖 Generated with [Claude Code](https://claude.com/claude-code)