### PR TITLE
fix(channels): render IM image attachments as inline previews

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import type { TMessage } from '@/common/chatLib';
 import { database as databaseBridge } from '@/common/ipcBridge';
+import { appendNexusFilesMarker } from '@/common/nexusFiles';
 import { getDatabase } from '@/process/database';
 import { ProcessConfig } from '@/process/initStorage';
 import { getDataPath } from '@/process/utils';
@@ -501,10 +502,16 @@ export class ActionExecutor {
         // Regular text message - send to AI
         await this.handleChatMessage(context, content.text);
       } else if (isMediaContentType(content.type)) {
-        // Media message (photo, document, voice, video) - extract file paths and send to AI
+        // Media message (photo, document, voice, video) - extract file paths and send to AI.
+        // Align with desktop SendBox: embed `[[NEXUS_FILES]]` so the renderer shows
+        // images/files inline (FilePreview) instead of only `[photo message]`.
+        // AcpAgent strips the marker before forwarding to the agent and turns the
+        // paths into image content blocks via processAtFileReferences().
         const files = content.attachments?.map((a) => a.fileId).filter((id) => !!id) || [];
-        const text = content.text || `[${content.type} message]`;
-        await this.handleChatMessage(context, text, files);
+        const plainText = content.text || `[${content.type} message]`;
+        const workspacePath = session.workspace || getChannelWorkspacePath(platform);
+        const displayMessage = appendNexusFilesMarker(plainText, files, workspacePath);
+        await this.handleChatMessage(context, displayMessage, files);
       } else {
         // Unsupported content type
         await context.sendMessage({

--- a/src/common/nexusFiles.ts
+++ b/src/common/nexusFiles.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NEXUS_FILES_MARKER } from './constants';
+
+/**
+ * Append the `[[NEXUS_FILES]]` marker + file list to a message so the desktop
+ * renderer can display files/images inline (see `MessageText.tsx` →
+ * `parseFileMarker`), and the agent layer can turn them into `@` references.
+ *
+ * Mirrors the desktop SendBox behavior (`renderer/utils/messageFiles.ts#buildDisplayMessage`)
+ * so messages arriving from Channel plugins (Telegram, Lark, DingTalk, WeCom,
+ * WeChat) render the same way as user-uploaded files from the desktop UI.
+ *
+ * Path normalization rules (match desktop behavior):
+ * - Absolute paths (Unix `/...` or Windows `C:\...`) are rewritten to
+ *   `${workspacePath}/${fileName}` so the reference lives under the session
+ *   workspace that the agent will resolve.
+ * - Relative paths are prefixed with `${workspacePath}/`.
+ * - When `workspacePath` is empty, paths are used as‑is.
+ *
+ * @param input         Plain message text (e.g. `[photo message]`).
+ * @param files         Raw file paths (absolute or relative). Order preserved.
+ * @param workspacePath Session workspace root used to normalize paths.
+ */
+export function appendNexusFilesMarker(input: string, files: string[], workspacePath: string): string {
+  if (!files.length) return input;
+  const displayPaths = files.map((filePath) => {
+    if (!workspacePath) return filePath;
+    const isAbsolute = filePath.startsWith('/') || /^[A-Za-z]:/.test(filePath);
+    if (isAbsolute) {
+      const parts = filePath.split(/[\\/]/);
+      const fileName = parts[parts.length - 1] || filePath;
+      return `${workspacePath}/${fileName}`;
+    }
+    return `${workspacePath}/${filePath}`;
+  });
+  return `${input}\n\n${NEXUS_FILES_MARKER}\n${displayPaths.join('\n')}`;
+}

--- a/tests/unit/nexusFiles.test.ts
+++ b/tests/unit/nexusFiles.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { NEXUS_FILES_MARKER } from '@/common/constants';
+import { appendNexusFilesMarker } from '@/common/nexusFiles';
+
+const CHANNEL_WORKSPACE = '/Users/test/.nexus/sudowork/channel-media/wechat';
+
+describe('appendNexusFilesMarker', () => {
+  it('returns input unchanged when files list is empty', () => {
+    expect(appendNexusFilesMarker('hello', [], CHANNEL_WORKSPACE)).toBe('hello');
+  });
+
+  it('rewrites absolute unix paths to workspace/fileName', () => {
+    const result = appendNexusFilesMarker('[photo message]', ['/tmp/channel-media/wechat/wechat_123.jpg'], CHANNEL_WORKSPACE);
+    expect(result).toContain(NEXUS_FILES_MARKER);
+    expect(result).toContain(`${CHANNEL_WORKSPACE}/wechat_123.jpg`);
+    // Preserves the leading text
+    expect(result.startsWith('[photo message]\n\n')).toBe(true);
+  });
+
+  it('rewrites absolute Windows paths to workspace/fileName', () => {
+    const result = appendNexusFilesMarker('[photo message]', ['C:\\Users\\bot\\channel-media\\wechat\\img.png'], CHANNEL_WORKSPACE);
+    expect(result).toContain(`${CHANNEL_WORKSPACE}/img.png`);
+  });
+
+  it('joins relative paths under the workspace', () => {
+    const result = appendNexusFilesMarker('text', ['subdir/file.txt'], CHANNEL_WORKSPACE);
+    expect(result).toContain(`${CHANNEL_WORKSPACE}/subdir/file.txt`);
+  });
+
+  it('uses paths as-is when workspacePath is empty', () => {
+    const result = appendNexusFilesMarker('text', ['/tmp/file.txt'], '');
+    expect(result).toBe(`text\n\n${NEXUS_FILES_MARKER}\n/tmp/file.txt`);
+  });
+
+  it('joins multiple files on separate lines', () => {
+    const result = appendNexusFilesMarker('text', ['/a/b/one.jpg', '/c/d/two.png'], CHANNEL_WORKSPACE);
+    const afterMarker = result.split(NEXUS_FILES_MARKER)[1].trim();
+    expect(afterMarker.split('\n')).toEqual([`${CHANNEL_WORKSPACE}/one.jpg`, `${CHANNEL_WORKSPACE}/two.png`]);
+  });
+
+  it('produces a message that MessageText.parseFileMarker can split back into text + files', () => {
+    const result = appendNexusFilesMarker('[photo message]', ['/tmp/channel-media/wechat/img.jpg'], CHANNEL_WORKSPACE);
+    const markerIndex = result.indexOf(NEXUS_FILES_MARKER);
+    const text = result.slice(0, markerIndex).trimEnd();
+    const files = result
+      .slice(markerIndex + NEXUS_FILES_MARKER.length)
+      .trim()
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    expect(text).toBe('[photo message]');
+    expect(files).toEqual([`${CHANNEL_WORKSPACE}/img.jpg`]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
         'src/agent/acp/modelInfo.ts',
         // Common
         'src/common/chatLib.ts',
+        'src/common/nexusFiles.ts',
         'src/common/update/models/VersionInfo.ts',
         'src/common/types/conversion.ts',
         // Renderer utils


### PR DESCRIPTION
Closes #331

## Summary

- IM-channel media messages (WeChat/WeCom/Telegram/Lark/DingTalk photos, documents, voice, video) were saved to history as plain text `[photo message]`, so the desktop session view had no way to render the attachment inline.
- Align the channel branch of `ActionExecutor` with the desktop SendBox by embedding the shared `[[NEXUS_FILES]]` marker + normalized file paths. `MessageText.parseFileMarker` then splits text + files for `FilePreview`, and `AcpAgent` ’s existing `processAtFileReferences` → `tryReadAsImage` emits an ACP image content block to the agent.
- Extract the path-normalization logic into `src/common/nexusFiles.ts#appendNexusFilesMarker` so it's reusable by process and renderer alike.

## Test plan
- [x] `bun run test tests/unit/nexusFiles.test.ts` → 7/7 passed
- [x] `bun run test tests/unit/channels tests/unit/messageFiles.test.ts tests/unit/nexusFiles.test.ts` → 144/145 passed (pre-existing wecomCrypto AES-256 failure unrelated)
- [x] `bunx tsc --noEmit` on edited files → no new type errors
- [ ] Manual: send a WeChat photo to the bot and confirm the desktop session view shows the image inline (not just `[photo message]`)
- [ ] Manual: verify the agent response acknowledges the image content (ACP image block delivered)
- [ ] Manual: repeat for a photo-only message (no caption) to confirm empty-text path works