### PR TITLE
fix(acp): disallow chrome-devtools MCP tools in ACP sessions

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -719,21 +719,37 @@ export class AcpConnection {
     // Build _meta for Claude/CodeBuddy ACP resume support
     // claude-agent-acp and codebuddy use _meta.claudeCode.options.resume for session resume
     const useMetaResume = (this.backend === 'claude' || this.backend === 'codebuddy') && options?.resumeSessionId;
-    const meta = useMetaResume
-      ? {
-          claudeCode: {
-            options: {
-              resume: options.resumeSessionId,
-            },
-          },
-        }
-      : undefined;
+
+    // Disallow chrome-devtools MCP tools — browser automation should use the
+    // app-level NavigationInterceptor / browser skill instead of raw CDP access
+    // which can navigate the Electron main window and cause hangs on permission prompts.
+    const disallowedChromeDevToolsTools = [
+      'mcp__chrome-devtools__navigate_page',
+      'mcp__chrome-devtools__new_page',
+      'mcp__chrome-devtools__list_pages',
+      'mcp__chrome-devtools__select_page',
+      'mcp__chrome-devtools__take_screenshot',
+      'mcp__chrome-devtools__take_snapshot',
+      'mcp__chrome-devtools__click',
+      'mcp__chrome-devtools__fill',
+      'mcp__chrome-devtools__fill_form',
+      'mcp__chrome-devtools__evaluate_script',
+      'mcp__chrome-devtools__wait_for',
+    ];
+
+    const meta = {
+      claudeCode: {
+        options: {
+          ...(useMetaResume && { resume: options.resumeSessionId }),
+          disallowedTools: disallowedChromeDevToolsTools,
+        },
+      },
+    };
 
     const response = await this.sendRequest<AcpResponse & { sessionId?: string }>('session/new', {
       cwd: normalizedCwd,
       mcpServers: [] as unknown[],
-      // Claude/CodeBuddy ACP uses _meta for resume
-      ...(meta && { _meta: meta }),
+      _meta: meta,
       // Generic resume parameters for other ACP backends
       ...(this.backend !== 'claude' && this.backend !== 'codebuddy' && options?.resumeSessionId && { resumeSessionId: options.resumeSessionId }),
       ...(options?.forkSession && { forkSession: options.forkSession }),
@@ -766,6 +782,25 @@ export class AcpConnection {
       sessionId,
       cwd: normalizedCwd,
       mcpServers: [] as unknown[],
+      _meta: {
+        claudeCode: {
+          options: {
+            disallowedTools: [
+              'mcp__chrome-devtools__navigate_page',
+              'mcp__chrome-devtools__new_page',
+              'mcp__chrome-devtools__list_pages',
+              'mcp__chrome-devtools__select_page',
+              'mcp__chrome-devtools__take_screenshot',
+              'mcp__chrome-devtools__take_snapshot',
+              'mcp__chrome-devtools__click',
+              'mcp__chrome-devtools__fill',
+              'mcp__chrome-devtools__fill_form',
+              'mcp__chrome-devtools__evaluate_script',
+              'mcp__chrome-devtools__wait_for',
+            ],
+          },
+        },
+      },
     });
 
     // session/load returns modes/models/configOptions but not sessionId — keep the one we sent


### PR DESCRIPTION
## Summary

- Block all `chrome-devtools` MCP tools (`navigate_page`, `new_page`, `take_screenshot`, etc.) in ACP sessions via `disallowedTools` in `_meta.claudeCode.options`
- Applies to both `session/new` and `session/load` requests
- Prevents the chrome-devtools MCP server (when globally configured in `~/.claude.json`) from giving Claude Code raw CDP access to the Electron main window, which can hijack the window to external URLs and cause permission prompt hangs in headless sessions

## Background

When `chrome-devtools` MCP is configured globally, Claude Code ACP sessions can use `navigate_page` to navigate the Electron main window to arbitrary URLs (e.g., baidu.com), breaking the app. Additionally, MCP tool permission prompts cause ACP sessions to hang indefinitely since there's no interactive terminal to approve them.

The `disallowedTools` option is supported by the `claude-agent-acp` bridge SDK, which merges user-provided disallowed tools with its own list.

## Test plan

- [x] Verified `disallowedTools` is passed correctly via `_meta.claudeCode.options` in both `session/new` and `session/load`
- [x] Tested browser skill works correctly through SudoClaw/OpenClaw gateway (5 successful tests: baidu.com, news.ycombinator.com, github.com, wikipedia.org, example.com)
- [x] Confirmed chrome-devtools MCP tools are no longer invoked by ACP sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)