### PR TITLE
fix: rename imageAnalysisModel to imageModel in image skill scripts

### DIFF
--- a/skills/image-analysis/scripts/analyze_image.sh
+++ b/skills/image-analysis/scripts/analyze_image.sh
@@ -28,7 +28,7 @@ try:
     sr = c.get('models',{}).get('providers',{}).get('sudorouter',{})
     base_url = sr.get('baseUrl','')
     api_key = sr.get('apiKey','')
-    m = c.get('agents',{}).get('defaults',{}).get('imageAnalysisModel','')
+    m = c.get('agents',{}).get('defaults',{}).get('imageModel','')
     model = m.split('/')[-1] if '/' in m else m
     print(f'_CFG_BASE_URL={repr(base_url.rstrip(\"/\"))}')
     print(f'_CFG_API_KEY={repr(api_key)}')

--- a/skills/image-generation/scripts/generate_image.sh
+++ b/skills/image-generation/scripts/generate_image.sh
@@ -5,7 +5,7 @@
 #   generate_image.sh edit "<prompt>" "<image_path>" [<filename_no_ext>] [size]
 # Reads config from sudoclaw.json via SUDOCLAW_CONFIG_PATH env var.
 # IMAGE_MODEL is read from agents.defaults.imageGenerationModel in sudoclaw.json.
-# (Note: agents.defaults.imageAnalysisModel is the image *parsing* model for the gateway;
+# (Note: agents.defaults.imageModel is the image *parsing* model for the gateway;
 #  image generation uses the separate imageGenerationModel field.)
 # Any leading "provider/" prefix is stripped before sending to /images/generations.
 # Overrides: PROVIDER_BASE_URL, PROVIDER_API_KEY, IMAGE_MODEL


### PR DESCRIPTION
## Summary
- Rename `imageAnalysisModel` config key to `imageModel` in `analyze_image.sh` and `generate_image.sh`
- Aligns image skill scripts with the gateway schema rename done in 37b171f

## Test plan
- [ ] Verify image analysis skill reads the correct `imageModel` config key
- [ ] Verify image generation script comment reflects the updated key name

🤖 Generated with [Claude Code](https://claude.com/claude-code)