### PR TITLE
feat(settings): move Zentao to secrets tab and add enable/disable toggles

### DIFF
--- a/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
@@ -24,7 +24,6 @@ import LarkConfigForm from './LarkConfigForm';
 import TelegramConfigForm from './TelegramConfigForm';
 import WeChatConfigForm from './WeChatConfigForm';
 import WeComConfigForm from './WeComConfigForm';
-import ZentaoConfigForm from './ZentaoConfigForm';
 
 type ChannelModelConfigKey = 'assistant.telegram.defaultModel' | 'assistant.lark.defaultModel' | 'assistant.dingtalk.defaultModel' | 'assistant.wechat.defaultModel' | 'assistant.wecom.defaultModel';
 
@@ -41,7 +40,7 @@ type ExtensionFieldSchema = {
 
 type ExtensionFieldValues = Record<string, Record<string, string | number | boolean>>;
 
-const BUILTIN_CHANNEL_TYPES = new Set(['telegram', 'lark', 'dingtalk', 'wechat', 'wecom', 'zentao']);
+const BUILTIN_CHANNEL_TYPES = new Set(['telegram', 'lark', 'dingtalk', 'wechat', 'wecom']);
 
 /**
  * Internal hook: wraps useGeminiModelSelection with ConfigStorage persistence
@@ -162,10 +161,6 @@ const ChannelModalContent: React.FC = () => {
   const [wecomPluginStatus, setWecomPluginStatus] = useState<IChannelPluginStatus | null>(null);
   const [wecomEnableLoading, setWecomEnableLoading] = useState(false);
 
-  // Zentao plugin state
-  const [zentaoPluginStatus, setZentaoPluginStatus] = useState<IChannelPluginStatus | null>(null);
-  const [zentaoEnableLoading, setZentaoEnableLoading] = useState(false);
-
   // Track the token entered in TelegramConfigForm so the toggle handler can use it
   const telegramTokenRef = React.useRef<string>('');
 
@@ -179,7 +174,6 @@ const ChannelModalContent: React.FC = () => {
     dingtalk: true,
     wechat: true,
     wecom: true,
-    zentao: true,
   });
 
   // Model selection state — uses unified hook with ConfigStorage persistence
@@ -199,15 +193,13 @@ const ChannelModalContent: React.FC = () => {
         const dingtalkPlugin = result.data.find((p) => p.type === 'dingtalk');
         const wechatPlugin = result.data.find((p) => p.type === 'wechat');
         const wecomPlugin = result.data.find((p) => p.type === 'wecom');
-        const zentaoPlugin = result.data.find((p) => p.type === 'zentao');
-        const extensionPlugins = result.data.filter((p) => !BUILTIN_CHANNEL_TYPES.has(p.type));
+        const extensionPlugins = result.data.filter((p) => !BUILTIN_CHANNEL_TYPES.has(p.type) && p.type !== 'zentao');
 
         setPluginStatus(telegramPlugin || null);
         setLarkPluginStatus(larkPlugin || null);
         setDingtalkPluginStatus(dingtalkPlugin || null);
         setWechatPluginStatus(wechatPlugin || null);
         setWecomPluginStatus(wecomPlugin || null);
-        setZentaoPluginStatus(zentaoPlugin || null);
         setExtensionStatuses(() => {
           const next: Record<string, IChannelPluginStatus> = {};
           for (const plugin of extensionPlugins) {
@@ -269,8 +261,6 @@ const ChannelModalContent: React.FC = () => {
         setWechatPluginStatus(status);
       } else if (status.type === 'wecom') {
         setWecomPluginStatus(status);
-      } else if (status.type === 'zentao') {
-        setZentaoPluginStatus(status);
       } else if (!BUILTIN_CHANNEL_TYPES.has(status.type)) {
         setExtensionStatuses((prev) => ({
           ...prev,
@@ -532,45 +522,6 @@ const ChannelModalContent: React.FC = () => {
     }
   };
 
-  // Enable/Disable Zentao plugin
-  const handleToggleZentaoPlugin = async (enabled: boolean) => {
-    setZentaoEnableLoading(true);
-    try {
-      if (enabled) {
-        if (!zentaoPluginStatus?.hasToken) {
-          Message.warning(t('settings.zentao.credentialsRequired', 'Please configure Zentao credentials first'));
-          setZentaoEnableLoading(false);
-          return;
-        }
-
-        const result = await channel.enablePlugin.invoke({
-          pluginId: 'zentao_default',
-          config: {},
-        });
-
-        if (result.success) {
-          Message.success(t('settings.zentao.pluginEnabled', 'Zentao enabled'));
-          await loadPluginStatus();
-        } else {
-          Message.error(result.msg || t('settings.zentao.enableFailed', 'Failed to enable Zentao'));
-        }
-      } else {
-        const result = await channel.disablePlugin.invoke({ pluginId: 'zentao_default' });
-
-        if (result.success) {
-          Message.success(t('settings.zentao.pluginDisabled', 'Zentao disabled'));
-          await loadPluginStatus();
-        } else {
-          Message.error(result.msg || t('settings.zentao.disableFailed', 'Failed to disable Zentao'));
-        }
-      }
-    } catch (error: any) {
-      Message.error(error.message);
-    } finally {
-      setZentaoEnableLoading(false);
-    }
-  };
-
   const updateExtensionFieldValue = useCallback((pluginType: string, key: string, value: string | number | boolean) => {
     setExtensionFieldValues((prev) => ({
       ...prev,
@@ -789,17 +740,6 @@ const ChannelModalContent: React.FC = () => {
       ),
     };
 
-    const zentaoChannel: ChannelConfig = {
-      id: 'zentao',
-      title: t('settings.channels.zentaoTitle', 'Zentao'),
-      description: t('settings.channels.zentaoDesc', 'Connect Zentao project management, AI can read and create bugs'),
-      status: 'active',
-      enabled: zentaoPluginStatus?.enabled || false,
-      disabled: zentaoEnableLoading,
-      isConnected: zentaoPluginStatus?.connected || false,
-      content: <ZentaoConfigForm pluginStatus={zentaoPluginStatus} onStatusChange={setZentaoPluginStatus} />,
-    };
-
     const extensionChannels: ChannelConfig[] = Object.values(extensionStatuses)
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((status) => ({
@@ -817,8 +757,8 @@ const ChannelModalContent: React.FC = () => {
 
     const extensionTypeSet = new Set(extensionChannels.map((channel) => String(channel.id).toLowerCase()));
 
-    return [telegramChannel, larkChannel, dingtalkChannel, wechatChannel, wecomChannel, zentaoChannel, ...extensionChannels];
-  }, [pluginStatus, larkPluginStatus, dingtalkPluginStatus, wechatPluginStatus, wecomPluginStatus, zentaoPluginStatus, extensionStatuses, extensionLoadingMap, telegramModelSelection, larkModelSelection, dingtalkModelSelection, wechatModelSelection, wecomModelSelection, wechatEnableLoading, wecomEnableLoading, zentaoEnableLoading, enableLoading, larkEnableLoading, dingtalkEnableLoading, renderExtensionConfigForm, t]);
+    return [telegramChannel, larkChannel, dingtalkChannel, wechatChannel, wecomChannel, ...extensionChannels];
+  }, [pluginStatus, larkPluginStatus, dingtalkPluginStatus, wechatPluginStatus, wecomPluginStatus, extensionStatuses, extensionLoadingMap, telegramModelSelection, larkModelSelection, dingtalkModelSelection, wechatModelSelection, wecomModelSelection, wechatEnableLoading, wecomEnableLoading, enableLoading, larkEnableLoading, dingtalkEnableLoading, renderExtensionConfigForm, t]);
 
   // Get toggle handler for each channel
   const getToggleHandler = (channelId: string) => {
@@ -827,7 +767,6 @@ const ChannelModalContent: React.FC = () => {
     if (channelId === 'dingtalk') return handleToggleDingtalkPlugin;
     if (channelId === 'wechat') return handleToggleWechatPlugin;
     if (channelId === 'wecom') return handleToggleWecomPlugin;
-    if (channelId === 'zentao') return handleToggleZentaoPlugin;
     if (extensionStatuses[channelId]) {
       return (enabled: boolean) => {
         void handleToggleExtensionPlugin(channelId, enabled);

--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -8,7 +8,6 @@ import { shell, webui, type IWebUIStatus } from '@/common/ipcBridge';
 import AionModal from '@/renderer/components/base/AionModal';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import ChannelDingTalkLogo from '@/renderer/assets/channel-logos/dingtalk.svg';
-import ChannelZentaoLogo from '@/renderer/assets/channel-logos/zentao.svg';
 import ChannelLarkLogo from '@/renderer/assets/channel-logos/lark.svg';
 import ChannelTelegramLogo from '@/renderer/assets/channel-logos/telegram.svg';
 import ChannelWeChatLogo from '@/renderer/assets/channel-logos/wechat.svg';
@@ -41,7 +40,6 @@ const CHANNEL_LOGOS = [
   { src: ChannelTelegramLogo, alt: 'Telegram' },
   { src: ChannelLarkLogo, alt: 'Lark' },
   { src: ChannelDingTalkLogo, alt: 'DingTalk' },
-  { src: ChannelZentaoLogo, alt: 'Zentao' },
 ] as const;
 
 const ChannelModalContentLazy = React.lazy(() => import('./ChannelModalContent'));

--- a/src/renderer/components/SettingsModal/contents/ZentaoConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/ZentaoConfigForm.tsx
@@ -9,6 +9,8 @@ import { channel } from '@/common/ipcBridge';
 import { Button, Input, Message } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ChannelItem from './channels/ChannelItem';
+import type { ChannelConfig } from './channels/types';
 
 /**
  * Preference row component
@@ -45,13 +47,10 @@ const SectionHeader: React.FC<{ title: string; action?: React.ReactNode }> = ({ 
   </div>
 );
 
-interface ZentaoConfigFormProps {
-  pluginStatus: IChannelPluginStatus | null;
-  onStatusChange: (status: IChannelPluginStatus | null) => void;
-}
-
-const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onStatusChange }) => {
+const ZentaoConfigForm: React.FC<{ pluginStatus?: IChannelPluginStatus | null; onStatusChange?: (status: IChannelPluginStatus | null) => void }> = (props) => {
   const { t } = useTranslation();
+  const [internalPluginStatus, setInternalPluginStatus] = useState<IChannelPluginStatus | null>(null);
+  const pluginStatus = props.pluginStatus !== undefined ? props.pluginStatus : internalPluginStatus;
 
   const [serverUrl, setServerUrl] = useState('');
   const [zentaoUsername, setZentaoUsername] = useState('');
@@ -60,6 +59,23 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
   const [testLoading, setTestLoading] = useState(false);
   const [_credentialsTested, setCredentialsTested] = useState(false);
   const [touched, setTouched] = useState({ serverUrl: false, zentaoUsername: false, zentaoPassword: false });
+
+  // Load plugin status on mount
+  const loadPluginStatus = useCallback(async () => {
+    try {
+      const result = await channel.getPluginStatus.invoke();
+      if (result.success && result.data) {
+        const zentaoPlugin = result.data.find((p) => p.type === 'zentao');
+        setInternalPluginStatus(zentaoPlugin || null);
+      }
+    } catch (error) {
+      console.error('[ZentaoConfig] Failed to load plugin status:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPluginStatus();
+  }, [loadPluginStatus]);
 
   // Load saved credentials for backfill
   useEffect(() => {
@@ -135,7 +151,9 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
         const statusResult = await channel.getPluginStatus.invoke();
         if (statusResult.success && statusResult.data) {
           const zentaoPlugin = statusResult.data.find((p) => p.type === 'zentao');
-          onStatusChange(zentaoPlugin || null);
+          const newStatus = zentaoPlugin || null;
+          setInternalPluginStatus(newStatus);
+          props.onStatusChange?.(newStatus);
         }
       } else {
         console.error('[ZentaoConfig] enablePlugin failed:', result.msg);
@@ -151,6 +169,8 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
     setCredentialsTested(false);
   };
 
+  const isCredentialsLocked = pluginStatus?.enabled && pluginStatus?.hasToken;
+
   return (
     <div className='flex flex-col gap-24px'>
       {/* Server URL */}
@@ -162,9 +182,10 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
             handleCredentialsChange();
           }}
           onBlur={() => setTouched((prev) => ({ ...prev, serverUrl: true }))}
-          placeholder={pluginStatus?.hasToken ? '••••••••••' : 'https://zentao.company.com'}
+          placeholder={isCredentialsLocked ? '••••••••••' : 'https://zentao.company.com'}
           style={{ width: 280 }}
           status={touched.serverUrl && !serverUrl.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
+          disabled={isCredentialsLocked}
         />
       </PreferenceRow>
 
@@ -177,9 +198,10 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
             handleCredentialsChange();
           }}
           onBlur={() => setTouched((prev) => ({ ...prev, zentaoUsername: true }))}
-          placeholder={pluginStatus?.hasToken ? '••••••••••' : 'admin'}
+          placeholder={isCredentialsLocked ? '••••••••••' : 'admin'}
           style={{ width: 280 }}
           status={touched.zentaoUsername && !zentaoUsername.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
+          disabled={isCredentialsLocked}
         />
       </PreferenceRow>
 
@@ -192,15 +214,16 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
             handleCredentialsChange();
           }}
           onBlur={() => setTouched((prev) => ({ ...prev, zentaoPassword: true }))}
-          placeholder={pluginStatus?.hasToken ? '••••••••••' : '••••••••••'}
+          placeholder={isCredentialsLocked ? '••••••••••' : '••••••••••'}
           style={{ width: 280 }}
           status={touched.zentaoPassword && !zentaoPassword.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
           visibilityToggle
+          disabled={isCredentialsLocked}
         />
       </PreferenceRow>
 
-      {/* Test Connection Button */}
-      {!pluginStatus?.connected && (
+      {/* Test Connection Button - hide when credentials locked */}
+      {!isCredentialsLocked && !pluginStatus?.connected && (
         <div className='flex justify-end'>
           {pluginStatus?.hasToken && !serverUrl.trim() && !zentaoUsername.trim() && !zentaoPassword.trim() ? <span className='text-12px text-t-tertiary mr-12px self-center'>{t('settings.zentao.credentialsSaved', 'Credentials already configured. Enter new values to update.')}</span> : null}
           <Button type='primary' loading={testLoading} onClick={handleTestConnection} disabled={pluginStatus?.hasToken && !serverUrl.trim() && !zentaoUsername.trim() && !zentaoPassword.trim()}>
@@ -214,7 +237,13 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
         <div className={`rd-12px p-16px border ${pluginStatus?.connected ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800' : pluginStatus?.error ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800' : 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800'}`}>
           <SectionHeader title={t('settings.zentao.connectionStatus', 'Connection Status')} action={<span className={`text-12px px-8px py-2px rd-4px ${pluginStatus?.connected ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300' : pluginStatus?.error ? 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300' : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300'}`}>{pluginStatus?.connected ? t('settings.zentao.statusConnected', 'Connected') : pluginStatus?.error ? t('settings.zentao.statusError', 'Error') : t('settings.zentao.statusConnecting', 'Connecting...')}</span>} />
           {pluginStatus?.error && <div className='text-14px text-red-600 dark:text-red-400 mb-12px'>{pluginStatus.error}</div>}
-          {pluginStatus?.connected && <div className='text-14px text-t-secondary'>{t('settings.zentao.connectedDesc', 'Zentao is connected. AI can now read and create bugs.')}</div>}
+          {pluginStatus?.connected && (
+            <div className='text-14px text-t-secondary space-y-8px'>
+              <p className='m-0 font-500'>下一步操作：</p>
+              <p className='m-0'>可以和 Sudoclaw 对话，直接使用禅道技能进行项目问题的跟踪与处理。</p>
+            </div>
+          )}
+          {!pluginStatus?.connected && !pluginStatus?.error && <div className='text-14px text-t-secondary'>正在建立连接，请稍候...</div>}
         </div>
       )}
     </div>
@@ -222,3 +251,84 @@ const ZentaoConfigForm: React.FC<ZentaoConfigFormProps> = ({ pluginStatus, onSta
 };
 
 export default ZentaoConfigForm;
+
+/**
+ * Self-contained Zentao channel item with enable/disable toggle.
+ * Manages its own plugin status and toggle logic internally.
+ */
+export const ZentaoChannelItem: React.FC = () => {
+  const { t } = useTranslation();
+  const [collapsed, setCollapsed] = useState(true);
+  const [pluginStatus, setPluginStatus] = useState<IChannelPluginStatus | null>(null);
+  const [enableLoading, setEnableLoading] = useState(false);
+
+  const loadPluginStatus = useCallback(async () => {
+    try {
+      const result = await channel.getPluginStatus.invoke();
+      if (result.success && result.data) {
+        const zentaoPlugin = result.data.find((p) => p.type === 'zentao');
+        setPluginStatus(zentaoPlugin || null);
+      }
+    } catch (error) {
+      console.error('[ZentaoChannelItem] Failed to load plugin status:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPluginStatus();
+  }, [loadPluginStatus]);
+
+  const handleToggle = useCallback(
+    async (enabled: boolean) => {
+      setEnableLoading(true);
+      try {
+        if (enabled) {
+          if (!pluginStatus?.hasToken) {
+            Message.warning(t('settings.zentao.credentialsRequired', 'Please configure Zentao credentials first'));
+            setEnableLoading(false);
+            return;
+          }
+
+          const result = await channel.enablePlugin.invoke({
+            pluginId: 'zentao_default',
+            config: {},
+          });
+
+          if (result.success) {
+            Message.success(t('settings.zentao.pluginEnabled', 'Zentao enabled'));
+            await loadPluginStatus();
+          } else {
+            Message.error(result.msg || t('settings.zentao.enableFailed', 'Failed to enable Zentao'));
+          }
+        } else {
+          const result = await channel.disablePlugin.invoke({ pluginId: 'zentao_default' });
+
+          if (result.success) {
+            Message.success(t('settings.zentao.pluginDisabled', 'Zentao disabled'));
+            await loadPluginStatus();
+          } else {
+            Message.error(result.msg || t('settings.zentao.disableFailed', 'Failed to disable Zentao'));
+          }
+        }
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setEnableLoading(false);
+      }
+    },
+    [pluginStatus, loadPluginStatus, t],
+  );
+
+  const channelConfig: ChannelConfig = {
+    id: 'zentao',
+    title: t('settings.channels.zentaoTitle', 'Zentao'),
+    description: t('settings.channels.zentaoDesc', 'Connect Zentao project management, AI can read and create bugs'),
+    status: 'active',
+    enabled: pluginStatus?.enabled || false,
+    disabled: enableLoading,
+    isConnected: pluginStatus?.connected || false,
+    content: <ZentaoConfigForm pluginStatus={pluginStatus} onStatusChange={setPluginStatus} />,
+  };
+
+  return <ChannelItem channel={channelConfig} isCollapsed={collapsed} onToggleCollapse={() => setCollapsed((prev) => !prev)} onToggleEnabled={handleToggle} />;
+};

--- a/src/renderer/components/SettingsModal/contents/secrets/JsbConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/JsbConfigForm.tsx
@@ -29,7 +29,7 @@ const PreferenceRow: React.FC<{ label: string; description?: React.ReactNode; re
   </div>
 );
 
-const JsbConfigForm: React.FC = () => {
+const JsbConfigForm: React.FC<{ disabled?: boolean; onSaveSuccess?: () => void }> = ({ disabled, onSaveSuccess }) => {
   const { t } = useTranslation();
   const [appKey, setAppKey] = useState('');
   const [appSecret, setAppSecret] = useState('');
@@ -82,6 +82,7 @@ const JsbConfigForm: React.FC = () => {
 
       if (keyResult.success && secretResult.success) {
         Message.success(t('settings.secrets.saveSuccess', '秘钥保存成功'));
+        onSaveSuccess?.();
       } else {
         Message.error(t('settings.secrets.saveFailed', '秘钥保存失败'));
       }
@@ -97,14 +98,14 @@ const JsbConfigForm: React.FC = () => {
     <div className='flex flex-col gap-24px'>
       <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
         <PreferenceRow label={t('settings.secrets.appKey', 'App Key')} description={t('settings.secrets.appKeyDesc', '建设库开放平台的应用标识')} required>
-          <Input value={appKey} onChange={setAppKey} placeholder={t('settings.secrets.appKeyPlaceholder', '请输入 App Key')} style={{ width: 240 }} disabled={loading} />
+          <Input value={appKey} onChange={setAppKey} placeholder={t('settings.secrets.appKeyPlaceholder', '请输入 App Key')} style={{ width: 240 }} disabled={loading || disabled} />
         </PreferenceRow>
         <PreferenceRow label={t('settings.secrets.appSecret', 'App Secret')} description={t('settings.secrets.appSecretDesc', '建设库开放平台的应用密钥')} required>
-          <Input.Password value={appSecret} onChange={setAppSecret} placeholder={t('settings.secrets.appSecretPlaceholder', '请输入 App Secret')} style={{ width: 240 }} disabled={loading} />
+          <Input.Password value={appSecret} onChange={setAppSecret} placeholder={t('settings.secrets.appSecretPlaceholder', '请输入 App Secret')} style={{ width: 240 }} disabled={loading || disabled} />
         </PreferenceRow>
       </div>
       <div className='flex justify-end'>
-        <Button type='primary' loading={saving} disabled={loading} onClick={handleSave}>
+        <Button type='primary' loading={saving} disabled={loading || disabled} onClick={handleSave}>
           {t('settings.secrets.save', '保存')}
         </Button>
       </div>

--- a/src/renderer/components/SettingsModal/contents/secrets/SecretModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/SecretModalContent.tsx
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ConfigStorage } from '@/common/storage';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
-import { Collapse } from '@arco-design/web-react';
+import { Collapse, Switch } from '@arco-design/web-react';
 import { CheckOne } from '@icon-park/react';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSettingsViewMode } from '../../settingsViewContext';
 import jianshekuLogo from '@/renderer/assets/logos/jiansheku.png';
 import JsbConfigForm from './JsbConfigForm';
+import { ZentaoChannelItem } from '../ZentaoConfigForm';
 
 /**
  * Secret Management Content Component
@@ -22,6 +24,22 @@ const SecretModalContent: React.FC = () => {
   const isPageMode = viewMode === 'page';
 
   const [jsbCollapsed, setJsbCollapsed] = useState(true);
+  const [jsbEnabled, setJsbEnabled] = useState(false);
+
+  useEffect(() => {
+    ConfigStorage.get('settings.jsb.enabled').then((val) => {
+      if (typeof val === 'boolean') setJsbEnabled(val);
+    }).catch(() => {});
+  }, []);
+
+  const handleJsbToggle = useCallback(async (checked: boolean) => {
+    setJsbEnabled(checked);
+    try {
+      await ConfigStorage.set('settings.jsb.enabled', checked);
+    } catch (error) {
+      console.error('[SecretModal] Failed to save jsb enabled state:', error);
+    }
+  }, []);
 
   const guideText = t('settings.secrets.description', '管理各服务的秘钥凭证，秘钥安全存储在本地 Nexus 密钥库中。');
   const setupSteps = [t('settings.secrets.step1', '选择服务并填写秘钥信息。'), t('settings.secrets.step2', '点击保存完成配置。')];
@@ -48,17 +66,23 @@ const SecretModalContent: React.FC = () => {
           <Collapse activeKey={jsbCollapsed ? [] : ['jsb']} onChange={() => setJsbCollapsed((prev) => !prev)} className='[&_div.arco-collapse-item-header-title]:flex-1'>
             <Collapse.Item
               header={
-                <div className='flex items-center gap-8px'>
-                  <img src={jianshekuLogo} alt='Jiansheku' className='w-14px h-14px rd-3px shrink-0' />
-                  <span className='text-14px text-t-primary'>{t('settings.secrets.jsbTitle', '建设库')}</span>
+                <div className='flex items-center justify-between gap-8px'>
+                  <div className='flex items-center gap-8px'>
+                    <img src={jianshekuLogo} alt='Jiansheku' className='w-14px h-14px rd-3px shrink-0' />
+                    <span className='text-14px text-t-primary'>{t('settings.secrets.jsbTitle', '建设库')}</span>
+                  </div>
+                  <Switch size='small' checked={jsbEnabled} onChange={(checked) => { handleJsbToggle(checked); }} onClick={(e) => e.stopPropagation()} />
                 </div>
               }
               name='jsb'
               className='[&_div.arco-collapse-item-content-box]:py-3'
             >
-              <JsbConfigForm />
+              <JsbConfigForm disabled={jsbEnabled} onSaveSuccess={() => { setJsbEnabled(true); void ConfigStorage.set('settings.jsb.enabled', true); }} />
             </Collapse.Item>
           </Collapse>
+
+          {/* 禅道 */}
+          <ZentaoChannelItem />
         </div>
       </div>
     </AionScrollArea>


### PR DESCRIPTION
## Summary
- Move Zentao from "渠道配置" (Channel Config) tab to "秘钥管理" (Secrets) tab as a self-contained `ZentaoChannelItem` component
- Add enable/disable switch for 建设库 (Jiansheku), auto-enable after successful save
- Lock Zentao inputs after connection, show connected status with Chinese instructions, restore on disable
- Remove Zentao from channel config list, collapse keys, event handlers, and tab logos

## Changes
- `ChannelModalContent.tsx`: Remove all Zentao-related state, handlers, and config
- `WebuiModalContent.tsx`: Remove Zentao logo from tab header
- `ZentaoConfigForm.tsx`: Refactor to self-contained component with internal plugin status management, credential locking, and connected status display
- `JsbConfigForm.tsx`: Add `disabled` and `onSaveSuccess` props
- `SecretModalContent.tsx`: Add Jiansheku switch with persistence, import ZentaoChannelItem

## Test plan
- [ ] Verify Zentao no longer appears in channel config tab
- [ ] Verify Zentao appears in secrets tab below Jiansheku with enable/disable toggle
- [ ] Verify Zentao test & connect locks inputs, hides button, shows connected status
- [ ] Verify Zentao disable restores editable state
- [ ] Verify Jiansheku switch defaults to off, enables after save, locks on enable
- [ ] Verify Jiansheku switch does not trigger collapse toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)