### PR TITLE
fix(sudoclaw): rename imageAnalysisModel to imageModel to match gateway schema

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -534,7 +534,7 @@ export type SudoclawProvider = {
 };
 export type SudoclawConfig = {
   lastRunMode?: string;
-  agents?: { defaults?: { model?: { primary?: string; fallbacks?: string[] }; imageAnalysisModel?: string; imageGenerationModel?: string; models?: Record<string, { alias?: string }> } };
+  agents?: { defaults?: { model?: { primary?: string; fallbacks?: string[] }; imageModel?: string; imageAnalysisModel?: string; imageGenerationModel?: string; models?: Record<string, { alias?: string }> } };
   models?: {
     mode?: 'merge' | 'replace';
     providers?: Record<string, SudoclawProvider>;

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -361,10 +361,6 @@ export class ServiceManager {
       // whether config was manually modified, or whether repair was skipped.
       repairOpenClawConfig();
 
-      // Clean up stale keys that the gateway schema doesn't recognize,
-      // BEFORE the gateway starts and validates the config.
-      this.cleanSudoclawConfig(SUDOCLAW_CONFIG_PATH);
-
       this.gateway = new OpenClawGatewayManager({
         port: SUDOCLAW_DEFAULT_PORT,
         stateDir: SUDOCLAW_DIR,
@@ -400,33 +396,6 @@ export class ServiceManager {
       // Resolve with null so waiters don't hang forever.
       this.gatewayReadyResolve?.(null);
       throw err;
-    }
-  }
-
-  /** Remove keys from sudoclaw.json that the gateway schema doesn't recognize. */
-  private cleanSudoclawConfig(sudoclawConfigPath: string): void {
-    try {
-      if (!fs.existsSync(sudoclawConfigPath)) return;
-      const raw = fs.readFileSync(sudoclawConfigPath, 'utf-8');
-      const config = JSON.parse(raw);
-      let dirty = false;
-
-      // "imageAnalysisModel" was renamed to "imageModel" in the gateway schema
-      if (config.agents?.defaults?.imageAnalysisModel !== undefined) {
-        // Preserve value → imageModel if imageModel is not already set
-        if (config.agents.defaults.imageModel === undefined) {
-          config.agents.defaults.imageModel = config.agents.defaults.imageAnalysisModel;
-        }
-        delete config.agents.defaults.imageAnalysisModel;
-        dirty = true;
-      }
-
-      if (dirty) {
-        fs.writeFileSync(sudoclawConfigPath, JSON.stringify(config, null, 2), 'utf-8');
-        mainLog('ServiceManager', 'Cleaned unrecognized keys from sudoclaw.json');
-      }
-    } catch (err) {
-      mainWarn('ServiceManager', 'Failed to clean sudoclaw.json', err);
     }
   }
 

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -361,6 +361,10 @@ export class ServiceManager {
       // whether config was manually modified, or whether repair was skipped.
       repairOpenClawConfig();
 
+      // Clean up stale keys that the gateway schema doesn't recognize,
+      // BEFORE the gateway starts and validates the config.
+      this.cleanSudoclawConfig(SUDOCLAW_CONFIG_PATH);
+
       this.gateway = new OpenClawGatewayManager({
         port: SUDOCLAW_DEFAULT_PORT,
         stateDir: SUDOCLAW_DIR,
@@ -399,6 +403,33 @@ export class ServiceManager {
     }
   }
 
+  /** Remove keys from sudoclaw.json that the gateway schema doesn't recognize. */
+  private cleanSudoclawConfig(sudoclawConfigPath: string): void {
+    try {
+      if (!fs.existsSync(sudoclawConfigPath)) return;
+      const raw = fs.readFileSync(sudoclawConfigPath, 'utf-8');
+      const config = JSON.parse(raw);
+      let dirty = false;
+
+      // "imageAnalysisModel" was renamed to "imageModel" in the gateway schema
+      if (config.agents?.defaults?.imageAnalysisModel !== undefined) {
+        // Preserve value → imageModel if imageModel is not already set
+        if (config.agents.defaults.imageModel === undefined) {
+          config.agents.defaults.imageModel = config.agents.defaults.imageAnalysisModel;
+        }
+        delete config.agents.defaults.imageAnalysisModel;
+        dirty = true;
+      }
+
+      if (dirty) {
+        fs.writeFileSync(sudoclawConfigPath, JSON.stringify(config, null, 2), 'utf-8');
+        mainLog('ServiceManager', 'Cleaned unrecognized keys from sudoclaw.json');
+      }
+    } catch (err) {
+      mainWarn('ServiceManager', 'Failed to clean sudoclaw.json', err);
+    }
+  }
+
   private async syncImageModelToSudoclaw(sudoclawConfigPath: string): Promise<void> {
     try {
       const { ProcessConfig } = await import('@/process/initStorage');
@@ -431,8 +462,8 @@ export class ServiceManager {
         return modelId.includes('/') ? modelId : `${provider}/${modelId}`;
       };
 
-      // Sync parsing model (看图) → agents.defaults.imageAnalysisModel (read by gateway)
-      config.agents.defaults.imageAnalysisModel = findProvider(DEFAULT_IMAGE_PARSING_MODEL);
+      // Sync parsing model (看图) → agents.defaults.imageModel (read by gateway)
+      config.agents.defaults.imageModel = findProvider(DEFAULT_IMAGE_PARSING_MODEL);
 
       // Sync generation model (生图) → agents.defaults.imageGenerationModel (read by Electron)
       config.agents.defaults.imageGenerationModel = switchOn ? generationModel : '';

--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -420,6 +420,16 @@ export function repairOpenClawConfig(): void {
       changed = true;
     }
 
+    // "imageAnalysisModel" is not in the gateway zod schema; migrate to "imageModel"
+    const agentDefaults = (config.agents as { defaults?: Record<string, unknown> } | undefined)?.defaults;
+    if (agentDefaults?.imageAnalysisModel !== undefined) {
+      if (agentDefaults.imageModel === undefined) {
+        agentDefaults.imageModel = agentDefaults.imageAnalysisModel;
+      }
+      delete agentDefaults.imageAnalysisModel;
+      changed = true;
+    }
+
     // Ensure gateway config exists with auth: { mode: 'none' }
     if (!config.gateway || typeof config.gateway !== 'object') {
       (config as Record<string, unknown>).gateway = {

--- a/src/renderer/components/SettingsModal/contents/ToolsModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/ToolsModalContent.tsx
@@ -275,7 +275,7 @@ const ToolsModalContent: React.FC = () => {
       ConfigStorage.set('tools.imageGenerationModel', newImageGenerationModel).catch((error) => {
         console.error('Failed to update image generation model config:', error);
       });
-      // Persist to sudoclaw.json agents.defaults.imageAnalysisModel so skill scripts pick it up dynamically
+      // Persist to sudoclaw.json agents.defaults.imageModel so skill scripts pick it up dynamically
       const modelId = newImageGenerationModel.switch && newImageGenerationModel.useModel ? newImageGenerationModel.useModel : null;
       openclaw.updateImageModel.invoke({ modelId }).catch(console.error);
       return newImageGenerationModel;


### PR DESCRIPTION
## Summary
- Sudoclaw gateway schema only recognizes `imageModel`, not `imageAnalysisModel` — the mismatch caused config validation failure and gateway crash on every startup (requiring retry)
- Add `cleanSudoclawConfig()` to migrate the stale key **before** gateway starts
- Write `imageModel` instead of `imageAnalysisModel` in `syncImageModelToSudoclaw()`

## Test plan
- [x] Verified gateway starts successfully on first attempt (no more `Unrecognized key` error)
- [ ] Verify image analysis model setting still works correctly in Settings > Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)