### PR TITLE
fix(renderer): display Chinese names for channel chat group headers

### DIFF
--- a/src/renderer/utils/workspace.ts
+++ b/src/renderer/utils/workspace.ts
@@ -59,7 +59,21 @@ export const getWorkspaceDisplayName = (workspacePath: string, t?: (key: string)
 
   // For regular workspace, show the last directory name
   const parts = splitPathSegments(workspacePath);
-  return parts[parts.length - 1] || workspacePath;
+  const lastDir = parts[parts.length - 1] || workspacePath;
+
+  // Map channel-media platform directories to friendly names
+  const channelNameMap: Record<string, string> = {
+    lark: '飞书',
+    wecom: '企业微信',
+    dingtalk: '钉钉',
+    wechat: '个人微信',
+    telegram: 'Telegram',
+  };
+  if (parts.includes('channel-media') && channelNameMap[lastDir]) {
+    return channelNameMap[lastDir];
+  }
+
+  return lastDir;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Left sidebar channel conversation group headers now display Chinese names instead of English platform identifiers (e.g. `lark`→飞书, `wecom`→企业微信, `dingtalk`→钉钉, `wechat`→个人微信, `telegram`→Telegram)
- Added channel-media path detection in `getWorkspaceDisplayName()` with a platform name mapping

## Test plan
- [ ] Verify channel conversation groups display Chinese names in the left sidebar
- [ ] Verify non-channel workspace groups are unaffected
- [ ] Verify existing channel conversations also show correct Chinese names

🤖 Generated with [Claude Code](https://claude.com/claude-code)