### PR TITLE
fix: 修复安装助手时关联技能图标在技能商店"我的技能"中不显示的问题

### DIFF
--- a/src/renderer/utils/skillDisplay.ts
+++ b/src/renderer/utils/skillDisplay.ts
@@ -9,6 +9,9 @@ import defaultSkillIcon from '@/renderer/assets/icon-catalogue.svg';
 import uploadSkillDefaultIcon from '../../../resources/upload_skill_default.svg';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 
+/** COS base URL for Hub skill icons */
+const HUB_SKILL_ICON_COS_BASE = 'https://sudoclaw-1309794936.cos.ap-beijing.myqcloud.com/';
+
 export function buildSkillDisplayName(skillName: string): string {
   return skillName
     .split(/[-_]/)
@@ -17,13 +20,56 @@ export function buildSkillDisplayName(skillName: string): string {
     .join(' ');
 }
 
+/**
+ * Check if a URL is a relative path (not absolute URL or protocol URL)
+ */
+function isRelativePath(url: string): boolean {
+  if (!url) return false;
+  return !url.startsWith('http://') &&
+    !url.startsWith('https://') &&
+    !url.startsWith('data:') &&
+    !url.startsWith('/') &&
+    !url.startsWith('aion-asset://') &&
+    !url.startsWith('file://') &&
+    !url.startsWith('./');
+}
+
+/**
+ * Resolve Hub skill icon URL.
+ * Hub skills may have relative icon paths that need COS URL prefix.
+ */
+function resolveHubSkillIcon(icon: string | undefined): string | undefined {
+  const normalized = (icon || '').trim();
+  if (!normalized) return undefined;
+
+  // If it's a relative path, prepend COS URL
+  if (isRelativePath(normalized)) {
+    return `${HUB_SKILL_ICON_COS_BASE}${normalized}`;
+  }
+
+  return normalized;
+}
+
 export function resolveSkillIcon(icon?: string | null, fallbackToDefault = true): string {
   const normalized = (icon || '').trim();
   if (normalized === 'upload_skill_default.svg') {
     return uploadSkillDefaultIcon;
   }
-  const resolved = resolveExtensionAssetUrl(icon || undefined) || icon || '';
-  return resolved || (fallbackToDefault ? defaultSkillIcon : '');
+
+  // First try to resolve as extension asset (aion-asset://, file:// protocols)
+  const extensionResolved = resolveExtensionAssetUrl(icon || undefined);
+  if (extensionResolved) {
+    return extensionResolved;
+  }
+
+  // If the original icon is a relative path, treat it as a Hub skill icon
+  // and prepend the COS URL
+  if (normalized && isRelativePath(normalized)) {
+    return `${HUB_SKILL_ICON_COS_BASE}${normalized}`;
+  }
+
+  // Return original value or fallback
+  return normalized || (fallbackToDefault ? defaultSkillIcon : '');
 }
 
 export function normalizeSkillVersion(version?: string | null): string {
@@ -47,7 +93,19 @@ export function getInstalledSkillDisplay(skill: Pick<IInstalledSkillInfo, 'name'
   emoji?: string | null;
 } {
   const isUploadSkill = skill.meta?.source_type === 'upload';
-  const resolvedIcon = skill.meta?.icon ? resolveSkillIcon(skill.meta.icon, false) : isUploadSkill ? uploadSkillDefaultIcon : '';
+  const isHubSkill = skill.meta?.source_type === 'hub' || (skill.meta?.source_type === undefined && skill.meta?.icon && isRelativePath(skill.meta.icon));
+
+  let resolvedIcon: string;
+  if (isHubSkill) {
+    // Hub skills: resolve relative icon paths to COS URL
+    resolvedIcon = resolveHubSkillIcon(skill.meta?.icon) || '';
+  } else if (isUploadSkill) {
+    // Upload skills: use upload default icon if no icon specified
+    resolvedIcon = skill.meta?.icon ? resolveSkillIcon(skill.meta.icon, false) : uploadSkillDefaultIcon;
+  } else {
+    // Builtin skills and other types: use existing resolution logic
+    resolvedIcon = skill.meta?.icon ? resolveSkillIcon(skill.meta.icon, false) : '';
+  }
 
   return {
     displayName: skill.meta?.display_name || buildSkillDisplayName(skill.name),


### PR DESCRIPTION
## Summary

- 修复了从 Hub 安装的技能图标在"我的技能"列表中无法显示的问题
- Hub 技能的 icon 字段可能是相对路径（如 `skills/some-skill/icon.png`），需要添加 COS URL 前缀才能正确加载
- 在 `resolveSkillIcon` 函数中添加了相对路径检测逻辑，自动添加 `https://sudoclaw-1309794936.cos.ap-beijing.myqcloud.com/` 前缀

## Problem

安装助手时关联安装的 skills，在技能商店"我的技能"中未加载出对应图标，但在：
- 安装时预览关联技能列表
- 技能商店助手库中

都能正常加载图标。

## Root Cause

Hub 技能的 `_sudowork_meta.json` 中 `icon` 字段保存的是 Hub API 返回的相对路径。`skillDisplay.ts` 的 `resolveSkillIcon` 函数只处理了 `aion-asset://` 和 `file://` 协议，没有处理相对路径。

而 `AgentModalContent.tsx` 中安装预览有专门的逻辑处理相对路径（添加 COS URL 前缀）。

## Solution

修改 `src/renderer/utils/skillDisplay.ts`：
- 新增 `isRelativePath` 函数检测相对路径
- 新增 `resolveHubSkillIcon` 函数处理 Hub 技能图标
- 在 `resolveSkillIcon` 中对相对路径添加 COS URL 前缀
- 在 `getInstalledSkillDisplay` 中根据 `source_type` 区分处理不同来源的技能图标

## Test plan

- [x] 安装一个带有关联技能的助手
- [x] 在技能商店"我的技能"中检查关联技能的图标是否正常显示
- [x] 检查内置技能和上传的自定义技能图标是否仍然正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)