### PR TITLE
chore(browser): bump ai-dev-browser v0.5.4 → v0.5.7 (docstring polish)

### DIFF
--- a/tests/e2e/cases/lis8-verify-patches.yaml
+++ b/tests/e2e/cases/lis8-verify-patches.yaml
@@ -1,12 +1,12 @@
 name: "lis8 verify patches"
-description: "Verify post-patch behaviour: compound-cmd FIFO串台 fix, read tool UI visibility, canvas tool removed from catalog. Triggers a lis8 login + nav flow that exercises browser tool calls + at least one read."
+description: "Full lis8 flow: login (with captcha) → nav to 新单录入 → fill form. Same prompt the user has been running manually. Verifies post-patch behaviour end-to-end on a real flow with compound cmds, browser/exec/read/write tool calls, no canvas."
 
 steps:
   # ── Phase 0: Wait for app startup ──
   - op: wait_for_app_ready
     timeout: 300
 
-  # ── Phase 1: New conversation, sudoclaw preset ──
+  # ── Phase 1: New conversation ──
   - op: mouse_click
     text: "新会话"
   - op: pause
@@ -14,7 +14,7 @@ steps:
   - op: screenshot
     path: "screenshots/lis8-verify-00-home.png"
 
-  # ── Phase 2: Send lis8 prompt (same wording the user has been testing) ──
+  # ── Phase 2: Send the exact same prompt the user has been using ──
   - op: type_text
     text: |
       https://lis8.sinosoft.ltd
@@ -23,14 +23,14 @@ steps:
       机构选 861100
       团险业务-新单管理-新单录入
 
-      你登录进去看一下，登录后用 read 看一下 package.json 的前 20 行（验证 read 工具 UI 可见性）。
+      你登录进去看一下
   - op: press_key
     key: "Enter"
     wait: 3
 
-  # ── Phase 3: Let it run ──
+  # ── Phase 3: Long run — captcha + login + nav + form takes 5–10 min ──
   - op: wait_for_response
-    timeout: 600
+    timeout: 1500
 
   # ── Phase 4: Final screenshot ──
   - op: screenshot


### PR DESCRIPTION
## Summary

- Bumps `vendor/ai-dev-browser` submodule from v0.5.4 → v0.5.7
- Three patch releases on the upstream side, **all docstring/README only — zero behaviour change**:
  - v0.5.5: README Quick Start fix + naming-pattern docs
  - v0.5.6: README stops duplicating API surface, points at docstrings/tests as SSOT
  - v0.5.7: bidirectional cross-refs `html_by_ref` ↔ `page_html`, iframe-scoping note in `page_discover` — these were the upstream response to the lis8 e2e discovery-gap observations sudowork forwarded after PR #408
- Also resolves leftover content in `tests/e2e/cases/lis8-verify-patches.yaml` (longer timeout + simpler prompt) that was mid-edit when #408 merged

## Why now

The upstream maintainer ([feedback transcript](https://internal-link)) declined our flag-alias proposal but accepted the docstring polish as the right level of fix — same end goal (LLM finds the right tool first try) without permanent surface-area debt.

## Test plan
- [x] Submodule HEAD is at v0.5.7 tag (`e6abfb0`)
- [x] No `.py`/`.json`/runtime files changed in upstream — confirmed via `git log v0.5.4..v0.5.7 -- '*.py' '*.json'` returns nothing relevant
- [ ] Local lis8 e2e re-run with new docstrings to observe whether LLM hits `html_by_ref` first try (pending — needs working e2e wiring; previous run had silent UX failure on 新会话 click that I'm separately diagnosing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)