### PR TITLE
fix: safeExec 使用跨平台 shell 以支持 Windows

### DIFF
--- a/src/process/services/mcporter/McporterService.ts
+++ b/src/process/services/mcporter/McporterService.ts
@@ -13,6 +13,7 @@ import type { IMcpServer } from '@/common/storage';
 import { convertToMcporterConfig, type McporterConfig } from './mcporterConfig';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { safeExec } from '@process/utils/safeExec';
+import { getEnhancedEnv } from '@process/utils/shellEnv';
 
 /**
  * mcporter daemon 状态
@@ -58,8 +59,10 @@ class McporterService {
    */
   async isAvailable(): Promise<boolean> {
     try {
+      // Use getEnhancedEnv to ensure bundled Node.js is in PATH
       const result = await safeExec('npx mcporter --version', {
         timeout: 10000,
+        env: getEnhancedEnv(),
       });
       return result.stdout.trim().length > 0;
     } catch {
@@ -74,8 +77,10 @@ class McporterService {
     mainLog('McporterService', 'Installing mcporter globally...');
 
     try {
+      // Use getEnhancedEnv to ensure bundled Node.js is in PATH
       await safeExec('npm install -g mcporter', {
         timeout: 60000,
+        env: getEnhancedEnv(),
       });
       mainLog('McporterService', 'mcporter installed successfully');
     } catch (error) {
@@ -246,15 +251,10 @@ class McporterService {
     mainLog('McporterService', 'Stopping mcporter daemon...');
 
     try {
-      // 使用 mcporter CLI 停止 daemon
-      const env = {
-        ...process.env,
-        MCPORTER_CONFIG: this.configPath,
-      };
-
+      // Use getEnhancedEnv to ensure bundled Node.js is in PATH
       await safeExec('npx mcporter daemon stop', {
         timeout: 10000,
-        env,
+        env: getEnhancedEnv({ MCPORTER_CONFIG: this.configPath }),
       });
 
       this.daemonProcess = null;
@@ -274,14 +274,10 @@ class McporterService {
    */
   private async reloadDaemon(): Promise<void> {
     try {
-      const env = {
-        ...process.env,
-        MCPORTER_CONFIG: this.configPath,
-      };
-
+      // Use getEnhancedEnv to ensure bundled Node.js is in PATH
       await safeExec('npx mcporter daemon restart', {
         timeout: 10000,
-        env,
+        env: getEnhancedEnv({ MCPORTER_CONFIG: this.configPath }),
       });
 
       mainLog('McporterService', 'Daemon reloaded');
@@ -295,14 +291,10 @@ class McporterService {
    */
   async getDaemonStatus(): Promise<DaemonStatus> {
     try {
-      const env = {
-        ...process.env,
-        MCPORTER_CONFIG: this.configPath,
-      };
-
+      // Use getEnhancedEnv to ensure bundled Node.js is in PATH
       const result = await safeExec('npx mcporter daemon status --json', {
         timeout: 5000,
-        env,
+        env: getEnhancedEnv({ MCPORTER_CONFIG: this.configPath }),
       });
 
       const status = JSON.parse(result.stdout) as DaemonStatus;

--- a/src/process/utils/safeExec.ts
+++ b/src/process/utils/safeExec.ts
@@ -15,6 +15,7 @@
  */
 
 import { spawn } from 'child_process';
+import { platform } from 'os';
 
 type ExecResult = { stdout: string; stderr: string };
 
@@ -24,12 +25,25 @@ interface SafeExecOptions {
 }
 
 /**
+ * Get the appropriate shell for the current platform.
+ * - Unix (darwin, linux): uses 'sh'
+ * - Windows: uses 'cmd.exe'
+ */
+function getShell(): { shell: string; flag: string } {
+  if (platform() === 'win32') {
+    return { shell: 'cmd.exe', flag: '/c' };
+  }
+  return { shell: 'sh', flag: '-c' };
+}
+
+/**
  * Shell-based command execution (replacement for `child_process.exec`).
- * Runs the command in `/bin/sh -c` with `detached: true`.
+ * Runs the command in a shell with `detached: true` for cross-platform compatibility.
  */
 export function safeExec(command: string, options: SafeExecOptions = {}): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn('sh', ['-c', command], {
+    const { shell, flag } = getShell();
+    const child = spawn(shell, [flag, command], {
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: options.env,


### PR DESCRIPTION
## Summary
- 修复 `safeExec` 函数在 Windows 上的兼容性问题
- Unix (darwin, linux): 使用 `'sh -c'`
- Windows: 使用 `'cmd.exe /c'`
- 解决 `McporterService.install()` 等服务在 Windows 上的 `spawn sh ENOENT` 错误

## Problem
原代码硬编码使用 `sh` shell，但 Windows 没有 `sh` 命令，导致执行 `npm install -g mcporter` 等命令时报错：
```
spawn sh ENOENT
```

## Solution
添加 `getShell()` 函数检测平台：
- Windows (`win32`): 使用 `cmd.exe /c`
- 其他平台: 保持使用 `sh -c`

## Test plan
- [ ] 在 Windows 上测试 `npm install -g mcporter`
- [ ] 在 macOS 上验证原有功能不受影响
- [ ] 在 Linux 上验证原有功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)