### PR TITLE
fix(ui): unify tool summary completed status to muted style

### DIFF
--- a/src/renderer/messages/MessageToolGroupSummary.css
+++ b/src/renderer/messages/MessageToolGroupSummary.css
@@ -84,6 +84,10 @@
   white-space: nowrap;
 }
 
+.tool-steps-card__title--muted {
+  color: var(--color-text-3, #86909c);
+}
+
 .tool-steps-card__count {
   display: inline-flex;
   align-items: center;
@@ -110,8 +114,8 @@
 }
 
 .tool-steps-card__count--done {
-  background: rgba(0, 180, 42, 0.12);
-  color: var(--color-success, #00b42a);
+  background: var(--color-fill-2, #f2f3f5);
+  color: var(--color-text-3, #86909c);
 }
 
 .tool-steps-card__chevron {
@@ -160,7 +164,7 @@
 }
 
 .tool-steps-status-dot--done {
-  background: var(--color-success, #00b42a);
+  background: var(--color-text-4, #c9cdd4);
 }
 
 .tool-steps-status-dot--error {

--- a/src/renderer/messages/MessageToolGroupSummary.tsx
+++ b/src/renderer/messages/MessageToolGroupSummary.tsx
@@ -346,7 +346,7 @@ const MessageToolGroupSummary: React.FC<MessageToolGroupSummaryProps> = ({ messa
 
   const overallStatus: ToolStatus = errorCount > 0 ? 'error' : runningCount > 0 ? 'running' : completedCount === totalCount && totalCount > 0 ? 'success' : 'default';
 
-  const headerLabel = overallStatus === 'running' ? '执行中...' : overallStatus === 'error' ? '执行失败' : overallStatus === 'success' ? '执行完成' : '查看步骤';
+  const headerLabel = overallStatus === 'running' ? '执行中...' : overallStatus === 'success' || overallStatus === 'error' ? '执行完成' : '查看步骤';
 
   return (
     <div ref={containerRef} className='tool-steps-card' onClick={(e) => e.stopPropagation()}>
@@ -361,18 +361,16 @@ const MessageToolGroupSummary: React.FC<MessageToolGroupSummaryProps> = ({ messa
           <span
             className={classNames('tool-steps-status-dot', {
               'tool-steps-status-dot--running': overallStatus === 'running',
-              'tool-steps-status-dot--done': overallStatus === 'success',
-              'tool-steps-status-dot--error': overallStatus === 'error',
+              'tool-steps-status-dot--done': overallStatus === 'success' || overallStatus === 'error',
               'tool-steps-status-dot--default': overallStatus === 'default',
             })}
             aria-hidden='true'
           />
-          <span className='tool-steps-card__title'>{headerLabel}</span>
+          <span className={classNames('tool-steps-card__title', { 'tool-steps-card__title--muted': overallStatus !== 'running' })}>{headerLabel}</span>
           <span
             className={classNames('tool-steps-card__count', {
               'tool-steps-card__count--running': overallStatus === 'running',
-              'tool-steps-card__count--error': overallStatus === 'error',
-              'tool-steps-card__count--done': overallStatus === 'success',
+              'tool-steps-card__count--done': overallStatus === 'success' || overallStatus === 'error',
             })}
           >
             {completedCount}/{totalCount}


### PR DESCRIPTION
## Summary
- 工具执行汇总卡片完成后，不再区分"执行成功"和"执行失败"，统一显示"执行完成"
- 完成后状态使用灰色弱化样式（圆点、文字、计数徽章均为灰色），避免误导

## Context
当大模型执行工具时，中间可能有工具失败但经过重试最终成功。原逻辑只要有一个工具 error 就显示红色"执行失败"，给用户造成误导。Closes #344

## Test plan
- [ ] 与 sudoclaw 对话触发工具执行，确认执行中显示不变（脉冲动画 + "执行中... N/M"）
- [ ] 执行完成后确认显示灰色"执行完成 N/M"，不再出现红色"执行失败"
- [ ] 点击展开确认单个步骤的状态图标仍保留成功绿、失败红等区分

🤖 Generated with [Claude Code](https://claude.com/claude-code)