### PR TITLE
fix(ui): detect tool failure from output JSON and fix all lint errors

### DIFF
--- a/src/agent/acp/AcpDetector.ts
+++ b/src/agent/acp/AcpDetector.ts
@@ -102,7 +102,7 @@ class AcpDetector {
       const assistants = await assistantManager.getInstalledAssistants();
       const enabledAssistants = assistants.filter((a) => a.enabled && a.meta);
       for (const a of enabledAssistants) {
-        const customAgentId = a.isBuiltin ? `builtin-${a.meta.id || a.name}` : (a.meta.id || a.name);
+        const customAgentId = a.isBuiltin ? `builtin-${a.meta.id || a.name}` : a.meta.id || a.name;
         detected.push({
           backend: 'custom',
           name: a.meta.nameI18n?.['zh-CN'] || a.meta.nameI18n?.['en-US'] || a.meta.id || a.name,

--- a/src/agent/acp/inferToolFailure.ts
+++ b/src/agent/acp/inferToolFailure.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Fallback heuristic: detect tool failure from output content when the backend
+ * did not explicitly set `isError`.
+ *
+ * Convention: a tool whose stdout is a JSON object with a top-level `"error"`
+ * key (and no substantive data alongside it) is treated as failed.
+ * This matches ai-dev-browser's structured error format and is a common CLI
+ * tool convention.
+ */
+export function inferToolFailure(content?: unknown, meta?: string): boolean {
+  // Try structured content array first (ACP content items)
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (isErrorContent(item)) return true;
+    }
+  }
+
+  // Try meta string (fallback text representation)
+  if (typeof meta === 'string' && meta.trim()) {
+    if (isErrorJson(meta)) return true;
+  }
+
+  return false;
+}
+
+function isErrorContent(item: unknown): boolean {
+  if (!item || typeof item !== 'object') return false;
+  const rec = item as Record<string, unknown>;
+
+  // ACP content item: { type: 'content', content: { type: 'text', text: '...' } }
+  if (rec.type === 'content' && rec.content && typeof rec.content === 'object') {
+    const inner = rec.content as Record<string, unknown>;
+    if (inner.type === 'text' && typeof inner.text === 'string') {
+      return isErrorJson(inner.text);
+    }
+  }
+
+  return false;
+}
+
+function isErrorJson(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{')) return false;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return false;
+
+    // Must have an "error" key with a truthy value
+    if (!parsed.error) return false;
+
+    // If the object has other substantive keys beyond "error", this may be a
+    // success response that happens to include an error field as a warning.
+    // Only treat as failure when "error" is the dominant signal.
+    const keys = Object.keys(parsed).filter((k) => k !== 'error');
+    if (keys.length > 1) return false;
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/channels/ARCHITECTURE.md
+++ b/src/channels/ARCHITECTURE.md
@@ -615,6 +615,7 @@ A keyword-based detection mechanism that allows users to query channel configura
 **Natural Language Triggers:**
 
 Users can ask about channel status using natural language:
+
 - "wechat配置了吗" → Returns wechat channel status
 - "微信的渠道状态" → Returns wechat channel status
 - "企业微信是否启用" → Returns wecom channel status
@@ -626,25 +627,27 @@ Users can ask about channel status using natural language:
 **Exclusion Patterns:**
 
 The following patterns will NOT trigger a query (to avoid false positives):
+
 - "我想关闭wechat" (关闭/禁用/删除 keywords)
 - "不用微信" (不用 keyword)
 - "disable telegram" (disable keyword)
 
 **Supported Channel Keywords:**
 
-| Chinese | English | Channel Type |
-|---------|---------|--------------|
-| 微信 | wechat | wechat |
-| 企业微信 | weecom | wecom |
-| 飞书 | lark | lark |
-| 钉钉 | dingtalk | dingtalk |
-| Telegram | telegram | telegram |
-| tg | telegram | telegram |
-| 禅道 | zentao | zentao |
+| Chinese  | English  | Channel Type |
+| -------- | -------- | ------------ |
+| 微信     | wechat   | wechat       |
+| 企业微信 | weecom   | wecom        |
+| 飞书     | lark     | lark         |
+| 钉钉     | dingtalk | dingtalk     |
+| Telegram | telegram | telegram     |
+| tg       | telegram | telegram     |
+| 禅道     | zentao   | zentao       |
 
 **Response Format:**
 
 Returns formatted markdown showing:
+
 - Channel name and type
 - Enable status (enabled/disabled)
 - Connection status (connected/not connected)

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -153,6 +153,8 @@ export interface IConfigStorageRefer {
   'safetyHook.enabled'?: boolean;
   // Safety hook blacklist configuration / 安全 Hook 黑名单配置
   'safetyHook.blacklist'?: import('./safetyTypes').BlacklistConfig;
+  // 建设库 enabled state / 建设库启用状态
+  'settings.jsb.enabled'?: boolean;
   // LLM request timeout in seconds / LLM 请求超时（秒）
   'agent.promptTimeout'?: number;
   // Agent idle timeout in minutes for recycling / Agent 空闲超时（分钟）用于回收

--- a/src/common/utils/pathValidation.ts
+++ b/src/common/utils/pathValidation.ts
@@ -9,7 +9,9 @@
  * 目录名合法性验证工具函数
  */
 
+// eslint-disable-next-line no-control-regex
 const INVALID_CHARS_WINDOWS = /[<>:"/\\|?*\x00-\x1f]/;
+// eslint-disable-next-line no-control-regex
 const INVALID_CHARS_UNIX = /[/\x00]/;
 const RESERVED_NAMES_WINDOWS = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
 

--- a/src/process/AssistantManager.ts
+++ b/src/process/AssistantManager.ts
@@ -46,9 +46,18 @@ export class AssistantManager {
     this._initialized = true;
   }
 
-  private get hubDir(): string { this.init(); return this._hubDir!; }
-  private get systemDir(): string { this.init(); return this._systemDir!; }
-  private get customDir(): string { this.init(); return this._customDir!; }
+  private get hubDir(): string {
+    this.init();
+    return this._hubDir!;
+  }
+  private get systemDir(): string {
+    this.init();
+    return this._systemDir!;
+  }
+  private get customDir(): string {
+    this.init();
+    return this._customDir!;
+  }
 
   private ensureDirs(): void {
     for (const dir of [getAssistantsDir(), this._hubDir!, this._systemDir!, this._customDir!]) {

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -4,8 +4,7 @@
  */
 
 import { ipcBridge } from '@/common';
-import type { IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill } from '@/common/ipcBridge';
-import type { IBridgeResponse } from '@/common/ipcBridge';
+import type { IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill, IBridgeResponse } from '@/common/ipcBridge';
 import { assistantManager } from '@/process/AssistantManager';
 import { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir } from '@/process/initStorage';
 import { skillManager } from '@/process/SkillManager';
@@ -220,23 +219,17 @@ export function initAssistantHubBridge(): void {
 
   ipcBridge.assistantHub.enableAssistant.provider(async ({ name }) => {
     const result = await assistantManager.enableAssistant(name);
-    return result.success
-      ? { success: true, data: undefined }
-      : { success: false, msg: result.msg };
+    return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
   ipcBridge.assistantHub.disableAssistant.provider(async ({ name }) => {
     const result = await assistantManager.disableAssistant(name);
-    return result.success
-      ? { success: true, data: undefined }
-      : { success: false, msg: result.msg };
+    return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
   ipcBridge.assistantHub.updateAssistantMeta.provider(async ({ name, updates }) => {
     const result = await assistantManager.updateAssistantMeta(name, updates);
-    return result.success
-      ? { success: true, data: undefined }
-      : { success: false, msg: result.msg };
+    return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
   ipcBridge.assistantHub.getAssistantMeta.provider(async ({ name }) => {
@@ -251,16 +244,12 @@ export function initAssistantHubBridge(): void {
 
   ipcBridge.assistantHub.createAssistant.provider(async ({ meta, ruleContent }) => {
     const result = await assistantManager.createAssistant(meta, ruleContent);
-    return result.success
-      ? { success: true, data: undefined }
-      : { success: false, msg: result.msg };
+    return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
   ipcBridge.assistantHub.uninstallAssistant.provider(async ({ name }) => {
     const result = await assistantManager.uninstallAssistant(name);
-    return result.success
-      ? { success: true, data: undefined }
-      : { success: false, msg: result.msg };
+    return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
   // === Hub API operations ===
@@ -284,29 +273,31 @@ export function initAssistantHubBridge(): void {
       // API returns: { data: { assistants: [{ id, name, profession, description, avatar, categories, sourceUrl, ... }] } }
       const rawAssistants = result.data?.assistants || [];
 
-      const mappedAssistants = rawAssistants.map((a: Record<string, unknown>): IAssistantHubSkill => ({
-        id: a.id as string,
-        name: a.name as string,
-        display_name: (a.profession as string) || (a.name as string),
-        description: a.description as string,
-        avatar: a.avatar as string | null,
-        emoji: null as string | null,
-        // Use categories array from API (may be null)
-        categories: (a.categories as string[]) || [],
-        category: ((a.categories as string[]) || [])[0] || '',
-        preset_agent_type: null as string | null,
-        skills: (a.skills as string[]) || [] as string[],
-        tag: 'hub' as const,
-        homepage: null as string | null,
-        author_id: '',
-        star_count: 0,
-        applicable_scenarios: null as string | null,
-        core_features: null as string | null,
-        created_at: a.createdAt as string,
-        updated_at: a.updatedAt as string,
-        // Store sourceUrl for download (not in original type but needed for install)
-        _sourceUrl: a.sourceUrl as string,
-      }));
+      const mappedAssistants = rawAssistants.map(
+        (a: Record<string, unknown>): IAssistantHubSkill => ({
+          id: a.id as string,
+          name: a.name as string,
+          display_name: (a.profession as string) || (a.name as string),
+          description: a.description as string,
+          avatar: a.avatar as string | null,
+          emoji: null as string | null,
+          // Use categories array from API (may be null)
+          categories: (a.categories as string[]) || [],
+          category: ((a.categories as string[]) || [])[0] || '',
+          preset_agent_type: null as string | null,
+          skills: (a.skills as string[]) || ([] as string[]),
+          tag: 'hub' as const,
+          homepage: null as string | null,
+          author_id: '',
+          star_count: 0,
+          applicable_scenarios: null as string | null,
+          core_features: null as string | null,
+          created_at: a.createdAt as string,
+          updated_at: a.updatedAt as string,
+          // Store sourceUrl for download (not in original type but needed for install)
+          _sourceUrl: a.sourceUrl as string,
+        })
+      );
 
       const mappedData = {
         assistants: mappedAssistants,
@@ -497,7 +488,9 @@ export function initAssistantHubBridge(): void {
               try {
                 await fs.access(skillDir);
                 await fs.rm(skillDir, { recursive: true, force: true });
-              } catch { }
+              } catch {
+                // ignored
+              }
 
               await fs.mkdir(skillDir, { recursive: true });
 
@@ -730,11 +723,7 @@ export function registerUploadAssistantToHubBridge() {
       if (avatarFilePath) {
         const avatarContent = await fs.readFile(avatarFilePath);
         const avatarExt = path.extname(avatarFilePath).toLowerCase();
-        const avatarMimeType = avatarExt === '.png' ? 'image/png' :
-          avatarExt === '.jpg' || avatarExt === '.jpeg' ? 'image/jpeg' :
-          avatarExt === '.svg' ? 'image/svg+xml' :
-          avatarExt === '.webp' ? 'image/webp' :
-          avatarExt === '.gif' ? 'image/gif' : 'application/octet-stream';
+        const avatarMimeType = avatarExt === '.png' ? 'image/png' : avatarExt === '.jpg' || avatarExt === '.jpeg' ? 'image/jpeg' : avatarExt === '.svg' ? 'image/svg+xml' : avatarExt === '.webp' ? 'image/webp' : avatarExt === '.gif' ? 'image/gif' : 'application/octet-stream';
         const avatarBlob = new Blob([new Uint8Array(avatarContent)], { type: avatarMimeType });
         formData.append('avatar', avatarBlob, path.basename(avatarFilePath));
       }
@@ -750,7 +739,7 @@ export function registerUploadAssistantToHubBridge() {
       const response = await fetch(uploadUrl, {
         method: 'POST',
         headers: {
-          'Authorization': AUTHORIZATION,
+          Authorization: AUTHORIZATION,
         },
         body: formData,
       });

--- a/src/process/bridge/imageGenerationBridge.ts
+++ b/src/process/bridge/imageGenerationBridge.ts
@@ -61,7 +61,9 @@ export async function resolveImageConfig(): Promise<{ baseUrl: string; apiKey: s
     const imageModel = config?.agents?.defaults?.imageGenerationModel;
     const model = typeof imageModel === 'string' ? imageModel : imageModel?.primary;
     if (model && typeof model === 'string' && model.trim()) imageModelId = model;
-  } catch {}
+  } catch {
+    // ignored
+  }
 
   // Fallback: ProcessConfig (before user has changed settings in this session)
   if (!imageModelId) {

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -1102,9 +1102,7 @@ export const loadSkillsContent = async (enabledSkills: string[]): Promise<string
   if (looksLikeIds) {
     // 转换 skill IDs → skill names
     const idToNameMap = await getSkillIdToNameMap();
-    skillNames = enabledSkills
-      .map((id) => idToNameMap.get(id))
-      .filter((name): name is string => Boolean(name));
+    skillNames = enabledSkills.map((id) => idToNameMap.get(id)).filter((name): name is string => Boolean(name));
     mainLog('Sudowork', `Converted skill IDs to names: ${enabledSkills.join(',')} → ${skillNames.join(',')}`);
   } else {
     // 直接作为 skill names 使用

--- a/src/process/services/cron/CronService.ts
+++ b/src/process/services/cron/CronService.ts
@@ -216,12 +216,12 @@ class CronService {
    * button) can show a toast instead of silently updating the job row.
    */
   async triggerJob(jobId: string): Promise<void> {
-    const job = await cronStore.getById(jobId);
+    const job = cronStore.getById(jobId);
     if (!job) {
       throw new Error(`Job ${jobId} not found`);
     }
     await this.executeJob(job);
-    const updated = await cronStore.getById(jobId);
+    const updated = cronStore.getById(jobId);
     if (updated?.state.lastStatus === 'error' && updated.state.lastError) {
       throw new Error(updated.state.lastError);
     }

--- a/src/process/services/mcporter/McporterService.ts
+++ b/src/process/services/mcporter/McporterService.ts
@@ -151,9 +151,12 @@ class McporterService {
       // 列出解压后的目录结构帮助调试
       mainWarn('McporterService', 'Expected CLI not found, listing extracted structure...');
       try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
         const items = require('fs').readdirSync(MCPORTER_EXTRACT_DIR);
         mainLog('McporterService', 'Extracted items:', items.join(', '));
-      } catch {}
+      } catch {
+        // ignored
+      }
       throw new Error('mcporter CLI not found after extraction');
     }
 
@@ -703,6 +706,7 @@ class McporterService {
 
     if (existsSync(wrapperPath)) {
       // 已存在，检查是否需要更新（CLI 路径是否正确）
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const existingContent = require('fs').readFileSync(wrapperPath, 'utf-8');
       if (existingContent.includes(cliPath)) {
         mainLog('McporterService', 'Wrapper already exists and is up-to-date');
@@ -764,6 +768,7 @@ class McporterService {
       'exit /b 1',
     ];
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('fs').writeFileSync(wrapperPath, lines.join('\r\n') + '\r\n');
   }
 
@@ -805,6 +810,7 @@ class McporterService {
       'exit 1',
     ];
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('fs').writeFileSync(wrapperPath, lines.join('\n') + '\n', { mode: 0o755 });
   }
 

--- a/src/process/services/safety/SafetyBlacklistService.ts
+++ b/src/process/services/safety/SafetyBlacklistService.ts
@@ -129,7 +129,7 @@ export async function initBlacklist(): Promise<void> {
     await client.mkdir(CONFIG_DIR, true);
     const merged = {
       ...(hookConfig || DEFAULT_HOOK_CONFIG),
-      blacklist: { rules: [] },
+      blacklist: { rules: [] as BlacklistRule[] },
     };
     await writeHookConfig(merged);
     mainLog('SafetyBlacklist', 'Initialized empty blacklist in unified config');

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -204,11 +204,9 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
       // Handle custom backend
       if (data.backend === 'custom' && data.customAgentId) {
         // Look up from AssistantManager (filesystem SSOT)
-        const strippedId = data.customAgentId.startsWith('builtin-')
-          ? data.customAgentId.slice('builtin-'.length)
-          : data.customAgentId;
+        const strippedId = data.customAgentId.startsWith('builtin-') ? data.customAgentId.slice('builtin-'.length) : data.customAgentId;
         const meta = await assistantManager.getAssistantMeta(strippedId);
-        let customAgentConfig = meta ? { id: data.customAgentId, name: meta.nameI18n?.['en-US'] || strippedId } as any : undefined;
+        let customAgentConfig = meta ? ({ id: data.customAgentId, name: meta.nameI18n?.['en-US'] || strippedId } as any) : undefined;
 
         if (!customAgentConfig && data.customAgentId.startsWith('ext:')) {
           const [, extensionName, ...idParts] = data.customAgentId.split(':');

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -28,6 +28,7 @@ import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { resolveImageConfig, callImagesGenerations, callImagesEdits, saveImageResult, resolveChatModel, callChatCompletionsWithImage, readSudorouterCredentials } from '../bridge/imageGenerationBridge';
 import { buildDraftsInstruction, hasMcpServersConfigured, buildMcporterCommandHint } from './agentUtils';
 import { cleanupIntermediateFiles } from './draftsCleanup';
+import { inferToolFailure } from '@/agent/acp/inferToolFailure';
 import * as nodePath from 'node:path';
 import { ProcessConfig } from '@process/initStorage';
 
@@ -809,6 +810,9 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
         let status: 'pending' | 'in_progress' | 'completed' | 'failed';
         if (toolData.phase === 'result') {
           status = toolData.isError ? 'failed' : 'completed';
+          if (status === 'completed' && inferToolFailure(toolData.content, toolData.meta)) {
+            status = 'failed';
+          }
         } else {
           status = phaseToStatus[toolData.phase ?? ''] ?? ((toolData.status as 'pending' | 'in_progress' | 'completed' | 'failed') || 'pending');
         }

--- a/src/process/task/presetRuntime.ts
+++ b/src/process/task/presetRuntime.ts
@@ -41,9 +41,7 @@ export async function applyPresetRuntime(ctx: PresetRuntimeContext): Promise<Pre
   if (!ctx.presetAssistantId) return result;
 
   // Look up from AssistantManager (reads _sudowork_meta.json)
-  const strippedId = ctx.presetAssistantId.startsWith('builtin-')
-    ? ctx.presetAssistantId.slice('builtin-'.length)
-    : ctx.presetAssistantId;
+  const strippedId = ctx.presetAssistantId.startsWith('builtin-') ? ctx.presetAssistantId.slice('builtin-'.length) : ctx.presetAssistantId;
   const meta = await assistantManager.getAssistantMeta(strippedId);
   if (!meta) return result;
 

--- a/src/process/utils/assistantResources.ts
+++ b/src/process/utils/assistantResources.ts
@@ -88,10 +88,7 @@ export async function readAssistantResource(resourceType: ResourceType, assistan
   const fileName = resourceTypeToFile(resourceType);
 
   // 1. Try directory-based paths with priority: custom > hub > system
-  const dirCandidates: string[] = [
-    path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.custom, assistantId, fileName),
-    path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.hub, assistantId, fileName),
-  ];
+  const dirCandidates: string[] = [path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.custom, assistantId, fileName), path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.hub, assistantId, fileName)];
 
   // For builtin assistants (id starts with "builtin-"), strip prefix for system dir lookup
   const strippedId = assistantId.startsWith('builtin-') ? assistantId.slice('builtin-'.length) : assistantId;

--- a/src/process/utils/scanWorkspaceSkills.ts
+++ b/src/process/utils/scanWorkspaceSkills.ts
@@ -93,13 +93,7 @@ function toSkillItem(skillPath: string, parsed: { name?: string; description?: s
  */
 function isRelativePath(url: string): boolean {
   if (!url) return false;
-  return !url.startsWith('http://') &&
-    !url.startsWith('https://') &&
-    !url.startsWith('data:') &&
-    !url.startsWith('/') &&
-    !url.startsWith('aion-asset://') &&
-    !url.startsWith('file://') &&
-    !url.startsWith('./');
+  return !url.startsWith('http://') && !url.startsWith('https://') && !url.startsWith('data:') && !url.startsWith('/') && !url.startsWith('aion-asset://') && !url.startsWith('file://') && !url.startsWith('./');
 }
 
 function resolveDeclaredIconUrl(skillPath: string, icon?: string): string | undefined {

--- a/src/renderer/components/CssThemeSettings/presets/discourse-horizon.css
+++ b/src/renderer/components/CssThemeSettings/presets/discourse-horizon.css
@@ -100,18 +100,7 @@
   --horizon-focus-ring: rgba(89, 91, 202, 0.18);
   --horizon-shadow-soft: 0 8px 24px -22px rgba(45, 52, 68, 0.22);
   --horizon-shadow-hover: 0 16px 28px -24px rgba(89, 91, 202, 0.24);
-  --horizon-aurora-input-gradient: linear-gradient(
-    90deg,
-    #ff6a01 0%,
-    #f8c91c 12.5%,
-    #8a2be2 25%,
-    #00bfff 37.5%,
-    #ff6a01 50%,
-    #f8c91c 62.5%,
-    #8a2be2 75%,
-    #00bfff 87.5%,
-    #ff6a01 100%
-  );
+  --horizon-aurora-input-gradient: linear-gradient(90deg, #ff6a01 0%, #f8c91c 12.5%, #8a2be2 25%, #00bfff 37.5%, #ff6a01 50%, #f8c91c 62.5%, #8a2be2 75%, #00bfff 87.5%, #ff6a01 100%);
   --horizon-aurora-input-ring: rgba(255, 162, 84, 0.24);
   --horizon-aurora-input-shadow: 0 18px 40px rgba(110, 58, 102, 0.16), 0 0 28px rgba(15, 120, 135, 0.1);
   --horizon-aurora-input-shadow-strong: 0 22px 48px rgba(110, 58, 102, 0.2), 0 0 34px rgba(0, 191, 255, 0.18);
@@ -216,18 +205,7 @@
   --horizon-focus-ring: rgba(123, 127, 240, 0.22);
   --horizon-shadow-soft: 0 12px 28px -24px rgba(0, 0, 0, 0.45);
   --horizon-shadow-hover: 0 18px 32px -24px rgba(0, 0, 0, 0.58);
-  --horizon-aurora-input-gradient: linear-gradient(
-    90deg,
-    #ff6a01 0%,
-    #f8c91c 12.5%,
-    #8a2be2 25%,
-    #00bfff 37.5%,
-    #ff6a01 50%,
-    #f8c91c 62.5%,
-    #8a2be2 75%,
-    #00bfff 87.5%,
-    #ff6a01 100%
-  );
+  --horizon-aurora-input-gradient: linear-gradient(90deg, #ff6a01 0%, #f8c91c 12.5%, #8a2be2 25%, #00bfff 37.5%, #ff6a01 50%, #f8c91c 62.5%, #8a2be2 75%, #00bfff 87.5%, #ff6a01 100%);
   --horizon-aurora-input-ring: rgba(166, 214, 255, 0.22);
   --horizon-aurora-input-shadow: 0 22px 48px rgba(6, 10, 18, 0.5), 0 0 32px rgba(138, 43, 226, 0.16);
   --horizon-aurora-input-shadow-strong: 0 26px 54px rgba(4, 8, 16, 0.62), 0 0 38px rgba(0, 191, 255, 0.22);
@@ -691,8 +669,7 @@ body {
   overflow: visible !important;
   border: 1px solid transparent !important;
   background-color: var(--dialog-fill-0) !important;
-  background-image:
-    linear-gradient(var(--dialog-fill-0), var(--dialog-fill-0)), var(--horizon-aurora-input-gradient) !important;
+  background-image: linear-gradient(var(--dialog-fill-0), var(--dialog-fill-0)), var(--horizon-aurora-input-gradient) !important;
   background-size:
     100% 100%,
     220% 100% !important;
@@ -1289,11 +1266,7 @@ body {
 .arco-tooltip-inner,
 .arco-popover-inner,
 .arco-popover-content {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--horizon-surface) 94%, var(--aou-1)) 0%,
-    var(--horizon-surface-soft) 100%
-  ) !important;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--horizon-surface) 94%, var(--aou-1)) 0%, var(--horizon-surface-soft) 100%) !important;
   color: var(--text-primary) !important;
   border: 1px solid var(--border-base) !important;
   border-radius: 12px !important;
@@ -1312,11 +1285,7 @@ body {
 }
 
 .arco-modal-header {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--horizon-selected) 58%, var(--horizon-surface)) 0%,
-    var(--horizon-surface) 100%
-  ) !important;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--horizon-selected) 58%, var(--horizon-surface)) 0%, var(--horizon-surface) 100%) !important;
   border-bottom: 1px solid color-mix(in srgb, var(--border-base) 82%, transparent) !important;
   color: var(--text-primary) !important;
 }
@@ -1361,8 +1330,7 @@ body {
 .aionui-modal-wrapper .cm-content,
 .aionui-modal-wrapper .cm-line,
 .aionui-modal-wrapper .cm-gutters {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
 }
 
 .aionui-modal-wrapper .arco-btn {

--- a/src/renderer/components/CssThemeSettings/presets/glittering-input-field.css
+++ b/src/renderer/components/CssThemeSettings/presets/glittering-input-field.css
@@ -95,18 +95,7 @@
   --hl-chip-border: #d7ccb7;
 
   /* ===== Aurora Input Accent ===== */
-  --retroma-aurora-input-gradient: linear-gradient(
-    90deg,
-    #ff6a01 0%,
-    #f8c91c 12.5%,
-    #8a2be2 25%,
-    #00bfff 37.5%,
-    #ff6a01 50%,
-    #f8c91c 62.5%,
-    #8a2be2 75%,
-    #00bfff 87.5%,
-    #ff6a01 100%
-  );
+  --retroma-aurora-input-gradient: linear-gradient(90deg, #ff6a01 0%, #f8c91c 12.5%, #8a2be2 25%, #00bfff 37.5%, #ff6a01 50%, #f8c91c 62.5%, #8a2be2 75%, #00bfff 87.5%, #ff6a01 100%);
   --retroma-aurora-input-ring: rgba(255, 162, 84, 0.24);
   --retroma-aurora-input-shadow: 0 18px 40px rgba(110, 58, 102, 0.16), 0 0 28px rgba(15, 120, 135, 0.1);
   --retroma-aurora-input-shadow-strong: 0 22px 48px rgba(110, 58, 102, 0.2), 0 0 34px rgba(0, 191, 255, 0.18);
@@ -480,8 +469,7 @@ body {
   overflow: visible !important;
   border: 2px solid transparent !important;
   background-color: var(--dialog-fill-0) !important;
-  background-image:
-    linear-gradient(var(--dialog-fill-0), var(--dialog-fill-0)), var(--retroma-aurora-input-gradient) !important;
+  background-image: linear-gradient(var(--dialog-fill-0), var(--dialog-fill-0)), var(--retroma-aurora-input-gradient) !important;
   background-size:
     100% 100%,
     220% 100% !important;

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -103,13 +103,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
   if (isImage) {
     return (
       <div className='relative inline-block'>
-        <div className='rd-8px overflow-hidden border-1 border-solid b-color-border-2'>
-          {imageUrl ? (
-            <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview />
-          ) : (
-            <div className='w-60px h-60px bg-bg-3'></div>
-          )}
-        </div>
+        <div className='rd-8px overflow-hidden border-1 border-solid b-color-border-2'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : <div className='w-60px h-60px bg-bg-3'></div>}</div>
         {!readonly && (
           <div className='absolute -top-4px -right-4px w-16px h-16px rd-50% bg-white dark:bg-gray-700 cursor-pointer flex items-center justify-center shadow-md hover:shadow-lg transition-all z-10 border-1 border-solid border-gray-200 dark:border-gray-600' onClick={handleRemove}>
             <Close theme='filled' size='10' fill='#666' />

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -114,10 +114,7 @@ const InstalledAssistantCard: React.FC<{
   const description = assistant.descriptionI18n?.[localeKey] || assistant.description || '';
 
   return (
-    <div
-      className={classNames('group bg-fill-1 rd-12px border border-line p-12px flex items-start gap-12px relative overflow-hidden transition-colors cursor-pointer hover:bg-fill-2', !isEnabled && 'opacity-65')}
-      onClick={onClick}
-    >
+    <div className={classNames('group bg-fill-1 rd-12px border border-line p-12px flex items-start gap-12px relative overflow-hidden transition-colors cursor-pointer hover:bg-fill-2', !isEnabled && 'opacity-65')} onClick={onClick}>
       {/* Avatar + toggle */}
       <div className='w-48px flex-shrink-0 flex flex-col items-center'>
         <div className='w-48px h-48px rd-8px overflow-hidden bg-fill-2'>
@@ -148,9 +145,7 @@ const InstalledAssistantCard: React.FC<{
         <div className='h-20px flex items-center'>
           <span className='font-medium text-13px text-t-primary truncate'>{displayName}</span>
         </div>
-        <div className='mt-3px min-h-30px'>
-          {description ? <div className='text-11px text-t-secondary line-clamp-2 leading-15px'>{description}</div> : <div className='text-11px text-t-tertiary italic line-clamp-2 leading-15px'>{assistant.id}</div>}
-        </div>
+        <div className='mt-3px min-h-30px'>{description ? <div className='text-11px text-t-secondary line-clamp-2 leading-15px'>{description}</div> : <div className='text-11px text-t-tertiary italic line-clamp-2 leading-15px'>{assistant.id}</div>}</div>
         {assistant.enabledSkills && assistant.enabledSkills.length > 0 && (
           <div className='mt-4px flex items-center gap-4px'>
             <Lightning size='12' className='text-primary flex-shrink-0' />
@@ -484,11 +479,7 @@ const AssistantDetailModal: React.FC<{
                       <Lightning size='14' className='text-primary' />
                       <span className='font-medium text-13px text-t-primary'>{t('settings.assistant.relatedSkills', { defaultValue: '关联技能' })}</span>
                       <span className='text-12px text-t-tertiary'>({relatedSkillDetails.length})</span>
-                      {installedSkillCount > 0 && (
-                        <span className='text-12px text-t-tertiary'>
-                          · {t('settings.assistant.skillsInstalled', { installed: installedSkillCount, defaultValue: `${installedSkillCount} 已安装` })}
-                        </span>
-                      )}
+                      {installedSkillCount > 0 && <span className='text-12px text-t-tertiary'>· {t('settings.assistant.skillsInstalled', { installed: installedSkillCount, defaultValue: `${installedSkillCount} 已安装` })}</span>}
                     </div>
                     {loadingSkills ? (
                       <div className='text-center text-t-secondary text-12px py-16px'>{t('common.loading', { defaultValue: '加载中...' })}</div>
@@ -507,9 +498,7 @@ const AssistantDetailModal: React.FC<{
                             skillIconUrl = resolveExtensionAssetUrl(skill.icon) || skill.icon;
                           } else {
                             // Hub skills: if icon is relative path, prepend COS URL
-                            skillIconUrl = skill.icon && !skill.icon.startsWith('http') && !skill.icon.startsWith('data:') && !skill.icon.startsWith('/') && !skill.icon.startsWith('aion-asset://') && !skill.icon.startsWith('file://')
-                              ? `https://sudoclaw-1309794936.cos.ap-beijing.myqcloud.com/${skill.icon}`
-                              : skill.icon;
+                            skillIconUrl = skill.icon && !skill.icon.startsWith('http') && !skill.icon.startsWith('data:') && !skill.icon.startsWith('/') && !skill.icon.startsWith('aion-asset://') && !skill.icon.startsWith('file://') ? `https://sudoclaw-1309794936.cos.ap-beijing.myqcloud.com/${skill.icon}` : skill.icon;
                           }
                           return (
                             <div key={skill.id} className='flex items-center gap-10px p-8px bg-fill-2 rd-8px'>
@@ -531,17 +520,13 @@ const AssistantDetailModal: React.FC<{
                                 </div>
                                 <div className='text-11px text-t-tertiary truncate'>{skill.description}</div>
                               </div>
-                              <span className={`px-4px py-0px text-10px rd-3px whitespace-nowrap ${isSkillInstalled ? 'bg-primary-light text-primary' : 'bg-fill-3 text-t-secondary'}`}>
-                                {isSkillInstalled ? t('settings.skill.installed', { defaultValue: '已安装' }) : t('settings.skill.notInstalled', { defaultValue: '未安装' })}
-                              </span>
+                              <span className={`px-4px py-0px text-10px rd-3px whitespace-nowrap ${isSkillInstalled ? 'bg-primary-light text-primary' : 'bg-fill-3 text-t-secondary'}`}>{isSkillInstalled ? t('settings.skill.installed', { defaultValue: '已安装' }) : t('settings.skill.notInstalled', { defaultValue: '未安装' })}</span>
                             </div>
                           );
                         })}
                       </div>
                     )}
-                    <div className='mt-12px text-11px text-t-tertiary'>
-                      {t('settings.assistant.skillsInstallHint', { defaultValue: '安装助手时会自动安装关联的技能' })}
-                    </div>
+                    <div className='mt-12px text-11px text-t-tertiary'>{t('settings.assistant.skillsInstallHint', { defaultValue: '安装助手时会自动安装关联的技能' })}</div>
                   </div>
                 )}
               </div>
@@ -557,9 +542,7 @@ const AssistantDetailModal: React.FC<{
                 {t('settings.skill.goUse', { defaultValue: '去使用' })}
               </Button>
             ) : !hasDownloadUrl ? (
-              <div className='flex-1 text-center text-t-secondary text-13px py-12px'>
-                {t('settings.assistant.noDownloadUrl', { defaultValue: '该助手暂不支持安装，请联系管理员' })}
-              </div>
+              <div className='flex-1 text-center text-t-secondary text-13px py-12px'>{t('settings.assistant.noDownloadUrl', { defaultValue: '该助手暂不支持安装，请联系管理员' })}</div>
             ) : installing ? (
               <div className='flex-1'>
                 <Progress percent={installProgress} size='small' />
@@ -759,11 +742,14 @@ const AgentModalContent: React.FC = () => {
   hubSearchQueryRef.current = hubSearchQuery;
 
   // Resolve tenant ID for exclusive tab
-  const resolveAssistantTenantId = useCallback((tab: AssistantStoreTab): string | undefined => {
-    const normalized = enterpriseCode;
-    if (tab !== 'exclusive' || !normalized) return undefined;
-    return normalized;
-  }, [enterpriseCode]);
+  const resolveAssistantTenantId = useCallback(
+    (tab: AssistantStoreTab): string | undefined => {
+      const normalized = enterpriseCode;
+      if (tab !== 'exclusive' || !normalized) return undefined;
+      return normalized;
+    },
+    [enterpriseCode]
+  );
 
   const currentAssistantTenantId = resolveAssistantTenantId(activeTab);
 
@@ -949,17 +935,16 @@ const AgentModalContent: React.FC = () => {
 
   const sortAssistants = useCallback((agents: AssistantListItem[]) => {
     const builtinOrder = ['builtin-copilot', 'builtin-sudoclaw-doctor'];
-    return agents
-      .sort((a, b) => {
-        const indexA = builtinOrder.indexOf(a.id);
-        const indexB = builtinOrder.indexOf(b.id);
-        if (indexA !== -1 || indexB !== -1) {
-          if (indexA === -1) return 1;
-          if (indexB === -1) return -1;
-          return indexA - indexB;
-        }
-        return 0;
-      });
+    return agents.sort((a, b) => {
+      const indexA = builtinOrder.indexOf(a.id);
+      const indexB = builtinOrder.indexOf(b.id);
+      if (indexA !== -1 || indexB !== -1) {
+        if (indexA === -1) return 1;
+        if (indexB === -1) return -1;
+        return indexA - indexB;
+      }
+      return 0;
+    });
   }, []);
 
   const loadAssistants = useCallback(async () => {
@@ -1195,15 +1180,18 @@ const AgentModalContent: React.FC = () => {
   }, [duplicateAssistant, duplicateInstalledAssistant, hubInstalledAssistantNames, localeKey, loadAssistants, t]);
 
   // Open upload confirm modal for custom assistant
-  const handleUploadAssistant = useCallback((assistant: AssistantListItem) => {
-    // Check tenantId - required for upload
-    if (!enterpriseCode) {
-      agentMessage.warning(t('settings.assistant.uploadNoTenantId', { defaultValue: '用户无租户ID，无法上传助手' }));
-      return;
-    }
-    setUploadAssistant(assistant);
-    setUploadConfirmVisible(true);
-  }, [enterpriseCode, t]);
+  const handleUploadAssistant = useCallback(
+    (assistant: AssistantListItem) => {
+      // Check tenantId - required for upload
+      if (!enterpriseCode) {
+        agentMessage.warning(t('settings.assistant.uploadNoTenantId', { defaultValue: '用户无租户ID，无法上传助手' }));
+        return;
+      }
+      setUploadAssistant(assistant);
+      setUploadConfirmVisible(true);
+    },
+    [enterpriseCode, t]
+  );
 
   // Upload assistant to Hub
   const handleUploadConfirm = useCallback(async () => {
@@ -1462,18 +1450,7 @@ const AgentModalContent: React.FC = () => {
   const renderAssistantGrid = (list: AssistantListItem[]) => (
     <div className='grid gap-8px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
       {list.map((assistant) => (
-        <InstalledAssistantCard
-          key={assistant.id}
-          assistant={assistant}
-          isExtension={isExtensionAssistant(assistant)}
-          localeKey={localeKey}
-          avatarImageMap={avatarImageMap}
-          onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)}
-          onDelete={() => void handleDeleteFromCard(assistant)}
-          onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)}
-          onUpload={!assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined}
-          onClick={() => void handleEdit(assistant)}
-        />
+        <InstalledAssistantCard key={assistant.id} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onUpload={!assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined} onClick={() => void handleEdit(assistant)} />
       ))}
     </div>
   );
@@ -1507,11 +1484,7 @@ const AgentModalContent: React.FC = () => {
 
         {/* Create button — only on installed tab */}
         {activeTab === 'installed' && (
-          <button
-            type='button'
-            className='group h-34px px-4 py-0 border border-solid rd-999px flex items-center gap-8px flex-shrink-0 cursor-pointer transition-all outline-none bg-[color-mix(in_srgb,var(--color-fill-2)_84%,transparent)] border-[color-mix(in_srgb,var(--color-border-2)_70%,transparent)] hover:bg-[color-mix(in_srgb,var(--color-primary-light-1)_58%,transparent)] hover:border-[color-mix(in_srgb,var(--color-primary)_36%,transparent)]'
-            onClick={() => void handleCreate()}
-          >
+          <button type='button' className='group h-34px px-4 py-0 border border-solid rd-999px flex items-center gap-8px flex-shrink-0 cursor-pointer transition-all outline-none bg-[color-mix(in_srgb,var(--color-fill-2)_84%,transparent)] border-[color-mix(in_srgb,var(--color-border-2)_70%,transparent)] hover:bg-[color-mix(in_srgb,var(--color-primary-light-1)_58%,transparent)] hover:border-[color-mix(in_srgb,var(--color-primary)_36%,transparent)]' onClick={() => void handleCreate()}>
             <span className='w-22px h-22px rd-full flex items-center justify-center bg-[color-mix(in_srgb,var(--color-primary)_14%,transparent)] text-[var(--color-primary)] transition-transform group-hover:scale-105'>
               <Plus size='13' />
             </span>
@@ -1625,11 +1598,7 @@ const AgentModalContent: React.FC = () => {
                   <div className='text-13px font-medium text-t-primary'>{t('settings.customAssistants', { defaultValue: '自定义助手' })}</div>
                   <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{customAssistants.length}</span>
                 </div>
-                {customAssistants.length > 0 ? (
-                  renderAssistantGrid(customAssistants)
-                ) : (
-                  <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomAssistants', { defaultValue: '暂无自定义助手' })}</div>
-                )}
+                {customAssistants.length > 0 ? renderAssistantGrid(customAssistants) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomAssistants', { defaultValue: '暂无自定义助手' })}</div>}
               </section>
 
               {/* Hub/store assistants section */}
@@ -1638,11 +1607,7 @@ const AgentModalContent: React.FC = () => {
                   <div className='text-13px font-medium text-t-primary'>{t('settings.hubAssistants', { defaultValue: '商店助手' })}</div>
                   <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{hubAssistants.length}</span>
                 </div>
-                {hubAssistants.length > 0 ? (
-                  renderAssistantGrid(hubAssistants)
-                ) : (
-                  <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>
-                )}
+                {hubAssistants.length > 0 ? renderAssistantGrid(hubAssistants) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>}
               </section>
 
               {/* Builtin assistants section */}
@@ -1651,11 +1616,7 @@ const AgentModalContent: React.FC = () => {
                   <div className='text-13px font-medium text-t-primary'>{t('settings.builtinAssistants', { defaultValue: '内置助手' })}</div>
                   <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{builtinAssistants.length}</span>
                 </div>
-                {builtinAssistants.length > 0 ? (
-                  renderAssistantGrid(builtinAssistants)
-                ) : (
-                  <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noBuiltinAssistants', { defaultValue: '暂无内置助手' })}</div>
-                )}
+                {builtinAssistants.length > 0 ? renderAssistantGrid(builtinAssistants) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noBuiltinAssistants', { defaultValue: '暂无内置助手' })}</div>}
               </section>
             </div>
           )}
@@ -1953,10 +1914,8 @@ const AgentModalContent: React.FC = () => {
           <div className='mt-12px p-12px bg-primary-light rounded-lg'>
             <div className='text-12px text-primary'>
               {t('settings.duplicateAssistantNameHint', {
-                name: duplicateAssistant
-                  ? duplicateAssistant.display_name || duplicateAssistant.name
-                  : duplicateInstalledAssistant?.nameI18n?.[localeKey] || duplicateInstalledAssistant?.name,
-                defaultValue: `复制后的助手名称: 自定义-${duplicateAssistant ? (duplicateAssistant.display_name || duplicateAssistant.name) : (duplicateInstalledAssistant?.nameI18n?.[localeKey] || duplicateInstalledAssistant?.name)}`,
+                name: duplicateAssistant ? duplicateAssistant.display_name || duplicateAssistant.name : duplicateInstalledAssistant?.nameI18n?.[localeKey] || duplicateInstalledAssistant?.name,
+                defaultValue: `复制后的助手名称: 自定义-${duplicateAssistant ? duplicateAssistant.display_name || duplicateAssistant.name : duplicateInstalledAssistant?.nameI18n?.[localeKey] || duplicateInstalledAssistant?.name}`,
               })}
             </div>
           </div>

--- a/src/renderer/components/SettingsModal/contents/CronModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/CronModalContent.tsx
@@ -602,11 +602,7 @@ const CronJobFormDrawer: React.FC<{
               {!(conversationMode === 'reuse' && selectedConversationId) && (
                 <div>
                   <div className='text-13px text-t-secondary mb-4px'>{t('cron.create.agent', { defaultValue: '数字助手' })}</div>
-                  <Select
-                    value={selectedAssistantId}
-                    onChange={(v) => setSelectedAssistantId(v as string)}
-                    disabled={editJob != null && conversationMode === 'reuse'}
-                  >
+                  <Select value={selectedAssistantId} onChange={(v) => setSelectedAssistantId(v as string)} disabled={editJob != null && conversationMode === 'reuse'}>
                     <Select.Option value={DEFAULT_ASSISTANT}>
                       <span className='text-t-secondary'>{t('cron.create.agentPlaceholder', { defaultValue: '默认 (Sudoclaw)' })}</span>
                     </Select.Option>

--- a/src/renderer/components/SettingsModal/contents/ZentaoConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/ZentaoConfigForm.tsx
@@ -316,7 +316,7 @@ export const ZentaoChannelItem: React.FC = () => {
         setEnableLoading(false);
       }
     },
-    [pluginStatus, loadPluginStatus, t],
+    [pluginStatus, loadPluginStatus, t]
   );
 
   const channelConfig: ChannelConfig = {

--- a/src/renderer/components/SettingsModal/contents/secrets/SecretModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/SecretModalContent.tsx
@@ -27,9 +27,11 @@ const SecretModalContent: React.FC = () => {
   const [jsbEnabled, setJsbEnabled] = useState(false);
 
   useEffect(() => {
-    ConfigStorage.get('settings.jsb.enabled').then((val) => {
-      if (typeof val === 'boolean') setJsbEnabled(val);
-    }).catch(() => {});
+    ConfigStorage.get('settings.jsb.enabled')
+      .then((val) => {
+        if (typeof val === 'boolean') setJsbEnabled(val);
+      })
+      .catch(() => {});
   }, []);
 
   const handleJsbToggle = useCallback(async (checked: boolean) => {
@@ -71,13 +73,26 @@ const SecretModalContent: React.FC = () => {
                     <img src={jianshekuLogo} alt='Jiansheku' className='w-14px h-14px rd-3px shrink-0' />
                     <span className='text-14px text-t-primary'>{t('settings.secrets.jsbTitle', '建设库')}</span>
                   </div>
-                  <Switch size='small' checked={jsbEnabled} onChange={(checked) => { handleJsbToggle(checked); }} onClick={(e) => e.stopPropagation()} />
+                  <Switch
+                    size='small'
+                    checked={jsbEnabled}
+                    onChange={(checked) => {
+                      void handleJsbToggle(checked);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                  />
                 </div>
               }
               name='jsb'
               className='[&_div.arco-collapse-item-content-box]:py-3'
             >
-              <JsbConfigForm disabled={jsbEnabled} onSaveSuccess={() => { setJsbEnabled(true); void ConfigStorage.set('settings.jsb.enabled', true); }} />
+              <JsbConfigForm
+                disabled={jsbEnabled}
+                onSaveSuccess={() => {
+                  setJsbEnabled(true);
+                  void ConfigStorage.set('settings.jsb.enabled', true);
+                }}
+              />
             </Collapse.Item>
           </Collapse>
 

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -118,10 +118,7 @@ function hasSudoclawApiKey(config: { models?: { providers?: Record<string, { api
 }
 
 async function invokeWithTimeout<T>(fn: () => Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    fn(),
-    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`IPC timeout after ${timeoutMs}ms`)), timeoutMs)),
-  ]);
+  return Promise.race([fn(), new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`IPC timeout after ${timeoutMs}ms`)), timeoutMs))]);
 }
 
 async function ensureSudoclawHasApiKey(): Promise<boolean> {

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -273,10 +273,7 @@ const Layout: React.FC<{
   // LayoutContext consumers when unrelated state (e.g. viewportWidth) changes.
   // Without this, every resize event creates a new object reference, causing
   // all consumers (including ChatWorkspace) to re-render.
-  const layoutContextValue = useMemo(
-    () => ({ isMobile, siderCollapsed: collapsed, setSiderCollapsed: setCollapsed }),
-    [isMobile, collapsed, setCollapsed]
-  );
+  const layoutContextValue = useMemo(() => ({ isMobile, siderCollapsed: collapsed, setSiderCollapsed: setCollapsed }), [isMobile, collapsed, setCollapsed]);
 
   return (
     <LayoutContext.Provider value={layoutContextValue}>

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -90,13 +90,7 @@ const MessageItem: React.FC<{ message: TMessage; isStreaming?: boolean }> = Reac
           'justify-start': message.position === 'left',
         })}
       >
-        {isAiMessage && (
-          <img
-            src={streamingAvatar}
-            alt='AI Avatar'
-            className={`flex-shrink-0 mr-12px mt-4px ${avatarSize} object-contain`}
-          />
-        )}
+        {isAiMessage && <img src={streamingAvatar} alt='AI Avatar' className={`flex-shrink-0 mr-12px mt-4px ${avatarSize} object-contain`} />}
         {props.children}
       </div>
     );
@@ -426,11 +420,7 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
       const avatarSizeForSummary = isStreamingForSummary ? 'w-40px h-40px' : 'w-24px h-24px';
       return (
         <div key={item.id} data-message-id={item.id} className={'min-w-0 flex items-start message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto ' + item.type}>
-          <img
-            src={streamingAvatarForSummary}
-            alt='AI Avatar'
-            className={`flex-shrink-0 mr-12px mt-4px ${avatarSizeForSummary} object-contain`}
-          />
+          <img src={streamingAvatarForSummary} alt='AI Avatar' className={`flex-shrink-0 mr-12px mt-4px ${avatarSizeForSummary} object-contain`} />
           <div className='flex-1 min-w-0'>
             {item.type === 'file_summary' && <MessageFileChanges diffsChanges={item.diffs} />}
             {item.type === 'tool_summary' &&

--- a/src/renderer/messages/MessageToolGroupSummary.css
+++ b/src/renderer/messages/MessageToolGroupSummary.css
@@ -42,7 +42,9 @@
   border-radius: 12px;
   background: var(--color-bg-1, #ffffff);
   overflow: hidden;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .tool-steps-card:hover {
@@ -319,7 +321,9 @@
   color: var(--color-text-4, #c9cdd4);
   flex-shrink: 0;
   cursor: pointer;
-  transition: color 0.15s ease, background-color 0.15s ease;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
 }
 
 .tool-step-row__toggle:hover {

--- a/src/renderer/messages/MessageToolGroupSummary.tsx
+++ b/src/renderer/messages/MessageToolGroupSummary.tsx
@@ -262,7 +262,13 @@ const MessageToolGroupSummary: React.FC<MessageToolGroupSummaryProps> = ({ messa
       return true;
     });
 
-    if (allCompleted && wasInProgress && isExpanded) {
+    const hasErrors = messages.some((m) => {
+      if (m.type === 'tool_group') return m.content.some((t) => t.status === 'Error');
+      if (m.type === 'acp_tool_call') return m.content.update.status === 'failed';
+      return false;
+    });
+
+    if (allCompleted && wasInProgress && isExpanded && !hasErrors) {
       const timer = setTimeout(() => {
         onToggle(summaryId);
       }, 100);

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -120,7 +120,6 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     return [];
   });
 
-
   const handleToggleScheduled = useCallback((jobName: string) => {
     setExpandedScheduled((prev) => {
       const next = prev.includes(jobName) ? prev.filter((n) => n !== jobName) : [...prev, jobName];
@@ -347,33 +346,31 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
         {scheduledGroups.length > 0 && (
           <div className='mb-8px min-w-0'>
             {!collapsed && (
-              <div
-                className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none'
-                onClick={handleToggleScheduledSection}
-              >
+              <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none' onClick={handleToggleScheduledSection}>
                 <Down size={12} className={classNames('line-height-0 transition-transform duration-200 flex-shrink-0', scheduledSectionExpanded ? 'rotate-0' : '-rotate-90')} />
                 <span>{t('cron.sidebar.scheduled', { defaultValue: 'Scheduled' })}</span>
               </div>
             )}
-            {(collapsed || scheduledSectionExpanded) && scheduledGroups.map(({ jobName, conversations: cronConvs }) => {
-              const isExpanded = expandedScheduled.includes(jobName);
-              return (
-                <div key={jobName} className={classNames('min-w-0', { 'px-8px': !collapsed })}>
-                  <WorkspaceCollapse
-                    expanded={isExpanded}
-                    onToggle={() => handleToggleScheduled(jobName)}
-                    siderCollapsed={collapsed}
-                    header={
-                      <div className='flex items-center gap-8px text-14px min-w-0'>
-                        <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{jobName}</span>
-                      </div>
-                    }
-                  >
-                    <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{cronConvs.map((conv) => renderConversation(conv))}</div>
-                  </WorkspaceCollapse>
-                </div>
-              );
-            })}
+            {(collapsed || scheduledSectionExpanded) &&
+              scheduledGroups.map(({ jobName, conversations: cronConvs }) => {
+                const isExpanded = expandedScheduled.includes(jobName);
+                return (
+                  <div key={jobName} className={classNames('min-w-0', { 'px-8px': !collapsed })}>
+                    <WorkspaceCollapse
+                      expanded={isExpanded}
+                      onToggle={() => handleToggleScheduled(jobName)}
+                      siderCollapsed={collapsed}
+                      header={
+                        <div className='flex items-center gap-8px text-14px min-w-0'>
+                          <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{jobName}</span>
+                        </div>
+                      }
+                    >
+                      <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{cronConvs.map((conv) => renderConversation(conv))}</div>
+                    </WorkspaceCollapse>
+                  </div>
+                );
+              })}
           </div>
         )}
 
@@ -400,56 +397,54 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
           return (
             <div key={section.timeline} className='mb-8px min-w-0'>
               {!collapsed && (
-                <div
-                  className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none'
-                  onClick={() => handleToggleTimeline(section.timeline)}
-                >
+                <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none' onClick={() => handleToggleTimeline(section.timeline)}>
                   <Down size={12} className={classNames('line-height-0 transition-transform duration-200 flex-shrink-0', sectionExpanded ? 'rotate-0' : '-rotate-90')} />
                   <span>{section.timeline}</span>
                 </div>
               )}
 
-              {(collapsed || sectionExpanded) && section.items.map((item) => {
-                if (item.type === 'workspace' && item.workspaceGroup) {
-                  const group = item.workspaceGroup;
-                  return (
-                    <div key={group.workspace} className={classNames('min-w-0 group', { 'px-8px': !collapsed })}>
-                      <WorkspaceCollapse
-                        expanded={expandedWorkspaces.includes(group.workspace)}
-                        onToggle={() => handleToggleWorkspace(group.workspace)}
-                        siderCollapsed={collapsed}
-                        header={
-                          <div className='flex items-center gap-8px text-14px min-w-0'>
-                            <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{group.displayName}</span>
-                            <button
-                              type='button'
-                              className='opacity-0 group-hover:opacity-100 hover:text-t-primary text-t-secondary flex-shrink-0 border-none bg-transparent p-0 cursor-pointer transition-opacity'
-                              title={t('conversation.workspace.renameWorkspace.title')}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleWorkspaceRenameStart(group.workspace, group.displayName);
-                              }}
-                            >
-                              <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
-                                <path d='M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7' />
-                                <path d='M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z' />
-                              </svg>
-                            </button>
-                          </div>
-                        }
-                      >
-                        <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{group.conversations.map((conversation) => renderConversation(conversation))}</div>
-                      </WorkspaceCollapse>
-                    </div>
-                  );
-                }
+              {(collapsed || sectionExpanded) &&
+                section.items.map((item) => {
+                  if (item.type === 'workspace' && item.workspaceGroup) {
+                    const group = item.workspaceGroup;
+                    return (
+                      <div key={group.workspace} className={classNames('min-w-0 group', { 'px-8px': !collapsed })}>
+                        <WorkspaceCollapse
+                          expanded={expandedWorkspaces.includes(group.workspace)}
+                          onToggle={() => handleToggleWorkspace(group.workspace)}
+                          siderCollapsed={collapsed}
+                          header={
+                            <div className='flex items-center gap-8px text-14px min-w-0'>
+                              <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{group.displayName}</span>
+                              <button
+                                type='button'
+                                className='opacity-0 group-hover:opacity-100 hover:text-t-primary text-t-secondary flex-shrink-0 border-none bg-transparent p-0 cursor-pointer transition-opacity'
+                                title={t('conversation.workspace.renameWorkspace.title')}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleWorkspaceRenameStart(group.workspace, group.displayName);
+                                }}
+                              >
+                                <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
+                                  <path d='M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7' />
+                                  <path d='M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z' />
+                                </svg>
+                              </button>
+                            </div>
+                          }
+                        >
+                          <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{group.conversations.map((conversation) => renderConversation(conversation))}</div>
+                        </WorkspaceCollapse>
+                      </div>
+                    );
+                  }
 
-                if (item.type === 'conversation' && item.conversation) {
-                  return renderConversation(item.conversation);
-                }
+                  if (item.type === 'conversation' && item.conversation) {
+                    return renderConversation(item.conversation);
+                  }
 
-                return null;
-              })}
+                  return null;
+                })}
             </div>
           );
         })}

--- a/src/renderer/pages/conversation/index.tsx
+++ b/src/renderer/pages/conversation/index.tsx
@@ -37,7 +37,7 @@ const ChatConversationIndex: React.FC = () => {
   useEffect(() => {
     if (!id) return;
     return addEventListener('chat.history.refresh', () => {
-      mutate();
+      void mutate();
     });
   }, [id, mutate]);
 

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
@@ -144,7 +144,7 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
       scheduleRefresh();
     });
 
-    (async () => {
+    void (async () => {
       try {
         const res = await ipcBridge.fileWatch.startWatchDir.invoke({ dirPath: workspace, recursive: true });
         if (cancelled) {

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -359,6 +359,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
     if (!folderName) return;
 
     // Validate folder name characters
+    // eslint-disable-next-line no-control-regex
     const invalidCharsRegex = /[<>:"/\\|?*\x00-\x1f]/;
     if (invalidCharsRegex.test(folderName)) {
       Message.error(t('conversation.workspace.newFolder.invalidName'));
@@ -381,7 +382,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
       if (result) {
         Message.success(t('conversation.workspace.newFolder.success'));
         setNewFolderModal({ visible: false, name: '', parentPath: '' });
-        treeHook.refreshWorkspace();
+        void treeHook.refreshWorkspace();
       } else {
         Message.error(t('conversation.workspace.newFolder.failed'));
       }
@@ -1141,7 +1142,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
               onClick={(event) => {
                 event.stopPropagation();
                 if (activeTab === 'files') {
-                  treeHook.refreshWorkspace();
+                  void treeHook.refreshWorkspace();
                 } else {
                   void skillsHandleRef.current?.refresh();
                 }

--- a/src/renderer/pages/conversation/workspace/workspace-card.css
+++ b/src/renderer/pages/conversation/workspace/workspace-card.css
@@ -76,7 +76,9 @@
   font-weight: 500;
   cursor: pointer;
   position: relative;
-  transition: color 0.15s ease, background-color 0.15s ease;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
   outline: none;
@@ -161,7 +163,9 @@
   justify-content: center;
   cursor: pointer;
   flex-shrink: 0;
-  transition: background-color 0.15s ease, color 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
   outline: none;
 }
 
@@ -399,7 +403,9 @@
   min-height: 52px;
   height: 100%;
   box-sizing: border-box;
-  transition: border-color 0.15s ease, background-color 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
   outline: none;
 }
 
@@ -425,7 +431,9 @@
   border: 1px solid color-mix(in srgb, var(--bg-3) 72%, transparent);
   background: var(--color-bg-1, transparent);
   overflow: hidden;
-  transition: border-color 0.15s ease, background-color 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
 }
 
 .chat-workspace .workspace-skill-card__icon-image {

--- a/src/renderer/pages/cron/hooks/useCronJobs.ts
+++ b/src/renderer/pages/cron/hooks/useCronJobs.ts
@@ -267,10 +267,7 @@ export function useCronJobsMap() {
   const setActiveConversation = useCallback((_conversationId: string) => {}, []);
   const hasUnread = useCallback((_conversationId: string) => false, []);
 
-  return useMemo(
-    () => ({ getJobStatus, markAsRead, setActiveConversation, hasUnread }),
-    [getJobStatus, markAsRead, setActiveConversation, hasUnread]
-  );
+  return useMemo(() => ({ getJobStatus, markAsRead, setActiveConversation, hasUnread }), [getJobStatus, markAsRead, setActiveConversation, hasUnread]);
 }
 
 export default useCronJobs;

--- a/src/renderer/pages/guid/components/AssistantAgentDropdown.tsx
+++ b/src/renderer/pages/guid/components/AssistantAgentDropdown.tsx
@@ -9,6 +9,7 @@
  * Shown on the right side of the assistant header in the GUID page.
  */
 
+import type { AcpBackend } from '@/types/acpTypes';
 import { getAgentLogo } from '@/renderer/utils/agentLogo';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import type { AvailableAgent } from '../types';
@@ -48,7 +49,7 @@ const AssistantAgentDropdown: React.FC<AssistantAgentDropdownProps> = ({ availab
 
   // Filter options to only show available agents, plus extension agents
   const filteredOptions = useMemo(() => {
-    const builtinFiltered = BUILTIN_AGENT_OPTIONS.filter((opt) => availableBackends.has(opt.backendId || opt.value));
+    const builtinFiltered = BUILTIN_AGENT_OPTIONS.filter((opt) => availableBackends.has((opt.backendId ?? opt.value) as AcpBackend));
 
     // Add extension-contributed agents
     const extensionOptions: AgentOption[] = availableAgents

--- a/src/renderer/utils/skillDisplay.ts
+++ b/src/renderer/utils/skillDisplay.ts
@@ -25,13 +25,7 @@ export function buildSkillDisplayName(skillName: string): string {
  */
 function isRelativePath(url: string): boolean {
   if (!url) return false;
-  return !url.startsWith('http://') &&
-    !url.startsWith('https://') &&
-    !url.startsWith('data:') &&
-    !url.startsWith('/') &&
-    !url.startsWith('aion-asset://') &&
-    !url.startsWith('file://') &&
-    !url.startsWith('./');
+  return !url.startsWith('http://') && !url.startsWith('https://') && !url.startsWith('data:') && !url.startsWith('/') && !url.startsWith('aion-asset://') && !url.startsWith('file://') && !url.startsWith('./');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `inferToolFailure()` generic fallback to detect tool errors from output JSON when ACP backend doesn't set `isError` — parses for top-level `"error"` field
- Fix auto-collapse hiding errors: tool groups with failed steps stay expanded so humans can inspect
- Fix all pre-existing lint/format/TypeScript errors across 36 files (prettier, no-floating-promises, await-thenable, no-var-requires, no-control-regex, strict type errors)

## Test plan
- [ ] Verify tool steps with `{"error": "..."}` output now show red AlertIcon instead of green CheckIcon
- [ ] Verify tool groups with errors do NOT auto-collapse when all steps finish
- [ ] Verify tool groups without errors still auto-collapse normally
- [ ] Verify `tsc --noEmit` passes with 0 errors
- [ ] Verify `eslint src/` passes with 0 errors (warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)