### PR TITLE
fix(windows): use System32 tar.exe to avoid MSYS2 path misinterpretation

### DIFF
--- a/src/process/services/archiveProgress.ts
+++ b/src/process/services/archiveProgress.ts
@@ -34,7 +34,8 @@ function createProgressReporter(onProgress?: ArchiveProgressCallback): (processe
 async function isNativeTarAvailable(): Promise<boolean> {
   if (process.platform !== 'win32') return false;
   try {
-    await execFileAsync('tar', ['--version']);
+    const tarBin = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'tar.exe');
+    await execFileAsync(tarBin, ['--version']);
     return true;
   } catch {
     return false;
@@ -49,10 +50,12 @@ export async function extractTarGzWithProgress(archivePath: string, targetDir: s
   reportProgress(0, totalBytes);
 
   // On Windows, prefer native tar.exe for better performance (2-5x faster than Node.js tar)
+  // Must use absolute path to avoid MSYS2/Git-Bash tar which misinterprets C: as remote host
   if (await isNativeTarAvailable()) {
+    const tarBin = process.platform === 'win32' ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'tar.exe') : 'tar';
     const args = ['-xzf', archivePath, '-C', targetDir];
     if (strip > 0) args.push(`--strip-components=${strip}`);
-    await execFileAsync('tar', args);
+    await execFileAsync(tarBin, args);
     reportProgress(totalBytes, totalBytes);
     return;
   }

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -640,7 +640,12 @@ const SendBox: React.FC<{
           )}
         </div>
         <div className={isSingleLine ? 'flex items-center gap-2 w-full min-w-0 overflow-hidden' : 'w-full overflow-hidden'}>
-          {isSingleLine && <div className={isMobile ? 'sendbox-tools sendbox-tools-scroll-mobile' : 'flex-shrink-0 sendbox-tools flex items-center'}>{tools}{skillTriggerButton}</div>}
+          {isSingleLine && (
+            <div className={isMobile ? 'sendbox-tools sendbox-tools-scroll-mobile' : 'flex-shrink-0 sendbox-tools flex items-center'}>
+              {tools}
+              {skillTriggerButton}
+            </div>
+          )}
           <Input.TextArea
             autoFocus={!isMobile}
             disabled={disabled}
@@ -695,7 +700,10 @@ const SendBox: React.FC<{
         </div>
         {!isSingleLine && (
           <div className='flex items-center justify-between gap-2 w-full'>
-            <div className={isMobile ? 'sendbox-tools sendbox-tools-scroll-mobile' : 'sendbox-tools flex items-center'}>{tools}{skillTriggerButton}</div>
+            <div className={isMobile ? 'sendbox-tools sendbox-tools-scroll-mobile' : 'sendbox-tools flex items-center'}>
+              {tools}
+              {skillTriggerButton}
+            </div>
             <div className='flex items-center gap-2'>
               {sendButtonPrefix}
               {isLoading || loading ? <Button shape='circle' type='secondary' className='bg-animate' icon={<div className='mx-auto size-12px bg-6'></div>} onClick={stopHandler}></Button> : sendButton}


### PR DESCRIPTION
## Summary
- MSYS2/Git-Bash `tar` interprets `C:` in Windows paths as a remote host (`host:file` syntax), causing `Cannot connect to C: resolve failed` when extracting SudoClaw archives
- Fix: use absolute path `%SystemRoot%\System32\tar.exe` in `archiveProgress.ts` instead of bare `tar` which may resolve to MSYS2 tar
- Also fixes pre-existing prettier error in `sendbox.tsx`

## Root cause
`execFileAsync('tar', args)` on Windows finds Git Bash's MSYS2 tar first in PATH. MSYS tar treats the colon in `C:\Users\...` as remote host syntax, failing with "Cannot connect to C: resolve failed". Windows native `System32\tar.exe` handles Windows paths correctly.

## Test plan
- [x] Verified SudoClaw installation succeeds in dev mode on Windows 11
- [x] Verified browser skill works end-to-end (agent opens baidu.com and screenshots)
- [ ] CI build tests pass on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)