### PR TITLE
feat(messages): activate bottom spacer only during an active turn

### DIFF
--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -31,7 +31,7 @@ import MessageToolGroupSummary from './MessageToolGroupSummary';
 import MessageText from './MessagetText';
 import TurnActions from './TurnActions';
 import type { WriteFileResult } from './types';
-import { useAutoScroll } from './useAutoScroll';
+import { BOTTOM_BUFFER_PX, useAutoScroll } from './useAutoScroll';
 import ContextMenu, { type ContextMenuItem } from '@/renderer/components/ContextMenu';
 import { copyText } from '@/renderer/utils/clipboard';
 import { IconCopy } from '@arco-design/web-react/icon';
@@ -339,7 +339,7 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
   }, [list]);
 
   // Use auto-scroll hook
-  const { virtuosoRef, handleScroll, handleAtBottomStateChange, handleFollowOutput, showScrollButton, scrollToBottom, hideScrollButton } = useAutoScroll({
+  const { virtuosoRef, handleScroll, handleAtBottomStateChange, handleFollowOutput, handleScrollerRef, showScrollButton, scrollToBottom, hideScrollButton, bottomSpacerHeight } = useAutoScroll({
     messages: list,
     itemCount: processedList.length,
   });
@@ -437,10 +437,14 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
         <ImagePreviewContext.Provider value={{ inPreviewGroup: true }}>
           <Virtuoso
             ref={virtuosoRef}
+            scrollerRef={handleScrollerRef}
             className='flex-1 h-full pb-10px box-border'
             data={processedList}
             initialTopMostItemIndex={processedList.length - 1}
-            atBottomThreshold={100}
+            // atBottom must encompass the dynamic spacer so "at bottom" still
+            // means "the last message is in view" while the user prompt is
+            // pinned at the top with an empty canvas below it.
+            atBottomThreshold={bottomSpacerHeight + 100}
             increaseViewportBy={200}
             itemContent={renderItem}
             followOutput={handleFollowOutput}
@@ -448,14 +452,13 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
             atBottomStateChange={handleAtBottomStateChange}
             components={{
               Header: () => <div className='h-10px' />,
-              // Footer doubles as the bottom buffer between the last message and
-              // the SendBox below. useAutoScroll scrolls to the absolute bottom
-              // of the scroller (not align:end), so this Footer is visible at
-              // the bottom of the viewport — keeping the last message's bottom
-              // border clear of the input area during ToolCall streaming.
-              // Footer 同时作为最后一条消息与下方输入框之间的缓冲区，确保
-              // ToolCall 流式输出时消息底边不会被输入框遮挡。
-              Footer: () => <div className='h-40px' />,
+              // Footer = static BOTTOM_BUFFER_PX (breathing room between the
+              // last message and the SendBox below) + dynamic bottomSpacerHeight
+              // that pins the user prompt to the top of the viewport while the
+              // AI streams into the empty canvas below. bottomSpacerHeight is 0
+              // in idle state, so the chat log looks like a regular list when
+              // no turn is active.
+              Footer: () => <div style={{ height: BOTTOM_BUFFER_PX + bottomSpacerHeight }} />,
             }}
           />
         </ImagePreviewContext.Provider>

--- a/src/renderer/messages/useAutoScroll.ts
+++ b/src/renderer/messages/useAutoScroll.ts
@@ -5,24 +5,23 @@
  */
 
 /**
- * useAutoScroll - Auto-scroll hook with user scroll detection.
+ * useAutoScroll - Auto-scroll hook with user scroll detection and a dynamic
+ * bottom spacer that pins the latest user prompt to the top of the viewport.
  *
- * Behavior:
- * - When the user sends a message, scrolls the prompt to the top of the viewport.
- * - When the AI streams output (text or ToolCall), auto-scrolls to the absolute
- *   bottom of the scroll container so the latest content stays visible. This
- *   covers both new messages AND in-place content updates (e.g. long-running
- *   tool output that streams into an existing message), which Virtuoso's native
- *   `followOutput` does not handle.
- *
- *   We use `scrollTo({ top: MAX })` (not `scrollToIndex({ align: 'end' })`)
- *   so that the Virtuoso Footer is visible at the bottom of the viewport,
- *   acting as a buffer between the last message's bottom border and the input
- *   box below the message list. Otherwise, `align: 'end'` would flush the
- *   message bottom directly against the viewport edge, making the bottom
- *   border appear clipped against the SendBox during streaming.
- * - When the user manually scrolls up, auto-follow pauses to preserve their
- *   reading position, and resumes once they scroll back to the bottom.
+ * Behavior (see #345):
+ * - When the user sends a message, the message is pinned to the top of the
+ *   viewport and a "bottom spacer" is reserved below the last rendered item so
+ *   the viewport under the prompt is initially empty — giving the upcoming AI
+ *   response a full viewport of "canvas" to stream into, similar to ChatGPT /
+ *   Claude.ai. The spacer shrinks 1:1 as the AI streams content, so the prompt
+ *   stays pinned at the top while content fills the empty area below it.
+ * - Once the turn's content (user prompt + AI output) reaches the viewport
+ *   height, the spacer collapses to 0 and auto-follow resumes — the prompt is
+ *   then free to scroll off the top as we keep the latest AI output in view.
+ * - In idle state (no active turn, or the current turn has already overflowed
+ *   the viewport) the spacer is 0 and the list behaves like a regular chat log.
+ * - When the user manually scrolls up, auto-follow pauses so their reading
+ *   position is preserved; it resumes once they scroll back to the bottom.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { VirtuosoHandle } from 'react-virtuoso';
@@ -30,6 +29,15 @@ import type { TMessage } from '@/common/chatLib';
 
 // Ignore scroll events within this window after a programmatic scroll (ms)
 const PROGRAMMATIC_SCROLL_GUARD_MS = 150;
+
+/**
+ * Baseline breathing room between the last rendered message and the SendBox
+ * that sits below the message list. This is applied as a static Footer height
+ * outside of `bottomSpacerHeight`, so the spacer itself can cleanly go to 0 in
+ * idle state without the last message's bottom border being clipped against
+ * the input box.
+ */
+export const BOTTOM_BUFFER_PX = 40;
 
 interface UseAutoScrollOptions {
   /** Message list for detecting new messages */
@@ -47,6 +55,8 @@ interface UseAutoScrollReturn {
   handleAtBottomStateChange: (atBottom: boolean) => void;
   /** Virtuoso followOutput callback for streaming auto-scroll */
   handleFollowOutput: (isAtBottom: boolean) => false | 'auto';
+  /** Virtuoso scrollerRef callback — lets us measure the viewport for spacer sizing */
+  handleScrollerRef: (ref: HTMLElement | Window | null) => void;
   /** Whether to show scroll-to-bottom button */
   showScrollButton: boolean;
   /** Manually scroll to bottom (e.g., when clicking button) */
@@ -55,11 +65,18 @@ interface UseAutoScrollReturn {
   hideScrollButton: () => void;
   /** Manually scroll to top (e.g., when user sends message) */
   scrollToTop: (behavior?: 'smooth' | 'auto') => void;
+  /**
+   * Extra bottom padding (on top of BOTTOM_BUFFER_PX) that keeps the user's
+   * latest prompt pinned to the top of the viewport while the AI streams into
+   * the empty area below. 0 in idle state.
+   */
+  bottomSpacerHeight: number;
 }
 
 export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): UseAutoScrollReturn {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
+  const [bottomSpacerHeight, setBottomSpacerHeight] = useState(0);
 
   // Refs for scroll control
   const userScrolledRef = useRef(false);
@@ -67,11 +84,143 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   const previousListLengthRef = useRef(messages.length);
   const lastProgrammaticScrollTimeRef = useRef(0);
 
+  // Turn-mode refs — track the "pin user prompt to top" state.
+  const turnStartMsgIdRef = useRef<string | null>(null);
+  const isPinnedRef = useRef(false);
+  /**
+   * Mirrors `bottomSpacerHeight` state so `recomputeSpacer` can reason about
+   * the current spacer without reading stale state. Updating the state inside
+   * `recomputeSpacer` would otherwise feed back into `scrollHeight`, creating
+   * a circular dependency.
+   */
+  const spacerHeightRef = useRef(0);
+  const scrollerElRef = useRef<HTMLElement | null>(null);
+  const viewportHeightRef = useRef(0);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  const resetTurnMode = useCallback(() => {
+    turnStartMsgIdRef.current = null;
+    isPinnedRef.current = false;
+    if (spacerHeightRef.current !== 0) {
+      spacerHeightRef.current = 0;
+      setBottomSpacerHeight(0);
+    }
+  }, []);
+
+  /**
+   * Recompute the bottom spacer so the user prompt can reach the top of the
+   * viewport with the "empty canvas" effect below it.
+   *
+   *   spacer = max(0, viewportHeight - heightOfContentSinceTurnStart)
+   *
+   * Where heightOfContentSinceTurnStart is the distance from the top of the
+   * user-prompt element to the bottom of the last rendered item (excluding the
+   * spacer itself and the static BOTTOM_BUFFER_PX Footer). As the AI streams
+   * more content, the second term grows and the spacer shrinks 1:1, so the
+   * prompt stays pinned at the top until the turn's content fills the viewport.
+   *
+   * Once the spacer collapses to 0, we clear `isPinnedRef` so auto-follow can
+   * resume — the prompt is then free to scroll off the top as we keep the
+   * latest AI output in view.
+   */
+  const recomputeSpacer = useCallback(() => {
+    const scroller = scrollerElRef.current;
+    const vh = viewportHeightRef.current;
+    const turnMsgId = turnStartMsgIdRef.current;
+
+    if (!turnMsgId || !scroller || vh <= 0) {
+      if (spacerHeightRef.current !== 0) {
+        spacerHeightRef.current = 0;
+        setBottomSpacerHeight(0);
+      }
+      isPinnedRef.current = false;
+      return;
+    }
+
+    // `CSS.escape` may not exist in all test environments — fall back to a
+    // naive quote escape for IDs that don't contain special characters.
+    const escapeId = typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(turnMsgId) : turnMsgId.replace(/"/g, '\\"');
+    const userEl = scroller.querySelector(`[data-message-id="${escapeId}"]`) as HTMLElement | null;
+    if (!userEl) {
+      // The user prompt is no longer rendered (either virtualized off-screen
+      // because the turn overflowed, or the conversation was swapped out).
+      // Either way, no spacer is needed anymore.
+      if (spacerHeightRef.current !== 0) {
+        spacerHeightRef.current = 0;
+        setBottomSpacerHeight(0);
+      }
+      isPinnedRef.current = false;
+      return;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const userRect = userEl.getBoundingClientRect();
+    // Offset of the user prompt's top within the scroll content.
+    const userOffsetInScroll = userRect.top - scrollerRect.top + scroller.scrollTop;
+
+    // scrollHeight includes both the current spacer and the static footer
+    // buffer, so subtract them to get the content height without padding.
+    const footerHeight = BOTTOM_BUFFER_PX + spacerHeightRef.current;
+    const turnContent = Math.max(0, scroller.scrollHeight - footerHeight - userOffsetInScroll);
+
+    const desiredSpacer = Math.max(0, vh - turnContent);
+
+    if (Math.abs(desiredSpacer - spacerHeightRef.current) >= 1) {
+      spacerHeightRef.current = desiredSpacer;
+      setBottomSpacerHeight(desiredSpacer);
+    }
+
+    // When the turn content has filled the viewport there is nothing left to
+    // pin — let auto-follow take over.
+    if (desiredSpacer === 0) {
+      isPinnedRef.current = false;
+    }
+  }, []);
+
+  // Virtuoso calls this with the scroll container (an HTMLElement) or null on
+  // unmount / remount. We use it to measure the viewport for spacer sizing.
+  const handleScrollerRef = useCallback(
+    (ref: HTMLElement | Window | null) => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      }
+
+      const el = ref instanceof HTMLElement ? ref : null;
+      scrollerElRef.current = el;
+      if (!el) return;
+
+      viewportHeightRef.current = el.clientHeight;
+
+      if (typeof ResizeObserver !== 'undefined') {
+        const ro = new ResizeObserver((entries) => {
+          for (const entry of entries) {
+            viewportHeightRef.current = (entry.target as HTMLElement).clientHeight;
+          }
+          recomputeSpacer();
+        });
+        ro.observe(el);
+        resizeObserverRef.current = ro;
+      }
+
+      recomputeSpacer();
+    },
+    [recomputeSpacer]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      }
+    };
+  }, []);
+
   // Scroll to absolute bottom of the scroller. Using `scrollTo` (not
-  // `scrollToIndex({ align: 'end' })`) puts the Virtuoso Footer at the bottom
-  // of the viewport, leaving the Footer's worth of breathing room below the
-  // last message. This prevents the last message's bottom border from being
-  // visually clipped against the SendBox sitting below the message list.
+  // `scrollToIndex({ align: 'end' })`) keeps the static BOTTOM_BUFFER_PX footer
+  // visible at the bottom of the viewport, preventing the last message's
+  // bottom border from being clipped against the SendBox below.
   const scrollToBottom = useCallback((behavior: 'smooth' | 'auto' = 'smooth') => {
     if (!virtuosoRef.current) return;
 
@@ -95,9 +244,12 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   }, []);
 
   // Virtuoso native followOutput - handles streaming auto-scroll internally
-  // without external scrollToIndex calls that cause jitter
+  // without external scrollToIndex calls that cause jitter. Disabled while we
+  // are pinning the user prompt at the top, so the empty spacer below gets
+  // filled instead of scrolling the prompt off the screen.
   const handleFollowOutput = useCallback((isAtBottom: boolean): false | 'auto' => {
     if (userScrolledRef.current || !isAtBottom) return false;
+    if (isPinnedRef.current) return false;
     return 'auto';
   }, []);
 
@@ -131,8 +283,8 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   }, []);
 
   // Force scroll when user sends a message, or auto-follow AI output (including
-  // ToolCall streaming content updates) unless the user has manually scrolled up.
-  // 处理用户发送消息 / 跟随 AI 输出（包含 ToolCall 运行时内容更新）
+  // ToolCall streaming content updates) unless the user has manually scrolled
+  // up or we're currently pinning the user prompt at the top.
   useEffect(() => {
     const currentListLength = messages.length;
     const prevLength = previousListLengthRef.current;
@@ -140,14 +292,35 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
 
     previousListLengthRef.current = currentListLength;
 
-    if (!messages.length || itemCount <= 0) return;
+    if (!messages.length || itemCount <= 0) {
+      // Conversation cleared — drop any stale turn state.
+      resetTurnMode();
+      return;
+    }
 
     const lastMessage = messages[messages.length - 1];
 
-    // User sent a new message - scroll to show the message at top of viewport.
-    // 用户发送消息后将其滚动到视口顶部，方便用户对照自己的输入
+    // User sent a new message - pin it to the top of the viewport and reserve a
+    // viewport-tall spacer below so the AI has an empty canvas to stream into.
+    // We only enter pinned mode when we actually have a scroller to measure —
+    // in headless / test environments without a scroller we preserve the old
+    // "just scroll to top" behavior.
     if (isNewMessage && lastMessage?.position === 'right') {
       userScrolledRef.current = false;
+      const vh = viewportHeightRef.current;
+      const canPin = vh > 0 && scrollerElRef.current !== null;
+      if (canPin) {
+        turnStartMsgIdRef.current = lastMessage.id;
+        isPinnedRef.current = true;
+        // Seed the spacer at full viewport height so the user prompt can
+        // actually reach the top on the first scrollToIndex call. The next
+        // recompute (after layout settles) will refine it to the exact value.
+        if (spacerHeightRef.current !== vh) {
+          spacerHeightRef.current = vh;
+          setBottomSpacerHeight(vh);
+        }
+      }
+
       // Use double RAF to ensure DOM is updated before scrolling
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
@@ -158,30 +331,41 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
               align: 'start',
               behavior: 'auto', // Use auto for immediate positioning
             });
+            if (canPin) {
+              requestAnimationFrame(() => recomputeSpacer());
+            }
           }
         });
       });
       return;
     }
 
-    // AI output (new message or in-place content update, including ToolCall streaming).
-    // Auto-scroll to the absolute bottom of the scroller so the Virtuoso Footer
-    // is visible at the bottom of the viewport — this leaves a real, visible
-    // breathing margin between the last message's bottom border and the SendBox
-    // below, preventing the bottom border from being clipped against the input
-    // box during streaming. Unless the user has manually scrolled up, in which
-    // case we respect their reading position.
-    //
-    // 自动滚动到滚动容器的绝对底部以跟随 AI 输出（含 ToolCall 运行时内容更新），
-    // 让 Virtuoso Footer 留在视口底部，作为最后一条消息底边与下方输入框之间的
-    // 缓冲区，避免消息底边紧贴输入框被遮挡。
-    // 若用户已手动向上滚动，则保留其阅读位置，不干扰阅读。
+    // AI output (new message or in-place content update, including ToolCall
+    // streaming). First, keep the spacer in sync with the new content so we
+    // can correctly decide whether to stay pinned or resume auto-follow.
+    if (turnStartMsgIdRef.current) {
+      requestAnimationFrame(() => recomputeSpacer());
+    }
+
+    // While pinned we intentionally do NOT auto-scroll — the user prompt needs
+    // to stay at the top, and the AI content fills the empty spacer below.
+    // Once the turn overflows the viewport, `recomputeSpacer` clears
+    // `isPinnedRef` and subsequent updates fall through to the follow branch.
+    if (isPinnedRef.current) return;
+
+    // Auto-scroll to the absolute bottom of the scroller so the Virtuoso
+    // Footer is visible at the bottom of the viewport — this leaves a real,
+    // visible breathing margin between the last message's bottom border and
+    // the SendBox below, preventing the bottom border from being clipped
+    // against the input box during streaming. Unless the user has manually
+    // scrolled up, in which case we respect their reading position.
     //
     // Note: we intentionally do NOT update lastProgrammaticScrollTimeRef here.
     // Auto-follow always scrolls DOWN (scrollTop increases → delta > 0), so it
     // cannot be misdetected as a user scroll-up in handleScroll. Skipping the
-    // guard update keeps user scroll-up detection responsive during high-frequency
-    // streaming updates where the guard window would otherwise never close.
+    // guard update keeps user scroll-up detection responsive during high-
+    // frequency streaming updates where the guard window would otherwise
+    // never close.
     if (!userScrolledRef.current && lastMessage?.position === 'left') {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
@@ -194,7 +378,7 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
         });
       });
     }
-  }, [messages, itemCount]);
+  }, [messages, itemCount, recomputeSpacer, resetTurnMode]);
 
   // Hide scroll button handler
   const hideScrollButton = useCallback(() => {
@@ -207,9 +391,11 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     handleScroll,
     handleAtBottomStateChange,
     handleFollowOutput,
+    handleScrollerRef,
     showScrollButton,
     scrollToBottom,
     hideScrollButton,
     scrollToTop,
+    bottomSpacerHeight,
   };
 }

--- a/tests/unit/useAutoScroll.dom.test.ts
+++ b/tests/unit/useAutoScroll.dom.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useAutoScroll } from '../../src/renderer/messages/useAutoScroll';
+import { BOTTOM_BUFFER_PX, useAutoScroll } from '../../src/renderer/messages/useAutoScroll';
 import type { TMessage, IMessageText, IMessageToolGroup } from '../../src/common/chatLib';
 
 // Mock VirtuosoHandle
@@ -363,5 +363,255 @@ describe('useAutoScroll - tool call auto-follow (#306)', () => {
 
     // Auto-scroll should have resumed (scroll to absolute bottom).
     expect(mockVirtuosoHandle.scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: Number.MAX_SAFE_INTEGER }));
+  });
+});
+
+/**
+ * Helpers for building a jsdom scroller element with the size properties
+ * needed by `recomputeSpacer`. jsdom defaults clientHeight/scrollHeight to 0
+ * and doesn't expose a real ResizeObserver, so we stub both.
+ */
+const setSize = (el: HTMLElement, prop: 'clientHeight' | 'scrollHeight' | 'scrollTop', value: number) => {
+  Object.defineProperty(el, prop, { value, configurable: true, writable: true });
+};
+
+const mockRect = (el: HTMLElement, top: number, height: number) => {
+  el.getBoundingClientRect = () =>
+    ({
+      top,
+      left: 0,
+      right: 800,
+      bottom: top + height,
+      width: 800,
+      height,
+      x: 0,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+};
+
+describe('useAutoScroll - turn-mode bottom spacer (#345)', () => {
+  let mockVirtuosoHandle: ReturnType<typeof createMockVirtuosoHandle>;
+  let scrollerEl: HTMLElement;
+  let originalResizeObserver: typeof ResizeObserver | undefined;
+
+  beforeEach(() => {
+    mockVirtuosoHandle = createMockVirtuosoHandle();
+    vi.useFakeTimers();
+
+    originalResizeObserver = (globalThis as any).ResizeObserver;
+    class StubResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+    (globalThis as any).ResizeObserver = StubResizeObserver;
+
+    scrollerEl = document.createElement('div');
+    setSize(scrollerEl, 'clientHeight', 600);
+    setSize(scrollerEl, 'scrollHeight', 0);
+    setSize(scrollerEl, 'scrollTop', 0);
+    mockRect(scrollerEl, 0, 600);
+    document.body.appendChild(scrollerEl);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    document.body.removeChild(scrollerEl);
+    (globalThis as any).ResizeObserver = originalResizeObserver;
+  });
+
+  const createMessage = (position: 'left' | 'right', id: string): IMessageText => ({
+    id,
+    msg_id: id,
+    type: 'text',
+    position,
+    conversation_id: 'test-conv',
+    content: { content: 'test message' },
+    createdAt: Date.now(),
+  });
+
+  /**
+   * Render a `data-message-id` child on the scroller and set the scroller's
+   * `scrollHeight` to reflect a realistic DOM state:
+   *
+   *   scrollHeight = itemsTotalHeight + BOTTOM_BUFFER_PX + currentSpacer
+   *
+   * where `currentSpacer` must match what the hook currently thinks the spacer
+   * is — otherwise the recompute sees an inconsistent layout. Tests should
+   * pass `result.current.bottomSpacerHeight` for this argument after the
+   * previous rerender has settled.
+   */
+  const renderTurnDom = (userMsgId: string, userTop: number, userHeight: number, itemsTotalHeight: number, currentSpacer: number) => {
+    scrollerEl.innerHTML = '';
+    const el = document.createElement('div');
+    el.setAttribute('data-message-id', userMsgId);
+    mockRect(el, userTop, userHeight);
+    scrollerEl.appendChild(el);
+    setSize(scrollerEl, 'scrollHeight', itemsTotalHeight + BOTTOM_BUFFER_PX + currentSpacer);
+    setSize(scrollerEl, 'scrollTop', 0);
+  };
+
+  it('starts with no bottom spacer in idle state', () => {
+    const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [] as TMessage[], itemCount: 0 },
+    });
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    expect(result.current.bottomSpacerHeight).toBe(0);
+  });
+
+  it('seeds the spacer to full viewport height when the user sends a message', async () => {
+    const initial: TMessage[] = [];
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: initial, itemCount: 0 },
+    });
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    // Before rerender, hook's spacer is still 0 (idle). DOM reflects that.
+    renderTurnDom('u1', 10, 100, 100, 0);
+
+    const next: TMessage[] = [createMessage('right', 'u1')];
+    rerender({ messages: next, itemCount: 1 });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // scrollToIndex pins the user message to the top.
+    expect(mockVirtuosoHandle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: 0,
+        align: 'start',
+        behavior: 'auto',
+      })
+    );
+    // Spacer is active (> 0) and bounded by the viewport height.
+    expect(result.current.bottomSpacerHeight).toBeGreaterThan(0);
+    expect(result.current.bottomSpacerHeight).toBeLessThanOrEqual(600);
+  });
+
+  it('does NOT auto-scroll while pinned — AI output fills the spacer instead', async () => {
+    const userMsg = createMessage('right', 'u1');
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [] as TMessage[], itemCount: 0 },
+    });
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    // User sends — enter pinned mode.
+    renderTurnDom('u1', 10, 100, 100, 0);
+    rerender({ messages: [userMsg], itemCount: 1 });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    expect(result.current.bottomSpacerHeight).toBeGreaterThan(0);
+    mockVirtuosoHandle.scrollTo.mockClear();
+    mockVirtuosoHandle.scrollToIndex.mockClear();
+
+    // AI streams a short response that still fits inside the viewport:
+    // user(100) + ai(200) = 300 < 600 (viewport), so we should remain pinned.
+    renderTurnDom('u1', 10, 100, 300, result.current.bottomSpacerHeight);
+    const aiMsg = createMessage('left', 'a1');
+    rerender({ messages: [userMsg, aiMsg], itemCount: 2 });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // Pinned → no auto-scroll: neither scrollTo nor scrollToIndex should fire.
+    expect(mockVirtuosoHandle.scrollTo).not.toHaveBeenCalled();
+    expect(mockVirtuosoHandle.scrollToIndex).not.toHaveBeenCalled();
+    // And the spacer should still be positive (we haven't overflowed yet).
+    expect(result.current.bottomSpacerHeight).toBeGreaterThan(0);
+  });
+
+  it('releases the pin and resumes auto-follow once turn content overflows the viewport', async () => {
+    const userMsg = createMessage('right', 'u1');
+    const aiMsg = createMessage('left', 'a1');
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [] as TMessage[], itemCount: 0 },
+    });
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    // User sends.
+    renderTurnDom('u1', 10, 100, 100, 0);
+    rerender({ messages: [userMsg], itemCount: 1 });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    expect(result.current.bottomSpacerHeight).toBeGreaterThan(0);
+
+    // AI response grows large enough to overflow the viewport
+    // (user 100 + AI 700 = items 800 > 600 viewport) → spacer should collapse
+    // to 0 and the pin should release.
+    renderTurnDom('u1', 10, 100, 800, result.current.bottomSpacerHeight);
+    rerender({ messages: [userMsg, aiMsg], itemCount: 2 });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    expect(result.current.bottomSpacerHeight).toBe(0);
+
+    mockVirtuosoHandle.scrollTo.mockClear();
+
+    // Further AI streaming after overflow should trigger auto-follow to the
+    // absolute bottom of the scroller.
+    renderTurnDom('u1', 10, 100, 900, 0);
+    const aiMsg2 = createMessage('left', 'a2');
+    rerender({ messages: [userMsg, aiMsg, aiMsg2], itemCount: 3 });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current.bottomSpacerHeight).toBe(0);
+    expect(mockVirtuosoHandle.scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        top: Number.MAX_SAFE_INTEGER,
+        behavior: 'auto',
+      })
+    );
+  });
+
+  it('clears the spacer when the message list becomes empty (e.g., conversation switch)', async () => {
+    const userMsg = createMessage('right', 'u1');
+    const { result, rerender } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [userMsg], itemCount: 1 },
+    });
+    (result.current.virtuosoRef as any).current = mockVirtuosoHandle;
+
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    // Simulate a fresh user send establishing pinned state.
+    renderTurnDom('u1', 10, 100, 100, 0);
+    rerender({ messages: [userMsg, createMessage('right', 'u2')], itemCount: 2 });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // Conversation cleared.
+    rerender({ messages: [] as TMessage[], itemCount: 0 });
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current.bottomSpacerHeight).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #345

## Summary
- Dynamic bottom spacer that only takes effect while a turn is "open": after the user sends a message we reserve up to a viewport of empty canvas below the prompt, then shrink it 1:1 as the AI streams content into it. In idle state the spacer is `0` so the chat log looks like a regular list — no permanent empty area below the last message.
- While pinned, `useAutoScroll` suppresses auto-follow so the prompt stays at the top and the AI fills the empty area. Once the turn content overflows the viewport the spacer collapses to 0, the pin releases, and auto-follow resumes — the prompt is then free to scroll off the top while the latest AI output stays in view.
- `MessageList` wires Virtuoso's `scrollerRef`, renders the Footer as `BOTTOM_BUFFER_PX + bottomSpacerHeight`, and widens `atBottomThreshold` by the spacer so "at bottom" still means "last message in view" during pinning.

## Test plan
- [x] `bun run test tests/unit/useAutoScroll.dom.test.ts` — 15/15 passing
- [ ] Manual: open a fresh conversation → no extra empty area at the bottom of the list.
- [ ] Manual: send a prompt → it pins to the top of the viewport with an empty canvas below; short AI reply streams into that canvas without moving the prompt.
- [ ] Manual: long AI reply overflows the viewport → the spacer disappears, the prompt scrolls off the top, and the bottom of the latest AI output stays visible.
- [ ] Manual: scroll up during a turn → auto-follow pauses; scrolling back to the bottom resumes it.