### PR TITLE
fix(chat): fix tool group summary status flicker during streaming

### DIFF
--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -414,6 +414,7 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
                       setToolSummaryStates((prev) => ({ ...prev, [id]: !prev[id] }));
                     }
                   }}
+                  isStreaming={isStreaming}
                 />
               );
             })()}

--- a/src/renderer/messages/MessageToolGroupSummary.tsx
+++ b/src/renderer/messages/MessageToolGroupSummary.tsx
@@ -230,9 +230,10 @@ interface MessageToolGroupSummaryProps {
   summaryId: string;
   isExpanded: boolean;
   onToggle: (id: string) => void;
+  isStreaming?: boolean;
 }
 
-const MessageToolGroupSummary: React.FC<MessageToolGroupSummaryProps> = ({ messages, summaryId, isExpanded, onToggle }) => {
+const MessageToolGroupSummary: React.FC<MessageToolGroupSummaryProps> = ({ messages, summaryId, isExpanded, onToggle, isStreaming }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLDivElement>(null);
   const prevMessagesRef = useRef(messages);
@@ -346,7 +347,9 @@ const MessageToolGroupSummary: React.FC<MessageToolGroupSummaryProps> = ({ messa
 
   const overallStatus: ToolStatus = errorCount > 0 ? 'error' : runningCount > 0 ? 'running' : completedCount === totalCount && totalCount > 0 ? 'success' : 'default';
 
-  const headerLabel = overallStatus === 'running' ? '执行中...' : overallStatus === 'success' || overallStatus === 'error' ? '执行完成' : '查看步骤';
+  const isRunning = !!isStreaming || overallStatus === 'running';
+
+  const headerLabel = isRunning ? '执行中...' : overallStatus === 'success' || overallStatus === 'error' ? '执行完成' : '查看步骤';
 
   return (
     <div ref={containerRef} className='tool-steps-card' onClick={(e) => e.stopPropagation()}>
@@ -360,17 +363,17 @@ const MessageToolGroupSummary: React.FC<MessageToolGroupSummaryProps> = ({ messa
         <div className='tool-steps-card__header-left'>
           <span
             className={classNames('tool-steps-status-dot', {
-              'tool-steps-status-dot--running': overallStatus === 'running',
-              'tool-steps-status-dot--done': overallStatus === 'success' || overallStatus === 'error',
+              'tool-steps-status-dot--running': isRunning,
+              'tool-steps-status-dot--done': !isRunning && (overallStatus === 'success' || overallStatus === 'error'),
               'tool-steps-status-dot--default': overallStatus === 'default',
             })}
             aria-hidden='true'
           />
-          <span className={classNames('tool-steps-card__title', { 'tool-steps-card__title--muted': overallStatus !== 'running' })}>{headerLabel}</span>
+          <span className={classNames('tool-steps-card__title', { 'tool-steps-card__title--muted': !isRunning })}>{headerLabel}</span>
           <span
             className={classNames('tool-steps-card__count', {
-              'tool-steps-card__count--running': overallStatus === 'running',
-              'tool-steps-card__count--done': overallStatus === 'success' || overallStatus === 'error',
+              'tool-steps-card__count--running': isRunning,
+              'tool-steps-card__count--done': !isRunning && (overallStatus === 'success' || overallStatus === 'error'),
             })}
           >
             {completedCount}/{totalCount}


### PR DESCRIPTION
## Summary
- 将 `MessageList.tsx` 中已计算好的 `isStreaming` 传入 `MessageToolGroupSummary`，当 `isStreaming === true` 时强制显示"执行中..."状态
- 修复工具依次执行时，间隙期间 `runningCount` 为 0 导致汇总卡片短暂闪烁"执行完成"的问题

## Test plan
- [ ] 与 AI 对话触发多步骤工具执行
- [ ] 确认执行全过程中持续显示"执行中..."，不再闪烁"执行完成"
- [ ] 确认 AI 响应结束后显示灰色"执行完成"
- [ ] 点击展开确认单个步骤状态仍保留成功绿、失败红等区分

🤖 Generated with [Claude Code](https://claude.com/claude-code)