### PR TITLE
fix: backfill tools.web.search.provider in repairOpenClawConfig

### DIFF
--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -539,6 +539,19 @@ export function repairOpenClawConfig(): void {
       }
     }
     topTools.deny = topDeny;
+
+    // Backfill tools.web.search.provider — present in ensureDefaultConfig but was
+    // missing from repair, so users who upgrade won't have this field. See #404.
+    const webConfig = (topTools.web ?? {}) as Record<string, unknown>;
+    const searchConfig = (webConfig.search ?? {}) as Record<string, unknown>;
+    if (!searchConfig.provider) {
+      searchConfig.provider = 'tavily';
+      webConfig.search = searchConfig;
+      topTools.web = webConfig;
+      changed = true;
+      mainLog('Sudoclaw', 'Backfilled tools.web.search.provider = tavily');
+    }
+
     (config as Record<string, unknown>).tools = topTools;
 
     // Disable the builtin image-analysis skill. Rationale: image-analysis

--- a/tests/unit/sudoclawInstallService.test.ts
+++ b/tests/unit/sudoclawInstallService.test.ts
@@ -304,6 +304,55 @@ describe('SudoclawInstallService', () => {
     });
   });
 
+  it('backfills tools.web.search.provider when missing', async () => {
+    const sudoclawDir = path.join(homeDir, '.nexus', 'sudoclaw');
+    fs.mkdirSync(sudoclawDir, { recursive: true });
+    const configPath = path.join(sudoclawDir, 'sudoclaw.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          agents: { defaults: { workspace: '/tmp/ws' } },
+          gateway: { port: 17863, mode: 'local', auth: { mode: 'none' }, reload: { mode: 'hot' } },
+          tools: { deny: ['browser', 'image'] },
+        },
+        null,
+        2
+      )
+    );
+
+    const module = await import('@/process/services/sudoclaw/SudoclawInstallService');
+    module.repairOpenClawConfig();
+
+    const repaired = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(repaired.tools.web).toEqual({ search: { provider: 'tavily' } });
+    expect(repaired.tools.deny).toEqual(['browser', 'image']);
+  });
+
+  it('preserves existing tools.web.search.provider value', async () => {
+    const sudoclawDir = path.join(homeDir, '.nexus', 'sudoclaw');
+    fs.mkdirSync(sudoclawDir, { recursive: true });
+    const configPath = path.join(sudoclawDir, 'sudoclaw.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          agents: { defaults: { workspace: '/tmp/ws' } },
+          gateway: { port: 17863, mode: 'local', auth: { mode: 'none' }, reload: { mode: 'hot' } },
+          tools: { deny: ['browser', 'image'], web: { search: { provider: 'custom-provider' } } },
+        },
+        null,
+        2
+      )
+    );
+
+    const module = await import('@/process/services/sudoclaw/SudoclawInstallService');
+    module.repairOpenClawConfig();
+
+    const repaired = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(repaired.tools.web.search.provider).toBe('custom-provider');
+  });
+
   it('does not delete legacy dir when new sudoclaw dir already exists', async () => {
     const newPkgRoot = path.join(homeDir, '.nexus', 'sudoclaw', 'cli', 'package');
     fs.mkdirSync(path.join(newPkgRoot, 'dist'), { recursive: true });


### PR DESCRIPTION
# Pull Request

## Description

The default config (ensureDefaultConfig) sets tools.web.search.provider to 'tavily', but repairOpenClawConfig was missing this field. Users who upgrade from older versions would not get the web search provider configured, breaking tavily web search functionality.

Add backfill logic to repairOpenClawConfig that sets tools.web.search.provider to 'tavily' when the field is absent, while preserving any existing custom provider value.

## Related Issues

- Closes #404

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors
