### PR TITLE
fix: preserve all sudoclaw.json keys on config save

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -522,13 +522,42 @@ export type SudoclawProvider = {
   models?: SudoclawProviderModel[];
 };
 export type SudoclawConfig = {
-  lastRunMode?: string;
-  agents?: { defaults?: { model?: { primary?: string; fallbacks?: string[] }; imageModel?: string; models?: Record<string, { alias?: string }> } };
+  // Metadata (auto-managed by OpenClaw)
+  meta?: { lastTouchedVersion?: string; lastTouchedAt?: string | null };
+  // Setup wizard state (auto-managed by OpenClaw)
+  wizard?: { lastRunAt?: string; lastRunVersion?: string; lastRunCommand?: string; lastRunMode?: string };
+  // Gateway configuration (managed by repair logic + OpenClaw)
+  gateway?: { port?: number; mode?: string; auth?: { mode?: string }; reload?: { mode?: string } };
+  // Agent configuration
+  agents?: {
+    defaults?: {
+      model?: { primary?: string; fallbacks?: string[] };
+      imageModel?: string;
+      imageGenerationModel?: string;
+      workspace?: string;
+      models?: Record<string, { alias?: string }>;
+    };
+    list?: Array<{ id: string; identity?: { name?: string; emoji?: string; avatar?: string } }>;
+  };
+  // Model providers
   models?: {
     mode?: 'merge' | 'replace';
     providers?: Record<string, SudoclawProvider>;
   };
+  // Environment variables
   env?: { vars?: Record<string, string> };
+  // Tool access control
+  tools?: { deny?: string[] };
+  // Command configuration
+  commands?: Record<string, unknown>;
+  // Channel configurations
+  channels?: Record<string, unknown>;
+  // Skills configuration
+  skills?: { load?: { extraDirs?: string[] } };
+  // Browser runtime controls
+  browser?: { enabled?: boolean; headless?: boolean; cdpUrl?: string };
+  // Catch-all for any other OpenClaw config keys we don't explicitly type
+  [key: string]: unknown;
 };
 
 export type SudoclawTestGatewayResult = {

--- a/src/process/bridge/sudoclawBridge.ts
+++ b/src/process/bridge/sudoclawBridge.ts
@@ -39,18 +39,19 @@ function readConfig(): SudoclawConfig | null {
 }
 
 function mergeConfig(existing: SudoclawConfig | null, patch: SudoclawConfig): SudoclawConfig {
-  const base = existing ? JSON.parse(JSON.stringify(existing)) : {};
+  const base: Record<string, unknown> = existing ? JSON.parse(JSON.stringify(existing)) : {};
   if ('lastRunMode' in base) delete base.lastRunMode;
   if (patch.agents?.defaults) {
-    base.agents = base.agents || {};
-    base.agents.defaults = { ...base.agents.defaults, ...patch.agents.defaults };
+    const baseAgents = (base.agents as SudoclawConfig['agents']) || {};
+    baseAgents.defaults = { ...baseAgents.defaults, ...patch.agents.defaults };
     if (patch.agents.defaults.model) {
-      base.agents.defaults.model = { ...base.agents?.defaults?.model, ...patch.agents.defaults.model };
+      baseAgents.defaults.model = { ...baseAgents.defaults?.model, ...patch.agents.defaults.model };
     }
+    base.agents = baseAgents;
   }
   if (patch.models) {
-    base.models = base.models || {};
-    if (patch.models.mode !== undefined) base.models.mode = patch.models.mode;
+    const baseModels = (base.models as SudoclawConfig['models']) || {};
+    if (patch.models.mode !== undefined) baseModels.mode = patch.models.mode;
     if (patch.models.providers) {
       // Ensure each provider has models as array (not undefined)
       const providersWithModels: typeof patch.models.providers = {};
@@ -60,10 +61,16 @@ function mergeConfig(existing: SudoclawConfig | null, patch: SudoclawConfig): Su
           models: prov.models ?? [],
         };
       }
-      base.models.providers = providersWithModels;
+      baseModels.providers = providersWithModels;
     }
+    base.models = baseModels;
   }
-  return base;
+  // Overlay any other patch keys (env, etc.) onto base, preserving base keys not in patch
+  for (const key of Object.keys(patch)) {
+    if (key === 'agents' || key === 'models') continue; // already merged above
+    base[key] = patch[key];
+  }
+  return base as SudoclawConfig;
 }
 
 /**
@@ -119,7 +126,10 @@ export function initSudoclawBridge(): void {
   ipcBridge.sudoclaw.saveConfig.provider(async ({ config }) => {
     try {
       fs.mkdirSync(SUDOCLAW_DIR, { recursive: true });
-      fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf8');
+      // Read existing config to preserve keys not in the patch
+      const existing = readConfig();
+      const merged = mergeConfig(existing, config);
+      fs.writeFileSync(CONFIG_PATH, JSON.stringify(merged, null, 2), 'utf8');
       if (process.platform !== 'win32') {
         try {
           fs.chmodSync(CONFIG_PATH, 0o600);
@@ -129,7 +139,7 @@ export function initSudoclawBridge(): void {
       }
 
       // Sync to ~/.claude/settings.json for Claude CLI
-      syncToClaudeSettings(config);
+      syncToClaudeSettings(merged);
 
       return { success: true };
     } catch (err) {


### PR DESCRIPTION
## Summary
- **Fix `saveConfig` to merge instead of overwrite** — reads existing `sudoclaw.json` first and deep-merges the UI patch, so OpenClaw-managed keys (`tools`, `gateway`, `commands`, `skills`, `meta`, `wizard`, `channels`, `browser`, etc.) are preserved
- **Expand `SudoclawConfig` type** to match the actual `sudoclaw.json` schema (9+ top-level keys), with an index signature catch-all for future keys
- **Remove deprecated `lastRunMode`** from the type (already cleaned up by repair logic)

## Test plan
- [ ] `npx tsc --noEmit` passes (no new type errors)
- [ ] Add `"tools": { "deny": ["browser"] }` to `sudoclaw.json`, change model in settings UI, verify `tools.deny` is preserved after save
- [ ] Verify existing settings flows (AuthContext, CopilotModalContent, OpsModal) still save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)