### PR TITLE
feat: 在 @技能 选择器中添加搜索框和搜索功能

### DIFF
--- a/src/renderer/components/SkillSelectorMenu.tsx
+++ b/src/renderer/components/SkillSelectorMenu.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from 'classnames';
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import type { AtMentionTab } from '@/renderer/hooks/useSkillSelectorController';
 import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 
@@ -46,9 +46,21 @@ interface SkillSelectorMenuProps {
   skillsTabTitle?: string;
   /** Empty text for files tab */
   filesEmptyText?: string;
+  /** Search query for filtering */
+  searchQuery?: string;
+  /** Callback when search query changes */
+  onSearchChange?: (query: string) => void;
+  /** Callback to dismiss/close the menu */
+  onDismiss?: () => void;
+  /** Placeholder text for skills search */
+  skillsSearchPlaceholder?: string;
+  /** Placeholder text for files search */
+  filesSearchPlaceholder?: string;
+  /** Text shown when search has no results */
+  noSearchResultsText?: string;
 }
 
-const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, items, selectedKeys, activeIndex, loading = false, loadingText = 'Loading...', onHoverItem, onSelectItem, emptyText, showTabs = false, activeTab = 'skills', onTabChange, fileItems = [], onSelectFile, filesTabTitle = 'Files', skillsTabTitle = 'Skills', filesEmptyText = 'No files' }) => {
+const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, items, selectedKeys, activeIndex, loading = false, loadingText = 'Loading...', onHoverItem, onSelectItem, emptyText, showTabs = false, activeTab = 'skills', onTabChange, fileItems = [], onSelectFile, filesTabTitle = 'Files', skillsTabTitle = 'Skills', filesEmptyText = 'No files', searchQuery = '', onSearchChange, onDismiss, skillsSearchPlaceholder = '搜索技能...', filesSearchPlaceholder = '搜索文件...', noSearchResultsText = '未找到匹配结果' }) => {
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
@@ -57,6 +69,39 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
       current.scrollIntoView({ block: 'nearest' });
     }
   }, [activeIndex, items.length, fileItems.length, activeTab]);
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const currentItems = activeTab === 'skills' ? items : fileItems;
+      const itemCount = currentItems?.length ?? 0;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        onHoverItem(Math.min(activeIndex + 1, itemCount - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        onHoverItem(Math.max(activeIndex - 1, 0));
+      } else if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        if (activeTab === 'skills' && items[activeIndex]) {
+          onSelectItem(items[activeIndex]);
+        } else if (activeTab === 'files' && fileItems?.[activeIndex]) {
+          onSelectFile?.(fileItems[activeIndex]);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        if (searchQuery) {
+          onSearchChange?.('');
+        } else {
+          onDismiss?.();
+        }
+      } else if (e.key === 'Tab' && showTabs && onTabChange) {
+        e.preventDefault();
+        onTabChange(activeTab === 'skills' ? 'files' : 'skills');
+      }
+    },
+    [activeTab, items, fileItems, activeIndex, onHoverItem, onSelectItem, onSelectFile, onDismiss, onSearchChange, searchQuery, showTabs, onTabChange]
+  );
 
   return (
     <div
@@ -111,13 +156,54 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
         {showTabs && <div className='text-11px text-t-secondary truncate'>Tab to switch</div>}
       </div>
 
+      {/* Search box */}
+      {onSearchChange && (
+        <div
+          className='px-8px py-6px border-b border-solid'
+          style={{
+            borderColor: 'color-mix(in srgb, var(--color-border-2) 56%, transparent)',
+          }}
+        >
+          <div
+            className='flex items-center gap-6px px-8px py-4px rounded-8px'
+            style={{
+              background: 'color-mix(in srgb, var(--color-fill-2) 60%, transparent)',
+            }}
+          >
+            <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' className='shrink-0 text-t-tertiary'>
+              <circle cx='11' cy='11' r='8' />
+              <path d='m21 21-4.35-4.35' />
+            </svg>
+            <input
+              type='text'
+              className='flex-1 min-w-0 text-13px bg-transparent border-none outline-none text-t-primary placeholder:text-t-tertiary'
+              style={{ caretColor: 'var(--color-primary)' }}
+              placeholder={activeTab === 'skills' ? skillsSearchPlaceholder : filesSearchPlaceholder}
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+            />
+            {searchQuery && (
+              <button
+                type='button'
+                className='shrink-0 w-16px h-16px flex items-center justify-center rounded-full text-t-tertiary hover:text-t-secondary cursor-pointer border-none outline-none text-11px bg-transparent'
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => onSearchChange('')}
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Content area */}
       <div role='listbox' aria-busy={loading} className='overflow-y-auto p-6px' style={{ maxHeight: 'min(34vh, 260px)' }}>
         {/* Skills tab content */}
         {activeTab === 'skills' && (
           <>
             {loading && <div className='px-10px py-12px text-13px text-t-secondary'>{loadingText}</div>}
-            {!loading && items.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{emptyText}</div>}
+            {!loading && items.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{searchQuery ? noSearchResultsText : emptyText}</div>}
             {!loading &&
               items.map((item, index) => {
                 const isSelected = selectedKeys.includes(item.key);
@@ -164,7 +250,7 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
         {/* Files tab content */}
         {activeTab === 'files' && (
           <>
-            {fileItems.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{filesEmptyText}</div>}
+            {fileItems.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{searchQuery ? noSearchResultsText : filesEmptyText}</div>}
             {fileItems.map((file, index) => (
               <button
                 key={file.fullPath}

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -585,6 +585,12 @@ const SendBox: React.FC<{
               skillsTabTitle={t('messages.skills.tabSkills', { defaultValue: 'Skills' })}
               filesTabTitle={t('messages.skills.tabFiles', { defaultValue: 'Files' })}
               filesEmptyText={t('messages.skills.filesEmpty', { defaultValue: 'No files in workspace' })}
+              searchQuery={skillSelectorController.searchQuery}
+              onSearchChange={skillSelectorController.setSearchQuery}
+              onDismiss={() => skillSelectorController.setDismissed(true)}
+              skillsSearchPlaceholder={t('messages.skills.searchSkills', { defaultValue: '搜索技能...' })}
+              filesSearchPlaceholder={t('messages.skills.searchFiles', { defaultValue: '搜索文件...' })}
+              noSearchResultsText={t('messages.skills.noSearchResults', { defaultValue: '未找到匹配结果' })}
             />
           </div>
         )}

--- a/src/renderer/hooks/useSkillSelectorController.ts
+++ b/src/renderer/hooks/useSkillSelectorController.ts
@@ -80,6 +80,7 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
   const [activeIndex, setActiveIndex] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const [activeTab, setActiveTab] = useState<AtMentionTab>('skills');
+  const [searchQuery, setSearchQuery] = useState('');
   const prevQueryRef = useRef<string | null>(null);
 
   // Determine if tabs should be shown (always show when in conversation with workspace)
@@ -91,34 +92,45 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
     if (query !== prevQueryRef.current) {
       setActiveIndex(0);
       setDismissed(false);
+      setSearchQuery('');
       prevQueryRef.current = query;
     }
   }, [query]);
+
+  // Reset active index when search query changes
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [searchQuery]);
 
   const filteredSkills = useMemo(() => {
     if (query === null) {
       return [];
     }
-    const keyword = query.trim().toLowerCase();
+    // Use searchQuery if available, otherwise fall back to @ query
+    const rawKeyword = searchQuery.trim() || query.trim();
+    const keyword = rawKeyword.toLowerCase();
     if (!keyword) {
       // Show all skills when query is empty
       return skills;
     }
-    // Filter by display name or internal name
+    // Filter by display name, internal name, or description
     return skills.filter((skill) => {
       const nameMatch = skill.name.toLowerCase().includes(keyword);
       const displayNameMatch = skill.displayName.toLowerCase().includes(keyword);
+      const descriptionMatch = skill.description?.toLowerCase().includes(keyword) ?? false;
       // Also support Chinese character matching
-      const chineseMatch = query && skill.displayName.includes(query);
-      return nameMatch || displayNameMatch || chineseMatch;
+      const chineseMatch = rawKeyword ? skill.displayName.includes(rawKeyword) : false;
+      return nameMatch || displayNameMatch || descriptionMatch || chineseMatch;
     });
-  }, [skills, query]);
+  }, [skills, query, searchQuery]);
 
   const filteredFiles = useMemo(() => {
     if (query === null) {
       return [];
     }
-    const keyword = query.trim().toLowerCase();
+    // Use searchQuery if available, otherwise fall back to @ query
+    const rawKeyword = searchQuery.trim() || query.trim();
+    const keyword = rawKeyword.toLowerCase();
     if (!keyword) {
       return workspaceFiles;
     }
@@ -127,7 +139,7 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
       const pathMatch = file.relativePath.toLowerCase().includes(keyword);
       return nameMatch || pathMatch;
     });
-  }, [workspaceFiles, query]);
+  }, [workspaceFiles, query, searchQuery]);
 
   // Get items for current tab
   const currentTabItems = activeTab === 'skills' ? filteredSkills : filteredFiles;
@@ -159,6 +171,7 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
     if (!showTabs) return;
     setActiveTab((prev) => (prev === 'skills' ? 'files' : 'skills'));
     setActiveIndex(0);
+    setSearchQuery('');
   }, [showTabs]);
 
   const onKeyDown = useCallback(
@@ -220,7 +233,10 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
     setActiveTab: (tab: AtMentionTab) => {
       setActiveTab(tab);
       setActiveIndex(0);
+      setSearchQuery('');
     },
+    searchQuery,
+    setSearchQuery,
     onKeyDown,
     onSelectByIndex: executeSkill,
     setDismissed,

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -595,7 +595,7 @@ const GuidPage: React.FC = () => {
               mentionSelectorBadge={<MentionSelectorBadge visible={mention.mentionSelectorVisible} open={mention.mentionSelectorOpen} onOpenChange={mention.setMentionSelectorOpen} agentLabel={mention.selectedAgentLabel} mentionMenu={mentionDropdownNode} onResetQuery={() => mention.setMentionQuery(null)} />}
               mentionDropdown={mentionDropdownNode}
               skillSelectorOpen={skillSelectorController.isOpen}
-              skillSelectorMenu={skillSelectorController.isOpen ? <SkillSelectorMenu title='技能' items={skillMenuItems} selectedKeys={selectedSkills} activeIndex={skillSelectorController.activeIndex} onHoverItem={(index) => skillSelectorController.setActiveIndex(index)} onSelectItem={(_item) => skillSelectorController.onSelectByIndex(skillSelectorController.activeIndex)} emptyText='暂无技能' /> : null}
+              skillSelectorMenu={skillSelectorController.isOpen ? <SkillSelectorMenu title='技能' items={skillMenuItems} selectedKeys={selectedSkills} activeIndex={skillSelectorController.activeIndex} onHoverItem={(index) => skillSelectorController.setActiveIndex(index)} onSelectItem={(_item) => skillSelectorController.onSelectByIndex(skillSelectorController.activeIndex)} emptyText='暂无技能' searchQuery={skillSelectorController.searchQuery} onSearchChange={skillSelectorController.setSearchQuery} onDismiss={() => skillSelectorController.setDismissed(true)} /> : null}
               selectedSkills={selectedSkills}
               onRemoveSkill={(skillName) => setSelectedSkills(selectedSkills.filter((s) => s !== skillName))}
               getSkillDisplayName={(skillName) => {


### PR DESCRIPTION
## Summary

- 在 SkillSelectorMenu 组件中添加搜索框 UI，位于 tab 下方
- 技能搜索支持名称、显示名称、描述的模糊匹配；文件搜索支持文件名和相对路径匹配
- 搜索框内支持键盘导航（↑↓选择、Enter确认、Escape清除/关闭、Tab切换）
- guide 页面和会话界面均支持搜索功能

Closes #389

Generated with [Claude Code](https://claude.ai/code)