### PR TITLE
fix: 在 Windows 上的 InitLoading 页面添加 WindowControls 组件

### DIFF
--- a/src/renderer/components/InitLoading.tsx
+++ b/src/renderer/components/InitLoading.tsx
@@ -8,6 +8,19 @@ import React, { useRef, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { init } from '@/common/ipcBridge';
 import { useInit } from '../context/InitContext';
+import WindowControls from './WindowControls';
+
+// 运行时判断 / Runtime check
+const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
+
+// 窗口控制按钮悬浮容器样式 / Floating container style for window controls
+const WINDOW_CONTROLS_WRAPPER_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  zIndex: 9999,
+  WebkitAppRegion: 'no-drag',
+} as React.CSSProperties;
 
 // ── Step definitions ─────────────────────────────────────────────────────────
 type StepId = 'git' | 'node' | 'claude' | 'sudoclaw' | 'nexus' | 'bdpan';
@@ -272,6 +285,12 @@ const InitLoading: React.FC<InitLoadingProps> = ({ variant = 'full' }) => {
           } as React.CSSProperties
         }
       >
+        {/* 桌面端窗口控制按钮 / Window controls for desktop */}
+        {isDesktopRuntime && (
+          <div style={WINDOW_CONTROLS_WRAPPER_STYLE}>
+            <WindowControls />
+          </div>
+        )}
         <div
           style={{
             width: '100%',
@@ -519,6 +538,12 @@ const InitLoading: React.FC<InitLoadingProps> = ({ variant = 'full' }) => {
         } as React.CSSProperties
       }
     >
+      {/* 桌面端窗口控制按钮 / Window controls for desktop */}
+      {isDesktopRuntime && (
+        <div style={WINDOW_CONTROLS_WRAPPER_STYLE}>
+          <WindowControls />
+        </div>
+      )}
       <div
         style={{
           width: '100%',


### PR DESCRIPTION
## Summary

在 `src/renderer/components/InitLoading.tsx` 的 `full` 和 `startup` 两个 variant 中添加 `WindowControls` 组件，使得 Windows 用户在初始化加载页面也可以正常对窗口进行最小化/最大化/关闭操作。

实现方式与 `src/renderer/pages/login/index.tsx` 一致：
- 仅在 `isDesktopRuntime` （检测 `window.electronAPI`）时渲染
- 用带 `position: fixed; top: 0; right: 0` 和 `WebkitAppRegion: 'no-drag'` 的容器悬浮在页面右上角
- macOS 场景下 `WindowControls` 内部因 IPC 不可用自动隐藏，不会影响原生红绿灯

Fixes #326

## Test plan

- [ ] 在 Windows 上验证 InitLoading 加载时右上角显示最小化/最大化/关闭按钮，且功能正常
- [ ] 在 macOS 上验证 InitLoading 加载时不会重复显示自定义 WindowControls
- [ ] 验证 `startup` 和 `full` 两种 variant 均可操作窗口

🤖 Generated with [Claude Code](https://claude.ai/code)