### PR TITLE
feat(browser): aidb dispatcher + disable image-analysis

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -131,6 +131,11 @@ extraResources:
     to: hook-0.0.1-py3-none-any.whl
   - from: hook/python/pythonpath/sitecustomize.py
     to: pythonpath/sitecustomize.py
+  # sudowork-owned aidb dispatcher (bash + cmd) — installed to
+  # ~/.nexus/sudoclaw/bin/ at startup and put on PATH so LLM can write
+  # `aidb <tool>` instead of `python -m ai_dev_browser.tools.<tool>`.
+  - from: resources/sudoclaw-bin
+    to: sudoclaw-bin
   # CLI tools (bundled at build time via scripts/download-*.js)
   - from: resources/claude-code.tgz
     to: claude-code.tgz

--- a/hook/node/src/process/SudoclawConfigGuard.ts
+++ b/hook/node/src/process/SudoclawConfigGuard.ts
@@ -58,6 +58,7 @@ function guardPayload(data: string | Uint8Array | Buffer): string | Uint8Array |
   const cfg = obj as {
     browser?: { enabled?: unknown };
     tools?: { deny?: unknown };
+    skills?: { entries?: Record<string, { enabled?: unknown }> };
   };
   let mutated = false;
 
@@ -66,30 +67,38 @@ function guardPayload(data: string | Uint8Array | Buffer): string | Uint8Array |
   if (cfg.browser && typeof cfg.browser === 'object' && cfg.browser.enabled === true) {
     cfg.browser.enabled = false;
     mutated = true;
-    try {
-      console.error('[SudoclawConfigGuard] reverted browser.enabled=true → false on write');
-    } catch {
-      /* swallow */
-    }
   }
 
-  // Invariant 2: tools.deny must include 'browser'. This is what actually
-  // removes the builtin browser tool from the LLM's tool catalog via
-  // openclaw's filterToolsByPolicy. If the LLM drops 'browser' from the
-  // deny list, re-add it.
+  // Invariant 2: tools.deny must include both 'browser' and 'image'.
+  // These control what's in the LLM's tool catalog (openclaw's
+  // filterToolsByPolicy). If the LLM drops either, re-add.
   const tools = (cfg.tools ?? {}) as { deny?: unknown };
   const denyArr = Array.isArray(tools.deny) ? (tools.deny as unknown[]).slice() : [];
-  const hasBrowser = denyArr.some((v) => v === 'browser');
-  if (!hasBrowser) {
-    denyArr.push('browser');
+  for (const toolName of ['browser', 'image']) {
+    if (!denyArr.some((v) => v === toolName)) {
+      denyArr.push(toolName);
+      mutated = true;
+    }
+  }
+  if (mutated) {
     tools.deny = denyArr;
     cfg.tools = tools;
+  }
+
+  // Invariant 3: the builtin image-analysis skill stays disabled.
+  // Its analyze_image.sh spawns a separate vision LLM subprocess, which
+  // breaks the orchestrating LLM's browser-session context continuity —
+  // ai-dev-browser's page_discover (ARIA semantics) is the first-class
+  // signal for web automation.
+  const skills = (cfg.skills ?? {}) as { entries?: Record<string, { enabled?: unknown }> };
+  const entries = (skills.entries ?? {}) as Record<string, { enabled?: unknown }>;
+  const ia = (entries['image-analysis'] ?? {}) as { enabled?: unknown };
+  if (ia.enabled !== false) {
+    ia.enabled = false;
+    entries['image-analysis'] = ia;
+    skills.entries = entries;
+    cfg.skills = skills;
     mutated = true;
-    try {
-      console.error('[SudoclawConfigGuard] re-added "browser" to tools.deny on write');
-    } catch {
-      /* swallow */
-    }
   }
 
   if (!mutated) return data;

--- a/resources/sudoclaw-bin/aidb
+++ b/resources/sudoclaw-bin/aidb
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ai-dev-browser dispatcher (sudowork-side).
+#
+# Thin wrapper: `aidb <tool> [args]` → `python -m ai_dev_browser.tools.<tool> [args]`.
+# Skips uv / venv bootstrap — sudowork already pre-configures the Python path
+# (PYTHONPATH=~/.nexus/skills/_system/browser) when it starts the openclaw
+# gateway, so `python -m ai_dev_browser.tools.*` resolves directly.
+#
+# Discovery: `aidb --list` lists tools by enumerating the `tools/` directory
+# next to this script's resolved ai_dev_browser package.
+#
+# Upstream ai-dev-browser removed its own `aidb` in v0.4.3 (per-call uv-run
+# cost ~8s). This sudowork-owned dispatcher fills the same UX slot at ~50ms.
+
+set -euo pipefail
+
+# Resolve ai_dev_browser package path. We rely on PYTHONPATH being set by
+# sudowork's gateway; otherwise fall back to the stable system-skills dir.
+# Prefer the first entry when PYTHONPATH carries multiple `:`-separated paths.
+__pythonpath="${PYTHONPATH:-}"
+__first_pp="${__pythonpath%%:*}"
+if [ -n "$__first_pp" ] && [ -d "$__first_pp/ai_dev_browser/tools" ]; then
+    TOOLS_DIR="$__first_pp/ai_dev_browser/tools"
+else
+    TOOLS_DIR="$HOME/.nexus/skills/_system/browser/ai_dev_browser/tools"
+fi
+
+if [ $# -eq 0 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    cat <<EOF
+Usage: aidb <tool> [args]
+       aidb --list              # list available tools
+       aidb <tool> --help       # tool-specific help
+
+Tool files: $TOOLS_DIR
+EOF
+    exit 0
+fi
+
+if [ "${1:-}" = "--list" ]; then
+    if [ -d "$TOOLS_DIR" ]; then
+        for f in "$TOOLS_DIR"/*.py; do
+            name=$(basename "$f" .py)
+            case "$name" in
+                _*) ;;
+                *) echo "$name" ;;
+            esac
+        done
+    else
+        echo "Error: tools directory not found: $TOOLS_DIR" >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+tool="${1//-/_}"
+shift
+exec python -m "ai_dev_browser.tools.$tool" "$@"

--- a/resources/sudoclaw-bin/aidb.cmd
+++ b/resources/sudoclaw-bin/aidb.cmd
@@ -1,0 +1,58 @@
+@echo off
+setlocal EnableDelayedExpansion
+:: ai-dev-browser dispatcher (sudowork-side, Windows).
+::
+:: Thin wrapper: `aidb <tool> [args]` -> `python -m ai_dev_browser.tools.<tool> [args]`.
+:: Skips uv / venv bootstrap — sudowork pre-configures PYTHONPATH when it
+:: starts the openclaw gateway, so `python -m ai_dev_browser.tools.*` resolves
+:: directly. ~50ms per call.
+
+:: Resolve ai_dev_browser tools directory. Prefer PYTHONPATH (set by sudowork),
+:: fall back to the stable system-skills junction location.
+set "TOOLS_DIR=%PYTHONPATH%\ai_dev_browser\tools"
+:: If PYTHONPATH contains multiple paths (; separated on Windows), take the first.
+for /f "tokens=1 delims=;" %%p in ("%PYTHONPATH%") do set "TOOLS_DIR=%%p\ai_dev_browser\tools"
+if not exist "%TOOLS_DIR%" (
+    set "TOOLS_DIR=%USERPROFILE%\.nexus\skills\_system\browser\ai_dev_browser\tools"
+)
+
+if "%~1"=="" goto :help
+if "%~1"=="--help" goto :help
+if "%~1"=="-h" goto :help
+
+if "%~1"=="--list" goto :list
+
+:: Dispatch. Replace hyphens in tool name with underscores (Python module rule).
+set "tool=%~1"
+set "tool=%tool:-=_%"
+shift
+:: %* still has the original first arg; build forwarded args manually.
+set "forwarded="
+:collect_args
+if "%~1"=="" goto :run
+if defined forwarded (set "forwarded=%forwarded% %1") else (set "forwarded=%1")
+shift
+goto :collect_args
+
+:run
+python -m "ai_dev_browser.tools.%tool%" %forwarded%
+exit /b %errorlevel%
+
+:list
+if not exist "%TOOLS_DIR%" (
+    echo Error: tools directory not found: %TOOLS_DIR% 1>&2
+    exit /b 1
+)
+for %%f in ("%TOOLS_DIR%\*.py") do (
+    set "name=%%~nf"
+    if not "!name:~0,1!"=="_" echo !name!
+)
+exit /b 0
+
+:help
+echo Usage: aidb ^<tool^> [args]
+echo        aidb --list            list available tools
+echo        aidb ^<tool^> --help     tool-specific help
+echo.
+echo Tool files: %TOOLS_DIR%
+exit /b 0

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -6,8 +6,8 @@ description: "AI-native browser. Explore websites, discover page structure, take
 # Browser
 
 ```bash
-ls skills/browser/ai_dev_browser/tools/
-python -m ai_dev_browser.tools.<name> [--flag ...]
+aidb --list
+aidb <tool> [--flag ...]
 ```
 
 Every CLI tool has an identical Python function in `ai_dev_browser.core` — explore interactively with CLI, then script with the same functions:

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -578,6 +578,24 @@ const syncBuiltinSkillsToUserDir = async (): Promise<void> => {
     await copyDirectoryRecursively(builtinSkillsDir, userSystemSkillsDir, { overwrite: true });
     mainLog('Sudowork', 'Builtin skills synced to _system/ (overwrite)');
 
+    // Remove image-analysis skill from user dir — it's config-disabled (see
+    // SudoclawInstallService ensureDefaultConfig/repairOpenClawConfig) because
+    // it spawns a separate LLM subprocess that breaks the orchestrating LLM's
+    // browser-session context. But if we leave the files on disk, the LLM can
+    // (and empirically does) bypass the skill registry by invoking the bash
+    // script directly via exec. Physical removal is what actually stops it.
+    for (const legacySubpath of ['image-analysis', path.join('_builtin', 'image-analysis')]) {
+      const stalePath = path.join(userSystemSkillsDir, legacySubpath);
+      if (existsSync(stalePath)) {
+        try {
+          rmSync(stalePath, { recursive: true, force: true });
+          mainLog('Sudowork', `Removed image-analysis skill from ${stalePath} (config-disabled)`);
+        } catch (error) {
+          mainWarn('Sudowork', `Failed to remove ${stalePath}:`, error);
+        }
+      }
+    }
+
     // Link the bundled ai-dev-browser package into the browser skill so the agent
     // sees `skills/browser/ai_dev_browser/tools/` at a stable relative path.
     linkAiDevBrowserIntoSystemSkill(userSystemSkillsDir);

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -398,6 +398,39 @@ export class ServiceManager {
         mainWarn('ServiceManager', 'Failed to resolve system skills dir for PYTHONPATH injection', err);
       }
 
+      // Install sudowork-owned aidb dispatcher (skips upstream uv overhead)
+      // into ~/.nexus/sudoclaw/bin/ and surface it on PATH for every exec
+      // child. LLM writes `aidb page_info --url X` instead of
+      // `$env:PYTHONPATH=...; python -m ai_dev_browser.tools.page_info --url X`.
+      const sudoworkBinEnv: Record<string, string> = {};
+      try {
+        const { ensureSudoworkBinDispatchers, SUDOCLAW_SUDOWORK_BIN_DIR } = await import('../sudoclaw/SudoclawInstallService');
+        ensureSudoworkBinDispatchers();
+        const prevPath = process.env.PATH ?? '';
+        sudoworkBinEnv.PATH = prevPath.length > 0 ? `${SUDOCLAW_SUDOWORK_BIN_DIR}${path.delimiter}${prevPath}` : SUDOCLAW_SUDOWORK_BIN_DIR;
+      } catch (err) {
+        mainWarn('ServiceManager', 'Failed to install sudowork bin dispatchers', err);
+      }
+
+      // SUDOROUTER creds injection so the sudowork image-analysis skill and
+      // any other tool expecting these env vars works out of the box.
+      // Source of truth: sudoclaw.json models.providers.sudorouter.
+      // (Normally harmless — the image tool and image-analysis skill are
+      // disabled in ensureDefaultConfig/repairOpenClawConfig, but we still
+      // inject to support ad-hoc scripts referencing SUDOROUTER.)
+      const sudorouterEnv: Record<string, string> = {};
+      try {
+        const raw = await fs.promises.readFile(SUDOCLAW_CONFIG_PATH, 'utf-8');
+        const cfg = JSON.parse(raw) as {
+          models?: { providers?: Record<string, { baseUrl?: string; apiKey?: string }> };
+        };
+        const sr = cfg.models?.providers?.sudorouter;
+        if (sr?.baseUrl) sudorouterEnv.SUDOROUTER_BASE_URL = sr.baseUrl;
+        if (sr?.apiKey) sudorouterEnv.SUDOROUTER_API_KEY = sr.apiKey;
+      } catch (err) {
+        mainWarn('ServiceManager', 'Could not read sudorouter provider creds from sudoclaw.json', err);
+      }
+
       this.gateway = new OpenClawGatewayManager({
         port: SUDOCLAW_DEFAULT_PORT,
         stateDir: SUDOCLAW_DIR,
@@ -406,6 +439,8 @@ export class ServiceManager {
           OPENCLAW_CONFIG_PATH: SUDOCLAW_CONFIG_PATH,
           ...adbSidechannelEnv,
           ...pythonPathEnv,
+          ...sudoworkBinEnv,
+          ...sudorouterEnv,
         },
         forceSubprocessGateway: true,
       });

--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -45,6 +45,8 @@ const SUDOCLAW_CLI_STAGING_DIR = path.join(SUDOCLAW_DIR, 'cli.new');
 const SUDOCLAW_CLI_BACKUP_DIR = path.join(SUDOCLAW_DIR, 'cli.old');
 /** CLI bin path: ~/.nexus/sudoclaw/cli/package/bin/ (included in tgz) */
 export const SUDOCLAW_BIN_DIR = path.join(SUDOCLAW_CLI_DIR, 'package', 'bin');
+/** sudowork-owned dispatcher bin (aidb wrapper + future per-tool shims). */
+export const SUDOCLAW_SUDOWORK_BIN_DIR = path.join(SUDOCLAW_DIR, 'bin');
 const SUDOCLAW_WORKSPACE_DIR = path.join(SUDOCLAW_DIR, 'workspace');
 const SUDOCLAW_INSTALL_MANIFEST_PATH = path.join(SUDOCLAW_DIR, 'install-manifest.json');
 
@@ -529,12 +531,36 @@ export function repairOpenClawConfig(): void {
     // nothing when docker sandbox isn't in play.
     const topTools = (config.tools ?? {}) as Record<string, unknown>;
     const topDeny = Array.isArray(topTools.deny) ? (topTools.deny as string[]) : [];
-    if (!topDeny.includes('browser')) {
-      topDeny.push('browser');
-      topTools.deny = topDeny;
-      (config as Record<string, unknown>).tools = topTools;
+    for (const toolName of ['browser', 'image']) {
+      if (!topDeny.includes(toolName)) {
+        topDeny.push(toolName);
+        changed = true;
+        mainLog('Sudoclaw', `Added ${toolName} to top-level tools.deny (hides from LLM catalog)`);
+      }
+    }
+    topTools.deny = topDeny;
+    (config as Record<string, unknown>).tools = topTools;
+
+    // Disable the builtin image-analysis skill. Rationale: image-analysis
+    // invokes a SEPARATE LLM (via SUDOROUTER) in a subprocess — it has no
+    // continuity with the orchestrating LLM's browser session context, and
+    // ai-dev-browser's page_discover returns ARIA semantics (role, name,
+    // ref, box) which is a richer signal for web automation than pixel
+    // vision anyway. The skill's analyze_image.sh also requires
+    // SUDOROUTER_{BASE_URL,API_KEY} env vars that aren't injected, so the
+    // LLM wastes 5-8 steps manually sourcing them from sudoclaw.json and
+    // re-exporting per exec call. Disabling removes both the context
+    // break and the env-setup loop.
+    const skills = (config.skills ?? {}) as Record<string, unknown>;
+    const skillEntries = (skills.entries ?? {}) as Record<string, unknown>;
+    const imageAnalysis = (skillEntries['image-analysis'] ?? {}) as Record<string, unknown>;
+    if (imageAnalysis.enabled !== false) {
+      imageAnalysis.enabled = false;
+      skillEntries['image-analysis'] = imageAnalysis;
+      skills.entries = skillEntries;
+      (config as Record<string, unknown>).skills = skills;
       changed = true;
-      mainLog('Sudoclaw', 'Added browser to top-level tools.deny (hides from LLM catalog)');
+      mainLog('Sudoclaw', 'Disabled builtin image-analysis skill (breaks browser context continuity)');
     }
     // Clean up the old misplaced entry if present.
     const topSbx = topTools.sandbox as Record<string, unknown> | undefined;
@@ -616,13 +642,18 @@ export function ensureDefaultConfig(): void {
         },
       },
     },
+    skills: {
+      entries: {
+        'image-analysis': { enabled: false },
+      },
+    },
     tools: {
       web: {
         search: {
           provider: 'tavily' as const,
         },
       },
-      deny: ['browser'],
+      deny: ['browser', 'image'],
     },
   };
 
@@ -694,6 +725,44 @@ function updateMarkerBlock(existingContent: string, marker: string, newBlock: st
  *
  * This guarantees that fresh installs *and* upgrades always have the latest prompt.
  */
+/**
+ * Copy the sudowork-owned `aidb` dispatcher (bash + cmd) into
+ * ~/.nexus/sudoclaw/bin/ so the openclaw gateway can expose it on PATH for
+ * every exec child. Idempotent — overwrites existing copies so updates to
+ * the bundled wrapper propagate on next startup. On Unix the bash variant
+ * gets the exec bit; on Windows the .cmd works directly.
+ */
+export function ensureSudoworkBinDispatchers(): void {
+  const source = resolveSudoworkBinSource();
+  if (!source) {
+    mainWarn('Sudoclaw', 'sudoclaw-bin source dir not found; aidb dispatcher unavailable');
+    return;
+  }
+  try {
+    fs.mkdirSync(SUDOCLAW_SUDOWORK_BIN_DIR, { recursive: true });
+    for (const entry of fs.readdirSync(source)) {
+      const srcPath = path.join(source, entry);
+      const destPath = path.join(SUDOCLAW_SUDOWORK_BIN_DIR, entry);
+      try {
+        fs.copyFileSync(srcPath, destPath);
+        if (process.platform !== 'win32' && !entry.endsWith('.cmd')) {
+          fs.chmodSync(destPath, 0o755);
+        }
+      } catch (err) {
+        mainWarn('Sudoclaw', `Failed to install dispatcher ${entry}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    mainLog('Sudoclaw', `Installed aidb dispatcher into ${SUDOCLAW_SUDOWORK_BIN_DIR}`);
+  } catch (err) {
+    mainWarn('Sudoclaw', `Failed to install sudowork bin dispatchers: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function resolveSudoworkBinSource(): string | null {
+  const candidates = app.isPackaged ? [path.join(app.getAppPath().replace('app.asar', 'app.asar.unpacked'), 'resources', 'sudoclaw-bin'), path.join(process.resourcesPath, 'sudoclaw-bin')] : [path.join(app.getAppPath(), 'resources', 'sudoclaw-bin')];
+  return candidates.find((p) => fs.existsSync(p)) ?? null;
+}
+
 export function ensureUserMdSafetyRules(): void {
   const userMdPath = path.join(SUDOCLAW_WORKSPACE_DIR, 'USER.md');
   const safetyRulesBlock = `


### PR DESCRIPTION
## Summary

Phase 2 follow-up to #402. Four architectural changes, collectively drop the insurance-form E2E task from 54 to **48 steps** (−11% vs phase 1, −33% vs baseline #394). Commit body has the details; test plan below.

## Scope

1. **`aidb` dispatcher** (resources/sudoclaw-bin/). `aidb page_info --url X` instead of `$env:PYTHONPATH=...; python -m ai_dev_browser.tools.page_info --url X`. Installed to `~/.nexus/sudoclaw/bin/` + put on gateway PATH. ~50ms/call (no uv rebuild). Upstream ai-dev-browser v0.4.3 revert-dropped their `aidb` name so we own it.
2. **image-analysis skill disabled**, three layers:
   - `tools.deny: ['browser', 'image']` (top-level → openclaw's `filterToolsByPolicy` removes `image` from LLM catalog, same mechanism as `browser`)
   - `skills.entries.image-analysis.enabled: false`
   - `initStorage.syncBuiltinSkillsToUserDir` physically rm's `~/.nexus/skills/_system/image-analysis/` + legacy `_system/_builtin/image-analysis/` after every sync. Without this, LLM bypasses config by direct `bash <path>/analyze_image.sh` (11 such invocations observed in run 4b8fb175, dropped to 0 after physical removal).
3. **`SUDOROUTER_{BASE_URL,API_KEY}` injection** into gateway customEnv from `sudoclaw.json models.providers.sudorouter` (defense-in-depth).
4. **`SudoclawConfigGuard`** extended — also pins `tools.deny` to include `'image'` and `skills.entries.image-analysis.enabled: false` on every sudoclaw.json write.

Rationale for disabling image-analysis: the skill spawns a separate LLM subprocess via SUDOROUTER — it has **no context continuity** with the orchestrating LLM's browser session. ai-dev-browser's `page_discover` (ARIA role/name/ref/box) is the first-class signal for web automation anyway; pixel vision is architecturally misplaced here.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] Unit tests (16 pass): `adbResultSidechannel`, `adbStdoutCapture`, `acpAdapter`
- [x] Hook rebuilt — `SudoclawConfigGuard` pins all three invariants
- [x] E2E insurance-form task — **48 steps / 393s / 31 aidb calls / 0 manual PYTHONPATH / 0 bash image-analysis / 0 `image`-title invocations**
- [x] aidb `--list` + `aidb browser_list` manual smoke — returns real JSON under 50ms

## A/B data (insurance-form E2E)

| run | steps | dur | aidb | bash-img | manual-PATH | image-title |
|---|---|---|---|---|---|---|
| baseline #394 | 72 | 368s | 0 | 6 | 9 | 1 |
| built-in browser | 39 | 152s | 0 | 0 | 0 | 0 |
| phase 1 #402 | 54 | 390s | 0 | 5 | 33 | 2 |
| phase 2 v1 (config only) | 62 | 415s | 33 | 11 | 0 | 0 |
| **phase 2 FINAL** | **48** | **393s** | **31** | **0** | **0** | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)