### PR TITLE
fix(assistant): write rule file to correct directory structure

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -214,12 +214,20 @@ async function writeAssistantResource(resourceType: ResourceType, assistantId: s
   try {
     const assistantsDir = getAssistantsDir();
 
-    // For custom assistants, use new directory structure
-    if (assistantId.startsWith('custom-')) {
-      const customDir = path.join(assistantsDir, ASSISTANT_SUBDIRS.custom, assistantId);
-      await fs.mkdir(customDir, { recursive: true });
-      await fs.writeFile(path.join(customDir, 'AGENT.md'), content, 'utf-8');
-      return true;
+    // Check if the assistant directory exists in any of the new subdirs (hub, system, custom).
+    // This ensures writes go to the same location that readAssistantResource() reads from,
+    // preventing a read/write path mismatch where edits would be silently lost.
+    const subdirs = [ASSISTANT_SUBDIRS.custom, ASSISTANT_SUBDIRS.hub, ASSISTANT_SUBDIRS.system];
+    for (const subdir of subdirs) {
+      const assistantDir = path.join(assistantsDir, subdir, assistantId);
+      try {
+        await fs.access(assistantDir);
+        // Directory exists — write AGENT.md here
+        await fs.writeFile(path.join(assistantDir, 'AGENT.md'), content, 'utf-8');
+        return true;
+      } catch {
+        // Directory doesn't exist in this subdir, try next
+      }
     }
 
     // For other assistants, use legacy flat structure


### PR DESCRIPTION
writeAssistantResource() used assistantId.startsWith('custom-') to decide whether to write to the new directory structure. However, custom assistant IDs are directory names that rarely start with 'custom-'. This caused a read/write path mismatch: reads found AGENT.md under _my-custom-assistant/{id}/ while writes went to the legacy flat file, silently discarding edits.

Closes #395