### PR TITLE
feat: add tenant-level customization for client logo and name fields

### DIFF
--- a/src/common/types/tenantConfig.ts
+++ b/src/common/types/tenantConfig.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tenant configuration types
+ * 租户配置类型定义
+ */
+
+/**
+ * 租户配置接口响应字段
+ */
+export interface TenantConfig {
+  /** Logo 图片 base64 编码（如：data:image/png;base64,xxx） */
+  logo?: string;
+  /** App Name - 登录页标题、首页侧栏名称 */
+  app_name?: string;
+  /** Top Name - 客户端顶部 header（标题栏 Titlebar）显示 */
+  top_name?: string;
+  /** Login Description - 登录页副标题 */
+  login_desp?: string;
+  /** About Name - 关于页标题 */
+  about_name?: string;
+  /** 公司主体名称 - 关于页公司信息 */
+  app_company_name?: string;
+}
+
+/**
+ * 租户配置接口响应结构
+ */
+export interface TenantConfigResponse {
+  success: boolean;
+  data?: TenantConfig;
+  msg?: string;
+}
+
+/**
+ * 默认租户配置
+ * 当接口未返回或字段为空时使用此默认值
+ */
+export const DEFAULT_TENANT_CONFIG: Required<TenantConfig> = {
+  logo: undefined,
+  app_name: 'SudoClaw',
+  top_name: 'SudoClaw',
+  login_desp: 'AgentOps | 办公专家',
+  about_name: 'SudoClaw',
+  app_company_name: '北京数牍科技有限公司',
+};

--- a/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
@@ -11,6 +11,7 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useSettingsViewMode } from '../settingsViewContext';
+import { useTenantConfig } from '@/renderer/context/TenantConfigContext';
 import { buildVersion, buildDate, buildCommit, isNightlyBuild } from '@/common/buildInfo';
 import OpsModal from '@/renderer/components/OpsModal';
 import sudoIcon from '@/renderer/assets/sudowork-icon-dark.svg';
@@ -22,6 +23,7 @@ const AboutModalContent: React.FC = () => {
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
   const { t } = useTranslation();
+  const { config } = useTenantConfig();
   const [opsVisible, setOpsVisible] = useState<boolean>(false);
 
   return (
@@ -30,12 +32,12 @@ const AboutModalContent: React.FC = () => {
         <div className='flex flex-col max-w-540px mx-auto'>
           <div className='flex flex-col items-center py-28px'>
             <div className='w-48px h-48px flex items-center justify-center mb-12px'>
-              <img src={sudoIcon} alt='SudoClaw' className='w-42px h-42px' />
+              <img src={config.logo || sudoIcon} alt={config.about_name} className='w-42px h-42px' />
             </div>
             <Typography.Title heading={4} className='text-18px font-700 text-t-primary mb-4px mt-0'>
-              SudoClaw
+              {config.about_name}
             </Typography.Title>
-            <div className='text-12px text-t-tertiary'>北京数牍科技有限公司</div>
+            <div className='text-12px text-t-tertiary'>{config.app_company_name}</div>
             <button type='button' className='mt-6px mb-10px inline-flex items-center gap-4px bg-transparent border-none p-0 text-12px text-primary cursor-pointer underline-offset-3 hover:underline' onClick={() => void openExternalUrl(OFFICIAL_WEBSITE_URL).catch(console.error)}>
               <span>{t('settings.officialWebsite')}</span>
               <IconLink className='text-12px' />

--- a/src/renderer/components/Titlebar/index.tsx
+++ b/src/renderer/components/Titlebar/index.tsx
@@ -10,17 +10,26 @@ import { WORKSPACE_STATE_EVENT, dispatchWorkspaceToggleEvent } from '@renderer/u
 import type { WorkspaceStateDetail } from '@renderer/utils/workspaceEvents';
 import { useLayoutContext } from '@/renderer/context/LayoutContext';
 import { isElectronDesktop, isMacOS } from '@/renderer/utils/platform';
+import { useTenantConfig } from '@/renderer/context/TenantConfigContext';
+import { DEFAULT_TENANT_CONFIG } from '@/common/types/tenantConfig';
 import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 
 interface TitlebarProps {
   workspaceAvailable: boolean;
 }
 
-const AionLogoMark: React.FC = () => <img src={SudoworkIcon} alt='SudoClaw' className='app-titlebar__brand-logo w-5 h-5 object-contain' />;
+const AionLogoMark: React.FC<{ config: Required<typeof DEFAULT_TENANT_CONFIG> }> = ({ config }) => (
+  <img
+    src={config.logo || SudoworkIcon}
+    alt={config.app_name}
+    className='app-titlebar__brand-logo w-5 h-5 object-contain'
+  />
+);
 
 const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
   const { t } = useTranslation();
-  const appTitle = useMemo(() => 'SudoClaw', []);
+  const { config } = useTenantConfig();
+  const appTitle = useMemo(() => config.top_name, [config.top_name]);
   const [workspaceCollapsed, setWorkspaceCollapsed] = useState(true);
   const [mobileCenterTitle, setMobileCenterTitle] = useState(appTitle);
   const [mobileCenterOffset, setMobileCenterOffset] = useState(0);
@@ -212,7 +221,7 @@ const Titlebar: React.FC<TitlebarProps> = ({ workspaceAvailable }) => {
       <div className='app-titlebar__brand' aria-label={layout?.isMobile ? mobileCenterTitle : appTitle} title={layout?.isMobile ? mobileCenterTitle : appTitle}>
         {layout?.isMobile ? (
           <span className='app-titlebar__brand-mobile'>
-            <AionLogoMark />
+            <AionLogoMark config={config} />
             <span className='app-titlebar__brand-text'>{mobileCenterTitle}</span>
           </span>
         ) : (

--- a/src/renderer/context/TenantConfigContext.tsx
+++ b/src/renderer/context/TenantConfigContext.tsx
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { ipcBridge } from '@/common';
+import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { TenantConfig, TenantConfigResponse, DEFAULT_TENANT_CONFIG } from '@/common/types/tenantConfig';
+import { useAuth } from './AuthContext';
+
+const TENANT_CONFIG_STORAGE_KEY = 'sudowork_tenant_config';
+const POLL_INTERVAL_MS = 10 * 60 * 1000; // 10 分钟
+
+interface TenantConfigContextValue {
+  /** 当前租户配置 */
+  config: Required<TenantConfig>;
+  /** 加载状态 */
+  loading: boolean;
+  /** 手动刷新配置 */
+  refresh: () => Promise<void>;
+}
+
+const TenantConfigContext = createContext<TenantConfigContextValue | undefined>(undefined);
+
+/**
+ * 租户配置 Provider
+ *
+ * 更新策略：
+ * 1. 登录成功后立即刷新配置
+ * 2. 登录状态下每 10 分钟定时轮询刷新
+ * 3. 登出时重置 config 为默认值，停止轮询（不清除 localStorage）
+ */
+export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { user, status, ensureValidToken } = useAuth();
+
+  // 初始化时从 localStorage 加载缓存
+  const [config, setConfig] = useState<Required<TenantConfig>>(() => {
+    try {
+      const cached = localStorage.getItem(TENANT_CONFIG_STORAGE_KEY);
+      if (cached) {
+        const parsed = JSON.parse(cached);
+        return { ...DEFAULT_TENANT_CONFIG, ...parsed };
+      }
+    } catch {
+      // ignore parse error
+    }
+    return DEFAULT_TENANT_CONFIG;
+  });
+
+  const [loading, setLoading] = useState(false);
+  const isRefreshing = useRef(false);
+  const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  /**
+   * 从服务端获取租户配置
+   */
+  const fetchConfig = useCallback(async () => {
+    // 未登录或缺少 enterprise_code，不请求
+    if (status !== 'authenticated' || !user?.enterprise_code) {
+      return;
+    }
+
+    // 防止重复请求
+    if (isRefreshing.current) return;
+    isRefreshing.current = true;
+    setLoading(true);
+
+    try {
+      const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
+      const baseUrl = serverConfig.baseUrl || SUDOWORK_SERVER_BASE_URL;
+      const token = await ensureValidToken();
+
+      if (!token) {
+        console.warn('[TenantConfig] No valid token');
+        isRefreshing.current = false;
+        setLoading(false);
+        return;
+      }
+
+      // 使用 enterprise_code 作为租户 code 参数
+      const url = `${baseUrl}/api/v1/tenant/config?code=${user.enterprise_code}`;
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        console.warn('[TenantConfig] API response not OK:', response.status);
+        isRefreshing.current = false;
+        setLoading(false);
+        return;
+      }
+
+      const data: TenantConfigResponse = await response.json();
+
+      if (data.success && data.data) {
+        // 合并默认值，空字段使用默认值
+        const mergedConfig: Required<TenantConfig> = {
+          logo: data.data.logo || DEFAULT_TENANT_CONFIG.logo,
+          app_name: data.data.app_name || DEFAULT_TENANT_CONFIG.app_name,
+          top_name: data.data.top_name || DEFAULT_TENANT_CONFIG.top_name,
+          login_desp: data.data.login_desp || DEFAULT_TENANT_CONFIG.login_desp,
+          about_name: data.data.about_name || DEFAULT_TENANT_CONFIG.about_name,
+          app_company_name: data.data.app_company_name || DEFAULT_TENANT_CONFIG.app_company_name,
+        };
+        setConfig(mergedConfig);
+        // 缓存到 localStorage
+        localStorage.setItem(TENANT_CONFIG_STORAGE_KEY, JSON.stringify(mergedConfig));
+        console.log('[TenantConfig] Config updated:', mergedConfig);
+      } else {
+        console.warn('[TenantConfig] API returned unsuccessful:', data.msg);
+      }
+    } catch (error) {
+      console.error('[TenantConfig] Fetch failed:', error);
+    }
+
+    isRefreshing.current = false;
+    setLoading(false);
+  }, [status, user?.enterprise_code, ensureValidToken]);
+
+  /**
+   * 启动定时轮询
+   */
+  const startPolling = useCallback(() => {
+    if (pollTimerRef.current) return; // 已在运行
+
+    pollTimerRef.current = setInterval(() => {
+      console.log('[TenantConfig] Polling refresh...');
+      void fetchConfig();
+    }, POLL_INTERVAL_MS);
+    console.log('[TenantConfig] Polling started (10min interval)');
+  }, [fetchConfig]);
+
+  /**
+   * 停止定时轮询
+   */
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+      console.log('[TenantConfig] Polling stopped');
+    }
+  }, []);
+
+  // 监听登录状态变化
+  useEffect(() => {
+    if (status === 'authenticated' && user?.enterprise_code) {
+      // 登录成功 → 立即刷新 + 启动轮询
+      void fetchConfig();
+      startPolling();
+    } else if (status === 'unauthenticated') {
+      // 登出 → 重置 config 为默认值，停止轮询
+      // 注意：不清除 localStorage，保留缓存供下次启动登录页使用
+      setConfig(DEFAULT_TENANT_CONFIG);
+      stopPolling();
+    }
+  }, [status, user?.enterprise_code, fetchConfig, startPolling, stopPolling]);
+
+  // 清理定时器
+  useEffect(() => {
+    return () => {
+      stopPolling();
+    };
+  }, [stopPolling]);
+
+  const value = useMemo<TenantConfigContextValue>(
+    () => ({
+      config,
+      loading,
+      refresh: fetchConfig,
+    }),
+    [config, loading, fetchConfig]
+  );
+
+  return (
+    <TenantConfigContext.Provider value={value}>
+      {children}
+    </TenantConfigContext.Provider>
+  );
+};
+
+/**
+ * 获取租户配置 Context
+ */
+export function useTenantConfig(): TenantConfigContextValue {
+  const context = useContext(TenantConfigContext);
+  if (!context) {
+    throw new Error('useTenantConfig must be used within TenantConfigProvider');
+  }
+  return context;
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -11,6 +11,7 @@ import { createRoot } from 'react-dom/client';
 import '../adapter/browser';
 import Main from './main';
 import { AuthProvider } from './context/AuthContext';
+import { TenantConfigProvider } from './context/TenantConfigContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { PreviewProvider } from './pages/conversation/preview/context/PreviewContext';
 import { ConversationTabsProvider } from './pages/conversation/context/ConversationTabsContext';
@@ -62,7 +63,7 @@ const arcoLocales: Record<string, typeof enUS> = {
   'en-US': enUS,
 };
 
-const AppProviders: React.FC<PropsWithChildren> = ({ children }) => React.createElement(InitProvider, null, React.createElement(AuthProvider, null, React.createElement(ThemeProvider, null, React.createElement(PreviewProvider, null, React.createElement(ConversationTabsProvider, null, children)))));
+const AppProviders: React.FC<PropsWithChildren> = ({ children }) => React.createElement(InitProvider, null, React.createElement(AuthProvider, null, React.createElement(TenantConfigProvider, null, React.createElement(ThemeProvider, null, React.createElement(PreviewProvider, null, React.createElement(ConversationTabsProvider, null, children))))));
 
 const Config: React.FC<PropsWithChildren> = ({ children }) => {
   const {

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -16,6 +16,7 @@ import classNames from 'classnames';
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { LayoutContext } from './context/LayoutContext';
+import { useTenantConfig } from './context/TenantConfigContext';
 import { useDeepLink } from './hooks/useDeepLink';
 import { useDirectorySelection } from './hooks/useDirectorySelection';
 import { useMultiAgentDetection } from './hooks/useMultiAgentDetection';
@@ -82,6 +83,7 @@ const Layout: React.FC<{
   onSessionClick?: () => void;
 }> = ({ sider, onSessionClick: _onSessionClick }) => {
   const { hasEvent, status, confirm, cancel } = useSafetyCheck();
+  const { config } = useTenantConfig(); // 获取租户配置
   const [collapsed, setCollapsed] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [viewportWidth, setViewportWidth] = useState<number>(() => (typeof window === 'undefined' ? 390 : window.innerWidth));
@@ -315,8 +317,8 @@ const Layout: React.FC<{
                 onClick={onClick}
               >
                 <img
-                  src={SudoworkIcon}
-                  alt='SudoClaw'
+                  src={config.logo || SudoworkIcon}
+                  alt={config.app_name}
                   className={classNames('absolute inset-0 m-auto', {
                     'w-5.5 h-5.5 p-1 scale-140': !collapsed,
                     'w-4 h-4 p-0.5': collapsed,
@@ -324,7 +326,7 @@ const Layout: React.FC<{
                   style={{ objectFit: 'contain' }}
                 />
               </div>
-              <div className='flex-1 text-20px text-1 collapsed-hidden font-bold'>SudoClaw</div>
+              <div className='flex-1 text-20px text-1 collapsed-hidden font-bold'>{config.app_name}</div>
               {isMobile && !collapsed && (
                 <button type='button' className='app-titlebar__button' onClick={() => setCollapsed(true)} aria-label='Collapse sidebar'>
                   {collapsed ? <MenuUnfold theme='outline' size='18' fill='currentColor' /> : <MenuFold theme='outline' size='18' fill='currentColor' />}

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../context/AuthContext';
 import { Button, Input, Message, Space } from '@arco-design/web-react';
 import { Phone, Protect, Key, User } from '@icon-park/react';
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { DEFAULT_TENANT_CONFIG } from '@/common/types/tenantConfig';
 import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import WindowControls from '../../components/WindowControls';
 import './LoginPage.css';
@@ -24,11 +25,26 @@ function isValidPhone(phone: string): boolean {
   return false;
 }
 
-const AionLogoMark: React.FC = () => <img src={SudoworkIcon} alt='Sudowork' className='w-64px h-64px object-contain' />;
+// 从 localStorage 读取缓存的租户配置
+function getCachedTenantConfig(): Required<typeof DEFAULT_TENANT_CONFIG> {
+  try {
+    const cached = localStorage.getItem('sudowork_tenant_config');
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      return { ...DEFAULT_TENANT_CONFIG, ...parsed };
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_TENANT_CONFIG;
+}
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const { status, login, register } = useAuth();
+
+  // 从 localStorage 读取缓存的租户配置
+  const tenantConfig = getCachedTenantConfig();
 
   const [mode, setMode] = useState<'login' | 'register'>('login');
   const [loginPhone, setLoginPhone] = useState('');
@@ -310,10 +326,14 @@ const LoginPage: React.FC = () => {
       <div className='login-page__card'>
         <div className='login-page__header'>
           <div className='login-page__logo'>
-            <AionLogoMark />
+            <img
+              src={tenantConfig.logo || SudoworkIcon}
+              alt={tenantConfig.app_name}
+              className='w-64px h-64px object-contain'
+            />
           </div>
-          <h1 className='text-28px font-800 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>SudoClaw</h1>
-          <p className='text-13px text-t-secondary'>AgentOps | 办公专家</p>
+          <h1 className='text-28px font-800 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>{tenantConfig.app_name}</h1>
+          <p className='text-13px text-t-secondary'>{tenantConfig.login_desp}</p>
         </div>
 
         {/* Tab switcher */}


### PR DESCRIPTION
## Summary

- Add tenant-level customization support for client branding
- Dynamic control of logo, app_name, top_name, login_desp, about_name, and app_company_name
- Config fetched from `/api/v1/tenant/config?code={enterprise_code}` after login
- 10-minute polling refresh while authenticated
- localStorage caching for persistence

## Changes

- `src/common/types/tenantConfig.ts` - New type definitions
- `src/renderer/context/TenantConfigContext.tsx` - New context with polling
- `src/renderer/index.ts` - Provider integration
- `src/renderer/layout.tsx` - Sidebar logo/name
- `src/renderer/pages/login/index.tsx` - Login page branding
- `src/renderer/components/Titlebar/index.tsx` - Titlebar name (top_name)
- `src/renderer/components/SettingsModal/contents/AboutModalContent.tsx` - About page branding

## Test plan

- [x] Login page displays cached tenant config (or defaults)
- [x] After login, config is fetched and applied to sidebar, titlebar, about
- [x] Polling refresh works every 10 minutes
- [x] Logout resets to defaults but keeps localStorage cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)