### PR TITLE
feat(browser): follow-ups on ai-dev-browser CLI pipeline

### DIFF
--- a/hook/node/src/index.ts
+++ b/hook/node/src/index.ts
@@ -8,6 +8,7 @@ import type { BlacklistConfig } from './blacklist/types';
 import { ProcessInterceptor } from './process/ProcessInterceptor';
 import type { ProcessController } from './process/ProcessController';
 import { AdbStdoutCapture } from './process/AdbStdoutCapture';
+import { SudoclawConfigGuard } from './process/SudoclawConfigGuard';
 
 export interface SafetyHookOptions {
   /** Nexus server URL, defaults to http://127.0.0.1:12012 */
@@ -30,6 +31,7 @@ let networkInterceptor: BatchInterceptor | null = null;
 let fileInterceptor: FileInterceptor | null = null;
 let processInterceptor: ProcessInterceptor | null = null;
 let adbStdoutCapture: AdbStdoutCapture | null = null;
+let sudoclawConfigGuard: SudoclawConfigGuard | null = null;
 let isApplied = false;
 let nexusController: NexusController | null = null;
 let configPollingTimer: NodeJS.Timeout | null = null;
@@ -119,6 +121,19 @@ export function initSafetyHook(options: SafetyHookOptions = {}): void {
     }
   }
 
+  // Always-on: prevent the LLM from re-enabling openclaw's builtin browser
+  // via gateway.config.patch by pinning `browser.enabled` back to false on
+  // every write to sudoclaw.json. This is cheap and has no dependencies.
+  if (!sudoclawConfigGuard) {
+    try {
+      sudoclawConfigGuard = new SudoclawConfigGuard();
+      sudoclawConfigGuard.apply();
+    } catch (err) {
+      console.error('[SafetyHook] Failed to apply sudoclaw config guard:', err);
+      sudoclawConfigGuard = null;
+    }
+  }
+
   isApplied = true;
   console.error(`[SafetyHook] Initialized with nexusUrl=${nexusUrl}, network=${enableNetwork}, file=${enableFile}`);
 
@@ -159,6 +174,10 @@ export function disposeSafetyHook(): void {
   if (adbStdoutCapture) {
     adbStdoutCapture.dispose();
     adbStdoutCapture = null;
+  }
+  if (sudoclawConfigGuard) {
+    sudoclawConfigGuard.dispose();
+    sudoclawConfigGuard = null;
   }
   nexusController = null;
   isApplied = false;

--- a/hook/node/src/process/AdbStdoutCapture.ts
+++ b/hook/node/src/process/AdbStdoutCapture.ts
@@ -30,11 +30,15 @@ const childProcess: typeof childProcessNs = (() => {
 
 const PYTHON_COMMAND_RE = /(?:^|[\\/])(python|python3)(?:\.exe)?$/i;
 const ADB_MODULE_RE = /^ai_dev_browser\.tools\./;
-// Matches a `python(-3|.exe|3) -m ai_dev_browser.tools.<name>` fragment
-// anywhere in a shell script string. Used when openclaw wraps the call
-// through cmd.exe / bash / sh / pwsh and spawns the shell rather than
-// python directly.
-const ADB_IN_SHELL_RE = /(?:^|[;\s&|])python(?:3|\.exe|3\.exe)?\s+-m\s+ai_dev_browser\.tools\./i;
+// Path form of the same tool — any argv that looks like
+// `.../ai_dev_browser/tools/<name>.py` (Windows or POSIX separators).
+const ADB_PY_PATH_RE = /(?:^|[\\/])ai_dev_browser[\\/]tools[\\/]([\w_]+)\.py$/i;
+// Either form embedded in a shell script. Matches the larger pattern of
+// `python ... -m ai_dev_browser.tools.<name>` OR `python ... ai_dev_browser/tools/<name>.py`
+// anywhere in the script, used when openclaw wraps the call through
+// cmd.exe / bash / sh / pwsh and spawns the shell rather than python
+// directly.
+const ADB_IN_SHELL_RE = /(?:^|[;\s&|"'])python(?:3|\.exe|3\.exe)?\s+(?:[^;\s&|]*\s+)*?(?:-m\s+ai_dev_browser\.tools\.\w+|[^\s;&|]*ai_dev_browser[\\/]tools[\\/]\w+\.py)/i;
 const DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
 
 interface CapturedState {
@@ -221,16 +225,22 @@ export class AdbStdoutCapture {
   }
 
   private matchAdbInvocation(command: string, args: string[]): { hashInput: string } | null {
-    // Case 1: direct python invocation — `python -m ai_dev_browser.tools.<x> ...`
+    // Case 1a: direct python invocation — `python -m ai_dev_browser.tools.<x> ...`
     if (PYTHON_COMMAND_RE.test(command)) {
       const dashMIdx = args.indexOf('-m');
       if (dashMIdx !== -1 && dashMIdx + 1 < args.length && ADB_MODULE_RE.test(args[dashMIdx + 1] ?? '')) {
         return { hashInput: `${command} ${args.join(' ')}`.trim() };
       }
+      // Case 1b: `python <path>/ai_dev_browser/tools/<name>.py ...`
+      for (const arg of args) {
+        if (typeof arg === 'string' && ADB_PY_PATH_RE.test(arg)) {
+          return { hashInput: `${command} ${args.join(' ')}`.trim() };
+        }
+      }
     }
     // Case 2: shell-wrapped invocation — openclaw's runExecProcess spawns
     // cmd.exe/bash/sh/pwsh with the user's shell script as one of the args.
-    // Scan every arg for the `python -m ai_dev_browser.tools.*` fragment.
+    // Scan every arg for the module-form OR path-form fragment.
     for (const arg of args) {
       if (typeof arg !== 'string') continue;
       if (ADB_IN_SHELL_RE.test(arg)) {
@@ -287,12 +297,34 @@ export class AdbStdoutCapture {
         state.bytes += buf.length;
       });
     }
+    // Also capture stderr — for failing invocations (e.g. Python
+    // ImportError from a wrong CLI form) nothing lands on stdout, but the
+    // traceback on stderr is exactly what the LLM needs to self-correct
+    // the next turn. We surface it as the payload when stdout is empty.
+    const stderrChunks: Buffer[] = [];
+    let stderrBytes = 0;
+    if (child.stderr && typeof (child.stderr as NodeJS.ReadableStream).on === 'function') {
+      (child.stderr as NodeJS.ReadableStream).on('data', (chunk: Buffer | string) => {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+        if (stderrBytes >= this.maxBytes) return;
+        const remaining = this.maxBytes - stderrBytes;
+        const slice = buf.length > remaining ? buf.subarray(0, remaining) : buf;
+        stderrChunks.push(slice);
+        stderrBytes += slice.length;
+      });
+    }
 
     const finalize = (exitCode: number | null) => {
       if (state.pid != null) this.byPid.delete(state.pid);
       const stdoutRaw = Buffer.concat(state.chunks, state.bytes).toString('utf8');
-      const trimmed = stdoutRaw.trim();
+      const stderrRaw = Buffer.concat(stderrChunks, stderrBytes).toString('utf8');
+      // When stdout is empty (failed invocation, e.g. Python ImportError),
+      // surface stderr as the "visible payload" so the LLM can read the
+      // real error message on its next turn and self-correct. When stdout
+      // has content, keep it as-is and only stash stderr separately.
+      const visible = stdoutRaw.trim() ? stdoutRaw : stderrRaw;
       let stdoutJson: unknown;
+      const trimmed = visible.trim();
       if (trimmed) {
         try {
           stdoutJson = JSON.parse(trimmed);
@@ -309,8 +341,9 @@ export class AdbStdoutCapture {
         startedAt: state.startedAt,
         finishedAt: Date.now(),
         exitCode,
-        stdoutRaw,
+        stdoutRaw: visible,
         stdoutJson,
+        stderrRaw,
         cmdHash: state.cmdHash,
         truncated: state.truncated,
       };

--- a/hook/node/src/process/SudoclawConfigGuard.ts
+++ b/hook/node/src/process/SudoclawConfigGuard.ts
@@ -1,0 +1,160 @@
+/**
+ * Architectural block for the LLM re-enabling openclaw's builtin browser.
+ *
+ * Openclaw exposes a `gateway` tool with `config.patch` / `config.apply`
+ * actions — the LLM can (and does, empirically) flip
+ * `browser.enabled: false → true` at runtime, overriding the setting we
+ * write in `SudoclawInstallService.ensureDefaultConfig` /
+ * `repairOpenClawConfig`. Text-level policy in SKILL.md is insufficient.
+ *
+ * This guard monkey-patches `fs.promises.writeFile` and `fs.writeFileSync`
+ * inside the gateway process. When the file path looks like the
+ * `sudoclaw.json` config (or its `.tmp` atomic-write companion) AND the
+ * payload is a config JSON containing `browser.enabled: true`, we mutate
+ * the value back to `false` before the real write happens. The LLM's
+ * config.patch call still returns success, but the persisted file — and
+ * therefore what the gateway reads after its restart — stays `false`.
+ */
+
+import * as fsNs from 'node:fs';
+import { createRequire } from 'node:module';
+
+// Same ESM-vs-CJS dance as AdbStdoutCapture: need the writable CJS exports
+// object, not the ESM namespace.
+const fs: typeof fsNs = (() => {
+  try {
+    const req = createRequire(import.meta.url);
+    return req('fs') as typeof fsNs;
+  } catch {
+    return fsNs;
+  }
+})();
+
+// Matches both the final file and any atomic-write `.tmp` companion
+// (openclaw names them `sudoclaw.json.<pid>.<uuid>.tmp`).
+const SUDOCLAW_JSON_PATH_RE = /[\\/]sudoclaw\.json(?:\.\d+\.[\w-]+\.tmp)?$/i;
+
+function looksLikeSudoclawConfigObj(obj: unknown): obj is Record<string, unknown> {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+  const o = obj as Record<string, unknown>;
+  // sudoclaw config has at minimum a gateway + agents section.
+  return 'gateway' in o || 'agents' in o || 'browser' in o;
+}
+
+function guardPayload(data: string | Uint8Array | Buffer): string | Uint8Array | Buffer {
+  let text: string;
+  try {
+    text = typeof data === 'string' ? data : Buffer.from(data as Uint8Array).toString('utf-8');
+  } catch {
+    return data;
+  }
+  let obj: unknown;
+  try {
+    obj = JSON.parse(text);
+  } catch {
+    return data;
+  }
+  if (!looksLikeSudoclawConfigObj(obj)) return data;
+  const cfg = obj as {
+    browser?: { enabled?: unknown };
+    tools?: { deny?: unknown };
+  };
+  let mutated = false;
+
+  // Invariant 1: browser.enabled must remain false. The LLM empirically
+  // discovers and attempts to flip this via gateway.config.patch.
+  if (cfg.browser && typeof cfg.browser === 'object' && cfg.browser.enabled === true) {
+    cfg.browser.enabled = false;
+    mutated = true;
+    try {
+      console.error('[SudoclawConfigGuard] reverted browser.enabled=true → false on write');
+    } catch {
+      /* swallow */
+    }
+  }
+
+  // Invariant 2: tools.deny must include 'browser'. This is what actually
+  // removes the builtin browser tool from the LLM's tool catalog via
+  // openclaw's filterToolsByPolicy. If the LLM drops 'browser' from the
+  // deny list, re-add it.
+  const tools = (cfg.tools ?? {}) as { deny?: unknown };
+  const denyArr = Array.isArray(tools.deny) ? (tools.deny as unknown[]).slice() : [];
+  const hasBrowser = denyArr.some((v) => v === 'browser');
+  if (!hasBrowser) {
+    denyArr.push('browser');
+    tools.deny = denyArr;
+    cfg.tools = tools;
+    mutated = true;
+    try {
+      console.error('[SudoclawConfigGuard] re-added "browser" to tools.deny on write');
+    } catch {
+      /* swallow */
+    }
+  }
+
+  if (!mutated) return data;
+  const nextJson = JSON.stringify(obj, null, 2);
+  return typeof data === 'string' ? nextJson : Buffer.from(nextJson, 'utf-8');
+}
+
+export class SudoclawConfigGuard {
+  private originalWriteFileSync: typeof fs.writeFileSync | null = null;
+  private originalWriteFileAsync: typeof fs.promises.writeFile | null = null;
+  private applied = false;
+
+  apply(): void {
+    if (this.applied) return;
+    this.applied = true;
+
+    this.originalWriteFileSync = fs.writeFileSync;
+    const origSync = this.originalWriteFileSync;
+    const self = this;
+    (fs as unknown as { writeFileSync: typeof fs.writeFileSync }).writeFileSync = function patchedWriteFileSync(
+      this: unknown,
+      file: unknown,
+      data: unknown,
+      options?: unknown,
+    ): void {
+      const next = self.guardIfApplicable(file, data);
+      return (origSync as unknown as (f: unknown, d: unknown, o?: unknown) => void).call(this, file, next, options);
+    } as typeof fs.writeFileSync;
+
+    this.originalWriteFileAsync = fs.promises.writeFile;
+    const origAsync = this.originalWriteFileAsync;
+    (fs.promises as unknown as { writeFile: typeof fs.promises.writeFile }).writeFile = async function patchedWriteFile(
+      this: unknown,
+      file: unknown,
+      data: unknown,
+      options?: unknown,
+    ): Promise<void> {
+      const next = self.guardIfApplicable(file, data);
+      return await (origAsync as unknown as (f: unknown, d: unknown, o?: unknown) => Promise<void>).call(this, file, next, options);
+    } as typeof fs.promises.writeFile;
+
+    try {
+      console.error('[SudoclawConfigGuard] applied (writeFile / writeFileSync wrapped)');
+    } catch {
+      /* swallow */
+    }
+  }
+
+  dispose(): void {
+    if (!this.applied) return;
+    if (this.originalWriteFileSync) {
+      (fs as unknown as { writeFileSync: typeof fs.writeFileSync }).writeFileSync = this.originalWriteFileSync;
+      this.originalWriteFileSync = null;
+    }
+    if (this.originalWriteFileAsync) {
+      (fs.promises as unknown as { writeFile: typeof fs.promises.writeFile }).writeFile = this.originalWriteFileAsync;
+      this.originalWriteFileAsync = null;
+    }
+    this.applied = false;
+  }
+
+  private guardIfApplicable(file: unknown, data: unknown): unknown {
+    if (typeof file !== 'string') return data;
+    if (!SUDOCLAW_JSON_PATH_RE.test(file)) return data;
+    if (typeof data !== 'string' && !Buffer.isBuffer(data) && !(data instanceof Uint8Array)) return data;
+    return guardPayload(data as string | Buffer | Uint8Array);
+  }
+}

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -5,7 +5,10 @@ description: "AI-native browser. Explore websites, discover page structure, take
 
 # Browser
 
-Tools directory: `./ai_dev_browser/tools/` (relative to this skill).
+```bash
+ls skills/browser/ai_dev_browser/tools/
+python -m ai_dev_browser.tools.<name> [--flag ...]
+```
 
 Every CLI tool has an identical Python function in `ai_dev_browser.core` — explore interactively with CLI, then script with the same functions:
 

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -380,6 +380,24 @@ export class ServiceManager {
         mainWarn('ServiceManager', 'Failed to start AdbResultSidechannel (ai-dev-browser UI bypass disabled for this run)', err);
       }
 
+      // PYTHONPATH injection: point at the system skills' browser dir so
+      // `python -m ai_dev_browser.tools.<name>` works from any cwd that
+      // openclaw's exec happens to run in. Without this the LLM has to
+      // prefix every invocation with `cd skills/browser &&` (brittle and
+      // ugly) or hit the ModuleNotFoundError + retry loop we keep seeing.
+      // Stable location: ~/.nexus/skills/_system/browser (junction inside
+      // it points at vendor/ai-dev-browser/ai_dev_browser).
+      const pythonPathEnv: Record<string, string> = {};
+      try {
+        const { getSystemSkillsDir } = await import('@/process/initStorage');
+        const browserSkillDir = path.join(getSystemSkillsDir(), 'browser');
+        // Append, don't stomp, if the caller/shell already set PYTHONPATH.
+        const prev = process.env.PYTHONPATH;
+        pythonPathEnv.PYTHONPATH = prev && prev.length > 0 ? `${browserSkillDir}${path.delimiter}${prev}` : browserSkillDir;
+      } catch (err) {
+        mainWarn('ServiceManager', 'Failed to resolve system skills dir for PYTHONPATH injection', err);
+      }
+
       this.gateway = new OpenClawGatewayManager({
         port: SUDOCLAW_DEFAULT_PORT,
         stateDir: SUDOCLAW_DIR,
@@ -387,6 +405,7 @@ export class ServiceManager {
           OPENCLAW_STATE_DIR: SUDOCLAW_DIR,
           OPENCLAW_CONFIG_PATH: SUDOCLAW_CONFIG_PATH,
           ...adbSidechannelEnv,
+          ...pythonPathEnv,
         },
         forceSubprocessGateway: true,
       });

--- a/src/process/services/sudoclaw/AdbResultSidechannel.ts
+++ b/src/process/services/sudoclaw/AdbResultSidechannel.ts
@@ -59,6 +59,10 @@ export class AdbResultSidechannel {
   private readonly byCmdHash = new Map<string, string[]>();
   private readonly insertOrder: string[] = [];
   private readonly waitersByHash = new Map<string, WaiterRecord[]>();
+  // Waiters that don't care about cmdHash — they consume the next entry
+  // from the global FIFO across all hashes. Used by sudowork when the
+  // openclaw meta is truncated and we can't reconstruct the hook-side hash.
+  private readonly globalWaiters: WaiterRecord[] = [];
 
   async start(): Promise<{ port: number; secret: string }> {
     if (this.server) {
@@ -103,6 +107,11 @@ export class AdbResultSidechannel {
       }
     }
     this.waitersByHash.clear();
+    for (const waiter of this.globalWaiters) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(null);
+    }
+    this.globalWaiters.length = 0;
     this.byCallId.clear();
     this.byCmdHash.clear();
     this.insertOrder.length = 0;
@@ -132,6 +141,30 @@ export class AdbResultSidechannel {
     }
     this.deleteEntry(callId);
     return entry;
+  }
+
+  /**
+   * Wait for the next captured ai-dev-browser entry in global FIFO order
+   * (across all cmdHashes). Used when the caller can't reconstruct the
+   * hook's hashInput — e.g. openclaw truncates the `meta` field, so the
+   * sudowork side can't reproduce the hash the hook computed. Callers that
+   * DO have a reliable key should still use `waitForCmd` for precise match.
+   */
+  async waitForNextAdbEntry(windowMs = DEFAULT_WAIT_MS): Promise<AdbResultEntry | null> {
+    const existing = this.popOldest();
+    if (existing) return existing;
+    if (windowMs <= 0) return null;
+    return await new Promise<AdbResultEntry | null>((resolve) => {
+      const waiter: WaiterRecord = {
+        resolve,
+        timer: setTimeout(() => {
+          const idx = this.globalWaiters.indexOf(waiter);
+          if (idx !== -1) this.globalWaiters.splice(idx, 1);
+          resolve(null);
+        }, windowMs),
+      };
+      this.globalWaiters.push(waiter);
+    });
   }
 
   /**
@@ -242,12 +275,20 @@ export class AdbResultSidechannel {
     this.evictStale();
     this.byCallId.set(entry.callId, entry);
     this.insertOrder.push(entry.callId);
+    // Priority 1: hash-specific waiter.
     const waiters = this.waitersByHash.get(entry.cmdHash);
     if (waiters && waiters.length > 0) {
       const waiter = waiters.shift()!;
       clearTimeout(waiter.timer);
       if (waiters.length === 0) this.waitersByHash.delete(entry.cmdHash);
-      // Waiter takes ownership — evict the entry so nobody else picks it up.
+      this.deleteEntry(entry.callId);
+      waiter.resolve(entry);
+      return;
+    }
+    // Priority 2: global FIFO waiter.
+    if (this.globalWaiters.length > 0) {
+      const waiter = this.globalWaiters.shift()!;
+      clearTimeout(waiter.timer);
       this.deleteEntry(entry.callId);
       waiter.resolve(entry);
       return;
@@ -256,6 +297,18 @@ export class AdbResultSidechannel {
     queue.push(entry.callId);
     this.byCmdHash.set(entry.cmdHash, queue);
     this.evictOverflow();
+  }
+
+  private popOldest(): AdbResultEntry | null {
+    if (this.insertOrder.length === 0) return null;
+    const callId = this.insertOrder[0];
+    const entry = this.byCallId.get(callId);
+    if (!entry) {
+      this.insertOrder.shift();
+      return this.popOldest();
+    }
+    this.deleteEntry(callId);
+    return entry;
   }
 
   private popByHash(cmdHash: string): AdbResultEntry | null {

--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -520,20 +520,31 @@ export function repairOpenClawConfig(): void {
       mainLog('Sudoclaw', 'Disabled built-in browser (ai-dev-browser used directly)');
     }
 
-    // Deny browser tool in top-level tools.sandbox so agent never sees it
-    // Schema path: tools.sandbox.tools.deny
+    // Remove the builtin `browser` tool from the LLM's tool catalog.
+    // The policy key is `tools.deny` (top-level) — this flows through
+    // openclaw's `pickSandboxToolPolicy` + `filterToolsByPolicy`, which
+    // actually *filters* the tool out of the agent's tool list instead
+    // of just denying its execute. `tools.sandbox.tools.deny` (which this
+    // file used to write) is the docker-sandbox-scoped policy and does
+    // nothing when docker sandbox isn't in play.
     const topTools = (config.tools ?? {}) as Record<string, unknown>;
-    const topSbx = (topTools.sandbox ?? {}) as Record<string, unknown>;
-    const topSbxTools = (topSbx.tools ?? {}) as Record<string, unknown>;
-    const topDeny = (topSbxTools.deny ?? []) as string[];
+    const topDeny = Array.isArray(topTools.deny) ? (topTools.deny as string[]) : [];
     if (!topDeny.includes('browser')) {
       topDeny.push('browser');
-      topSbxTools.deny = topDeny;
-      topSbx.tools = topSbxTools;
-      topTools.sandbox = topSbx;
+      topTools.deny = topDeny;
       (config as Record<string, unknown>).tools = topTools;
       changed = true;
-      mainLog('Sudoclaw', 'Added browser to top-level tools.sandbox deny list');
+      mainLog('Sudoclaw', 'Added browser to top-level tools.deny (hides from LLM catalog)');
+    }
+    // Clean up the old misplaced entry if present.
+    const topSbx = topTools.sandbox as Record<string, unknown> | undefined;
+    const topSbxTools = topSbx?.tools as Record<string, unknown> | undefined;
+    const topSbxDeny = Array.isArray(topSbxTools?.deny) ? (topSbxTools!.deny as string[]) : null;
+    if (topSbxDeny && topSbxDeny.includes('browser')) {
+      topSbxTools!.deny = topSbxDeny.filter((name) => name !== 'browser');
+      if ((topSbxTools!.deny as string[]).length === 0) delete topSbxTools!.deny;
+      changed = true;
+      mainLog('Sudoclaw', 'Removed obsolete tools.sandbox.tools.deny=[browser] entry');
     }
 
     if (changed) {
@@ -611,9 +622,7 @@ export function ensureDefaultConfig(): void {
           provider: 'tavily' as const,
         },
       },
-      sandbox: {
-        tools: { deny: ['browser'] },
-      },
+      deny: ['browser'],
     },
   };
 

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -30,7 +30,6 @@ import { buildDraftsInstruction, hasMcpServersConfigured, buildMcporterCommandHi
 import { cleanupIntermediateFiles } from './draftsCleanup';
 import { inferToolFailure } from '@/agent/acp/inferToolFailure';
 import * as nodePath from 'node:path';
-import { createHash } from 'node:crypto';
 import { ProcessConfig } from '@process/initStorage';
 import { serviceManager } from '@process/services/serviceManager';
 
@@ -1226,7 +1225,22 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
   private isAdbToolCall(data: ToolEventData): boolean {
     const meta = typeof data.meta === 'string' ? data.meta : '';
     const cmd = typeof data.args?.command === 'string' ? (data.args.command as string) : '';
-    return /ai_dev_browser\.tools\./.test(meta) || /ai_dev_browser\.tools\./.test(cmd);
+    const haystack = `${meta}\n${cmd}`;
+    // Must look like a Python invocation — this is the first filter so we
+    // don't accidentally consume FIFO entries for unrelated commands.
+    if (!/\bpython(?:3|\.exe|3\.exe)?\b/i.test(haystack)) return false;
+    // Tight match: full reference visible (either module or path form).
+    if (/ai_dev_browser[./\\]tools|ai_dev_br/i.test(haystack)) return true;
+    // Loose match: openclaw truncates `meta`'s backticked command (often
+    // around the 100-char mark). When a long prefix like `$env:PYTHONPATH
+    // = "<long path>"; python -m ai_…` eats the budget, the regex above
+    // misses. If we see `python` + the ellipsis marker that indicates
+    // truncation, treat it as an adb invocation and let the hook-side
+    // FIFO sort it out. The hook only POSTs for real ai_dev_browser
+    // spawns, so at worst we pop a null entry (no-op) when we guess
+    // wrong.
+    if (/…/.test(meta)) return true;
+    return false;
   }
 
   private extractResultText(data: ToolEventData): string | null {
@@ -1240,23 +1254,6 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
     }
     const joined = parts.join('\n').trim();
     return joined.length > 0 ? joined : null;
-  }
-
-  private computeAdbCmdHash(data: ToolEventData): string {
-    // Mirror the hash produced by hook/node/src/process/AdbStdoutCapture.ts.
-    // On `phase === 'result'` events, openclaw strips `args` from the
-    // external `onAgentEvent` callback — we get only {phase,name,toolCallId,
-    // meta,isError}. `meta` has the shape:
-    //   "run python (in <cwd>), `python -m ai_dev_browser.tools.page_info ...`"
-    // Extract the command between backticks, which matches the shell script
-    // string the hook used for its hashInput.
-    const args = data.args ?? {};
-    let cmd = typeof args.command === 'string' ? (args.command as string).trim() : '';
-    if (!cmd && typeof data.meta === 'string') {
-      const m = data.meta.match(/`([^`]+)`/);
-      if (m && m[1]) cmd = m[1].trim();
-    }
-    return createHash('sha1').update(cmd).digest('hex');
   }
 
   private async handleToolCallEvent(toolData: ToolEventData): Promise<void> {
@@ -1297,19 +1294,23 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
         }
       }
 
-      // Defense-in-depth: if the sidechannel captured a longer stdout than
-      // openclaw's 8 KB sanitized window, overwrite with that. Harmless when
-      // no entry is found (the `waitForCmd` times out quickly).
+      // Pull the matching stdout capture from the sidechannel and replace
+      // openclaw's truncated meta with the real text.
+      //
+      // Correlation strategy: global FIFO across all ai-dev-browser POSTs.
+      // We intentionally don't hash the command here — openclaw truncates
+      // the backticked command in `meta` (typically at ~100 chars), so any
+      // hash we compute from `meta` won't match the hook's hash over the
+      // full command string. But the hook only POSTs entries for matched
+      // ai-dev-browser invocations, and it POSTs on child exit — which is
+      // the same kernel event that triggers openclaw's result emission.
+      // So the order of POST arrivals matches the order of result events,
+      // and a simple FIFO pop lines up correctly.
       if (this.isAdbToolCall(toolData)) {
         try {
           const sink = serviceManager.getAdbSidechannel();
           if (sink) {
-            // The PowerShell / bash wrapper openclaw spawns around python
-            // takes several seconds (interpreter cold start + CDP connect
-            // attempts). Wait generously so the hook's POST has time to land
-            // — the hook only POSTs on the shell process's exit, which is
-            // strictly after the result event reaches sudowork.
-            const entry = await sink.waitForCmd(this.computeAdbCmdHash(toolData), 20_000);
+            const entry = await sink.waitForNextAdbEntry(20_000);
             if (entry && entry.stdoutRaw && entry.stdoutRaw.length > (this.extractResultText(toolData)?.length ?? 0)) {
               toolData.meta = entry.stdoutRaw;
               toolData.content = [{ type: 'content', content: { type: 'text', text: entry.stdoutRaw } }];


### PR DESCRIPTION
## Summary

Follow-up to #394. Four architectural fixes + one separate one (config-guard), found during E2E testing of the insurance-form browser task where the LLM kept stumbling on ai-dev-browser CLI invocation. Full commit message on the single commit has the blow-by-blow.

## Scope

- **Hook: `ChildProcess.prototype.spawn` interception** — openclaw's `import { spawn } from 'node:child_process'` captures the binding at ESM load time; reassigning `childProcess.spawn` after the fact doesn't propagate. The prototype method is what Node's public spawn always delegates to → binding-independent. Also extended detection to the `.py`-path form and shell-wrapper form.
- **Hook: capture stderr** — failed invocations (e.g. `python .py` → ImportError for relative imports) produce zero stdout + stderr traceback. Surface stderr when stdout is empty so LLM sees the real error on its next turn and can self-correct.
- **Sidechannel: global-FIFO correlation** — openclaw's `meta` field is truncated ~100 chars so long `$env:PYTHONPATH=…; python -m ai_dev_browser.tools.<name>` commands clip the tool name. Hash reconstruction was unreliable; FIFO-by-arrival-order is correct because the hook only POSTs on ai-dev-browser matches and POSTs in child-exit order.
- **ServiceManager: `PYTHONPATH` injection** — `~/.nexus/skills/_system/browser` added to gateway env so `python -m ai_dev_browser.tools.<name>` works from any cwd. Zero-overhead equivalent of "persistent cwd" under openclaw's stateless exec.
- **Architectural block on builtin browser re-enable** — `tools.deny: ['browser']` moved to the top level (where `filterToolsByPolicy` actually filters from the LLM's tool catalog, not just denies execute). Plus a `SudoclawConfigGuard` hook/fs layer that monkey-patches `fs.{promises.writeFile, writeFileSync}` to pin `browser.enabled: false` and ensure `browser` ∈ `tools.deny` on every sudoclaw.json write — the LLM empirically discovered it could call openclaw's `gateway` tool with `action: config.patch` to override. Migration code cleans up the obsolete `tools.sandbox.tools.deny` entry.
- **SKILL.md** simplified; path corrected to workspace-relative.
- **Submodule bump** to ai-dev-browser v0.4.3 (upstream reverted their `aidb` uv-bootstrap wrapper that had 8s/invocation overhead).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run tests/unit/adbResultSidechannel.test.ts tests/unit/adbStdoutCapture.test.ts tests/unit/acpAdapter.test.ts` — 16/16 green
- [x] Hook bundle rebuilt — `AdbStdoutCapture` + `SudoclawConfigGuard` present in `dist/hook.js`
- [x] E2E (Windows, insurance-form task): LLM gets real stderr on `python .py` (ImportError + traceback, previously was openclaw's 120-char meta description), self-corrects to `-m` form, subsequent calls return real JSON.

## Known follow-ups (next PR)

- `pip install -e` ai-dev-browser on sudowork startup → removes need for `PYTHONPATH` env injection
- Thin `aidb` dispatcher in `~/.nexus/sudoclaw/bin/` → LLM can write `aidb page_info --url X` instead of `python -m ai_dev_browser.tools.page_info --url X`. Upstream confirmed they're not reintroducing `aidb`, so the name is ours to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)