### PR TITLE
fix: set aiProcessing true in ACP stream handlers for streamingAvatar

### DIFF
--- a/src/renderer/pages/conversation/acp/AcpChat.tsx
+++ b/src/renderer/pages/conversation/acp/AcpChat.tsx
@@ -10,7 +10,7 @@ import FlexFullContainer from '@renderer/components/FlexFullContainer';
 import MessageList from '@renderer/messages/MessageList';
 import { MessageListProvider, useMessageLstCache } from '@renderer/messages/hooks';
 import HOC from '@renderer/utils/HOC';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ConversationChatConfirm from '../components/ConversationChatConfirm';
 import SafetyChatConfirm from '../SafetyChatConfirm';
 import AcpSendBox from './AcpSendBox';
@@ -23,16 +23,23 @@ const AcpChat: React.FC<{
   agentName?: string;
 }> = ({ conversation_id, workspace, backend, sessionMode, agentName }) => {
   useMessageLstCache(conversation_id);
+  const [aiProcessing, setAiProcessing] = useState(false);
+
+  // Reset aiProcessing when conversation changes
+  // 切换会话时重置 aiProcessing 状态
+  useEffect(() => {
+    setAiProcessing(false);
+  }, [conversation_id]);
 
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'acp' }}>
       <div className='flex-1 flex flex-col px-20px min-h-0'>
         <FlexFullContainer>
-          <MessageList className='flex-1'></MessageList>
+          <MessageList className='flex-1' aiProcessing={aiProcessing}></MessageList>
         </FlexFullContainer>
         <SafetyChatConfirm conversation_id={conversation_id}>
           <ConversationChatConfirm conversation_id={conversation_id}>
-            <AcpSendBox conversation_id={conversation_id} backend={backend} sessionMode={sessionMode} agentName={agentName}></AcpSendBox>
+            <AcpSendBox conversation_id={conversation_id} backend={backend} sessionMode={sessionMode} agentName={agentName} onAiProcessingChange={setAiProcessing}></AcpSendBox>
           </ConversationChatConfirm>
         </SafetyChatConfirm>
       </div>

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -159,19 +159,27 @@ const useAcpMessage = (conversation_id: string) => {
       }
       switch (message.type) {
         case 'thought':
-          // Auto-recover running state if thought arrives after finish
-          // 如果 thought 在 finish 后到达，自动恢复 running 状态
+          // Auto-recover running/aiProcessing state if thought arrives after finish
+          // 如果 thought 在 finish 后到达，自动恢复 running/aiProcessing 状态
           if (!runningRef.current) {
             setRunning(true);
             runningRef.current = true;
+          }
+          if (!aiProcessingRef.current) {
+            setAiProcessing(true);
+            aiProcessingRef.current = true;
           }
           throttledSetThought(message.data as ThoughtData);
           break;
         case 'start':
           setRunning(true);
           runningRef.current = true;
-          // Don't reset aiProcessing here - let content arrival handle it
-          // 不在这里重置 aiProcessing - 让 content 到达时处理
+          // Activate aiProcessing when AI starts responding
+          // AI 开始响应时激活 aiProcessing
+          if (!aiProcessingRef.current) {
+            setAiProcessing(true);
+            aiProcessingRef.current = true;
+          }
           break;
         case 'finish':
           console.log('[AcpSendBox] Processing finish message');
@@ -199,10 +207,14 @@ const useAcpMessage = (conversation_id: string) => {
         case 'content':
           // Mark that current turn has content output
           hasContentInTurnRef.current = true;
-          // Auto-recover running state if content arrives after finish
+          // Auto-recover running/aiProcessing state if content arrives after finish
           if (!runningRef.current) {
             setRunning(true);
             runningRef.current = true;
+          }
+          if (!aiProcessingRef.current) {
+            setAiProcessing(true);
+            aiProcessingRef.current = true;
           }
           // Clear thought when final answer arrives
           setThought({ subject: '', description: '' });
@@ -241,10 +253,14 @@ const useAcpMessage = (conversation_id: string) => {
           addOrUpdateMessage(transformedMessage);
           break;
         case 'acp_permission':
-          // Auto-recover running state if permission request arrives after finish
+          // Auto-recover running/aiProcessing state if permission request arrives after finish
           if (!runningRef.current) {
             setRunning(true);
             runningRef.current = true;
+          }
+          if (!aiProcessingRef.current) {
+            setAiProcessing(true);
+            aiProcessingRef.current = true;
           }
           addOrUpdateMessage(transformedMessage);
           break;
@@ -408,7 +424,8 @@ const AcpSendBox: React.FC<{
   backend: AcpBackend;
   sessionMode?: string;
   agentName?: string;
-}> = ({ conversation_id, backend, sessionMode, agentName }) => {
+  onAiProcessingChange?: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({ conversation_id, backend, sessionMode, agentName, onAiProcessingChange }) => {
   const { thought, running, acpStatus, aiProcessing, setAiProcessing, resetState, tokenUsage, contextLimit } = useAcpMessage(conversation_id);
   const { t } = useTranslation();
   const workspaceFiles = useWorkspaceFiles();
@@ -416,6 +433,14 @@ const AcpSendBox: React.FC<{
   const slashCommands = useSlashCommands(conversation_id, { agentStatus: acpStatus });
   const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
   const { setSendBoxHandler } = usePreviewContext();
+
+  // Sync local aiProcessing state to parent via onAiProcessingChange
+  // 将本地 aiProcessing 状态同步到父组件
+  useEffect(() => {
+    if (onAiProcessingChange) {
+      onAiProcessingChange(aiProcessing);
+    }
+  }, [aiProcessing, onAiProcessingChange]);
 
   // 使用 useRef 来跟踪组件是否已经挂载，避免重复初始化
   const hasInitialized = useRef(false);
@@ -561,6 +586,7 @@ const AcpSendBox: React.FC<{
     clearFiles();
 
     // Start AI processing loading state
+    setAiProcessing(true);
 
     // Send message via ACP
     try {


### PR DESCRIPTION
Closes #397

## Summary
- Set `aiProcessing = true` in ACP stream event handlers (`start`, `content`, `thought`, `acp_permission`) and in `onSendHandler`
- Add `onAiProcessingChange` callback to sync state from `AcpSendBox` to `AcpChat`
- Pass `aiProcessing` to `MessageList` to enable streaming avatar animation
- Mirrors the working pattern from `OpenClawSendBox` / `OpenClawChat`

Generated with [Claude Code](https://claude.ai/claude-code)