### PR TITLE
feat(browser): add `browser repl` — persistent Python REPL for multi-step batches

### DIFF
--- a/resources/sudoclaw-bin/browser_helper.py
+++ b/resources/sudoclaw-bin/browser_helper.py
@@ -139,6 +139,18 @@ def _list_tools() -> tuple[int, str, str]:
                 if doc:
                     summary = doc.split("\n", 1)[0].strip()
         _emit(buf, f"{name:<{name_col}}  {summary}".rstrip())
+    # Append sudowork-provided entries AFTER the ai_dev_browser tool
+    # block, with an explicit `(sudowork)` prefix on the summary so the
+    # LLM can tell upstream tools from orchestrator extensions at a
+    # glance — important because filing bugs for a `(sudowork)` tool
+    # against ai-dev-browser upstream would be a wrong-blame. The
+    # `repl` entry itself is the sole orchestrator-provided tool
+    # today; its full usage is one `browser repl --help` away.
+    _emit(
+        buf,
+        f"{'repl':<{name_col}}  "
+        "(sudowork) Use when: chaining 4+ atomic ops (e.g. login form, multi-step nav) — define Python fns, state + `tab` persist across calls.",
+    )
     out = buf.getvalue()
     sys.stdout.write(out)
     sys.stdout.flush()
@@ -207,6 +219,285 @@ def _post_sidechannel(
         # Sidechannel is best-effort; never fail the tool call because of
         # reporting trouble.
         pass
+
+
+REPL_INFO_PATH = pathlib.Path.home() / ".nexus" / "sudoclaw" / "repl-server.json"
+
+
+def _read_repl_info() -> dict | None:
+    """Load the running REPL server's {pid, port, secret} info file.
+
+    Returns None if the file is absent or malformed. Liveness is
+    verified downstream by `_probe_repl_health`, which additionally
+    confirms the PID on the port matches the file's PID — that
+    combination is stronger than a pid-exists check and works
+    uniformly on both POSIX and Windows (where `os.kill(pid, 0)`
+    raises rather than returning a boolean).
+    """
+    try:
+        info = json.loads(REPL_INFO_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    if not isinstance(info.get("pid"), int):
+        return None
+    return info
+
+
+def _probe_repl_health(info: dict, *, timeout: float = 0.5) -> bool:
+    """Confirm the server at `info` is actually answering /health.
+
+    Stale-pid mitigation isn't enough on its own: a PID can be recycled
+    by the OS to an unrelated process in the same second that we
+    crashed. A GET /health on the port settles it — either we get
+    `{"ok": true, "pid": <expected>}` or we assume the slot is dead.
+    """
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{info['port']}/health",
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status != 200:
+                return False
+            payload = json.loads(resp.read().decode("utf-8"))
+            return payload.get("pid") == info.get("pid")
+    except Exception:
+        return False
+
+
+def _spawn_repl_server() -> dict:
+    """Start `browser_repl_server.py` as a detached child and poll the
+    discovery file until it shows up. Returns the {pid, port, secret}
+    dict or raises RuntimeError on timeout.
+
+    We can't use `subprocess.run` + block — the server is long-lived.
+    On POSIX we'd use `os.setsid`; on Windows we use the DETACHED_
+    PROCESS creation flag so the child outlives this dispatcher.
+    """
+    import subprocess
+
+    here = pathlib.Path(__file__).parent
+    server_py = here / "browser_repl_server.py"
+
+    kwargs: dict = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if sys.platform == "win32":
+        DETACHED_PROCESS = 0x00000008  # noqa: N806
+        CREATE_NEW_PROCESS_GROUP = 0x00000200  # noqa: N806
+        kwargs["creationflags"] = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+    else:
+        kwargs["start_new_session"] = True
+
+    subprocess.Popen([sys.executable, str(server_py)], **kwargs)
+
+    # Poll the info file for up to ~5s. Server needs time to bind a
+    # port, write the file atomically, and become healthy.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        info = _read_repl_info()
+        if info and _probe_repl_health(info):
+            return info
+        time.sleep(0.1)
+    raise RuntimeError("browser repl server failed to start within 5s")
+
+
+def _ensure_repl_server() -> dict:
+    """Return a live server's connection info, spawning one if needed."""
+    info = _read_repl_info()
+    if info and _probe_repl_health(info):
+        return info
+    return _spawn_repl_server()
+
+
+_REPL_HELP = """\
+Use when: you're about to chain 4+ atomic browser ops (e.g. login:
+type user → type pw → type captcha → click submit) and the combined
+cold-start overhead (~700ms × N calls) would dominate. The REPL keeps
+one Python interpreter + one CDP connection alive across calls, so
+every call after the first is ~10ms + the actual work.
+
+Usage:
+  browser repl '<python code>'
+
+Pre-bound globals (no imports needed):
+  tab                  ready-to-use Tab attached to the running Chrome
+  type_by_html_id      every public function in ai_dev_browser.core
+  click_by_ref         (type_by_ref, click_by_ref, page_discover,
+  page_screenshot       page_screenshot, html_by_ref, page_goto, ...)
+  ...                   ──────────────────────────────────────────
+  asyncio              for asyncio.sleep, asyncio.gather, etc.
+  _                    the last non-None expression value (REPL convention)
+
+Semantics:
+  - top-level `await` works directly (no asyncio.run wrapper)
+  - last expression's repr() is returned as `=> ...` (Jupyter style)
+  - exceptions render as a Python traceback
+  - state persists: definitions in call N are callable in call N+1
+
+Examples:
+  # Define once, invoke twice (captcha retry doesn't redefine the fn):
+  browser repl '
+  async def login(user, pw, captcha):
+      await type_by_html_id(tab, "UserCode2", user)
+      await type_by_html_id(tab, "UserPass2", pw)
+      await type_by_html_id(tab, "Captcha", captcha)
+      await click_by_html_id(tab, "submit")
+  '
+  browser repl 'await login("alice", "secret", "9830")'
+  browser repl 'await login("alice", "secret", "6726")'   # captcha was wrong, retry
+
+  # Cache an expensive lookup for later use:
+  browser repl 'elements = (await page_discover(tab))["elements"]; len(elements)'
+  browser repl '[e for e in elements if e.get("role") == "button"]'
+
+When NOT to use:
+  - single-operation calls: `browser click_by_text --text "Sign in"` is
+    already atomic, has its own per-action feedback (navigated/url_after),
+    and doesn't pay the REPL-server startup cost. Don't use repl just
+    because you could — use it when chaining saves meaningful steps.
+  - exploration / probing: atomic tools print structured JSON per call;
+    repr'd Python objects inside the REPL are less skimmable.
+"""
+
+
+def _run_repl(rest: list[str]) -> int:
+    """POST the user's Python snippet to the persistent REPL server and
+    print its JSON response in a LLM-friendly format.
+
+    Input convention: everything after `browser repl` is joined as the
+    Python source, same as `python -c "..."`. Empty input prints a
+    usage hint; `--help` / `-h` prints the full doc (same shape as
+    the ai_dev_browser tools' own --help, so the LLM's discovery
+    flow is uniform: --list → pick tool → tool --help → invoke).
+    """
+    started = int(time.time() * 1000)
+    if rest and rest[0] in ("--help", "-h"):
+        sys.stdout.write(_REPL_HELP)
+        sys.stdout.flush()
+        _post_sidechannel(
+            argv=["repl", "--help"],
+            stdout=_REPL_HELP,
+            stderr="",
+            exit_code=0,
+            started_ms=started,
+            finished_ms=int(time.time() * 1000),
+        )
+        return 0
+    code = " ".join(rest).strip() if rest else ""
+    if not code:
+        msg = (
+            "Usage: browser repl '<python code>'  "
+            "(run `browser repl --help` for the full doc)\n"
+        )
+        sys.stderr.write(msg)
+        sys.stderr.flush()
+        _post_sidechannel(
+            argv=["repl"],
+            stdout="",
+            stderr=msg,
+            exit_code=2,
+            started_ms=started,
+            finished_ms=int(time.time() * 1000),
+        )
+        return 2
+
+    try:
+        info = _ensure_repl_server()
+    except Exception as exc:
+        err = f"failed to start browser repl server: {exc}\n"
+        sys.stderr.write(err)
+        sys.stderr.flush()
+        _post_sidechannel(
+            argv=["repl"] + rest,
+            stdout="",
+            stderr=err,
+            exit_code=1,
+            started_ms=started,
+            finished_ms=int(time.time() * 1000),
+        )
+        return 1
+
+    body = json.dumps({"code": code}).encode("utf-8")
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{info['port']}/exec",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body)),
+            "X-Repl-Secret": info["secret"],
+        },
+    )
+    try:
+        # No outer timeout: user code may legitimately run for minutes
+        # (waiting on a page_wait_ready, a slow navigation, etc.). The
+        # server-side asyncio loop is what bounds blocking CDP calls;
+        # if the server itself wedges, openclaw's exec timeout will
+        # catch us at a higher layer.
+        with urllib.request.urlopen(req) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        err = f"browser repl transport failure: {exc}\n"
+        sys.stderr.write(err)
+        sys.stderr.flush()
+        _post_sidechannel(
+            argv=["repl"] + rest,
+            stdout="",
+            stderr=err,
+            exit_code=1,
+            started_ms=started,
+            finished_ms=int(time.time() * 1000),
+        )
+        return 1
+
+    # Format for LLM consumption:
+    #   - any user-side stdout passes through first (prints the LLM did
+    #     inside their snippet)
+    #   - then the repr of the last expression value, if any, preceded
+    #     by a stable marker (`=> `) so the LLM can ignore prints and
+    #     lock onto the result when the snippet was eval-style
+    #   - stderr appended last, distinguished by the `[stderr] ` prefix
+    #   - errors render as a Python-style traceback block the LLM
+    #     already recognises from countless tracebacks in training data
+    stdout_raw = payload.get("stdout") or ""
+    stderr_raw = payload.get("stderr") or ""
+    result_repr = payload.get("result")
+    error_info = payload.get("error")
+
+    out_parts: list[str] = []
+    if stdout_raw:
+        out_parts.append(stdout_raw if stdout_raw.endswith("\n") else stdout_raw + "\n")
+    if result_repr is not None:
+        out_parts.append(f"=> {result_repr}\n")
+    combined_stdout = "".join(out_parts)
+
+    err_parts: list[str] = []
+    if stderr_raw:
+        err_parts.append(stderr_raw if stderr_raw.endswith("\n") else stderr_raw + "\n")
+    if error_info is not None:
+        tb = error_info.get("traceback") or f"{error_info.get('type')}: {error_info.get('message')}"
+        err_parts.append(tb if tb.endswith("\n") else tb + "\n")
+    combined_stderr = "".join(err_parts)
+
+    sys.stdout.write(combined_stdout)
+    sys.stdout.flush()
+    sys.stderr.write(combined_stderr)
+    sys.stderr.flush()
+
+    exit_code = 1 if error_info is not None else 0
+    _post_sidechannel(
+        argv=["repl"] + rest,
+        stdout=combined_stdout,
+        stderr=combined_stderr,
+        exit_code=exit_code,
+        started_ms=started,
+        finished_ms=int(time.time() * 1000),
+    )
+    return exit_code
 
 
 def _run_tool(tool: str, rest: list[str]) -> int:
@@ -278,6 +569,12 @@ def main() -> int:
             finished_ms=int(time.time() * 1000),
         )
         return code
+    if argv[0] == "repl":
+        # `repl` is a sudowork-side orchestration tool (persistent
+        # Python interpreter for batching atomic ops + state reuse)
+        # rather than an ai_dev_browser.tools.* module, so it's
+        # handled before the upstream tool-dispatch path.
+        return _run_repl(argv[1:])
     return _run_tool(argv[0], argv[1:])
 
 

--- a/resources/sudoclaw-bin/browser_repl_server.py
+++ b/resources/sudoclaw-bin/browser_repl_server.py
@@ -1,0 +1,497 @@
+"""Long-running Python REPL server for the `browser repl` tool.
+
+The file has two halves, separated by the `# ── sudowork orchestration
+below ──` marker. The top half is **generic** — if ai-dev-browser
+upstream ever ships a `ReplKernel`, the top half is what gets replaced
+by a 1-line `from ai_dev_browser import ReplKernel` import. The bottom
+half is sudowork-specific — HTTP transport, process lifecycle, the
+discovery file at `~/.nexus/sudoclaw/repl-server.json`, and the CLI
+entrypoint that `browser_helper.py` spawns.
+
+Why split inside one file (for now)
+-----------------------------------
+The sudoclaw-bin directory is a flat pool of scripts that get copied
+into `~/.nexus/sudoclaw/bin/`, not a Python package with module paths.
+Keeping the kernel + orchestration in one file matches that deployment
+shape while still encoding the generic/sudowork boundary with a
+prominent comment marker, so future extraction is a file split rather
+than an API redesign.
+
+Why a dedicated server at all
+-----------------------------
+Each `python -c "..."` invocation pays:
+  * Python interpreter cold start   ~200ms
+  * `import ai_dev_browser.core`    ~150ms
+  * Port detection + CDP connect    ~250ms
+  * `get_active_tab`                ~50ms
+  ────────────────────────────────
+  Total: ~650ms of overhead **before** the actual work runs, repeated
+  every tool_call. For a 60-step task that is ~40 seconds of waste.
+
+By keeping the interpreter + CDP connection hot across calls, the
+overhead collapses to one cold start per `browser_start` session;
+subsequent `browser repl` calls are ~10ms transport + whatever the
+user's code itself takes. The LLM can also define functions once and
+reuse them across tool_calls, which is impossible with per-call python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import asyncio
+import contextlib
+import hmac
+import http.server
+import io
+import json
+import os
+import pathlib
+import secrets
+import signal
+import socketserver
+import sys
+import threading
+import traceback
+from typing import Any
+
+
+def _ensure_ai_dev_browser_on_sys_path() -> None:
+    """Prepend the sudowork skill-dir to `sys.path` so `import
+    ai_dev_browser` resolves to the junction-linked upstream package
+    rather than any stale pip-installed copy.
+
+    Mirrors `browser_helper.py._ensure_ai_dev_browser_on_sys_path`.
+    This server runs in a separately-spawned Python process that
+    doesn't inherit PYTHONPATH (openclaw's safety hook strips it), so
+    we resolve the skill path directly from
+    `~/.nexus/skills/_system/browser`, the same junction the helper
+    uses.
+    """
+    skill_dir = pathlib.Path.home() / ".nexus" / "skills" / "_system" / "browser"
+    if not skill_dir.is_dir():
+        return
+    skill_dir_str = str(skill_dir)
+    if skill_dir_str in sys.path:
+        return
+    sys.path.insert(0, skill_dir_str)
+
+
+_ensure_ai_dev_browser_on_sys_path()
+
+
+# ────────────────────────────────────────────────────────────────────
+# Generic ReplKernel — ship candidate for ai-dev-browser upstream.
+#
+# Implements the three responsibilities a browser-bound Python REPL
+# needs regardless of which orchestrator hosts it:
+#   1. `start()`      — pre-import ai_dev_browser.core and open a
+#                       `quick_connect` session so `tab` + every core
+#                       function are ready in the exec namespace before
+#                       any user code runs. Graceful on Chrome being
+#                       absent (REPL still works for pure Python).
+#   2. `exec(code)`   — IPython-style compile/eval:
+#                         * parse as exec; peel off the trailing
+#                           `ast.Expr` if present;
+#                         * compile the rest with
+#                           `PyCF_ALLOW_TOP_LEVEL_AWAIT` so bare
+#                           `await foo()` at module level just works;
+#                         * run + await; then eval the trailing
+#                           expression for a Jupyter-style return
+#                           value; bind it to `_`.
+#                       Returns a JSON-safe dict: {stdout, stderr,
+#                       result, error}.
+#   3. `stop()`       — close the quick_connect CDP connection.
+#
+# Kept orchestrator-agnostic: no HTTP, no process spawning, no
+# discovery, no CLI. A hypothetical `ai_dev_browser.ReplKernel` would
+# be this class verbatim. When/if that lands upstream, the sudowork
+# orchestration below becomes `from ai_dev_browser import ReplKernel`
+# with no semantic change.
+# ────────────────────────────────────────────────────────────────────
+
+
+class ReplKernel:
+    """Persistent Python exec kernel with ai-dev-browser globals pre-bound."""
+
+    def __init__(self) -> None:
+        # Clean module namespace — matches what a freshly-imported
+        # `python -c` script's globals would hold, so code the LLM
+        # writes runs the same way in the REPL as outside it.
+        self._globals: dict[str, Any] = {"__name__": "__main__", "__doc__": None}
+        # quick_connect context manager + yielded Tab — held for the
+        # kernel's lifetime so `stop()` can close the CDP connection
+        # cleanly. `None` until `start()` succeeds.
+        self._qc_cm: Any = None
+        self._qc_tab: Any = None
+
+    @property
+    def globals(self) -> dict[str, Any]:
+        """Exposed so orchestrators can inject additional names (e.g.
+        their own helpers) before `start()`. Users of the kernel should
+        NOT mutate this after exec calls begin; it's shared with every
+        running user snippet.
+        """
+        return self._globals
+
+    async def start(self) -> None:
+        """Bind `ai_dev_browser.core` functions + an attached `tab` into
+        the exec globals. Never raises: if ai_dev_browser is missing or
+        no Chrome is reachable, the kernel still works for pure-Python
+        snippets and the orchestrator can surface a warning. Any code
+        the LLM writes that needs `tab` will raise `NameError` at
+        exec time, which is the right behaviour — "missing tab" is a
+        user-code concern, not a kernel-start concern.
+        """
+        self._globals.setdefault("asyncio", asyncio)
+
+        try:
+            import ai_dev_browser  # type: ignore[import-not-found]
+            from ai_dev_browser import core as _core  # type: ignore[import-not-found]
+        except Exception as exc:
+            sys.stderr.write(f"[ReplKernel] ai_dev_browser import failed: {exc!r}\n")
+            sys.stderr.flush()
+            return
+
+        self._globals["ai_dev_browser"] = ai_dev_browser
+        self._globals["core"] = _core
+        self._globals["quick_connect"] = getattr(ai_dev_browser, "quick_connect", None)
+        # Pull every public callable from `core` into globals — that's
+        # type_by_ref, click_by_ref, page_discover, etc. Skip dunders
+        # and submodules so the namespace stays browsable.
+        for name in dir(_core):
+            if name.startswith("_"):
+                continue
+            obj = getattr(_core, name)
+            if callable(obj):
+                self._globals[name] = obj
+
+        quick_connect = self._globals.get("quick_connect")
+        if quick_connect is None:
+            sys.stderr.write(
+                "[ReplKernel] ai_dev_browser.quick_connect not found "
+                "(need v0.6.2+); `tab` will not be pre-bound\n"
+            )
+            sys.stderr.flush()
+            return
+
+        try:
+            cm = quick_connect()
+            tab = await cm.__aenter__()
+        except Exception as exc:
+            sys.stderr.write(
+                f"[ReplKernel] quick_connect failed "
+                f"(continuing without `tab`): {exc!r}\n"
+            )
+            sys.stderr.flush()
+            return
+
+        self._qc_cm = cm
+        self._qc_tab = tab
+        self._globals["tab"] = tab
+        sys.stderr.write(
+            "[ReplKernel] ai_dev_browser.core bound; `tab` ready via quick_connect\n"
+        )
+        sys.stderr.flush()
+
+    async def stop(self) -> None:
+        """Release the quick_connect CDP connection. Never raises."""
+        if self._qc_cm is None:
+            return
+        try:
+            await self._qc_cm.__aexit__(None, None, None)
+        except Exception as exc:
+            sys.stderr.write(f"[ReplKernel] quick_connect teardown warning: {exc!r}\n")
+            sys.stderr.flush()
+        finally:
+            self._qc_cm = None
+            self._qc_tab = None
+
+    async def exec(self, code: str) -> dict:
+        """Run `code` in the persistent globals.
+
+        Returns a dict with keys:
+          * stdout (str)   — whatever user code printed to stdout
+          * stderr (str)   — …and to stderr
+          * result (str | None) — `repr()` of the trailing expression's
+                                  value, or None if the last statement
+                                  isn't an expression (or is None)
+          * error  (dict | None) — {type, message, traceback} on
+                                   exception; None on success
+
+        Top-level `await` works directly. The split-last-expression
+        eval is what lets `await x` work as both a statement (inline
+        side-effect) and an expression (returns value as `=> ...`).
+        """
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        result_repr: str | None = None
+        error_info: dict | None = None
+
+        try:
+            tree = ast.parse(code, filename="<repl>", mode="exec")
+        except SyntaxError as exc:
+            return {
+                "stdout": "",
+                "stderr": "",
+                "result": None,
+                "error": {
+                    "type": "SyntaxError",
+                    "message": str(exc),
+                    "traceback": traceback.format_exc(),
+                },
+            }
+
+        last_expr: ast.Expr | None = None
+        if tree.body and isinstance(tree.body[-1], ast.Expr):
+            last_expr = tree.body.pop()  # type: ignore[assignment]
+
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                if tree.body:
+                    body_code = compile(
+                        ast.Module(body=tree.body, type_ignores=[]),
+                        "<repl>",
+                        "exec",
+                        flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+                    )
+                    maybe_coro = eval(body_code, self._globals)  # noqa: S307
+                    if asyncio.iscoroutine(maybe_coro):
+                        await maybe_coro
+
+                if last_expr is not None:
+                    expr_code = compile(
+                        ast.Expression(body=last_expr.value),
+                        "<repl-expr>",
+                        "eval",
+                        flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+                    )
+                    value = eval(expr_code, self._globals)  # noqa: S307
+                    if asyncio.iscoroutine(value):
+                        value = await value
+                    if value is not None:
+                        # Python REPL convention: `_` = last non-None
+                        # expression value, so follow-up snippets can
+                        # reference it without the LLM having to
+                        # assign every intermediate.
+                        self._globals["_"] = value
+                        try:
+                            result_repr = repr(value)
+                        except Exception as exc:
+                            result_repr = f"<unrepresentable: {exc!r}>"
+        except BaseException as exc:
+            error_info = {
+                "type": type(exc).__name__,
+                "message": str(exc),
+                "traceback": traceback.format_exc(),
+            }
+
+        return {
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+            "result": result_repr,
+            "error": error_info,
+        }
+
+
+# ────────────────────────────────────────────────────────────────────
+# ── sudowork orchestration below ──
+#
+# Everything past this marker is sudowork-specific plumbing around
+# `ReplKernel`: HTTP transport with a per-server shared secret, the
+# discovery file at `~/.nexus/sudoclaw/repl-server.json` that lets the
+# dispatcher find a running instance, process spawn / shutdown via
+# signals, and the CLI entrypoint the dispatcher calls. None of this
+# belongs upstream — each orchestrator (sudowork, Claude Code, etc.)
+# has its own process-lifecycle and transport choices.
+# ────────────────────────────────────────────────────────────────────
+
+
+REPL_INFO_PATH = pathlib.Path.home() / ".nexus" / "sudoclaw" / "repl-server.json"
+
+_SECRET: str = ""
+_KERNEL: ReplKernel | None = None
+_MAIN_LOOP: asyncio.AbstractEventLoop | None = None
+_SHUTDOWN_EVENT: asyncio.Event | None = None
+
+
+class _ReplHTTPHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal HTTP handler. Routes:
+      GET  /health     — liveness probe, no auth required
+      POST /exec       — run Python code; requires X-Repl-Secret
+      POST /shutdown   — stop the server; requires X-Repl-Secret
+    """
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Silence the default per-request stderr spam; the dispatcher
+        # only cares about the response body.
+        return
+
+    def _json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _check_secret(self) -> bool:
+        provided = self.headers.get("X-Repl-Secret", "")
+        return hmac.compare_digest(provided, _SECRET)
+
+    def do_GET(self) -> None:  # noqa: N802 — stdlib API
+        if self.path == "/health":
+            self._json(200, {"ok": True, "pid": os.getpid()})
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802 — stdlib API
+        if not self._check_secret():
+            self._json(401, {"error": "unauthorized"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0") or 0)
+        raw = self.rfile.read(length) if length > 0 else b""
+        try:
+            body = json.loads(raw.decode("utf-8")) if raw else {}
+        except json.JSONDecodeError as exc:
+            self._json(400, {"error": f"bad json: {exc}"})
+            return
+
+        if self.path == "/shutdown":
+            if _MAIN_LOOP is not None and _SHUTDOWN_EVENT is not None:
+                _MAIN_LOOP.call_soon_threadsafe(_SHUTDOWN_EVENT.set)
+            self._json(202, {"ok": True})
+            return
+
+        if self.path == "/exec":
+            code = body.get("code", "")
+            if not isinstance(code, str):
+                self._json(400, {"error": "code must be a string"})
+                return
+            if _MAIN_LOOP is None or _KERNEL is None:
+                self._json(503, {"error": "kernel not ready"})
+                return
+            # Marshal the coroutine onto the main event loop (the one
+            # that owns quick_connect's Tab listener task) and wait
+            # for its result. Running it here in the HTTP thread's
+            # event loop would divorce it from that listener and the
+            # CDP round-trip would hang.
+            fut = asyncio.run_coroutine_threadsafe(_KERNEL.exec(code), _MAIN_LOOP)
+            try:
+                result = fut.result()
+            except Exception as exc:
+                self._json(
+                    500,
+                    {
+                        "error": "server-side exec failure",
+                        "detail": repr(exc),
+                        "traceback": traceback.format_exc(),
+                    },
+                )
+                return
+            self._json(200, result)
+            return
+
+        self._json(404, {"error": "not found"})
+
+
+class _ReuseAddrHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    """Threaded HTTP server so long-running exec calls don't block
+    concurrent health probes from the dispatcher. Daemon threads
+    mean shutdown doesn't have to gracefully join every outstanding
+    request.
+    """
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def _write_info_file(port: int) -> None:
+    REPL_INFO_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPL_INFO_PATH.write_text(
+        json.dumps(
+            {"pid": os.getpid(), "port": port, "secret": _SECRET},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _remove_info_file() -> None:
+    with contextlib.suppress(FileNotFoundError):
+        REPL_INFO_PATH.unlink()
+
+
+async def _main_async(host: str, port_pref: int) -> None:
+    global _MAIN_LOOP, _SHUTDOWN_EVENT, _SECRET, _KERNEL
+
+    _MAIN_LOOP = asyncio.get_running_loop()
+    _SHUTDOWN_EVENT = asyncio.Event()
+    _SECRET = secrets.token_hex(32)
+
+    _KERNEL = ReplKernel()
+    await _KERNEL.start()
+
+    server = _ReuseAddrHTTPServer((host, port_pref), _ReplHTTPHandler)
+    actual_port = server.server_address[1]
+    _write_info_file(actual_port)
+
+    server_thread = threading.Thread(
+        target=server.serve_forever,
+        name="browser-repl-http",
+        daemon=True,
+    )
+    server_thread.start()
+
+    # POSIX signals — Windows console-close won't fire SIGTERM but
+    # ServiceManager can still kill the PID directly.
+    def _signal_shutdown(*_: Any) -> None:
+        if _MAIN_LOOP is not None and _SHUTDOWN_EVENT is not None:
+            _MAIN_LOOP.call_soon_threadsafe(_SHUTDOWN_EVENT.set)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(ValueError, AttributeError):
+            signal.signal(sig, _signal_shutdown)
+
+    sys.stderr.write(
+        f"[browser_repl_server] listening on http://{host}:{actual_port}"
+        f" (pid={os.getpid()})\n"
+    )
+    sys.stderr.flush()
+
+    try:
+        await _SHUTDOWN_EVENT.wait()
+    finally:
+        await _KERNEL.stop()
+        server.shutdown()
+        server.server_close()
+        _remove_info_file()
+        sys.stderr.write("[browser_repl_server] stopped\n")
+        sys.stderr.flush()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Persistent Python REPL for `browser repl`.")
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Loopback bind address; should stay on 127.0.0.1 — the server is not hardened for remote use.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="Preferred port; 0 lets the kernel pick a free one (default).",
+    )
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(_main_async(args.host, args.port))
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

New CLI subcommand `browser repl '<python code>'` that drives a persistent Python interpreter (alive across tool_calls, CDP connection held, `tab` pre-bound via `quick_connect()`).

Eliminates the ~700ms × N cold-start overhead LLMs pay when chaining atomic browser ops, and gives them a first-class way to define+reuse functions (useful for captcha-retry-style flows). lis8 run 2 observed the LLM trying to escape the cold-start treadmill by writing `python .drafts/login.py` and burning 4 steps on setup boilerplate — this PR gives them a clean path instead.

## What's in it

**`resources/sudoclaw-bin/browser_repl_server.py`** (new) — split into two halves by a comment marker:

- **Top half — generic `ReplKernel` class**: IPython-style compile+eval with `PyCF_ALLOW_TOP_LEVEL_AWAIT`, quick_connect-based tab binding, Jupyter-style `=> result` + `_` convention. Orchestrator-agnostic. **Candidate for upstream extraction to `ai_dev_browser.ReplKernel`** if/when a 2nd consumer signals demand.
- **Bottom half — sudowork orchestration**: loopback HTTP with per-server `hmac.compare_digest` secret, discovery file at `~/.nexus/sudoclaw/repl-server.json`, threaded `ReuseAddrHTTPServer`, CLI entrypoint. Stdlib only (no aiohttp).

**`resources/sudoclaw-bin/browser_helper.py`** — adds `repl` subcommand routing before the ai_dev_browser tool dispatch. Lazy-spawns the server on first call, reuses via discovery file on subsequent calls. `browser repl --help` prints a full docstring; `browser --list` appends a single-line entry prefixed `(sudowork)` for clear provenance.

## Semantics

```bash
# Call 1: define once
browser repl '
async def login(captcha):
    await type_by_html_id(tab, "UserCode2", "tuanxiancs")
    await type_by_html_id(tab, "Captcha", captcha)
    await click_by_html_id(tab, "submit")
'

# Call 2: invoke
browser repl 'await login("9830")'

# Call 3: captcha was wrong, retry without redefining
browser repl 'await login("6726")'
```

Pre-bound globals: `tab`, every public function in `ai_dev_browser.core`, `asyncio`, `_` (last non-None result).

## Scope boundaries

- **No ServiceManager-driven lifecycle yet** — dispatcher lazy-spawns, orphan processes linger if Chrome dies without clean `browser_stop`. Followup.
- **Not registered as an openclaw-tier tool** (peer of exec/read/write) — `browser --list` discovery works, and openclaw's tool-catalog injection is more invasive (bundle patching). Acceptable for now.
- **No data on LLM adoption rate yet** — re-running lis8 e2e to collect this; will update PR description with the data before merge.

## Why split inside one file

sudoclaw-bin is a flat script pool (not a Python package), so a single file matches the deployment shape. The `# ── sudowork orchestration below ──` marker encodes the generic/orchestrator-specific split explicitly. When/if `ReplKernel` goes upstream, the orchestration half will switch from defining the class inline to `from ai_dev_browser import ReplKernel` — mechanical.

## Test plan

- [x] Skeleton smoke test: `print("hello")`, state persistence, top-level await, error traceback — all verified locally
- [x] Real browser op via REPL: `await page_goto(tab, "https://example.com"); await tab.evaluate("document.title")` returns `'Example Domain'`
- [x] Function def + reuse across tool_calls — verified
- [x] `browser --list` shows `repl (sudowork) ...` line
- [x] `browser repl --help` returns full usage doc
- [ ] Full lis8 e2e with REPL available — pending, results will update PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)