### PR TITLE
feat(acp): graceful cancel via session/cancel

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -554,7 +554,7 @@ export class AcpConnection {
           // Check for end_turn message and extract usage data
           if (message.result && typeof message.result === 'object') {
             const promptResult = message.result as Record<string, unknown>;
-            if (promptResult.stopReason === 'end_turn') {
+            if (promptResult.stopReason === 'end_turn' || promptResult.stopReason === 'cancelled') {
               this.onEndTurn();
             }
             // Extract PromptResponse.usage (per-turn token data from codex-acp / PR #167)
@@ -929,8 +929,94 @@ export class AcpConnection {
     return this.models;
   }
 
+  /**
+   * Cancel the current turn via ACP session/cancel.
+   * Sends the cancel notification and waits for the backend to confirm
+   * by responding to the pending session/prompt with stopReason: 'cancelled'.
+   * Falls back to disconnect() if the backend doesn't respond within timeout.
+   */
+  async cancel(timeoutMs: number = 3000): Promise<'cancelled' | 'disconnected'> {
+    if (!this.child || !this.sessionId) {
+      await this.disconnect();
+      return 'disconnected';
+    }
+
+    // 1. Send session/cancel notification
+    this.sendMessage({
+      jsonrpc: JSONRPC_VERSION,
+      method: ACP_METHODS.SESSION_CANCEL,
+      params: { sessionId: this.sessionId },
+    });
+
+    // 2. Check if there's a pending session/prompt to wait for
+    const pendingPromptId = this.findPendingPromptRequestId();
+    if (pendingPromptId === null) {
+      // No pending prompt — cancel is a no-op, session is already idle
+      return 'cancelled';
+    }
+
+    // 3. Wait for the backend to respond to the pending prompt
+    //    (it should respond with stopReason: 'cancelled')
+    const resolved = await this.waitForRequestResolution(pendingPromptId, timeoutMs);
+
+    if (!resolved) {
+      // Backend didn't respond in time — force kill
+      await this.disconnect();
+      return 'disconnected';
+    }
+
+    return 'cancelled';
+  }
+
+  /** Find the request ID of a pending session/prompt request, if any. */
+  private findPendingPromptRequestId(): number | null {
+    for (const [id, request] of this.pendingRequests) {
+      if (request.method === 'session/prompt') return id;
+    }
+    return null;
+  }
+
+  /** Wait for a specific pending request to resolve/reject, with timeout. */
+  private waitForRequestResolution(requestId: number, timeoutMs: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      // If already resolved (race), return immediately
+      if (!this.pendingRequests.has(requestId)) {
+        resolve(true);
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        resolve(false); // Timed out
+      }, timeoutMs);
+
+      // Wrap the existing resolve/reject to detect completion
+      const pending = this.pendingRequests.get(requestId)!;
+      const origResolve = pending.resolve;
+      const origReject = pending.reject;
+
+      pending.resolve = (value: unknown) => {
+        clearTimeout(timer);
+        origResolve(value);
+        resolve(true);
+      };
+      pending.reject = (error: Error) => {
+        clearTimeout(timer);
+        origReject(error);
+        resolve(true);
+      };
+    });
+  }
+
   async disconnect(): Promise<void> {
     await this.terminateChild();
+
+    // Reject all pending requests so their callers' Promises settle
+    for (const [, request] of this.pendingRequests) {
+      if (request.timeoutId) {
+        clearTimeout(request.timeoutId);
+      }
+      request.reject(new Error('ACP connection disconnected'));
+    }
 
     // Reset session-level state
     this.pendingRequests.clear();

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -863,17 +863,51 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
   }
 
   async stop(): Promise<void> {
-    await this.connection.disconnect();
-    this.emitStatusMessage('disconnected');
-    this.approvalStore.clear();
+    // 1. Flush buffered streaming text
+    this.streamTextBuffer.flushAll();
+
+    // 2. Respond to pending permission requests with Cancelled
+    //    (ACP spec: client MUST do this when cancelling)
+    for (const [callId, pending] of this.pendingPermissions) {
+      pending.reject(new Error('Cancelled'));
+    }
+    this.pendingPermissions.clear();
     this.permissionRequestMeta.clear();
-    // Emit finish event
-    this.handleStreamEvent({
-      type: 'finish',
-      conversation_id: this.conversation_id,
-      msg_id: uuid(),
-      data: null,
-    });
+
+    // 3. Clear confirmation UI
+    for (const confirmation of this.confirmations) {
+      ipcBridge.conversation.confirmation.remove.emit({
+        conversation_id: this.conversation_id,
+        id: confirmation.id,
+      });
+    }
+    this.confirmations = [];
+
+    // 4. Cancel the current turn (waits for backend to confirm, or kills after 3s)
+    let result: 'cancelled' | 'disconnected';
+    try {
+      result = await this.connection.cancel();
+    } catch {
+      await this.connection.disconnect();
+      result = 'disconnected';
+    }
+
+    if (result === 'disconnected') {
+      // Backend didn't respond to cancel — process was killed
+      this.emitStatusMessage('disconnected');
+      this.approvalStore.clear();
+      // Clear bootstrap so next message re-initializes
+      this.bootstrap = undefined;
+      // Emit finish only for disconnect path (cancel path already emitted via onEndTurn)
+      this.handleStreamEvent({
+        type: 'finish',
+        conversation_id: this.conversation_id,
+        msg_id: uuid(),
+        data: null,
+      });
+    }
+    // If result === 'cancelled': session is alive, don't touch bootstrap/approvalStore
+    // The finish event was already emitted by handleEndTurn() when the backend responded
   }
 
   kill() {

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -882,6 +882,7 @@ export const ACP_METHODS = {
   READ_TEXT_FILE: 'fs/read_text_file',
   WRITE_TEXT_FILE: 'fs/write_text_file',
   SET_CONFIG_OPTION: 'session/set_config_option',
+  SESSION_CANCEL: 'session/cancel',
 } as const;
 
 export type AcpMethod = (typeof ACP_METHODS)[keyof typeof ACP_METHODS];

--- a/tests/e2e/cases/claude-graceful-cancel.yaml
+++ b/tests/e2e/cases/claude-graceful-cancel.yaml
@@ -1,0 +1,57 @@
+name: claude graceful cancel
+description: >
+  Test ACP session/cancel: send a 3-step prompt where step 2 is a long sleep,
+  stop mid-execution during the sleep, then ask what it completed.
+  Verifies session stays alive (no reconnect) and context is preserved.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Navigate to new conversation and select Claude Code ──
+  - op: mouse_click
+    text: "新会话"
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Claude Code"
+  - op: pause
+    duration: 5000
+
+  # ── Phase 2: Send a 3-step prompt (step 2 = sleep 30s = guaranteed busy time) ──
+  - op: type_text
+    text: "分开跑 3 步, 1. ls -la, 2. sleep 30 seconds, 3. echo \"完成\""
+  - op: click
+    element: textarea
+  - op: press_key
+    key: "Enter"
+    wait: 3
+
+  # ── Phase 3: Wait for step 1 to finish, then stop during step 2 (sleep) ──
+  - op: pause
+    duration: 15000
+  - op: screenshot
+    path: "screenshots/cancel-01-during-sleep.png"
+  - op: stop_conversation
+    timeout: 10
+    wait: 2
+  - op: screenshot
+    path: "screenshots/cancel-02-after-stop.png"
+
+  # ── Phase 4: Ask what it did ──
+  - op: type_text
+    text: "你做什么了?"
+  - op: click
+    element: textarea
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+
+  # ── Phase 5: Verify context preserved — agent should know about step 1 (ls) ──
+  - op: screenshot
+    path: "screenshots/cancel-03-followup.png"
+  - op: judge
+    expect: "ls sleep"


### PR DESCRIPTION
## Summary

- When a user clicks **stop** during an agent turn, send ACP `session/cancel` notification instead of killing the child process (`SIGTERM`)
- Agent confirms with `stopReason: 'cancelled'` → session stays alive → next message is instant (no 3-5s reconnect)
- Falls back to `disconnect()` (kill process) if backend doesn't respond within 3 seconds — same behavior as today for non-compliant backends
- Fix pre-existing bug: `disconnect()` now rejects pending requests before clearing, preventing dangling promises

## Changes

| File | What |
|------|------|
| `src/types/acpTypes.ts` | Add `SESSION_CANCEL` to `ACP_METHODS` |
| `src/agent/acp/AcpConnection.ts` | Add `cancel()` with 3s timeout fallback; handle `stopReason: 'cancelled'`; fix `disconnect()` to reject pending requests |
| `src/process/task/AcpAgent.ts` | Rewrite `stop()`: flush buffers → cancel permissions → clear confirmations → cancel turn → conditional cleanup |
| `tests/e2e/cases/claude-graceful-cancel.yaml` | E2E test: 3-step prompt with `sleep 30`, stop mid-execution, verify session alive + context preserved |

## Test plan

- [x] Send multi-step prompt (`ls -la` → `sleep 30` → `echo`), stop during sleep, send follow-up — verifies session stays alive and context preserved
- [ ] Stop during permission dialog — dialog clears, can send new message
- [ ] Test with backend that ignores cancel — 3s timeout, falls back to kill, next message reconnects
- [ ] Stop when agent is idle — no error, no state corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)