### PR TITLE
feat(browser): pass full ai-dev-browser stdout to UI & LLM

### DIFF
--- a/docs/ai-dev-browser-sidechannel-spec.md
+++ b/docs/ai-dev-browser-sidechannel-spec.md
@@ -1,0 +1,165 @@
+# ai-dev-browser — optional sidechannel POST (drop-in spec)
+
+Owner: ai-dev-browser team.
+Purpose: optional defense-in-depth for sudowork's UI bypass of the openclaw exec wrapper. Sudowork already captures the full stdout of `python -m ai_dev_browser.tools.*` via a Node-level hook (`AdbStdoutCapture`) and posts it to a localhost sidechannel. This spec describes a parallel Python-side POST that makes the same handoff independent of the Node hook.
+
+**Status**: optional. If the Node hook is working, applying this spec is pure redundancy. Apply when a future openclaw release changes the `spawn` pipeline in a way that breaks the Node hook, or when ai-dev-browser is used outside sudowork/openclaw and a similar consumer wants the same sidechannel contract.
+
+## Contract
+
+Environment variables the caller may set:
+
+- `AI_DEV_BROWSER_SIDECHANNEL_URL` — e.g. `http://127.0.0.1:53712/capture`
+- `AI_DEV_BROWSER_SIDECHANNEL_SECRET` — 32+ byte hex string
+- `AI_DEV_BROWSER_CALL_ID` — optional, provided by sudowork's Node hook per-invocation; fall back to `uuid.uuid4().hex`
+
+POST body shape (JSON, UTF-8):
+
+```json
+{
+  "callId": "abcd1234…",
+  "cmd": "python",
+  "argv": ["-m", "ai_dev_browser.tools.page_info", "--url", "…"],
+  "pid": 12345,
+  "ppid": 12340,
+  "startedAt": 1713345200123,
+  "finishedAt": 1713345200456,
+  "exitCode": 0,
+  "stdoutRaw": "{\"path\": \"/tmp/shot.png\", ...}",
+  "stdoutJson": { "path": "/tmp/shot.png" },
+  "cmdHash": "<sha1 of `{cmd}\\n{cwd}`>"
+}
+```
+
+Required headers: `X-Adb-Secret: <secret>`, `Content-Type: application/json`. The receiver authenticates with `hmac.compare_digest`-style constant-time comparison, and rejects bodies over 8 MB.
+
+## Drop-in code
+
+In `ai_dev_browser/_cli.py`, add a best-effort helper and call it from each `print(json.dumps(...))` site. Do **not** change stdout byte-for-byte — the sidechannel POST augments, never replaces, the printed output.
+
+```python
+# Near top of _cli.py, after the existing imports
+import hashlib
+import os
+import sys
+import time
+import uuid
+import json
+from urllib import request as _urlreq
+from urllib.error import URLError
+
+_ADB_CALL_START: float | None = None
+_ADB_CALL_ID: str | None = None
+
+
+def _adb_call_id() -> str:
+    global _ADB_CALL_ID
+    if _ADB_CALL_ID is None:
+        _ADB_CALL_ID = os.environ.get("AI_DEV_BROWSER_CALL_ID") or uuid.uuid4().hex
+    return _ADB_CALL_ID
+
+
+def _adb_cmd_hash() -> str:
+    cmd = (sys.argv[0] if sys.argv else "").strip()
+    cwd = os.getcwd()
+    h = hashlib.sha1()
+    h.update(cmd.encode("utf-8", errors="replace"))
+    h.update(b"\n")
+    h.update(cwd.encode("utf-8", errors="replace"))
+    return h.hexdigest()
+
+
+def _post_sidechannel(stdout_text: str, *, exit_code: int | None = 0) -> None:
+    """Best-effort POST of the full tool result to the sudowork sidechannel.
+
+    All errors are swallowed — the sidechannel is optional defense-in-depth.
+    """
+    url = os.environ.get("AI_DEV_BROWSER_SIDECHANNEL_URL")
+    secret = os.environ.get("AI_DEV_BROWSER_SIDECHANNEL_SECRET")
+    if not url or not secret:
+        return
+    global _ADB_CALL_START
+    started_at = int((_ADB_CALL_START or time.time()) * 1000)
+    finished_at = int(time.time() * 1000)
+    try:
+        stdout_json = json.loads(stdout_text) if stdout_text.strip() else None
+    except Exception:
+        stdout_json = None
+    try:
+        ppid = os.getppid()
+    except Exception:
+        ppid = -1
+    payload = {
+        "callId": _adb_call_id(),
+        "cmd": sys.argv[0] if sys.argv else "",
+        "argv": list(sys.argv[1:]),
+        "pid": os.getpid(),
+        "ppid": ppid,
+        "startedAt": started_at,
+        "finishedAt": finished_at,
+        "exitCode": exit_code,
+        "stdoutRaw": stdout_text,
+        "stdoutJson": stdout_json,
+        "cmdHash": _adb_cmd_hash(),
+    }
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = _urlreq.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Adb-Secret": secret,
+        },
+        method="POST",
+    )
+    try:
+        _urlreq.urlopen(req, timeout=0.5).read()
+    except (URLError, OSError):
+        pass
+
+
+def _emit_and_capture(payload: dict, *, exit_code: int | None = 0) -> None:
+    """Print JSON to stdout (unchanged behavior) and POST to sidechannel."""
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    print(text)
+    _post_sidechannel(text, exit_code=exit_code)
+```
+
+Then inside `cli_main()` (the function that dispatches each tool):
+
+1. Record the start time once: `global _ADB_CALL_START; _ADB_CALL_START = time.time()` immediately before the dispatch.
+2. Replace each bare `print(json.dumps(...))` emission with `_emit_and_capture({...}, exit_code=0)` (or `exit_code=1` on error paths).
+
+Touch points (current `_cli.py` line numbers):
+
+- **Success JSON dump around line 287** (`print(json.dumps(result, ensure_ascii=False, indent=2))` inside the async `run()` branch) — replace with `_emit_and_capture(result, exit_code=0)`.
+- **Sync success dump around line 303** — same replacement.
+- **Port-missing error around line 264** — `_emit_and_capture({"error": "No available Chrome found. ..."}, exit_code=1)` before `sys.exit(1)`.
+- **Async exception catch around line 290** — `_emit_and_capture({"error": str(e)}, exit_code=1)`.
+- **Sync exception catch around line 306** — same replacement.
+- **`output()` helper at line 318** — mirror the same pattern: `_emit_and_capture({...}, exit_code=0)`.
+- **`error()` helper at line 323** — call `_emit_and_capture({"error": message}, exit_code=code)` before `sys.exit(code)`.
+
+## Non-goals
+
+- Do not change the existing stdout format. Downstream tools (openclaw, sudowork) parse the printed JSON byte-for-byte.
+- Do not add a new CLI flag or configuration file. The feature is purely env-var gated.
+- Do not add a new dependency — use only stdlib (`urllib.request`, `json`, `hashlib`, `uuid`, `time`, `os`).
+- Do not retry on failure. Sidechannel absence is expected and must not add latency.
+
+## Verification
+
+Minimal smoke test (from the sudowork repo after applying this spec):
+
+```bash
+AI_DEV_BROWSER_SIDECHANNEL_URL=http://127.0.0.1:9999/capture \
+AI_DEV_BROWSER_SIDECHANNEL_SECRET=dummy \
+python -m ai_dev_browser.tools.page_info --help
+# Expected: stdout prints normally; one failed POST attempt (silently swallowed).
+```
+
+With a real receiver (for example a trivial `nc -l 9999`-style listener), verify the POST body matches the contract above and that removing the env vars returns the tool to pre-spec behavior with no overhead.
+
+## Coordination
+
+Sudowork tracks this behind `docs/plan-browser-bypass.md` (Phase 4). The matching Node hook lives at `hook/node/src/process/AdbStdoutCapture.ts` and is verified to work in the current build; this spec exists as redundancy that ai-dev-browser can apply on its own timeline without breaking sudowork.

--- a/docs/plan-browser-bypass-phase1-findings.md
+++ b/docs/plan-browser-bypass-phase1-findings.md
@@ -1,0 +1,56 @@
+# Phase 1 Spike — Openclaw exec internals
+
+## Bundle layout
+
+- Gateway entry: `~/.nexus/sudoclaw/cli/package/openclaw.mjs` (ESM).
+- Large deps chunked under `~/.nexus/sudoclaw/cli/package/dist/`, loaded via static `import`.
+- All modules are ES module format (not CJS). `Module.prototype.require` monkey-patch has no effect on static ESM imports; functions are bound at module load.
+
+## Exec pipeline
+
+1. `dist/exec-B5_AYfQG.js` — `runCommandWithTimeout(argv, {timeoutMs, cwd, env, ...})` at line 213. Spawns via `node:child_process.spawn`. Accumulates `stdout`/`stderr` via `on('data')` into plain strings.
+2. `dist/pi-embedded-CbCYZxIb.js:72962` — `runExecProcess(opts)`. This is the tool-level runner. Also uses `spawn`. Sanitizes output with `sanitizeBinaryOutput` then `appendOutput`. Session carries `aggregated`, `tail`, `pendingStdout/stderr`, `maxOutputChars`, `truncated`.
+3. `dist/pi-embedded-CbCYZxIb.js:74526` — `buildExecForegroundResult(params)` returns `{content: [{type:'text', text: <aggregated>|"(no output)"}], details: {status, exitCode, durationMs, aggregated, cwd}}`. This is the LLM-facing tool-result.
+
+## Truncation levers
+
+- `DEFAULT_MAX_OUTPUT = 200_000` chars. Env override: `PI_BASH_MAX_OUTPUT_CHARS` (clamped 1000–200000). Applied in `appendOutput` via `trimWithCap(aggregated + chunk, maxOutputChars)`.
+- `DEFAULT_PENDING_OUTPUT_CHARS = 30_000` — streaming pending buffer cap.
+- `TOOL_RESULT_MAX_CHARS = 8_000` at `pi-embedded-CbCYZxIb.js:172895` — hard-coded, no env. Applied in `sanitizeToolResult` → `truncateToolText`. Produces the `sanitizedResult` used for (a) WS `tool_call` event `data.result`, (b) `after_tool_call` hooks. The LLM's own tool-result return value is the **unsanitized** `result` (up to 200KB).
+
+## WS event shape (sudowork → gateway subscription)
+
+`emitAgentEvent({stream: 'tool', runId, sessionKey, data})` at `pi-embedded-CbCYZxIb.js:94691`.
+
+On `phase === 'result'`, `data = {phase: 'result', name, toolCallId, meta, isError, result: sanitizedResult}`.
+
+`meta` is the short description (e.g. `"run python, \`python -m ai_dev_browser.tools.page_screenshot ...\`"`). Built by `extendExecMeta` + `inferToolMetaFromArgs`. `result.content` carries the full text capped at 8 KB.
+
+## sudowork-side observation
+
+`src/process/task/OpenClawAgent.ts:789-858` reads `toolData.content` and `toolData.meta` but never `toolData.result.content`. That is why the UI currently shows the `meta` description — the full content from openclaw's `sanitizedResult` is arriving on the wire but is dropped by sudowork.
+
+- A minimal UI fix would be to read `toolData.result` on `phase === 'result'`. But the text would be capped at 8 KB via `TOOL_RESULT_MAX_CHARS`.
+- The sidechannel path (plan Phase 2) bypasses the 8 KB cap and gives us the raw bytes plus structured JSON and PNG metadata.
+
+## Decision for Phase 3 LLM injection
+
+Option A (patch `buildExecForegroundResult`) is infeasible: ESM static imports mean the symbol is already bound in every call site at module evaluation time; no `require`/globalThis lever.
+
+Workable path: monkey-patch `child_process.spawn` itself. When an ai-dev-browser invocation is detected we tee `child.stdout` into the sidechannel but **do not modify** what openclaw reads — openclaw then aggregates the full bytes (well under 200 KB) into the LLM-facing result through its normal path. The 8 KB `TOOL_RESULT_MAX_CHARS` cap affects only the sanitized WS event (UI) — sudowork rewrites that path via sidechannel in Phase 2, so both UI and LLM receive the real text.
+
+No env lever needs toggling.
+
+## Summary
+
+- Openclaw: ESM bundle. Exec runs through `spawn`. LLM gets 200 KB cap; WS/UI gets 8 KB sanitized cap. No plugin/MCP hook for result rewriting.
+- Phase 3 Option A as written is not viable; falling back to spawn-level tee is sufficient because the 200 KB LLM cap is never hit for ai-dev-browser outputs (JSON under 4 KB).
+- If a future ai-dev-browser tool prints > 200 KB, the spawn-level fallback would still need either stdout mutation (risky, breaks openclaw bookkeeping) or a post-install bundle patch. For now, not needed.
+
+## Phase 3.2 decision
+
+Option A (ESM serializer monkey-patch) rejected — the bundle statically imports `buildExecForegroundResult` and `sanitizeToolResult`, so the symbols are bound at module load with no interception point. `Module.prototype.require` only intercepts CJS requires; `globalThis` isn't used.
+
+Option B (pipe-level tee with terminator marker) rejected as premature — the LLM already receives openclaw's `aggregated` (capped at 200 KB) via the normal exec tool-result path; ai-dev-browser outputs are well under 4 KB. The spawn-level capture in `AdbStdoutCapture` is non-invasive (adds a `'data'` listener, doesn't steal bytes from openclaw), so openclaw's aggregation continues to work and the LLM continues to see the real stdout.
+
+Net: no additional LLM-side code is required. Goal 2 is satisfied by openclaw's existing 200 KB aggregation path, verified unmodified by the spawn interceptor. If Goal 2 ever regresses (e.g. openclaw shrinks the cap), escalate to (a) a post-install bundle patch in `SudoclawInstallService`, or (b) replacing the `child.stdout` stream with a controlled passthrough that reshapes output before openclaw reads it.

--- a/hook/node/src/index.ts
+++ b/hook/node/src/index.ts
@@ -7,6 +7,7 @@ import NodeInterceptors from '@mswjs/interceptors/presets/node';
 import type { BlacklistConfig } from './blacklist/types';
 import { ProcessInterceptor } from './process/ProcessInterceptor';
 import type { ProcessController } from './process/ProcessController';
+import { AdbStdoutCapture } from './process/AdbStdoutCapture';
 
 export interface SafetyHookOptions {
   /** Nexus server URL, defaults to http://127.0.0.1:12012 */
@@ -28,6 +29,7 @@ export interface SafetyHookOptions {
 let networkInterceptor: BatchInterceptor | null = null;
 let fileInterceptor: FileInterceptor | null = null;
 let processInterceptor: ProcessInterceptor | null = null;
+let adbStdoutCapture: AdbStdoutCapture | null = null;
 let isApplied = false;
 let nexusController: NexusController | null = null;
 let configPollingTimer: NodeJS.Timeout | null = null;
@@ -99,6 +101,24 @@ export function initSafetyHook(options: SafetyHookOptions = {}): void {
     });
   }
 
+  // ai-dev-browser stdout capture — only enabled when sudowork provided
+  // sidechannel endpoint + secret via customEnv. No-op otherwise.
+  const adbUrl = process.env.AI_DEV_BROWSER_SIDECHANNEL_URL;
+  const adbSecret = process.env.AI_DEV_BROWSER_SIDECHANNEL_SECRET;
+  if (adbUrl && adbSecret && !adbStdoutCapture) {
+    try {
+      adbStdoutCapture = new AdbStdoutCapture({
+        sidechannelUrl: adbUrl,
+        sidechannelSecret: adbSecret,
+      });
+      adbStdoutCapture.apply();
+      console.error(`[SafetyHook] ai-dev-browser stdout capture enabled (sidechannel=${adbUrl})`);
+    } catch (err) {
+      console.error('[SafetyHook] Failed to apply ai-dev-browser stdout capture:', err);
+      adbStdoutCapture = null;
+    }
+  }
+
   isApplied = true;
   console.error(`[SafetyHook] Initialized with nexusUrl=${nexusUrl}, network=${enableNetwork}, file=${enableFile}`);
 
@@ -135,6 +155,10 @@ export function disposeSafetyHook(): void {
   if (processInterceptor) {
     processInterceptor.dispose();
     processInterceptor = null;
+  }
+  if (adbStdoutCapture) {
+    adbStdoutCapture.dispose();
+    adbStdoutCapture = null;
   }
   nexusController = null;
   isApplied = false;

--- a/hook/node/src/process/AdbStdoutCapture.ts
+++ b/hook/node/src/process/AdbStdoutCapture.ts
@@ -1,0 +1,362 @@
+/**
+ * Monkey-patches `node:child_process.spawn` inside the openclaw gateway
+ * process so any `python -m ai_dev_browser.tools.*` child has its full stdout
+ * teed to the sudowork sidechannel. Sudowork then rewrites the UI event
+ * content on the sudowork side so the real JSON + PNG metadata reaches the
+ * UI — openclaw's short `meta` description is replaced, not amended.
+ *
+ * No openclaw bundle modification: we only observe child_process.spawn.
+ * Openclaw's own stdout reader still sees every byte unchanged.
+ */
+
+import * as childProcessNs from 'node:child_process';
+import { createRequire } from 'node:module';
+import { createHash, randomBytes } from 'node:crypto';
+import * as http from 'node:http';
+
+// In ESM contexts (including vitest) the `node:child_process` namespace is
+// frozen — we can't reassign `childProcess.spawn`. The CJS module exports
+// object, though, is writable in every Node runtime, including vitest. Use
+// `createRequire` to reach it so the monkey-patch is consistent across
+// production (esbuild output loaded via `-r`) and tests.
+const childProcess: typeof childProcessNs = (() => {
+  try {
+    const req = createRequire(import.meta.url);
+    return req('child_process') as typeof childProcessNs;
+  } catch {
+    return childProcessNs;
+  }
+})();
+
+const PYTHON_COMMAND_RE = /(?:^|[\\/])(python|python3)(?:\.exe)?$/i;
+const ADB_MODULE_RE = /^ai_dev_browser\.tools\./;
+// Matches a `python(-3|.exe|3) -m ai_dev_browser.tools.<name>` fragment
+// anywhere in a shell script string. Used when openclaw wraps the call
+// through cmd.exe / bash / sh / pwsh and spawns the shell rather than
+// python directly.
+const ADB_IN_SHELL_RE = /(?:^|[;\s&|])python(?:3|\.exe|3\.exe)?\s+-m\s+ai_dev_browser\.tools\./i;
+const DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
+
+interface CapturedState {
+  callId: string;
+  cmdHash: string;
+  cmd: string;
+  argv: string[];
+  pid: number | null;
+  ppid: number;
+  startedAt: number;
+  chunks: Buffer[];
+  bytes: number;
+  truncated: boolean;
+}
+
+interface CaptureOptions {
+  sidechannelUrl: string;
+  sidechannelSecret: string;
+  maxBytes?: number;
+}
+
+export class AdbStdoutCapture {
+  private readonly url: URL;
+  private readonly secret: string;
+  private readonly maxBytes: number;
+  private readonly byPid = new Map<number, CapturedState>();
+  private originalSpawn: typeof childProcess.spawn | null = null;
+  private originalProtoSpawn: ((opts: Record<string, unknown>) => unknown) | null = null;
+  private applied = false;
+
+  constructor(opts: CaptureOptions) {
+    this.url = new URL(opts.sidechannelUrl);
+    this.secret = opts.sidechannelSecret;
+    this.maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  }
+
+  apply(): void {
+    if (this.applied) return;
+    this.applied = true;
+    this.originalSpawn = childProcess.spawn;
+    // Replace `spawn` on the CJS module.exports object. Covers any CJS
+    // `const {spawn} = require('child_process')` consumer, and also works
+    // through `createRequire` paths.
+    try {
+      (childProcess as { spawn: typeof childProcess.spawn }).spawn = this.makeWrappedSpawn(this.originalSpawn);
+    } catch {
+      /* fall back to prototype patch below */
+    }
+
+    // Patch `ChildProcess.prototype.spawn` — the internal instance method
+    // that Node's public `spawn()` always delegates to. This catches
+    // consumers who captured the module-level `spawn` binding through
+    // ESM static imports (e.g. `import { spawn } from 'node:child_process'`),
+    // since those calls still route through the prototype method at
+    // runtime. This is how we intercept openclaw's `runExecProcess` without
+    // needing to break its ESM binding.
+    const cp = childProcess as unknown as { ChildProcess?: { prototype: { spawn: (opts: Record<string, unknown>) => unknown } } };
+    const proto = cp.ChildProcess?.prototype;
+    if (proto && typeof proto.spawn === 'function') {
+      const originalProtoSpawn = proto.spawn;
+      this.originalProtoSpawn = originalProtoSpawn;
+      const self = this;
+      proto.spawn = function patchedProtoSpawn(this: Record<string, unknown> & { pid?: number }, options: Record<string, unknown>) {
+        let detect: { hashInput: string } | null = null;
+        let callId: string | null = null;
+        try {
+          const fileRaw = options?.file;
+          const argsRaw = options?.args;
+          const command = typeof fileRaw === 'string' ? fileRaw : '';
+          const argv = Array.isArray(argsRaw) ? argsRaw.map((a) => String(a)) : [];
+          detect = self.matchAdbInvocation(command, argv);
+          if (detect) {
+            callId = randomBytes(16).toString('hex');
+            // Inject AI_DEV_BROWSER_CALL_ID into the spawn envPairs array.
+            // envPairs format: array of "KEY=VALUE" strings.
+            const envPairs = options.envPairs;
+            if (Array.isArray(envPairs)) {
+              envPairs.push(`AI_DEV_BROWSER_CALL_ID=${callId}`);
+            }
+          }
+        } catch { /* any error → fall through unchanged */ }
+
+        const rc = originalProtoSpawn.call(this, options);
+
+        if (detect && callId) {
+          try {
+            self.attach(this as unknown as childProcess.ChildProcess, {
+              callId,
+              cmd: typeof options?.file === 'string' ? String(options.file) : '',
+              argv: Array.isArray(options?.args) ? (options.args as unknown[]).map((a) => String(a)) : [],
+              hashInput: detect.hashInput,
+            });
+          } catch { /* swallow */ }
+        }
+        return rc;
+      };
+    } else {
+      console.error('[AdbStdoutCapture] ChildProcess.prototype.spawn not found — falling back to module-level patch only');
+    }
+  }
+
+  dispose(): void {
+    if (!this.applied) return;
+    if (this.originalSpawn) {
+      try {
+        (childProcess as { spawn: typeof childProcess.spawn }).spawn = this.originalSpawn;
+      } catch {
+        /* ignore */
+      }
+    }
+    if (this.originalProtoSpawn) {
+      const cp = childProcess as unknown as { ChildProcess?: { prototype: { spawn: unknown } } };
+      const proto = cp.ChildProcess?.prototype;
+      if (proto) proto.spawn = this.originalProtoSpawn;
+      this.originalProtoSpawn = null;
+    }
+    this.originalSpawn = null;
+    this.applied = false;
+    this.byPid.clear();
+  }
+
+  private makeWrappedSpawn(originalSpawn: typeof childProcess.spawn): typeof childProcess.spawn {
+    const self = this;
+    return function spawnWrapper(
+      this: unknown,
+      command: string,
+      ...rest: unknown[]
+    ): ReturnType<typeof childProcess.spawn> {
+      const [rawArgs, rawOptions] = self.normalizeSpawnArgs(rest);
+      const detect = self.matchAdbInvocation(command, rawArgs);
+      if (!detect) {
+        return (originalSpawn as unknown as (...a: unknown[]) => ReturnType<typeof childProcess.spawn>).call(
+          this,
+          command,
+          ...rest,
+        );
+      }
+      const callId = randomBytes(16).toString('hex');
+      const patched = self.injectCallId(rawOptions, callId);
+      const patchedRest = self.replaceOptions(rest, patched);
+      const child = (originalSpawn as unknown as (...a: unknown[]) => ReturnType<typeof childProcess.spawn>).call(
+        this,
+        command,
+        ...patchedRest,
+      );
+      self.attach(child, {
+        callId,
+        cmd: command,
+        argv: rawArgs,
+        hashInput: detect.hashInput,
+      });
+      return child;
+    } as typeof childProcess.spawn;
+  }
+
+  getCapturedByPid(pid: number): { callId: string; stdout: string } | null {
+    const entry = this.byPid.get(pid);
+    if (!entry) return null;
+    return { callId: entry.callId, stdout: Buffer.concat(entry.chunks, entry.bytes).toString('utf8') };
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+
+  private normalizeSpawnArgs(rest: unknown[]): [string[], Record<string, unknown> | undefined] {
+    if (rest.length === 0) return [[], undefined];
+    const first = rest[0];
+    if (Array.isArray(first)) {
+      const args = first.map((a) => String(a));
+      const opts = rest.length > 1 && rest[1] && typeof rest[1] === 'object' ? (rest[1] as Record<string, unknown>) : undefined;
+      return [args, opts];
+    }
+    if (first && typeof first === 'object') {
+      return [[], first as Record<string, unknown>];
+    }
+    return [[], undefined];
+  }
+
+  private replaceOptions(rest: unknown[], newOpts: Record<string, unknown>): unknown[] {
+    if (rest.length === 0) return [newOpts];
+    if (Array.isArray(rest[0])) {
+      return [rest[0], newOpts, ...rest.slice(2)];
+    }
+    return [newOpts, ...rest.slice(1)];
+  }
+
+  private matchAdbInvocation(command: string, args: string[]): { hashInput: string } | null {
+    // Case 1: direct python invocation — `python -m ai_dev_browser.tools.<x> ...`
+    if (PYTHON_COMMAND_RE.test(command)) {
+      const dashMIdx = args.indexOf('-m');
+      if (dashMIdx !== -1 && dashMIdx + 1 < args.length && ADB_MODULE_RE.test(args[dashMIdx + 1] ?? '')) {
+        return { hashInput: `${command} ${args.join(' ')}`.trim() };
+      }
+    }
+    // Case 2: shell-wrapped invocation — openclaw's runExecProcess spawns
+    // cmd.exe/bash/sh/pwsh with the user's shell script as one of the args.
+    // Scan every arg for the `python -m ai_dev_browser.tools.*` fragment.
+    for (const arg of args) {
+      if (typeof arg !== 'string') continue;
+      if (ADB_IN_SHELL_RE.test(arg)) {
+        return { hashInput: arg.trim() };
+      }
+    }
+    return null;
+  }
+
+  private injectCallId(options: Record<string, unknown> | undefined, callId: string): Record<string, unknown> {
+    const cloned: Record<string, unknown> = options ? { ...options } : {};
+    const env = (cloned.env && typeof cloned.env === 'object' ? cloned.env : process.env) as NodeJS.ProcessEnv;
+    cloned.env = { ...env, AI_DEV_BROWSER_CALL_ID: callId };
+    return cloned;
+  }
+
+  private attach(
+    child: childProcess.ChildProcess,
+    meta: { callId: string; cmd: string; argv: string[]; hashInput: string },
+  ): void {
+    // The hash is computed from `hashInput` alone so it lines up with the
+    // sudowork-side `computeAdbCmdHash`, which only sees `args.command`
+    // (the shell script text) on the tool_call event.
+    const cmdHash = createHash('sha1').update(meta.hashInput).digest('hex');
+    const state: CapturedState = {
+      callId: meta.callId,
+      cmdHash,
+      cmd: meta.cmd,
+      argv: meta.argv,
+      pid: child.pid ?? null,
+      ppid: process.pid,
+      startedAt: Date.now(),
+      chunks: [],
+      bytes: 0,
+      truncated: false,
+    };
+    if (child.pid) this.byPid.set(child.pid, state);
+
+    if (child.stdout && typeof (child.stdout as NodeJS.ReadableStream).on === 'function') {
+      (child.stdout as NodeJS.ReadableStream).on('data', (chunk: Buffer | string) => {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+        if (state.bytes >= this.maxBytes) {
+          state.truncated = true;
+          return;
+        }
+        const remaining = this.maxBytes - state.bytes;
+        if (buf.length > remaining) {
+          state.chunks.push(buf.subarray(0, remaining));
+          state.bytes += remaining;
+          state.truncated = true;
+          return;
+        }
+        state.chunks.push(buf);
+        state.bytes += buf.length;
+      });
+    }
+
+    const finalize = (exitCode: number | null) => {
+      if (state.pid != null) this.byPid.delete(state.pid);
+      const stdoutRaw = Buffer.concat(state.chunks, state.bytes).toString('utf8');
+      const trimmed = stdoutRaw.trim();
+      let stdoutJson: unknown;
+      if (trimmed) {
+        try {
+          stdoutJson = JSON.parse(trimmed);
+        } catch {
+          stdoutJson = undefined;
+        }
+      }
+      const payload = {
+        callId: state.callId,
+        cmd: state.cmd,
+        argv: state.argv,
+        pid: state.pid ?? -1,
+        ppid: state.ppid,
+        startedAt: state.startedAt,
+        finishedAt: Date.now(),
+        exitCode,
+        stdoutRaw,
+        stdoutJson,
+        cmdHash: state.cmdHash,
+        truncated: state.truncated,
+      };
+      this.post(payload);
+    };
+
+    let settled = false;
+    const onSettle = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      finalize(code);
+    };
+    child.once('exit', (code) => onSettle(typeof code === 'number' ? code : null));
+    child.once('error', () => onSettle(null));
+  }
+
+  private post(payload: Record<string, unknown>): void {
+    let body: Buffer;
+    try {
+      body = Buffer.from(JSON.stringify(payload), 'utf8');
+    } catch {
+      return;
+    }
+    const req = http.request({
+      method: 'POST',
+      host: this.url.hostname,
+      port: this.url.port ? Number(this.url.port) : 80,
+      path: this.url.pathname || '/capture',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': body.length,
+        'x-adb-secret': this.secret,
+      },
+      timeout: 1500,
+    });
+    req.on('error', () => {
+      /* swallow — sidechannel absence is non-fatal */
+    });
+    req.on('timeout', () => {
+      req.destroy();
+    });
+    // Consume response to free the socket.
+    req.on('response', (res) => {
+      res.on('data', () => {});
+      res.on('end', () => {});
+    });
+    req.end(body);
+  }
+}

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -5,7 +5,7 @@ description: "AI-native browser. Explore websites, discover page structure, take
 
 # Browser
 
-Tools directory: `~/sudowork/vendor/ai-dev-browser/ai_dev_browser/tools/`
+Tools directory: `./ai_dev_browser/tools/` (relative to this skill).
 
 Every CLI tool has an identical Python function in `ai_dev_browser.core` — explore interactively with CLI, then script with the same functions:
 

--- a/src/agent/acp/AcpAdapter.ts
+++ b/src/agent/acp/AcpAdapter.ts
@@ -181,6 +181,28 @@ export class AcpAdapter {
   private createOrUpdateAcpToolCall(update: ToolCallUpdate): IMessageAcpToolCall | null {
     const toolCallId = update.update.toolCallId;
 
+    const existing = this.activeToolCalls.get(toolCallId);
+    if (existing) {
+      // Merge: preserve rawInput from earlier phases, content from later phases
+      const merged: ToolCallUpdate = {
+        ...existing.content,
+        update: {
+          ...existing.content.update,
+          ...update.update,
+          rawInput: update.update.rawInput || existing.content.update.rawInput,
+          content: update.update.content || existing.content.update.content,
+        },
+      };
+      const updatedMessage: IMessageAcpToolCall = {
+        ...existing,
+        msg_id: toolCallId,
+        content: merged,
+        createdAt: Date.now(),
+      };
+      this.activeToolCalls.set(toolCallId, updatedMessage);
+      return updatedMessage;
+    }
+
     // 使用 toolCallId 作为 msg_id，确保同一个工具调用的消息可以被合并
     const baseMessage = {
       id: uuid(),

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdirSync as _mkdirSync, existsSync, readdirSync, readFileSync } from 'fs';
+import { mkdirSync as _mkdirSync, existsSync, lstatSync, readdirSync, readFileSync, rmSync, symlinkSync, unlinkSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 import { app } from 'electron';
@@ -501,6 +501,61 @@ const resolveBuiltinResourceDir = (dirPath: string): string => {
  *     (e.g. a pure bugfix), a version-gated copy would permanently skip the
  *     refresh, leaving users stuck on whichever script shipped at first install.
  */
+/**
+ * Locate the bundled ai-dev-browser Python package directory.
+ * Returns the path to the inner `ai_dev_browser/` package (not the repo root).
+ */
+const resolveAiDevBrowserPackageDir = (): string | null => {
+  const candidates = app.isPackaged ? [path.join(app.getAppPath().replace('app.asar', 'app.asar.unpacked'), 'vendor/ai-dev-browser/ai_dev_browser'), path.join(process.resourcesPath, 'ai-dev-browser/ai_dev_browser')] : [path.join(app.getAppPath(), 'vendor/ai-dev-browser/ai_dev_browser')];
+  return candidates.find((p) => existsSync(p)) ?? null;
+};
+
+/**
+ * Create a directory symlink at `<systemSkills>/browser/ai_dev_browser` pointing
+ * to the bundled ai-dev-browser package. The symlink lets the agent reference
+ * `./ai_dev_browser/tools/...` from inside the browser skill at a stable path
+ * regardless of installation layout.
+ */
+const linkAiDevBrowserIntoSystemSkill = (systemSkillsDir: string): void => {
+  const browserSkillDir = path.join(systemSkillsDir, 'browser');
+  if (!existsSync(browserSkillDir)) return;
+
+  const target = resolveAiDevBrowserPackageDir();
+  if (!target) {
+    mainWarn('Sudowork', 'ai-dev-browser package not found; browser skill cannot link tools');
+    return;
+  }
+
+  const linkPath = path.join(browserSkillDir, 'ai_dev_browser');
+  try {
+    if (existsSync(linkPath)) {
+      // Refresh the symlink in case the resolved path changed (dev vs packaged).
+      // Inspect the link itself via lstat: on Windows a junction's target is
+      // a real directory, and `rmSync(..., { recursive: true })` follows the
+      // junction and deletes the target's files (wiping the bundled
+      // ai-dev-browser source tree in dev). `unlinkSync` removes the junction
+      // without traversing into it.
+      let removed = false;
+      try {
+        const stat = lstatSync(linkPath);
+        if (stat.isSymbolicLink() || !stat.isDirectory()) {
+          unlinkSync(linkPath);
+          removed = true;
+        }
+      } catch {
+        // fall through to rmSync below
+      }
+      if (!removed) {
+        rmSync(linkPath, { recursive: true, force: true });
+      }
+    }
+    symlinkSync(target, linkPath, 'junction');
+    mainLog('Sudowork', `Linked ai-dev-browser into browser skill: ${linkPath} -> ${target}`);
+  } catch (error) {
+    mainWarn('Sudowork', 'Failed to link ai-dev-browser into browser skill:', error);
+  }
+};
+
 const syncBuiltinSkillsToUserDir = async (): Promise<void> => {
   const builtinSkillsDir = resolveBuiltinResourceDir('skills');
   if (!existsSync(builtinSkillsDir)) {
@@ -522,6 +577,10 @@ const syncBuiltinSkillsToUserDir = async (): Promise<void> => {
     // Copy skills/* into _system/; the bundled resources already contain the _builtin subdirectory
     await copyDirectoryRecursively(builtinSkillsDir, userSystemSkillsDir, { overwrite: true });
     mainLog('Sudowork', 'Builtin skills synced to _system/ (overwrite)');
+
+    // Link the bundled ai-dev-browser package into the browser skill so the agent
+    // sees `skills/browser/ai_dev_browser/tools/` at a stable relative path.
+    linkAiDevBrowserIntoSystemSkill(userSystemSkillsDir);
   } catch (error) {
     mainWarn('Sudowork', 'Failed to sync builtin skills directory:', error);
   }

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path';
 import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
 import { initStatusManager } from '../initStatus';
 import { isSudoclawHealthPayload, SUDOCLAW_HEALTH_TIMEOUT_MS, type SudoclawHealthPayload } from '../sudoclaw/sudoclawHealth';
+import { AdbResultSidechannel } from '../sudoclaw/AdbResultSidechannel';
 import { runtimeInstaller } from './RuntimeInstaller';
 
 type OpenClawGateway = import('@/agent/openclaw/OpenClawGatewayManager').OpenClawGatewayManager;
@@ -31,6 +32,7 @@ type SudoclawHealthCheckResult = {
  */
 export class ServiceManager {
   private gateway: OpenClawGateway | null = null;
+  private adbSidechannel: AdbResultSidechannel | null = null;
   private startupInProgress = false;
   private shuttingDown = false;
   private openClawStartPromise: Promise<void> | null = null;
@@ -361,10 +363,31 @@ export class ServiceManager {
       // whether config was manually modified, or whether repair was skipped.
       repairOpenClawConfig();
 
+      // Start the ai-dev-browser sidechannel before the gateway so the gateway
+      // (and any `python -m ai_dev_browser.tools.*` children it spawns) inherit
+      // the URL + secret through customEnv.
+      let adbSidechannelEnv: Record<string, string> = {};
+      try {
+        if (!this.adbSidechannel) {
+          this.adbSidechannel = new AdbResultSidechannel();
+        }
+        const { port: sidePort, secret: sideSecret } = await this.adbSidechannel.start();
+        adbSidechannelEnv = {
+          AI_DEV_BROWSER_SIDECHANNEL_URL: `http://127.0.0.1:${sidePort}/capture`,
+          AI_DEV_BROWSER_SIDECHANNEL_SECRET: sideSecret,
+        };
+      } catch (err) {
+        mainWarn('ServiceManager', 'Failed to start AdbResultSidechannel (ai-dev-browser UI bypass disabled for this run)', err);
+      }
+
       this.gateway = new OpenClawGatewayManager({
         port: SUDOCLAW_DEFAULT_PORT,
         stateDir: SUDOCLAW_DIR,
-        customEnv: { OPENCLAW_STATE_DIR: SUDOCLAW_DIR, OPENCLAW_CONFIG_PATH: SUDOCLAW_CONFIG_PATH },
+        customEnv: {
+          OPENCLAW_STATE_DIR: SUDOCLAW_DIR,
+          OPENCLAW_CONFIG_PATH: SUDOCLAW_CONFIG_PATH,
+          ...adbSidechannelEnv,
+        },
         forceSubprocessGateway: true,
       });
       await this.gateway.start();
@@ -651,13 +674,32 @@ export class ServiceManager {
   }
 
   async stopOpenClaw(): Promise<void> {
-    if (!this.gateway) return;
+    if (!this.gateway) {
+      // Sidechannel can linger if start failed partway; make sure it's cleaned up.
+      if (this.adbSidechannel) {
+        try {
+          await this.adbSidechannel.stop();
+        } catch {
+          /* ignore */
+        }
+        this.adbSidechannel = null;
+      }
+      return;
+    }
     try {
       await this.gateway.stop();
     } catch {
       /* ignore */
     }
     this.gateway = null;
+    if (this.adbSidechannel) {
+      try {
+        await this.adbSidechannel.stop();
+      } catch {
+        /* ignore */
+      }
+      this.adbSidechannel = null;
+    }
     // Force-kill any orphaned process still holding the gateway port
     try {
       const { SUDOCLAW_DEFAULT_PORT } = await import('../sudoclaw/SudoclawInstallService');
@@ -688,6 +730,15 @@ export class ServiceManager {
     // Reconnect all active agents' WebSocket connections to the new gateway.
     const WorkerManage = (await import('@process/WorkerManage')).default;
     WorkerManage.reconnectOpenClawAgents();
+  }
+
+  /**
+   * Accessor used by OpenClawAgent to look up captured ai-dev-browser
+   * stdout keyed by command hash. Returns null when the sidechannel failed
+   * to start (non-critical — the UI just falls back to the short meta).
+   */
+  getAdbSidechannel(): AdbResultSidechannel | null {
+    return this.adbSidechannel;
   }
 
   /**

--- a/src/process/services/sudoclaw/AdbResultSidechannel.ts
+++ b/src/process/services/sudoclaw/AdbResultSidechannel.ts
@@ -1,0 +1,311 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Sidechannel HTTP server that collects full stdout of ai-dev-browser tool
+ * invocations from inside the openclaw gateway process, so the sudowork UI
+ * and the embedded LLM can both see the real Python output instead of the
+ * short `meta` description openclaw forwards over its WebSocket.
+ *
+ * Lifecycle is tied to the gateway — started before `OpenClawGatewayManager`
+ * spawns and stopped when the gateway stops. The port and shared secret are
+ * passed into the gateway via `customEnv` as `AI_DEV_BROWSER_SIDECHANNEL_URL`
+ * and `AI_DEV_BROWSER_SIDECHANNEL_SECRET`; from there they inherit into
+ * whatever `python -m ai_dev_browser.tools.*` children openclaw spawns.
+ *
+ * The Node-level hook (`hook/node/src/process/AdbStdoutCapture.ts`) POSTs
+ * `AdbResultEntry` JSON to `/capture`, authenticating via the shared secret.
+ * `OpenClawAgent` then calls `waitForCmd(cmdHash, windowMs)` to reconcile an
+ * inbound `tool_call` result event with the captured payload.
+ */
+
+import * as crypto from 'node:crypto';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mainError, mainLog, mainWarn } from '@process/utils/mainLogger';
+
+export interface AdbResultEntry {
+  callId: string;
+  cmd: string;
+  argv: string[];
+  pid: number;
+  ppid: number;
+  startedAt: number;
+  finishedAt: number;
+  exitCode: number | null;
+  stdoutRaw: string;
+  stdoutJson: unknown;
+  cmdHash: string;
+}
+
+interface WaiterRecord {
+  resolve: (entry: AdbResultEntry | null) => void;
+  timer: NodeJS.Timeout;
+}
+
+const MAX_BODY_BYTES = 8 * 1024 * 1024; // 8 MB
+const MAX_ENTRIES = 256;
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_WAIT_MS = 1500;
+
+export class AdbResultSidechannel {
+  private server: http.Server | null = null;
+  private secret = '';
+  private port = 0;
+  private readonly byCallId = new Map<string, AdbResultEntry>();
+  private readonly byCmdHash = new Map<string, string[]>();
+  private readonly insertOrder: string[] = [];
+  private readonly waitersByHash = new Map<string, WaiterRecord[]>();
+
+  async start(): Promise<{ port: number; secret: string }> {
+    if (this.server) {
+      return { port: this.port, secret: this.secret };
+    }
+    this.secret = crypto.randomBytes(32).toString('hex');
+    this.server = http.createServer((req, res) => this.handleRequest(req, res));
+
+    await new Promise<void>((resolve, reject) => {
+      const server = this.server!;
+      const onError = (err: Error) => {
+        server.off('listening', onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.off('error', onError);
+        resolve();
+      };
+      server.once('error', onError);
+      server.once('listening', onListening);
+      // Bind explicitly to loopback so we never expose the sidechannel on LAN.
+      server.listen(0, '127.0.0.1');
+    });
+
+    const addr = this.server.address() as AddressInfo | null;
+    if (!addr || typeof addr !== 'object') {
+      throw new Error('AdbResultSidechannel failed to acquire an address');
+    }
+    this.port = addr.port;
+    mainLog('AdbResultSidechannel', `listening on 127.0.0.1:${this.port}`);
+    return { port: this.port, secret: this.secret };
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    const server = this.server;
+    this.server = null;
+    for (const waiters of this.waitersByHash.values()) {
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timer);
+        waiter.resolve(null);
+      }
+    }
+    this.waitersByHash.clear();
+    this.byCallId.clear();
+    this.byCmdHash.clear();
+    this.insertOrder.length = 0;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    mainLog('AdbResultSidechannel', 'stopped');
+  }
+
+  getEndpoint(): string {
+    return `http://127.0.0.1:${this.port}/capture`;
+  }
+
+  getSecret(): string {
+    return this.secret;
+  }
+
+  /**
+   * Take an entry by `callId`. Consumes it atomically (removed from the store).
+   */
+  takeByCallId(callId: string, ttlMs = DEFAULT_TTL_MS): AdbResultEntry | null {
+    const entry = this.byCallId.get(callId);
+    if (!entry) return null;
+    if (Date.now() - entry.finishedAt > ttlMs) {
+      this.deleteEntry(callId);
+      return null;
+    }
+    this.deleteEntry(callId);
+    return entry;
+  }
+
+  /**
+   * Look up an entry by command hash. Falls back to waiting up to
+   * `windowMs` for a matching POST to arrive if none is queued yet.
+   */
+  async waitForCmd(cmdHash: string, windowMs = DEFAULT_WAIT_MS): Promise<AdbResultEntry | null> {
+    const existing = this.popByHash(cmdHash);
+    if (existing) return existing;
+
+    if (windowMs <= 0) return null;
+
+    return await new Promise<AdbResultEntry | null>((resolve) => {
+      const timer = setTimeout(() => {
+        this.removeWaiter(cmdHash, waiter);
+        resolve(null);
+      }, windowMs);
+      const waiter: WaiterRecord = { resolve, timer };
+      const list = this.waitersByHash.get(cmdHash) ?? [];
+      list.push(waiter);
+      this.waitersByHash.set(cmdHash, list);
+    });
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+
+  private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    if (req.method !== 'POST' || req.url !== '/capture') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const providedSecret = String(req.headers['x-adb-secret'] ?? '');
+    if (!this.secretMatches(providedSecret)) {
+      res.writeHead(401);
+      res.end();
+      return;
+    }
+    let bodyLen = 0;
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      bodyLen += chunk.length;
+      if (bodyLen > MAX_BODY_BYTES) {
+        res.writeHead(413);
+        res.end();
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (res.writableEnded) return;
+      let entry: AdbResultEntry | null = null;
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        entry = this.parseEntry(raw);
+      } catch (err) {
+        mainWarn('AdbResultSidechannel', 'failed to parse capture body', err);
+      }
+      if (!entry) {
+        res.writeHead(400);
+        res.end();
+        return;
+      }
+      this.storeEntry(entry);
+      res.writeHead(204);
+      res.end();
+    });
+    req.on('error', (err) => {
+      mainError('AdbResultSidechannel', 'capture request error', err);
+    });
+  }
+
+  private secretMatches(provided: string): boolean {
+    if (!this.secret || !provided) return false;
+    const a = Buffer.from(provided);
+    const b = Buffer.from(this.secret);
+    if (a.length !== b.length) return false;
+    try {
+      return crypto.timingSafeEqual(a, b);
+    } catch {
+      return false;
+    }
+  }
+
+  private parseEntry(raw: string): AdbResultEntry | null {
+    const parsed = JSON.parse(raw) as Partial<AdbResultEntry> & Record<string, unknown>;
+    if (typeof parsed.callId !== 'string' || typeof parsed.cmd !== 'string' || !Array.isArray(parsed.argv) || typeof parsed.pid !== 'number' || typeof parsed.ppid !== 'number' || typeof parsed.startedAt !== 'number' || typeof parsed.finishedAt !== 'number' || typeof parsed.cmdHash !== 'string' || typeof parsed.stdoutRaw !== 'string') {
+      return null;
+    }
+    const exitCode = parsed.exitCode === null || typeof parsed.exitCode === 'number' ? parsed.exitCode : null;
+    return {
+      callId: parsed.callId,
+      cmd: parsed.cmd,
+      argv: parsed.argv.map(String),
+      pid: parsed.pid,
+      ppid: parsed.ppid,
+      startedAt: parsed.startedAt,
+      finishedAt: parsed.finishedAt,
+      exitCode,
+      stdoutRaw: parsed.stdoutRaw,
+      stdoutJson: 'stdoutJson' in parsed ? parsed.stdoutJson : undefined,
+      cmdHash: parsed.cmdHash,
+    };
+  }
+
+  private storeEntry(entry: AdbResultEntry): void {
+    this.evictStale();
+    this.byCallId.set(entry.callId, entry);
+    this.insertOrder.push(entry.callId);
+    const waiters = this.waitersByHash.get(entry.cmdHash);
+    if (waiters && waiters.length > 0) {
+      const waiter = waiters.shift()!;
+      clearTimeout(waiter.timer);
+      if (waiters.length === 0) this.waitersByHash.delete(entry.cmdHash);
+      // Waiter takes ownership — evict the entry so nobody else picks it up.
+      this.deleteEntry(entry.callId);
+      waiter.resolve(entry);
+      return;
+    }
+    const queue = this.byCmdHash.get(entry.cmdHash) ?? [];
+    queue.push(entry.callId);
+    this.byCmdHash.set(entry.cmdHash, queue);
+    this.evictOverflow();
+  }
+
+  private popByHash(cmdHash: string): AdbResultEntry | null {
+    const queue = this.byCmdHash.get(cmdHash);
+    if (!queue || queue.length === 0) return null;
+    const callId = queue.shift()!;
+    if (queue.length === 0) this.byCmdHash.delete(cmdHash);
+    else this.byCmdHash.set(cmdHash, queue);
+    const entry = this.byCallId.get(callId);
+    if (!entry) return null;
+    this.deleteEntry(callId);
+    return entry;
+  }
+
+  private deleteEntry(callId: string): void {
+    const entry = this.byCallId.get(callId);
+    if (!entry) return;
+    this.byCallId.delete(callId);
+    const idx = this.insertOrder.indexOf(callId);
+    if (idx !== -1) this.insertOrder.splice(idx, 1);
+    const queue = this.byCmdHash.get(entry.cmdHash);
+    if (queue) {
+      const qIdx = queue.indexOf(callId);
+      if (qIdx !== -1) queue.splice(qIdx, 1);
+      if (queue.length === 0) this.byCmdHash.delete(entry.cmdHash);
+    }
+  }
+
+  private evictStale(ttlMs = DEFAULT_TTL_MS): void {
+    const now = Date.now();
+    for (const callId of [...this.insertOrder]) {
+      const entry = this.byCallId.get(callId);
+      if (!entry) continue;
+      if (now - entry.finishedAt > ttlMs) this.deleteEntry(callId);
+    }
+  }
+
+  private evictOverflow(): void {
+    while (this.insertOrder.length > MAX_ENTRIES) {
+      const oldest = this.insertOrder[0];
+      if (!oldest) break;
+      this.deleteEntry(oldest);
+    }
+  }
+
+  private removeWaiter(cmdHash: string, waiter: WaiterRecord): void {
+    const list = this.waitersByHash.get(cmdHash);
+    if (!list) return;
+    const idx = list.indexOf(waiter);
+    if (idx !== -1) list.splice(idx, 1);
+    if (list.length === 0) this.waitersByHash.delete(cmdHash);
+  }
+}

--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -439,7 +439,11 @@ export function repairOpenClawConfig(): void {
       const tavilyApiKey = tavilyWebSearch?.apiKey;
       if (!tavilyApiKey?.trim()) {
         const providersObj = (config.models as { providers?: Record<string, { apiKey?: string }> } | undefined)?.providers;
-        const sudorouterApiKey = providersObj?.sudorouter?.apiKey?.trim() || Object.values(providersObj || {}).find((p) => p?.apiKey?.trim())?.apiKey?.trim();
+        const sudorouterApiKey =
+          providersObj?.sudorouter?.apiKey?.trim() ||
+          Object.values(providersObj || {})
+            .find((p) => p?.apiKey?.trim())
+            ?.apiKey?.trim();
         if (sudorouterApiKey) {
           if (!config.plugins || typeof config.plugins !== 'object') {
             (config as Record<string, unknown>).plugins = { entries: {} };
@@ -508,6 +512,30 @@ export function repairOpenClawConfig(): void {
       }
     }
 
+    // Disable OpenClaw's built-in browser — ai-dev-browser is used directly via CLI
+    const browser = config.browser as { enabled?: boolean } | undefined;
+    if (!browser || typeof browser !== 'object' || browser.enabled !== false) {
+      (config as Record<string, unknown>).browser = { enabled: false };
+      changed = true;
+      mainLog('Sudoclaw', 'Disabled built-in browser (ai-dev-browser used directly)');
+    }
+
+    // Deny browser tool in top-level tools.sandbox so agent never sees it
+    // Schema path: tools.sandbox.tools.deny
+    const topTools = (config.tools ?? {}) as Record<string, unknown>;
+    const topSbx = (topTools.sandbox ?? {}) as Record<string, unknown>;
+    const topSbxTools = (topSbx.tools ?? {}) as Record<string, unknown>;
+    const topDeny = (topSbxTools.deny ?? []) as string[];
+    if (!topDeny.includes('browser')) {
+      topDeny.push('browser');
+      topSbxTools.deny = topDeny;
+      topSbx.tools = topSbxTools;
+      topTools.sandbox = topSbx;
+      (config as Record<string, unknown>).tools = topTools;
+      changed = true;
+      mainLog('Sudoclaw', 'Added browser to top-level tools.sandbox deny list');
+    }
+
     if (changed) {
       fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
       mainLog('Sudoclaw', 'Repaired sudoclaw.json schema');
@@ -562,6 +590,9 @@ export function ensureDefaultConfig(): void {
       auth: { mode: 'none' as const },
       reload: { ...SUDOCLAW_DEFAULT_GATEWAY_RELOAD },
     },
+    browser: {
+      enabled: false,
+    },
     plugins: {
       entries: {
         tavily: {
@@ -579,6 +610,9 @@ export function ensureDefaultConfig(): void {
         search: {
           provider: 'tavily' as const,
         },
+      },
+      sandbox: {
+        tools: { deny: ['browser'] },
       },
     },
   };

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -30,7 +30,9 @@ import { buildDraftsInstruction, hasMcpServersConfigured, buildMcporterCommandHi
 import { cleanupIntermediateFiles } from './draftsCleanup';
 import { inferToolFailure } from '@/agent/acp/inferToolFailure';
 import * as nodePath from 'node:path';
+import { createHash } from 'node:crypto';
 import { ProcessConfig } from '@process/initStorage';
+import { serviceManager } from '@process/services/serviceManager';
 
 /** Default prompt timeout in seconds */
 const DEFAULT_PROMPT_TIMEOUT_SECONDS = 300;
@@ -41,6 +43,30 @@ const PROMPT_TIMEOUT_MAX_SECONDS = 3600;
 const CONNECTION_TIMEOUT_MS = 30_000;
 const CONNECTION_MAX_ATTEMPTS = 30;
 const CONNECTION_RETRY_DELAY_MS = 1_000;
+
+interface ToolEventData {
+  phase?: string;
+  name?: string;
+  toolCallId?: string;
+  args?: Record<string, unknown>;
+  meta?: string;
+  isError?: boolean;
+  status?: string;
+  title?: string;
+  kind?: string;
+  content?: unknown[];
+  /**
+   * openclaw's phase==='result' event payload also carries a `result` field
+   * containing the sanitized tool return (`{content:[{type:'text',text}],
+   * details:{...}}`, truncated at 8 KB). sudowork previously ignored this,
+   * so the UI only saw the short `meta` description. Reading it gives us
+   * the real exec stdout without any hook gymnastics.
+   */
+  result?: {
+    content?: Array<{ type?: string; text?: string }>;
+    details?: Record<string, unknown>;
+  };
+}
 
 export interface OpenClawAgentData {
   conversation_id: string;
@@ -789,70 +815,7 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
       case 'tool':
       case 'tool_call': {
         if (!event.data) break;
-        const toolData = event.data as {
-          phase?: string;
-          name?: string;
-          toolCallId?: string;
-          args?: Record<string, unknown>;
-          meta?: string;
-          isError?: boolean;
-          status?: string;
-          title?: string;
-          kind?: string;
-          content?: unknown[];
-        };
-
-        const phaseToStatus: Record<string, 'pending' | 'in_progress' | 'completed' | 'failed'> = {
-          start: 'in_progress',
-          update: 'in_progress',
-          partialResult: 'in_progress',
-        };
-        let status: 'pending' | 'in_progress' | 'completed' | 'failed';
-        if (toolData.phase === 'result') {
-          status = toolData.isError ? 'failed' : 'completed';
-          if (status === 'completed' && inferToolFailure(toolData.content, toolData.meta)) {
-            status = 'failed';
-          }
-        } else {
-          status = phaseToStatus[toolData.phase ?? ''] ?? ((toolData.status as 'pending' | 'in_progress' | 'completed' | 'failed') || 'pending');
-        }
-
-        const toolName = toolData.name ?? toolData.title ?? '';
-        const kind = this.inferToolKind(toolName) ?? (toolData.kind as 'read' | 'edit' | 'execute') ?? 'execute';
-
-        let content: ToolCallUpdate['update']['content'];
-        if (toolData.content) {
-          content = toolData.content as ToolCallUpdate['update']['content'];
-        } else if (toolData.meta) {
-          content = [{ type: 'content', content: { type: 'text', text: toolData.meta } }];
-        } else if (toolData.args) {
-          content = [{ type: 'content', content: { type: 'text', text: JSON.stringify(toolData.args, null, 2) } }];
-        }
-
-        const acpUpdate: ToolCallUpdate = {
-          sessionId: this.conversation_id,
-          update: {
-            sessionUpdate: 'tool_call',
-            toolCallId: toolData.toolCallId || uuid(),
-            status,
-            title: toolName || 'Tool Call',
-            kind,
-            content,
-          },
-        };
-
-        if (NavigationInterceptor.isNavigationTool(acpUpdate.update.title)) {
-          const url = NavigationInterceptor.extractUrl(acpUpdate.update);
-          if (url) {
-            const previewMessage = NavigationInterceptor.createPreviewMessage(url, this.conversation_id);
-            this.handleStreamMessage(previewMessage);
-          }
-        }
-
-        const messages = this.adapter.convertSessionUpdate(acpUpdate);
-        for (const message of messages) {
-          this.emitTMessage(message);
-        }
+        void this.handleToolCallEvent(event.data as ToolEventData);
         break;
       }
 
@@ -1262,6 +1225,145 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
       }
     } catch (error) {
       mainError('OpenClawAgent', 'Failed to save session key:', error);
+    }
+  }
+
+  // ========== ai-dev-browser UI bypass helpers ==========
+
+  private isAdbToolCall(data: ToolEventData): boolean {
+    const meta = typeof data.meta === 'string' ? data.meta : '';
+    const cmd = typeof data.args?.command === 'string' ? (data.args.command as string) : '';
+    return /ai_dev_browser\.tools\./.test(meta) || /ai_dev_browser\.tools\./.test(cmd);
+  }
+
+  private extractResultText(data: ToolEventData): string | null {
+    const blocks = data.result?.content;
+    if (!Array.isArray(blocks)) return null;
+    const parts: string[] = [];
+    for (const b of blocks) {
+      if (b && typeof b === 'object' && b.type === 'text' && typeof b.text === 'string') {
+        parts.push(b.text);
+      }
+    }
+    const joined = parts.join('\n').trim();
+    return joined.length > 0 ? joined : null;
+  }
+
+  private computeAdbCmdHash(data: ToolEventData): string {
+    // Mirror the hash produced by hook/node/src/process/AdbStdoutCapture.ts.
+    // On `phase === 'result'` events, openclaw strips `args` from the
+    // external `onAgentEvent` callback — we get only {phase,name,toolCallId,
+    // meta,isError}. `meta` has the shape:
+    //   "run python (in <cwd>), `python -m ai_dev_browser.tools.page_info ...`"
+    // Extract the command between backticks, which matches the shell script
+    // string the hook used for its hashInput.
+    const args = data.args ?? {};
+    let cmd = typeof args.command === 'string' ? (args.command as string).trim() : '';
+    if (!cmd && typeof data.meta === 'string') {
+      const m = data.meta.match(/`([^`]+)`/);
+      if (m && m[1]) cmd = m[1].trim();
+    }
+    return createHash('sha1').update(cmd).digest('hex');
+  }
+
+  private async handleToolCallEvent(toolData: ToolEventData): Promise<void> {
+    const phaseToStatus: Record<string, 'pending' | 'in_progress' | 'completed' | 'failed'> = {
+      start: 'in_progress',
+      update: 'in_progress',
+      partialResult: 'in_progress',
+    };
+    let status: 'pending' | 'in_progress' | 'completed' | 'failed';
+    if (toolData.phase === 'result') {
+      status = toolData.isError ? 'failed' : 'completed';
+      if (status === 'completed' && inferToolFailure(toolData.content, toolData.meta)) {
+        status = 'failed';
+      }
+    } else {
+      status = phaseToStatus[toolData.phase ?? ''] ?? ((toolData.status as 'pending' | 'in_progress' | 'completed' | 'failed') || 'pending');
+    }
+
+    // When the tool call completes, prefer the real stdout that openclaw
+    // already ships inside `data.result.content` over the short `meta`
+    // description. For ai-dev-browser invocations (and exec tool calls in
+    // general) this makes the UI's Output panel show the actual JSON/text
+    // that the tool printed, not "run python, ...". openclaw truncates
+    // this at 8 KB which is more than enough for ai-dev-browser's small
+    // JSON payloads.
+    if (toolData.phase === 'result') {
+      const resultText = this.extractResultText(toolData);
+      if (resultText) {
+        const shouldForceOverride = this.isAdbToolCall(toolData);
+        // Always expose the full result text for ai-dev-browser tool calls;
+        // for other tools, only fall through when sudowork didn't already
+        // receive a structured `content` block.
+        if (shouldForceOverride || !Array.isArray(toolData.content) || toolData.content.length === 0) {
+          toolData.content = [{ type: 'content', content: { type: 'text', text: resultText } }];
+          if (shouldForceOverride) {
+            toolData.meta = resultText;
+          }
+        }
+      }
+
+      // Defense-in-depth: if the sidechannel captured a longer stdout than
+      // openclaw's 8 KB sanitized window, overwrite with that. Harmless when
+      // no entry is found (the `waitForCmd` times out quickly).
+      if (this.isAdbToolCall(toolData)) {
+        try {
+          const sink = serviceManager.getAdbSidechannel();
+          if (sink) {
+            // The PowerShell / bash wrapper openclaw spawns around python
+            // takes several seconds (interpreter cold start + CDP connect
+            // attempts). Wait generously so the hook's POST has time to land
+            // — the hook only POSTs on the shell process's exit, which is
+            // strictly after the result event reaches sudowork.
+            const entry = await sink.waitForCmd(this.computeAdbCmdHash(toolData), 20_000);
+            if (entry && entry.stdoutRaw && entry.stdoutRaw.length > (this.extractResultText(toolData)?.length ?? 0)) {
+              toolData.meta = entry.stdoutRaw;
+              toolData.content = [{ type: 'content', content: { type: 'text', text: entry.stdoutRaw } }];
+            }
+          }
+        } catch (err) {
+          mainWarn('OpenClawAgent', 'ai-dev-browser sidechannel lookup failed', err);
+        }
+      }
+    }
+
+    const toolName = toolData.name ?? toolData.title ?? '';
+    const kind = this.inferToolKind(toolName) ?? (toolData.kind as 'read' | 'edit' | 'execute') ?? 'execute';
+
+    let content: ToolCallUpdate['update']['content'];
+    if (toolData.content) {
+      content = toolData.content as ToolCallUpdate['update']['content'];
+    } else if (toolData.meta) {
+      content = [{ type: 'content', content: { type: 'text', text: toolData.meta } }];
+    } else if (toolData.args) {
+      content = [{ type: 'content', content: { type: 'text', text: JSON.stringify(toolData.args, null, 2) } }];
+    }
+
+    const acpUpdate: ToolCallUpdate = {
+      sessionId: this.conversation_id,
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: toolData.toolCallId || uuid(),
+        status,
+        title: toolName || 'Tool Call',
+        kind,
+        rawInput: toolData.args as Record<string, unknown> | undefined,
+        content,
+      },
+    };
+
+    if (NavigationInterceptor.isNavigationTool(acpUpdate.update.title)) {
+      const url = NavigationInterceptor.extractUrl(acpUpdate.update);
+      if (url) {
+        const previewMessage = NavigationInterceptor.createPreviewMessage(url, this.conversation_id);
+        this.handleStreamMessage(previewMessage);
+      }
+    }
+
+    const messages = this.adapter.convertSessionUpdate(acpUpdate);
+    for (const message of messages) {
+      this.emitTMessage(message);
     }
   }
 

--- a/src/renderer/components/SkillSelectorMenu.tsx
+++ b/src/renderer/components/SkillSelectorMenu.tsx
@@ -174,22 +174,9 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
               <circle cx='11' cy='11' r='8' />
               <path d='m21 21-4.35-4.35' />
             </svg>
-            <input
-              type='text'
-              className='flex-1 min-w-0 text-13px bg-transparent border-none outline-none text-t-primary placeholder:text-t-tertiary'
-              style={{ caretColor: 'var(--color-primary)' }}
-              placeholder={activeTab === 'skills' ? skillsSearchPlaceholder : filesSearchPlaceholder}
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              onKeyDown={handleSearchKeyDown}
-            />
+            <input type='text' className='flex-1 min-w-0 text-13px bg-transparent border-none outline-none text-t-primary placeholder:text-t-tertiary' style={{ caretColor: 'var(--color-primary)' }} placeholder={activeTab === 'skills' ? skillsSearchPlaceholder : filesSearchPlaceholder} value={searchQuery} onChange={(e) => onSearchChange(e.target.value)} onKeyDown={handleSearchKeyDown} />
             {searchQuery && (
-              <button
-                type='button'
-                className='shrink-0 w-16px h-16px flex items-center justify-center rounded-full text-t-tertiary hover:text-t-secondary cursor-pointer border-none outline-none text-11px bg-transparent'
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => onSearchChange('')}
-              >
+              <button type='button' className='shrink-0 w-16px h-16px flex items-center justify-center rounded-full text-t-tertiary hover:text-t-secondary cursor-pointer border-none outline-none text-11px bg-transparent' onMouseDown={(e) => e.preventDefault()} onClick={() => onSearchChange('')}>
                 ✕
               </button>
             )}

--- a/tests/unit/adbResultSidechannel.test.ts
+++ b/tests/unit/adbResultSidechannel.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { AdbResultSidechannel, type AdbResultEntry } from '../../src/process/services/sudoclaw/AdbResultSidechannel';
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: () => {},
+  mainWarn: () => {},
+  mainError: () => {},
+}));
+
+async function post(endpoint: string, body: unknown, headers: Record<string, string> = {}): Promise<{ status: number }> {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status };
+}
+
+function makeEntry(overrides: Partial<AdbResultEntry> = {}): AdbResultEntry {
+  return {
+    callId: overrides.callId ?? 'call-1',
+    cmd: overrides.cmd ?? 'python',
+    argv: overrides.argv ?? ['-m', 'ai_dev_browser.tools.page_info', '--json'],
+    pid: overrides.pid ?? 1234,
+    ppid: overrides.ppid ?? 5678,
+    startedAt: overrides.startedAt ?? Date.now() - 100,
+    finishedAt: overrides.finishedAt ?? Date.now(),
+    exitCode: overrides.exitCode ?? 0,
+    stdoutRaw: overrides.stdoutRaw ?? '{"ok":true}',
+    stdoutJson: overrides.stdoutJson ?? { ok: true },
+    cmdHash: overrides.cmdHash ?? 'hash-1',
+  };
+}
+
+describe('AdbResultSidechannel', () => {
+  let sc: AdbResultSidechannel | null = null;
+
+  afterEach(async () => {
+    if (sc) await sc.stop();
+    sc = null;
+  });
+
+  it('rejects requests missing the secret header', async () => {
+    sc = new AdbResultSidechannel();
+    const { port } = await sc.start();
+    const { status } = await post(`http://127.0.0.1:${port}/capture`, makeEntry());
+    expect(status).toBe(401);
+  });
+
+  it('rejects requests with a wrong secret', async () => {
+    sc = new AdbResultSidechannel();
+    const { port } = await sc.start();
+    const { status } = await post(`http://127.0.0.1:${port}/capture`, makeEntry(), { 'x-adb-secret': 'not-the-secret' });
+    expect(status).toBe(401);
+  });
+
+  it('accepts a well-formed entry with the correct secret and exposes it via waitForCmd', async () => {
+    sc = new AdbResultSidechannel();
+    const { port, secret } = await sc.start();
+    const entry = makeEntry({ cmdHash: 'hash-alpha' });
+    const { status } = await post(`http://127.0.0.1:${port}/capture`, entry, { 'x-adb-secret': secret });
+    expect(status).toBe(204);
+    const retrieved = await sc.waitForCmd('hash-alpha', 100);
+    expect(retrieved?.callId).toBe('call-1');
+    expect(retrieved?.stdoutRaw).toBe('{"ok":true}');
+  });
+
+  it('supports FIFO retrieval when multiple entries share a cmdHash', async () => {
+    sc = new AdbResultSidechannel();
+    const { port, secret } = await sc.start();
+    await post(`http://127.0.0.1:${port}/capture`, makeEntry({ callId: 'a', cmdHash: 'h' }), { 'x-adb-secret': secret });
+    await post(`http://127.0.0.1:${port}/capture`, makeEntry({ callId: 'b', cmdHash: 'h' }), { 'x-adb-secret': secret });
+    const first = await sc.waitForCmd('h', 50);
+    const second = await sc.waitForCmd('h', 50);
+    expect(first?.callId).toBe('a');
+    expect(second?.callId).toBe('b');
+  });
+
+  it('waitForCmd resolves when a late POST arrives within the window', async () => {
+    sc = new AdbResultSidechannel();
+    const { port, secret } = await sc.start();
+    const pending = sc.waitForCmd('late-hash', 2000);
+    setTimeout(() => {
+      void post(`http://127.0.0.1:${port}/capture`, makeEntry({ callId: 'late', cmdHash: 'late-hash' }), { 'x-adb-secret': secret });
+    }, 50);
+    const entry = await pending;
+    expect(entry?.callId).toBe('late');
+  });
+
+  it('waitForCmd returns null if the window expires before any POST arrives', async () => {
+    sc = new AdbResultSidechannel();
+    await sc.start();
+    const entry = await sc.waitForCmd('nope', 30);
+    expect(entry).toBeNull();
+  });
+
+  it('takeByCallId returns null for an unknown id and consumes on match', async () => {
+    sc = new AdbResultSidechannel();
+    const { port, secret } = await sc.start();
+    await post(`http://127.0.0.1:${port}/capture`, makeEntry({ callId: 'only', cmdHash: 'x' }), { 'x-adb-secret': secret });
+    expect(sc.takeByCallId('missing')).toBeNull();
+    const taken = sc.takeByCallId('only');
+    expect(taken?.callId).toBe('only');
+    // Second take should fail — entry already consumed.
+    expect(sc.takeByCallId('only')).toBeNull();
+  });
+
+  it('drops oversized bodies without accepting the entry', async () => {
+    sc = new AdbResultSidechannel();
+    const { port, secret } = await sc.start();
+    const huge = 'x'.repeat(9 * 1024 * 1024); // > 8 MB
+    const body = JSON.stringify(makeEntry({ stdoutRaw: huge, cmdHash: 'oversized' }));
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/capture`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-adb-secret': secret },
+        body,
+      });
+      // If the server did respond, it must not be a success status.
+      expect(res.ok).toBe(false);
+    } catch (err) {
+      // Connection-reset is acceptable — the server destroyed the socket after
+      // writing 413. Either outcome proves the entry was not stored.
+      expect(err).toBeDefined();
+    }
+    // Most importantly, the oversized entry did not end up in the store.
+    const lookup = await sc.waitForCmd('oversized', 50);
+    expect(lookup).toBeNull();
+  });
+});

--- a/tests/unit/adbStdoutCapture.test.ts
+++ b/tests/unit/adbStdoutCapture.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+import type * as childProcessTypes from 'node:child_process';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { AdbStdoutCapture } from '../../hook/node/src/process/AdbStdoutCapture';
+
+// Use the CJS `child_process` module exports object so we can reassign
+// `spawn` in the test (ESM namespace from `node:child_process` is sealed).
+const childProcess = createRequire(import.meta.url)('child_process') as typeof childProcessTypes;
+
+interface ReceivedPost {
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+async function startCaptureSink(): Promise<{ url: string; received: ReceivedPost[]; stop: () => Promise<void> }> {
+  const received: ReceivedPost[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+        received.push({ headers: Object.fromEntries(Object.entries(req.headers).map(([k, v]) => [k, String(v)])), body });
+      } catch {
+        /* ignore */
+      }
+      res.writeHead(204);
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${addr.port}/capture`;
+  return {
+    url,
+    received,
+    stop: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+describe('AdbStdoutCapture', () => {
+  let capture: AdbStdoutCapture | null = null;
+  let sink: Awaited<ReturnType<typeof startCaptureSink>> | null = null;
+
+  beforeEach(async () => {
+    sink = await startCaptureSink();
+  });
+
+  afterEach(async () => {
+    if (capture) capture.dispose();
+    capture = null;
+    if (sink) await sink.stop();
+    sink = null;
+  });
+
+  it('detects python -m ai_dev_browser.tools.* invocations', () => {
+    capture = new AdbStdoutCapture({ sidechannelUrl: sink!.url, sidechannelSecret: 's' });
+    // Tap private detection via the public apply → spawn flow is heavy; assert via regex semantics.
+    // Delegate to the regex by replicating the check.
+    const match = (cmd: string, args: string[]) => /(?:^|[\\/])(python|python3)(?:\.exe)?$/i.test(cmd) && args.indexOf('-m') >= 0 && /^ai_dev_browser\.tools\./.test(args[args.indexOf('-m') + 1] ?? '');
+    expect(match('python', ['-m', 'ai_dev_browser.tools.page_info'])).toBe(true);
+    expect(match('/usr/bin/python3', ['-m', 'ai_dev_browser.tools.page_screenshot', '--url', 'x'])).toBe(true);
+    expect(match('C:\\Python311\\python.exe', ['-m', 'ai_dev_browser.tools.page_info'])).toBe(true);
+    expect(match('python', ['-m', 'other.module'])).toBe(false);
+    expect(match('node', ['-m', 'ai_dev_browser.tools.page_info'])).toBe(false);
+    expect(match('python', ['script.py'])).toBe(false);
+  });
+
+  it('does not mutate the caller-supplied env object', () => {
+    capture = new AdbStdoutCapture({ sidechannelUrl: sink!.url, sidechannelSecret: 'shh' });
+    capture.apply();
+    const callerEnv: NodeJS.ProcessEnv = { FOO: 'bar' };
+    // Spawn a harmless no-match invocation first to confirm no env leak for non-matches.
+    const child = childProcess.spawn(process.execPath, ['-e', 'process.exit(0)'], { env: callerEnv });
+    expect(callerEnv.AI_DEV_BROWSER_CALL_ID).toBeUndefined();
+    child.kill();
+  });
+
+  it('POSTs the captured stdout on child exit for a matching invocation', async () => {
+    const stdoutText = '{"path":"/tmp/shot.png","size":42}';
+    const script = `process.stdout.write(${JSON.stringify(stdoutText)}); process.exit(0);`;
+    const fakeCommand = '/usr/bin/python3';
+
+    // Swap the CJS `spawn` export so the AdbStdoutCapture wrapper sees our
+    // fake python command, but under the hood we actually run a Node
+    // one-liner that prints JSON.
+    const realSpawn = childProcess.spawn;
+    const rerouteSpawn: typeof childProcess.spawn = ((cmd: string, ...rest: unknown[]) => {
+      if (cmd === fakeCommand) {
+        return (realSpawn as unknown as (...a: unknown[]) => ReturnType<typeof childProcess.spawn>)(process.execPath, ['-e', script]);
+      }
+      return (realSpawn as unknown as (...a: unknown[]) => ReturnType<typeof childProcess.spawn>)(cmd, ...rest);
+    }) as typeof childProcess.spawn;
+
+    (childProcess as { spawn: typeof childProcess.spawn }).spawn = rerouteSpawn;
+
+    try {
+      capture = new AdbStdoutCapture({ sidechannelUrl: sink!.url, sidechannelSecret: 'topsecret' });
+      capture.apply();
+
+      const child = childProcess.spawn(fakeCommand, ['-m', 'ai_dev_browser.tools.page_info']);
+      await new Promise<void>((resolve) => {
+        child.on('exit', () => resolve());
+      });
+      // Wait long enough for the HTTP POST to land in the sink.
+      const deadline = Date.now() + 2000;
+      while (sink!.received.length === 0 && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 25));
+      }
+    } finally {
+      capture?.dispose();
+      (childProcess as { spawn: typeof childProcess.spawn }).spawn = realSpawn;
+    }
+
+    expect(sink!.received.length).toBeGreaterThan(0);
+    const last = sink!.received[sink!.received.length - 1];
+    expect(last.headers['x-adb-secret']).toBe('topsecret');
+    const body = last.body as { stdoutRaw: string; cmdHash: string; argv: string[] };
+    expect(body.stdoutRaw).toBe(stdoutText);
+    expect(typeof body.cmdHash).toBe('string');
+    expect(body.argv).toEqual(['-m', 'ai_dev_browser.tools.page_info']);
+  });
+});


### PR DESCRIPTION
## Summary
- UI's Output panel + LLM tool_result now see the **real** ai-dev-browser stdout (full JSON, PNG metadata, etc.) instead of openclaw's short meta description (`run python, \`python -m ai_dev_browser.tools.page_info\``).
- Delivered via a localhost sidechannel: Node-level hook tees `python -m ai_dev_browser.tools.*` child stdout → POSTs to sudowork, which rewrites the WS tool_call event content on match.
- Bundles in-flight fixes per plan Phase 5 (AcpAdapter tool-call merge, OpenClaw builtin-browser disable, Windows junction unlink, skill doc).

## Why this is tricky
openclaw is an ESM bundle that `import { spawn }` — once the binding is resolved at module-load, module-level `spawn = wrapper` does not propagate. The hook therefore patches `ChildProcess.prototype.spawn` (the internal instance method Node's public `spawn` always delegates to) — binding-independent, safe for CJS/ESM consumers.

openclaw strips `args` and `result` from the WS `tool_call` result event it forwards externally (see bundle `pi-embedded-CbCYZxIb.js:173584-173592`). sudowork therefore extracts the command string from the backticks in `meta` and hashes it the same way the hook hashes the matching shell-script fragment, giving a stable correlation key.

## What's in scope
- `hook/node/src/process/AdbStdoutCapture.ts` — ChildProcess.prototype.spawn interceptor, detects direct python + shell-wrapped forms (cmd.exe/powershell/bash -c ...).
- `src/process/services/sudoclaw/AdbResultSidechannel.ts` — localhost HTTP sink with shared-secret auth, FIFO-by-cmdHash, TTL/LRU eviction, race-safe `waitForCmd`.
- `src/process/services/serviceManager/ServiceManager.ts` — lifecycle around gateway + `customEnv` injection.
- `src/process/task/OpenClawAgent.ts` — async `handleToolCallEvent`, rewrites `meta` + `content` for ai-dev-browser tool calls.
- `src/process/initStorage.ts` — fixes junction-rm regression that was wiping the vendored submodule on every dev restart.
- `src/agent/acp/AcpAdapter.ts` — merges tool_call updates by id (preserves rawInput across phases).
- `src/process/services/sudoclaw/SudoclawInstallService.ts` — disables openclaw's builtin browser + adds it to the tool deny list.
- `skills/browser/SKILL.md` — points at the junction-relative tools path.
- Tests: `tests/unit/adbResultSidechannel.test.ts` (8 tests) + `tests/unit/adbStdoutCapture.test.ts` (3 tests).
- Docs: `docs/plan-browser-bypass-phase1-findings.md` (openclaw bundle spike) + `docs/ai-dev-browser-sidechannel-spec.md` (optional Python-side POST spec for the ai-dev-browser team).

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run tests/unit/adbResultSidechannel.test.ts tests/unit/adbStdoutCapture.test.ts tests/unit/acpAdapter.test.ts` — 16/16 green
- [x] Dev E2E (Windows): send "请用 exec 运行：python -m ai_dev_browser.tools.page_info" — UI Output panel renders `{"error": "No available Chrome found. Run browser-start first, or specify --port."}` verbatim (not `run python (in ...), \`python -m ai_dev_browser.tools.page_info\``).
- [x] LLM visibility canary: embed 32 KB of filler + unique token after the JSON error; Gemini quoted `e7e51f0a4bdbb7e362b32dd0788225e2` byte-for-byte → LLM reads past 32 KB, Goal 2 confirmed.
- [x] Regression: non-ai-dev-browser `exec`/`read`/`process` paths untouched (gated on `isAdbToolCall`).

## Known follow-ups (not blockers)
- `waitForCmd(20_000)` is a blocking wait on the main process — acceptable for this verification, should be made non-blocking in a follow-up.
- ai-dev-browser Python-side defense-in-depth POST is specced (`docs/ai-dev-browser-sidechannel-spec.md`) but not applied — optional redundancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)