### PR TITLE
fix(installer): fix "Run Sudowork" not launching after install (#366)

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -376,6 +376,10 @@ $\r$\n\
       ${else}
         StrCpy $1 ""
       ${endif}
+      ; Defensive fallback: if $launchLink target is missing, use the exe (#366)
+      ${IfNot} ${FileExists} "$launchLink"
+        StrCpy $launchLink "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+      ${EndIf}
       ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
     FunctionEnd
 
@@ -424,6 +428,9 @@ $\r$\n\
     !else
       Delete "$SMPROGRAMS\${SHORTCUT_NAME}.lnk"
     !endif
+    ; electron-builder sets $launchLink to the start menu .lnk BEFORE
+    ; customInstall runs; repoint it to the exe now that the .lnk is gone (#366)
+    StrCpy $launchLink "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
     DetailPrint "Skipped start menu shortcut per user preference."
   ${EndIf}
 


### PR DESCRIPTION
## Summary
- Fix "Run Sudowork" checkbox not working after installation when user skips start menu shortcut creation
- Add defensive fallback: if `$launchLink` target is missing, use the exe directly
- Repoint `$launchLink` to exe after `.lnk` deletion when user opts out of start menu shortcut

## Test plan
- [ ] Install with "Create start menu shortcut" enabled → "Run Sudowork" works
- [ ] Install with "Create start menu shortcut" disabled → "Run Sudowork" still works
- [ ] Verify existing installer flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)