### PR TITLE
fix(skill): 安装/卸载技能后 GuidPage 技能列表未刷新

### DIFF
--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -13,6 +13,7 @@ import { Button, Spin, Message, Input, Progress, Modal, Popconfirm, Switch } fro
 import { Download, Search, Delete, Close, Shield, Lightning, UploadOne, Install } from '@icon-park/react';
 import classNames from 'classnames';
 import { isElectronDesktop } from '@/renderer/utils/platform';
+import { emitter } from '@/renderer/utils/emitter';
 import { skillHub } from '@/common/ipcBridge';
 import type { ISkillHubSkill, ISkillHubDetail, ISkillHubListResponse, IInstalledSkillInfo, ISkillHubMeta } from '@/common/ipcBridge';
 import { useAuth } from '@/renderer/context/AuthContext';
@@ -664,6 +665,7 @@ const SkillModalContent: React.FC = () => {
           );
           await fetchInstalledSkills();
           await fetchInstalledList();
+          emitter.emit('skills.changed');
           // Open standalone audit report modal (just the audit summary, not the full detail page)
           setAuditReportSkillName(importedSkillName);
           setAuditReportVisible(true);
@@ -962,6 +964,7 @@ const SkillModalContent: React.FC = () => {
           );
           await fetchInstalledSkills();
           await fetchInstalledList();
+          emitter.emit('skills.changed');
         } else {
           Message.error(
             t('settings.skill.installFailed', {
@@ -1041,6 +1044,7 @@ const SkillModalContent: React.FC = () => {
           Message.success(`已卸载技能：${skillName}`);
           await fetchInstalledSkills();
           await fetchInstalledList();
+          emitter.emit('skills.changed');
           // Close detail modal if showing this skill
           if (detailSkill?.name === skillName) {
             setDetailVisible(false);
@@ -1095,6 +1099,7 @@ const SkillModalContent: React.FC = () => {
           );
           await fetchInstalledSkills();
           await fetchInstalledList();
+          emitter.emit('skills.changed');
         } else {
           Message.error(
             t('settings.skill.updateFailed', {
@@ -1128,6 +1133,7 @@ const SkillModalContent: React.FC = () => {
         if (res.success) {
           Message.success(enabled ? t('settings.skill.enableSuccess', { name: skillName, defaultValue: `已启用技能：${skillName}` }) : t('settings.skill.disableSuccess', { name: skillName, defaultValue: `已禁用技能：${skillName}` }));
           await fetchInstalledList();
+          emitter.emit('skills.changed');
         } else {
           Message.error(
             t('settings.skill.toggleEnabledFailed', {

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -96,6 +96,19 @@ const GuidPage: React.FC = () => {
     void fetchInstalledSkills();
   }, []);
 
+  // Re-fetch installed skills when skills are changed (install, uninstall, update, import, toggle)
+  useAddEventListener('skills.changed', async () => {
+    if (!isElectronDesktop()) return;
+    try {
+      const res = await skillHub.getInstalledSkills.invoke();
+      if (res.success && res.data) {
+        setInstalledSkills(res.data);
+      }
+    } catch (err) {
+      console.error('Failed to re-fetch installed skills after change:', err);
+    }
+  });
+
   // Handle skill parameter - auto-add skill to selected list
   useEffect(() => {
     if (skillParam && installedSkillsLoaded) {

--- a/src/renderer/utils/emitter.ts
+++ b/src/renderer/utils/emitter.ts
@@ -41,6 +41,8 @@ interface EventTypes {
   'agent.connection.status': [string, string]; // [conversationId, status]
   'staroffice.install.request': [{ conversationId: string; text: string; detectedUrl?: string | null }];
   'staroffice.install.finished': [{ conversationId: string }];
+  // 技能列表变更事件 / Skills list changed event (install, uninstall, update, import, toggle)
+  'skills.changed': void;
   // Guide 页面重置事件 / Guide page reset event (triggered by "New Conversation")
   'guid.reset': void;
 }

--- a/tests/unit/skillsChangedEvent.test.ts
+++ b/tests/unit/skillsChangedEvent.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { emitter } from '@/renderer/utils/emitter';
+
+describe('skills.changed event', () => {
+  let listener: () => void;
+
+  beforeEach(() => {
+    listener = vi.fn();
+    emitter.on('skills.changed', listener);
+  });
+
+  afterEach(() => {
+    emitter.off('skills.changed', listener);
+  });
+
+  it('is emitted when explicitly triggered', () => {
+    emitter.emit('skills.changed');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple listeners', () => {
+    const listener2 = vi.fn();
+    emitter.on('skills.changed', listener2);
+    emitter.emit('skills.changed');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenCalledTimes(1);
+    emitter.off('skills.changed', listener2);
+  });
+
+  it('does not trigger after listener is removed', () => {
+    emitter.off('skills.changed', listener);
+    emitter.emit('skills.changed');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('can be triggered multiple times', () => {
+    emitter.emit('skills.changed');
+    emitter.emit('skills.changed');
+    emitter.emit('skills.changed');
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- 修复在 GuidPage 内联技能商店安装/卸载/更新/导入/启用/禁用技能后，返回 GuidPage @ 技能时列表未刷新的问题
- 根因：GuidPage 组件在 /guid 和 /guid?menu=skill-store 之间切换时不卸载，useEffect 仅首次挂载时获取技能列表
- 通过已有的 emitter 事件机制，在技能变更时通知 GuidPage 重新获取列表

## Changes
- emitter.ts: 添加 skills.changed 事件类型
- SkillModalContent.tsx: 在 5 个技能变更 handler 成功分支中发射 skills.changed 事件
- GuidPage.tsx: 监听 skills.changed 事件并重新 fetch 技能列表
- 新增 skillsChangedEvent.test.ts 测试（4 个用例）

## Test plan
- [x] 单元测试通过（4 passed）
- [x] 回归测试通过（11 passed）
- [ ] 手动测试：安装专属技能后返回 GuidPage @ 技能可见
- [ ] 手动测试：卸载技能后返回 GuidPage 已卸载技能不再显示

Generated with [Claude Code](https://claude.com/claude-code)