### PR TITLE
chore(browser): bump v0.5.7 → v0.6.0 + raise exec async threshold to 120s

### DIFF
--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -425,6 +425,20 @@ export class ServiceManager {
         // and landing them at a persistent, discoverable location the
         // LLM doesn't need to `mv` out of scratch after the fact.
         sudoworkBinEnv.AI_DEV_BROWSER_OUTPUT_DIR = '.';
+        // openclaw's exec tool backgrounds any command running longer than
+        // `defaultBackgroundMs` (default 10s, env `PI_BASH_YIELD_MS`,
+        // clamped [10ms, 120s]). When backgrounded, the LLM gets a
+        // "Command still running (session foo, pid bar)" stub and has to
+        // poll via the `process` tool — costing 2-3 extra steps per
+        // affected call. Browser tool calls take 1-3s each; a compound of
+        // 3-4 (`browser type_by_ref ...\nbrowser type_by_ref ...`) crosses
+        // the 10s threshold and gets shunted to async. lis8 e2e audit
+        // observed 4 compound steps trigger this, accounting for ~12 steps
+        // of pure overhead. Push to the 120s ceiling so realistic browser
+        // compounds finish synchronously. Genuinely long-running commands
+        // (npm install, builds) still get backgrounded — they just have a
+        // longer fuse before being moved off the main path.
+        sudoworkBinEnv.PI_BASH_YIELD_MS = '120000';
       } catch (err) {
         mainWarn('ServiceManager', 'Failed to install sudowork bin dispatchers', err);
       }


### PR DESCRIPTION
## Summary

Two follow-up fixes from lis8 e2e audit:

1. **Bump `vendor/ai-dev-browser` v0.5.7 → v0.6.0**
   - v0.5.8 (`3b8db9e`): browser_start startup_timeout + orphan Chrome kill
   - v0.5.9 (`f12c735`): `find_by_text` added (closes pattern hole — LLM tried `find_by_text` and got ImportError, now succeeds), CLI errors pass through verbatim
   - v0.6.0 (`f48df34`): `dialog_respond --action accept|dismiss` replaces `--no-accept` — aligns with Playwright/CDP `dialog.accept()/dismiss()` mental model. **Breaking on CLI surface, but bare-call equivalent (default still accept).** Sudowork doesn't call dialog_respond directly so no consumer impact.

2. **`PI_BASH_YIELD_MS=120000`** in gateway env
   - openclaw exec backgrounds any command running >10s by default. Browser compounds (3-4 chained `type_by_ref`/`click_by_ref`) easily cross 10s and get shunted to async session, forcing LLM to do 2-3 `process` poll/log steps per compound.
   - lis8 audit observed **4 compounds triggering async, ~12 steps of pure overhead.**
   - Pushing to the 120s ceiling (clamp max). Genuinely long commands (npm install, builds) still background — just longer fuse.

## Known leftover (separate)

`page_reload` is still broken in v0.6.0 — `core/navigation.py:71` calls `await tab.reload(...)` but Tab method is `tab.page_reload(...)`. Direct AttributeError on any `browser page_reload` call. Flagged to upstream for next patch release; not blocking this PR.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Submodule pinned to v0.6.0 tag (`f48df34`)
- [x] Bundle patches (cap, image, tool result, canvas deny) re-asserted on every gateway start — already covered by previous PRs
- [ ] Re-run lis8 e2e to verify (a) no async-session detours on compound browser cmds, (b) `find_by_text` callable, (c) step count drops vs. previous 65-step run

🤖 Generated with [Claude Code](https://claude.com/claude-code)