### PR TITLE
feat(cron): multi-binding + scheduled-task UX polish

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -865,6 +865,10 @@ export interface ICreateConversationParams {
     cronJobId?: string;
     /** Cron job name that created this conversation */
     cronJobName?: string;
+    /** Cron job ID this conversation is pre-bound to (reuse mode, user-selected existing conversation) */
+    cronJobBoundId?: string;
+    /** Cron job name this conversation is pre-bound to */
+    cronJobBoundName?: string;
   };
 }
 interface IResetConversationParams {

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -233,6 +233,10 @@ export type TChatConversation =
           cronJobId?: string;
           /** Cron job name that created this conversation */
           cronJobName?: string;
+          /** Cron job ID this conversation is pre-bound to (reuse mode, user-selected existing conversation) */
+          cronJobBoundId?: string;
+          /** Cron job name this conversation is pre-bound to */
+          cronJobBoundName?: string;
         }
       >,
       'model'
@@ -292,6 +296,10 @@ export type TChatConversation =
           cronJobId?: string;
           /** Cron job name that created this conversation */
           cronJobName?: string;
+          /** Cron job ID this conversation is pre-bound to (reuse mode, user-selected existing conversation) */
+          cronJobBoundId?: string;
+          /** Cron job name this conversation is pre-bound to */
+          cronJobBoundName?: string;
         }
       >,
       'model'

--- a/src/process/bridge/cronBridge.ts
+++ b/src/process/bridge/cronBridge.ts
@@ -6,6 +6,38 @@
 
 import { ipcBridge } from '@/common';
 import { cronService } from '@process/services/cron/CronService';
+import { mainError } from '@process/utils/mainLogger';
+
+/**
+ * The @office-ai/platform bridge does not forward provider rejections to the
+ * renderer — if a provider throws, `invoke()` hangs forever. So we catch here
+ * and return a serializable error envelope. Callers check `.error` on the
+ * response; a thrown Error is converted to `{ error: message }` and surfaced
+ * back through the Promise so the UI can show a toast instead of hanging.
+ */
+async function safeAddJob(params: Parameters<typeof cronService.addJob>[0]) {
+  try {
+    const job = await cronService.addJob(params);
+    ipcBridge.cron.onJobCreated.emit(job);
+    return job;
+  } catch (err) {
+    mainError('CronBridge', 'addJob failed:', err);
+    // Throwing here would hang the renderer — return an error envelope.
+    // The renderer unwraps this and shows a toast.
+    return { __error: err instanceof Error ? err.message : String(err) } as never;
+  }
+}
+
+async function safeUpdateJob({ jobId, updates }: { jobId: string; updates: Parameters<typeof cronService.updateJob>[1] }) {
+  try {
+    const job = await cronService.updateJob(jobId, updates);
+    ipcBridge.cron.onJobUpdated.emit(job);
+    return job;
+  } catch (err) {
+    mainError('CronBridge', 'updateJob failed:', err);
+    return { __error: err instanceof Error ? err.message : String(err) } as never;
+  }
+}
 
 /**
  * Initialize cron IPC bridge handlers
@@ -24,26 +56,25 @@ export function initCronBridge(): void {
     return cronService.getJob(jobId);
   });
 
-  // CRUD handlers
-  ipcBridge.cron.addJob.provider(async (params) => {
-    const job = await cronService.addJob(params);
-    ipcBridge.cron.onJobCreated.emit(job);
-    return job;
-  });
-
-  ipcBridge.cron.updateJob.provider(async ({ jobId, updates }) => {
-    const job = await cronService.updateJob(jobId, updates);
-    ipcBridge.cron.onJobUpdated.emit(job);
-    return job;
-  });
+  // CRUD handlers — wrapped so renderer errors surface as rejections, not hangs.
+  ipcBridge.cron.addJob.provider(safeAddJob);
+  ipcBridge.cron.updateJob.provider(safeUpdateJob);
 
   ipcBridge.cron.removeJob.provider(async ({ jobId }) => {
-    await cronService.removeJob(jobId);
-    ipcBridge.cron.onJobRemoved.emit({ jobId });
+    try {
+      await cronService.removeJob(jobId);
+      ipcBridge.cron.onJobRemoved.emit({ jobId });
+    } catch (err) {
+      mainError('CronBridge', 'removeJob failed:', err);
+    }
   });
 
   ipcBridge.cron.triggerJob.provider(async ({ jobId }) => {
-    await cronService.triggerJob(jobId);
+    try {
+      await cronService.triggerJob(jobId);
+    } catch (err) {
+      mainError('CronBridge', 'triggerJob failed:', err);
+    }
   });
 
   // Power management handlers

--- a/src/process/services/cron/CronService.ts
+++ b/src/process/services/cron/CronService.ts
@@ -76,20 +76,12 @@ class CronService {
   }
 
   /**
-   * Add a new cron job
-   * @throws Error if conversation already has a cron job (one job per conversation limit)
+   * Add a new cron job. Multiple jobs may bind the same conversation.
    */
   async addJob(params: CreateCronJobParams): Promise<CronJob> {
-    // Check if conversation already has a cron job (one job per conversation limit)
-    // Skip this check when conversationId is empty (job created from Settings, not bound to a conversation)
-    if (params.conversationId) {
-      const existingJobs = cronStore.listByConversation(params.conversationId);
-      if (existingJobs.length > 0) {
-        const existingJob = existingJobs[0];
-        throw new Error(`This conversation already has a scheduled task "${existingJob.name}" (ID: ${existingJob.id}). Please delete it first before creating a new one, or use [CRON_LIST] to view existing tasks.`);
-      }
-    }
-
+    // Multiple scheduled tasks are allowed to bind the same conversation — each
+    // job appears as its own group in the sidebar, and a shared conversation
+    // shows up under every group it is bound to.
     const now = Date.now();
     const jobId = `cron_${uuid()}`;
 
@@ -589,21 +581,11 @@ class CronService {
           cronStore.update(job.id, { metadata: job.metadata, state: job.state });
 
           task = await WorkerManage.getTaskByIdRollbackBuild(activeConversationId, { yoloMode: true });
-        } else {
-          // Tag the existing conversation with cronJobId/cronJobName so it appears
-          // in the Scheduled sidebar section (only needs to happen once, idempotent)
-          try {
-            const db = getDatabase();
-            const existing = db.getConversation(activeConversationId);
-            if (existing.success && existing.data && !(existing.data.extra as any)?.cronJobId) {
-              db.updateConversation(activeConversationId, {
-                extra: { ...(existing.data.extra as any), cronJobId: job.id, cronJobName: job.name } as any,
-              });
-            }
-          } catch (err) {
-            mainWarn('CronService', 'Failed to tag reuse conversation with cronJobId:', err);
-          }
         }
+        // NOTE: We do NOT tag the pre-bound conversation with cron metadata on `extra`.
+        // The scheduled sidebar groups are built from the cron jobs table at render time
+        // (see groupingHelpers.buildGroupedHistory), which correctly supports a single
+        // conversation bound to multiple jobs.
       }
 
       if (!task) {

--- a/src/renderer/components/SettingsModal/contents/CronModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/CronModalContent.tsx
@@ -238,13 +238,25 @@ const CronJobDetail: React.FC<{
       {/* Conversation link */}
       {(() => {
         const isNewMode = (job.metadata.conversationMode ?? 'new') === 'new';
-        const targetConvId = isNewMode ? job.state.lastConversationId : job.metadata.conversationId;
-        const targetConvTitle = isNewMode ? t('cron.goToLastConversation', { defaultValue: '查看最近执行会话' }) : job.metadata.conversationTitle;
+        let targetConvId: string | undefined;
+        let targetConvTitle: string;
+        if (isNewMode) {
+          targetConvId = job.state.lastConversationId;
+          targetConvTitle = t('cron.goToLastConversation', { defaultValue: '查看最近执行会话' });
+        } else if (job.metadata.conversationId) {
+          targetConvId = job.metadata.conversationId;
+          targetConvTitle = job.metadata.conversationTitle || t('cron.goToConversationLink', { defaultValue: '查看会话' });
+        } else {
+          // reuse mode without pre-binding — fall back to lastConversationId
+          targetConvId = job.state.lastConversationId;
+          targetConvTitle = t('cron.goToConversationLink', { defaultValue: '查看会话' });
+        }
         if (!targetConvId) return null;
+        const convId = targetConvId;
         return (
           <div>
             <div className='text-13px text-t-secondary mb-4px'>{t('cron.goToConversation')}</div>
-            <span className='text-14px text-primary cursor-pointer hover:underline' onClick={() => onNavigate(targetConvId)}>
+            <span className='text-14px text-primary cursor-pointer hover:underline' onClick={() => onNavigate(convId)}>
               {targetConvTitle}
             </span>
           </div>
@@ -375,11 +387,12 @@ const CronJobFormDrawer: React.FC<{
       const reuseConvId = conversationMode === 'reuse' ? selectedConversationId : '';
       const reuseConvTitle = reuseConvId ? conversations.find((c) => c.id === reuseConvId)?.name : undefined;
 
+      let result: unknown;
       if (editJob) {
         // Update existing job. JSON IPC strips `undefined`, so we pass an explicit
         // `null` sentinel when clearing the assistant back to Default — the backend
         // normalizes `null` → cleared field.
-        await ipcBridge.cron.updateJob.invoke({
+        result = await ipcBridge.cron.updateJob.invoke({
           jobId: editJob.id,
           updates: {
             name: values.name,
@@ -400,7 +413,7 @@ const CronJobFormDrawer: React.FC<{
           },
         });
       } else {
-        await ipcBridge.cron.addJob.invoke({
+        result = await ipcBridge.cron.addJob.invoke({
           name: values.name,
           schedule: schedule || { kind: 'cron', expr: '0 9 * * *', description: values.description || values.name },
           message: values.prompt,
@@ -412,6 +425,14 @@ const CronJobFormDrawer: React.FC<{
           workspace: workspace || undefined,
           presetAssistantId: effectiveAssistantId,
         });
+      }
+
+      // The cron bridge wraps provider errors in an envelope so the IPC layer
+      // (which has no rejection path) doesn't hang the UI. Unwrap it here.
+      const errorEnvelope = result as { __error?: string } | null | undefined;
+      if (errorEnvelope && typeof errorEnvelope === 'object' && typeof errorEnvelope.__error === 'string') {
+        Message.error(errorEnvelope.__error);
+        return;
       }
 
       Message.success(t('cron.drawer.saveSuccess'));

--- a/src/renderer/i18n/locales/en-US/cron.json
+++ b/src/renderer/i18n/locales/en-US/cron.json
@@ -7,6 +7,7 @@
   "lastError": "Error",
   "message": "Message",
   "goToConversation": "Go to conversation",
+  "goToConversationLink": "View conversation",
   "status": {
     "active": "Active",
     "paused": "Paused",

--- a/src/renderer/i18n/locales/ja-JP/cron.json
+++ b/src/renderer/i18n/locales/ja-JP/cron.json
@@ -7,6 +7,7 @@
   "lastError": "エラー",
   "message": "実行内容",
   "goToConversation": "会話に移動",
+  "goToConversationLink": "会話を表示",
   "status": {
     "active": "実行中",
     "paused": "一時停止中",

--- a/src/renderer/i18n/locales/ko-KR/cron.json
+++ b/src/renderer/i18n/locales/ko-KR/cron.json
@@ -7,6 +7,7 @@
   "lastError": "오류",
   "message": "실행 내용",
   "goToConversation": "대화로 이동",
+  "goToConversationLink": "대화 보기",
   "status": {
     "active": "실행 중",
     "paused": "일시 중지됨",

--- a/src/renderer/i18n/locales/tr-TR/cron.json
+++ b/src/renderer/i18n/locales/tr-TR/cron.json
@@ -7,6 +7,7 @@
   "lastError": "Error",
   "message": "Message",
   "goToConversation": "Go to conversation",
+  "goToConversationLink": "Konuşmayı görüntüle",
   "status": {
     "active": "Active",
     "paused": "Paused",

--- a/src/renderer/i18n/locales/zh-CN/cron.json
+++ b/src/renderer/i18n/locales/zh-CN/cron.json
@@ -7,6 +7,7 @@
   "lastError": "错误信息",
   "message": "执行内容",
   "goToConversation": "跳转到所属会话",
+  "goToConversationLink": "查看会话",
   "status": {
     "active": "运行中",
     "paused": "已暂停",

--- a/src/renderer/i18n/locales/zh-TW/cron.json
+++ b/src/renderer/i18n/locales/zh-TW/cron.json
@@ -7,6 +7,7 @@
   "lastError": "錯誤訊息",
   "message": "執行內容",
   "goToConversation": "跳轉到所屬對話",
+  "goToConversationLink": "查看對話",
   "status": {
     "active": "執行中",
     "paused": "已暫停",

--- a/src/renderer/pages/conversation/ChatHistory.tsx
+++ b/src/renderer/pages/conversation/ChatHistory.tsx
@@ -8,6 +8,7 @@ import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import FlexFullContainer from '@/renderer/components/FlexFullContainer';
 import { CronJobIndicator, useCronJobsMap } from '@/renderer/pages/cron';
+import { useAllCronJobs } from '@/renderer/pages/cron/hooks/useCronJobs';
 import { addEventListener, emitter } from '@/renderer/utils/emitter';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/focus';
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@/renderer/utils/siderTooltip';
@@ -82,6 +83,7 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { getJobStatus, markAsRead } = useCronJobsMap();
+  const { jobs: cronJobs } = useAllCronJobs();
   const siderTooltipProps = getSiderTooltipProps(collapsed && !isMobile);
 
   useScrollIntoView(id);
@@ -283,22 +285,41 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
     );
   };
 
-  // Split into scheduled (cron-execution) and recent conversations
-  const scheduledConvs = chatHistory.filter((c) => !!(c.extra as any)?.cronJobId);
+  // Recent section: exclude cron-created run records (tagged with `extra.cronJobId`).
+  // Pre-bound user conversations stay in their original timeline slot.
   const recentConvs = chatHistory.filter((c) => !(c.extra as any)?.cronJobId);
 
-  // Group scheduled by cronJobName, sorted by most recent first
-  const scheduledGroups: { jobName: string; convs: TChatConversation[] }[] = [];
-  scheduledConvs.forEach((conv) => {
-    const jobName = ((conv.extra as any)?.cronJobName as string) || 'Unknown';
-    const group = scheduledGroups.find((g) => g.jobName === jobName);
-    if (group) {
-      group.convs.push(conv);
-    } else {
-      scheduledGroups.push({ jobName, convs: [conv] });
-    }
+  // Scheduled section: one group per cron job, sourced from the cron jobs table
+  // so a single conversation bound to multiple jobs appears in multiple groups.
+  const convById = new Map(chatHistory.map((c) => [c.id, c]));
+  const runRecordsByJob = new Map<string, TChatConversation[]>();
+  chatHistory.forEach((conv) => {
+    const jobId = (conv.extra as any)?.cronJobId as string | undefined;
+    if (!jobId) return;
+    if (!runRecordsByJob.has(jobId)) runRecordsByJob.set(jobId, []);
+    runRecordsByJob.get(jobId)!.push(conv);
   });
-  // Sort groups by most recent conversation within each group
+  const scheduledGroups: { jobName: string; convs: TChatConversation[] }[] = [];
+  cronJobs.forEach((job) => {
+    const convs: TChatConversation[] = [];
+    const seen = new Set<string>();
+    if (job.metadata.conversationId) {
+      const bound = convById.get(job.metadata.conversationId);
+      if (bound) {
+        convs.push(bound);
+        seen.add(bound.id);
+      }
+    }
+    (runRecordsByJob.get(job.id) || []).forEach((conv) => {
+      if (!seen.has(conv.id)) {
+        convs.push(conv);
+        seen.add(conv.id);
+      }
+    });
+    if (convs.length === 0) return;
+    convs.sort((a, b) => getActivityTime(b) - getActivityTime(a));
+    scheduledGroups.push({ jobName: job.name, convs });
+  });
   scheduledGroups.sort((a, b) => getActivityTime(b.convs[0]) - getActivityTime(a.convs[0]));
 
   return (

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
@@ -7,6 +7,7 @@
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import { addEventListener } from '@/renderer/utils/emitter';
+import { useAllCronJobs } from '@/renderer/pages/cron/hooks/useCronJobs';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -96,9 +97,11 @@ export const useConversations = () => {
     }
   }, [expandedWorkspaces]);
 
+  const { jobs: cronJobs } = useAllCronJobs();
+
   const groupedHistory: GroupedHistoryResult = useMemo(() => {
-    return buildGroupedHistory(conversations, t);
-  }, [conversations, t]);
+    return buildGroupedHistory(conversations, t, cronJobs);
+  }, [conversations, t, cronJobs]);
 
   const { pinnedConversations, timelineSections, scheduledGroups } = groupedHistory;
 

--- a/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { ICronJob } from '@/common/ipcBridge';
 import type { TChatConversation } from '@/common/storage';
 import { getActivityTime, getTimelineLabel } from '@/renderer/utils/timeline';
 import { getWorkspaceDisplayName } from '@/renderer/utils/workspace';
@@ -121,31 +122,70 @@ export const groupConversationsByTimelineAndWorkspace = (conversations: TChatCon
   return sections;
 };
 
-const buildScheduledGroups = (cronConvs: TChatConversation[]): ScheduledGroup[] => {
-  const groupMap = new Map<string, TChatConversation[]>();
+/**
+ * Build scheduled-task groups.
+ *
+ * Groups are keyed by cron job (one group per job) so a conversation bound to
+ * multiple jobs appears in multiple groups. Sources:
+ *   - For every cron job: if it has a bound conversation (metadata.conversationId),
+ *     that conversation appears in this job's group.
+ *   - Auto-created run-record conversations (tagged with `extra.cronJobId`) are
+ *     slotted into the matching job's group too, so per-run history still shows up.
+ *
+ * A conversation tagged with `extra.cronJobId` is a cron-generated run record and
+ * must NOT appear in the regular timeline — see `buildGroupedHistory` below.
+ */
+const buildScheduledGroups = (conversations: TChatConversation[], cronJobs: ICronJob[]): ScheduledGroup[] => {
+  const convById = new Map<string, TChatConversation>();
+  conversations.forEach((c) => convById.set(c.id, c));
 
-  cronConvs.forEach((conv) => {
-    const jobName = ((conv.extra as any)?.cronJobName as string) || 'Scheduled';
-    if (!groupMap.has(jobName)) {
-      groupMap.set(jobName, []);
-    }
-    groupMap.get(jobName)!.push(conv);
+  // Group run-record conversations by the job id recorded in their extra.
+  const runRecordsByJob = new Map<string, TChatConversation[]>();
+  conversations.forEach((conv) => {
+    const jobId = (conv.extra as any)?.cronJobId as string | undefined;
+    if (!jobId) return;
+    if (!runRecordsByJob.has(jobId)) runRecordsByJob.set(jobId, []);
+    runRecordsByJob.get(jobId)!.push(conv);
   });
 
   const groups: ScheduledGroup[] = [];
-  groupMap.forEach((convs, jobName) => {
-    const sorted = [...convs].sort((a, b) => getActivityTime(b) - getActivityTime(a));
-    groups.push({ jobName, conversations: sorted });
+  cronJobs.forEach((job) => {
+    const convs: TChatConversation[] = [];
+    const seen = new Set<string>();
+
+    // Pre-bound conversation (if any) appears in this job's group.
+    const boundId = job.metadata.conversationId;
+    if (boundId) {
+      const bound = convById.get(boundId);
+      if (bound) {
+        convs.push(bound);
+        seen.add(bound.id);
+      }
+    }
+
+    // Per-run records tagged with this job id.
+    (runRecordsByJob.get(job.id) || []).forEach((conv) => {
+      if (!seen.has(conv.id)) {
+        convs.push(conv);
+        seen.add(conv.id);
+      }
+    });
+
+    if (convs.length === 0) return;
+    convs.sort((a, b) => getActivityTime(b) - getActivityTime(a));
+    groups.push({ jobName: job.name, conversations: convs });
   });
 
-  // Sort groups by most recent conversation within each group
+  // Sort groups by most recent conversation within each group.
   groups.sort((a, b) => getActivityTime(b.conversations[0]) - getActivityTime(a.conversations[0]));
   return groups;
 };
 
-export const buildGroupedHistory = (conversations: TChatConversation[], t: (key: string) => string): GroupedHistoryResult => {
-  // Separate cron-execution conversations — they go to the Scheduled section, not Recents
-  const cronConvs = conversations.filter((conv) => !!(conv.extra as any)?.cronJobId);
+export const buildGroupedHistory = (conversations: TChatConversation[], t: (key: string) => string, cronJobs: ICronJob[] = []): GroupedHistoryResult => {
+  // Conversations with `extra.cronJobId` are cron-created run records → Scheduled only.
+  // Pre-bound user conversations are NOT tagged; they stay in the regular timeline
+  // and are also included in the scheduled group for every job that binds them
+  // (resolved via cronJobs in buildScheduledGroups).
   const regularConvs = conversations.filter((conv) => !(conv.extra as any)?.cronJobId);
 
   const pinnedConversations = regularConvs
@@ -164,6 +204,6 @@ export const buildGroupedHistory = (conversations: TChatConversation[], t: (key:
   return {
     pinnedConversations,
     timelineSections: groupConversationsByTimelineAndWorkspace(normalConversations, t),
-    scheduledGroups: buildScheduledGroups(cronConvs),
+    scheduledGroups: buildScheduledGroups(conversations, cronJobs),
   };
 };

--- a/src/renderer/pages/cron/hooks/useCronJobs.ts
+++ b/src/renderer/pages/cron/hooks/useCronJobs.ts
@@ -22,10 +22,24 @@ interface CronJobActionsResult {
 /**
  * Creates common cron job action handlers
  */
+/**
+ * The cron bridge providers return an `{ __error: string }` envelope instead of
+ * rejecting, because the underlying IPC library has no rejection path (see
+ * src/process/bridge/cronBridge.ts). This helper unwraps the envelope and
+ * throws a real Error so callers can use normal try/catch.
+ */
+function unwrapCronResult<T>(result: T): T {
+  const envelope = result as { __error?: unknown } | null | undefined;
+  if (envelope && typeof envelope === 'object' && typeof envelope.__error === 'string') {
+    throw new Error(envelope.__error);
+  }
+  return result;
+}
+
 function useCronJobActions(onJobUpdated?: (jobId: string, job: ICronJob) => void, onJobDeleted?: (jobId: string) => void): CronJobActionsResult {
   const pauseJob = useCallback(
     async (jobId: string) => {
-      const updated = await ipcBridge.cron.updateJob.invoke({ jobId, updates: { enabled: false } });
+      const updated = unwrapCronResult(await ipcBridge.cron.updateJob.invoke({ jobId, updates: { enabled: false } }));
       onJobUpdated?.(jobId, updated);
     },
     [onJobUpdated]
@@ -33,7 +47,7 @@ function useCronJobActions(onJobUpdated?: (jobId: string, job: ICronJob) => void
 
   const resumeJob = useCallback(
     async (jobId: string) => {
-      const updated = await ipcBridge.cron.updateJob.invoke({ jobId, updates: { enabled: true } });
+      const updated = unwrapCronResult(await ipcBridge.cron.updateJob.invoke({ jobId, updates: { enabled: true } }));
       onJobUpdated?.(jobId, updated);
     },
     [onJobUpdated]
@@ -49,7 +63,7 @@ function useCronJobActions(onJobUpdated?: (jobId: string, job: ICronJob) => void
 
   const updateJob = useCallback(
     async (jobId: string, updates: Partial<ICronJob>) => {
-      const updated = await ipcBridge.cron.updateJob.invoke({ jobId, updates });
+      const updated = unwrapCronResult(await ipcBridge.cron.updateJob.invoke({ jobId, updates }));
       onJobUpdated?.(jobId, updated);
       return updated;
     },


### PR DESCRIPTION
## Summary

Follow-ups on scheduled-task work from #313:

- **Multi-binding**: a single conversation can now be bound to multiple scheduled tasks and appears under every group it is bound to. Removed the one-job-per-conversation throw in `CronService.addJob`.
- **Pre-bound conversations stay in their timeline slot**: a conversation bound to a job still shows up under Today / Yesterday / etc., *and* also under the job's expandable scheduled group. Auto-created per-run conversations continue to live only under Scheduled.
- **"View conversation" link in reuse mode without binding**: `CronJobDetail` now falls back to `state.lastConversationId` for reuse-mode jobs that auto-created their first conversation.
- **Fix Save hang when binding**: the `@office-ai/platform` bridge has no rejection path, so `cron.addJob` / `cron.updateJob` providers now catch and return a `{ __error }` envelope; the renderer unwraps it into a toast instead of hanging.

### Implementation notes

Sidebar scheduled groups are now built from the cron jobs table (one group per job) rather than from scalar `cronJobId` / `cronJobBoundId` tags on `conversation.extra`. The scalar approach could only place a conversation in one group, which broke multi-binding. Per-run record conversations keep their `extra.cronJobId` tag and are slotted into the matching job's group.

## Test plan

- [ ] Reuse-mode job with no binding, after first run: detail drawer shows "View conversation" linking to the auto-created conversation, which appears only under Scheduled.
- [ ] Reuse-mode job bound to an existing Today conversation: that conversation appears in both Today and under the job's expandable list.
- [ ] Bind the same conversation to a second job: it appears under Today, job1, and job2 simultaneously.
- [ ] New-mode job: per-run conversations appear only under Scheduled.
- [ ] Save binding to an existing conversation no longer hangs; any validation error surfaces as a toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)