### PR TITLE
fix: 合并草稿箱文件支持与文件删除即时更新到 @文件 选择器

### DIFF
--- a/src/renderer/components/SkillSelectorMenu.tsx
+++ b/src/renderer/components/SkillSelectorMenu.tsx
@@ -260,10 +260,13 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
               >
                 <div className='flex items-center gap-8px'>
                   <div className='w-24px h-24px flex-shrink-0 rd-4px bg-fill-2 flex items-center justify-center text-14px'>
-                    <span>📄</span>
+                    <span>{file.isDraft ? '📝' : '📄'}</span>
                   </div>
                   <div className='min-w-0 flex-1'>
-                    <div className={classNames('text-13px truncate', index === activeIndex ? 'text-t-primary font-semibold' : 'text-t-primary font-medium')}>{file.name}</div>
+                    <div className='flex items-center gap-6px min-w-0'>
+                      <span className={classNames('text-13px truncate', index === activeIndex ? 'text-t-primary font-semibold' : 'text-t-primary font-medium')}>{file.name}</span>
+                      {file.isDraft && <span className='px-4px py-0px text-9px rd-3px whitespace-nowrap flex-shrink-0 leading-14px' style={{ background: 'color-mix(in srgb, var(--color-warning-light-1) 60%, transparent)', color: 'var(--color-warning-6, #d4930a)' }}>草稿</span>}
+                    </div>
                     <div className='text-11px text-t-secondary truncate mt-1px'>{file.relativePath}</div>
                   </div>
                 </div>

--- a/src/renderer/hooks/useWorkspaceFiles.ts
+++ b/src/renderer/hooks/useWorkspaceFiles.ts
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';
+import { DRAFTS_DIR_NAME } from '@/common/constants';
 import { useConversationContextSafe } from '@/renderer/context/ConversationContext';
 import { useAddEventListener } from '@/renderer/utils/emitter';
 
@@ -22,6 +23,8 @@ export interface WorkspaceFileItem {
   relativePath: string;
   /** Whether this is a file (true) or directory (false) */
   isFile: boolean;
+  /** Whether this file is from the drafts folder / 是否为草稿箱文件 */
+  isDraft?: boolean;
 }
 
 /**
@@ -60,8 +63,31 @@ export function useWorkspaceFiles(): WorkspaceFileItem[] {
     if (!workspace || loadingRef.current) return;
     loadingRef.current = true;
     try {
-      const result = await ipcBridge.fs.getFilesByDir.invoke({ dir: workspace, root: workspace });
+      // Fetch workspace files and draft files in parallel
+      // 并行获取工作空间文件和草稿箱文件
+      const [result, draftsResult] = await Promise.all([
+        ipcBridge.fs.getFilesByDir.invoke({ dir: workspace, root: workspace }),
+        ipcBridge.workspaceManage.listDrafts.invoke({ workspace }).catch(() => null),
+      ]);
+
       const flatList = result && result.length > 0 && result[0].children ? flattenFileTree(result[0].children) : [];
+
+      // Merge draft files into the list with isDraft flag
+      // 将草稿箱文件合并到列表中，标记 isDraft
+      if (draftsResult?.success && draftsResult.data && draftsResult.data.length > 0) {
+        const sep = workspace.includes('\\') ? '\\' : '/';
+        const draftsDir = `${workspace}${sep}${DRAFTS_DIR_NAME}`;
+        for (const draft of draftsResult.data) {
+          flatList.push({
+            name: draft.name,
+            fullPath: `${draftsDir}${sep}${draft.name}`,
+            relativePath: `${DRAFTS_DIR_NAME}/${draft.name}`,
+            isFile: true,
+            isDraft: true,
+          });
+        }
+      }
+
       flatList.sort((a, b) => a.name.localeCompare(b.name));
       setFiles(flatList);
     } catch (error) {
@@ -75,6 +101,31 @@ export function useWorkspaceFiles(): WorkspaceFileItem[] {
   useEffect(() => {
     void loadFiles();
   }, [loadFiles]);
+
+  // Listen for file system changes (dirChanged) to auto-refresh on delete/rename
+  // 监听文件系统变更事件，文件删除/重命名后自动刷新列表
+  useEffect(() => {
+    if (!workspace) return;
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const lastRefreshRef = { current: 0 };
+    const COOLDOWN_MS = 1000;
+
+    const unsubscribe = ipcBridge.fileWatch.dirChanged.on(() => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        if (Date.now() - lastRefreshRef.current < COOLDOWN_MS) return;
+        lastRefreshRef.current = Date.now();
+        void loadFiles();
+      }, 300);
+    });
+
+    return () => {
+      unsubscribe();
+      if (debounceTimer) clearTimeout(debounceTimer);
+    };
+  }, [workspace, loadFiles]);
 
   // Listen for workspace refresh events (when agent creates/modifies files)
   useAddEventListener(

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
@@ -162,6 +162,8 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
       } else {
         emitter.emit('acp.selected.file', []);
       }
+      // Notify @file selector to refresh / 通知 @文件 选择器刷新
+      emitter.emit(`${eventPrefix}.workspace.refresh` as any);
       closeDeleteModal();
       setTimeout(() => refreshWorkspace(), 200);
     } catch (error) {
@@ -259,6 +261,8 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
       }
 
       messageApi.success(t('conversation.workspace.contextMenu.renameSuccess'));
+      // Notify @file selector to refresh / 通知 @文件 选择器刷新
+      emitter.emit(`${eventPrefix}.workspace.refresh` as any);
     } catch (error) {
       if (error instanceof Error && error.message === 'timeout') {
         messageApi.error(t('conversation.workspace.contextMenu.renameTimeout'));


### PR DESCRIPTION
## Summary
- 并行获取草稿箱文件（listDrafts），合并到 @文件选择器并显示 📝 “草稿” 标识
- 添加 dirChanged 文件系统监听器，实现文件删除/重命名后选择器即时刷新
- 文件删除/重命名操作后发送 workspace.refresh 事件通知

Closes #418

Generated with [Claude Code](https://claude.ai/code)