### PR TITLE
fix(browser): steer LLM to read tool for images + bump v0.8.0

### DIFF
--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -404,16 +404,20 @@ export class ServiceManager {
       // `$env:PYTHONPATH=...; python -m ai_dev_browser.tools.page_info --url X`.
       const sudoworkBinEnv: Record<string, string> = {};
       try {
-        const { ensureSudoworkBinDispatchers, patchOpenclawToolResultCap, patchOpenclawKeepImageData, patchOpenclawKeepToolResult, SUDOCLAW_SUDOWORK_BIN_DIR } = await import('../sudoclaw/SudoclawInstallService');
+        const { ensureSudoworkBinDispatchers, patchOpenclawToolResultCap, patchOpenclawKeepImageData, patchOpenclawKeepToolResult, patchOpenclawReadDescription, patchOpenclawPdfDescription, SUDOCLAW_SUDOWORK_BIN_DIR } = await import('../sudoclaw/SudoclawInstallService');
         ensureSudoworkBinDispatchers();
-        // Re-assert the openclaw bundle patches on every gateway start so
-        // an upstream openclaw update doesn't silently re-cap tool results
-        // to 8 KB, re-strip image bytes before the LLM, or re-strip
+        // Re-assert openclaw bundle patches on every gateway start so an
+        // upstream openclaw update doesn't silently re-cap tool results
+        // to 8 KB, re-strip image bytes before the LLM, re-strip
         // `result.content` from the WS broadcast that drives the UI's
-        // Output panel. All three are idempotent + fail-open.
+        // Output panel, or re-introduce the misleading read/pdf tool
+        // descriptions that steer multimodal LLMs away from the
+        // functioning image pipeline. All are idempotent + fail-open.
         patchOpenclawToolResultCap();
         patchOpenclawKeepImageData();
         patchOpenclawKeepToolResult();
+        patchOpenclawReadDescription();
+        patchOpenclawPdfDescription();
         const prevPath = process.env.PATH ?? '';
         sudoworkBinEnv.PATH = prevPath.length > 0 ? `${SUDOCLAW_SUDOWORK_BIN_DIR}${path.delimiter}${prevPath}` : SUDOCLAW_SUDOWORK_BIN_DIR;
         // ai-dev-browser v0.5.1 reads AI_DEV_BROWSER_OUTPUT_DIR as the

--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -1011,6 +1011,138 @@ export function patchOpenclawKeepToolResult(): void {
   }
 }
 
+/**
+ * Rewrite openclaw's `read` tool description so multimodal LLMs
+ * understand that calling `read` on an image file makes the pixels
+ * directly visible in their context.
+ *
+ * Upstream's current phrasing is `"Images are sent as attachments."`
+ * This is accurate but doesn't map onto the decision the LLM needs
+ * to make at tool-pick time — "attachments" as a concept isn't
+ * strongly connected, in multimodal LLM training distributions, to
+ * "the model will see pixels after this call returns". The lis8 e2e
+ * trace (conv 826463af) showed a concrete failure: gemini-3-flash
+ * with a captcha screenshot on disk **never called `read`** to see
+ * the captcha, instead trying pdf/gemini CLI/tesseract OCR routes,
+ * all failed, then blind-guessing 3 times.
+ *
+ * Journey B (agent saves screenshot → `read <path>` → tool_result
+ * with image block → convertMessages2 wraps in functionResponse
+ * parts[].inlineData → Gemini API) is architecturally correct — the
+ * code path is wired end-to-end and `supportsMultimodalFunctionResponse`
+ * (line ~125109) returns true for Gemini 3+. The only bottleneck is
+ * that the LLM doesn't know the path exists. Changing the description
+ * to something concrete ("pixel data is embedded into your context")
+ * should steer the LLM to actually use it.
+ *
+ * Kept as a surgical one-phrase replacement — no behaviour change,
+ * no tool signature change, just clearer steering for the LLM. If
+ * upstream ever ships a better phrasing themselves, this patch
+ * becomes a no-op (pattern miss → warn + fail open).
+ */
+export function patchOpenclawReadDescription(): void {
+  const bundlePath = path.join(SUDOCLAW_DIR, 'cli', 'package', 'openclaw.mjs');
+  if (!fs.existsSync(bundlePath)) {
+    return;
+  }
+  let source: string;
+  try {
+    source = fs.readFileSync(bundlePath, 'utf8');
+  } catch (err) {
+    mainWarn('Sudoclaw', `patchOpenclawReadDescription: failed to read bundle: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  // Uniqueness marker — the replacement phrase is distinctive enough
+  // to detect "already applied" without a separate sentinel comment.
+  // Choosing the exact string 'pixel data is embedded directly' makes
+  // the detection robust even if upstream later rewords the rest of
+  // the description.
+  const replacementMarker = 'pixel data is embedded directly into your context';
+  if (source.includes(replacementMarker)) {
+    return;
+  }
+  const originalPhrase = 'Images are sent as attachments.';
+  // NOTE: the surrounding openclaw source uses a backtick-delimited template
+  // literal (it contains `${DEFAULT_MAX_LINES}` interpolation), so the
+  // replacement MUST NOT contain unescaped backticks — they would close the
+  // template literal and break the bundle's JS parse. Keep "read" plain.
+  const replacementPhrase = 'For images (jpg/png/gif/webp), the pixel data is embedded directly into your context — use the read tool to read captchas, inspect screenshots, and verify UI state visually.';
+  if (!source.includes(originalPhrase)) {
+    mainWarn(
+      'Sudoclaw',
+      'patchOpenclawReadDescription: pattern not found in openclaw bundle (upstream may have already reworded). LLMs may continue to skip `read` for images.',
+    );
+    return;
+  }
+  source = source.replace(originalPhrase, replacementPhrase);
+  try {
+    fs.writeFileSync(bundlePath, source);
+    mainLog('Sudoclaw', `patchOpenclawReadDescription: read tool description clarified in ${bundlePath}`);
+  } catch (err) {
+    mainWarn('Sudoclaw', `patchOpenclawReadDescription: failed to write patched bundle: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * Rewrite openclaw's `pdf` tool description so the LLM stops reaching
+ * for it as an OCR tool for image files.
+ *
+ * Upstream's current phrasing:
+ *     "Analyze one or more PDF documents with a model. Supports
+ *      native PDF analysis for Anthropic and Google models, with
+ *      text/image extraction fallback for other providers. Use pdf
+ *      for a single path/URL..."
+ *
+ * The `"text/image extraction fallback for other providers"` clause
+ * is technically about PDFs (extracting embedded images/text out of a
+ * PDF for non-native providers), but on LLM read it parses as "this
+ * tool can fall back to extracting text and images" — i.e. a generic
+ * OCR affordance. The lis8 trace shows gemini-3-flash feeding a
+ * `.png` captcha into `pdf` and getting back
+ * `"Expected PDF but got image/png"`; the LLM then spent 10+ steps
+ * moving the PNG between directories trying to placate the tool's
+ * path-validation rather than giving up on the wrong tool.
+ *
+ * We keep the pdf tool fully functional — per product owner, real
+ * PDF analysis is an active use-case (17:32 message in 产研Lead).
+ * We only strip the misleading fallback clause and add an explicit
+ * pointer to `read` for image files, so the LLM picks the right
+ * tool on the first try.
+ */
+export function patchOpenclawPdfDescription(): void {
+  const bundlePath = path.join(SUDOCLAW_DIR, 'cli', 'package', 'openclaw.mjs');
+  if (!fs.existsSync(bundlePath)) {
+    return;
+  }
+  let source: string;
+  try {
+    source = fs.readFileSync(bundlePath, 'utf8');
+  } catch (err) {
+    mainWarn('Sudoclaw', `patchOpenclawPdfDescription: failed to read bundle: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  const replacementMarker = 'For non-PDF image files';
+  if (source.includes(replacementMarker)) {
+    return;
+  }
+  const originalPhrase = 'Supports native PDF analysis for Anthropic and Google models, with text/image extraction fallback for other providers. Use pdf for a single path/URL, or pdfs for multiple (up to 10). Provide a prompt describing what to analyze.';
+  const replacementPhrase = 'Supports native PDF analysis for Anthropic and Google models. Use pdf for a single path/URL, or pdfs for multiple (up to 10). Provide a prompt describing what to analyze. For non-PDF image files (jpg/png/gif/webp), use the `read` tool instead — pdf only accepts PDF input.';
+  if (!source.includes(originalPhrase)) {
+    mainWarn(
+      'Sudoclaw',
+      'patchOpenclawPdfDescription: pattern not found in openclaw bundle (upstream may have already reworded). LLMs may continue to misuse pdf for image OCR.',
+    );
+    return;
+  }
+  source = source.replace(originalPhrase, replacementPhrase);
+  try {
+    fs.writeFileSync(bundlePath, source);
+    mainLog('Sudoclaw', `patchOpenclawPdfDescription: pdf tool description clarified in ${bundlePath}`);
+  } catch (err) {
+    mainWarn('Sudoclaw', `patchOpenclawPdfDescription: failed to write patched bundle: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 export function ensureUserMdSafetyRules(): void {
   const userMdPath = path.join(SUDOCLAW_WORKSPACE_DIR, 'USER.md');
   const safetyRulesBlock = `


### PR DESCRIPTION
## Summary

Two tool-description patches + a submodule bump targeting the lis8 e2e finding that the LLM's image pipeline is architecturally wired but the tool descriptions steer it away.

## Root cause (from lis8 run 3, conv 826463af, 65 steps, 2026-04-20)

- `browser page_screenshot` saves PNG to disk → LLM gets `{path, size, w, h}` metadata (no pixels)
- LLM must call `read <path>` to see pixels → `read` returns `{type: "image", data: base64, mimeType}`
- `sanitizeToolResult` (already patched `KEEP_IMAGE_DATA`) preserves the image block
- `convertMessages2` (line 125200-125219) wraps it in `functionResponse.parts[].inlineData` when `supportsMultimodalFunctionResponse()` is true (gemini-3+ matches)
- **Journey B reaches Gemini end-to-end at the code layer.**

But LLM **never called `read` on the captcha**. Instead: tried `pdf` tool for OCR (fails: PNG not PDF), tried `gemini --help`, tried `tesseract` — all failed — then blind-guessed captcha 3 times.

The tool descriptions are the reason:
- `read`: "Images are sent as attachments." — doesn't convey "you'll see pixels"
- `pdf`: "with text/image extraction fallback for other providers" — reads as "OCR fallback"

## Changes

**`patchOpenclawReadDescription`** (SudoclawInstallService.ts)

`"Images are sent as attachments."` → `"For images (jpg/png/gif/webp), the pixel data is embedded directly into your context — use \`read\` to read captchas, inspect screenshots, and verify UI state visually."`

**`patchOpenclawPdfDescription`** (SudoclawInstallService.ts)

Strips `"with text/image extraction fallback for other providers"`; appends `"For non-PDF image files (jpg/png/gif/webp), use the \`read\` tool instead — pdf only accepts PDF input."` PDF tool keeps all behaviour (product owner confirmed real PDF analysis is an active use case).

Both idempotent, fail-open. Re-applied on every gateway start alongside existing 3 bundle patches.

**Submodule bump v0.7.0 → v0.8.0**
- v0.7.1: `page_discover` surfaces nameless `<img>` in `interactable_only` mode — helps find captcha images
- v0.8.0: removes `cloudflare_verify` + related (-931 lines). Zero sudowork call sites.

## Expected effect on lis8 step count

Pre-patch run (65 steps) breakdown: 20 necessary + 10 move housekeeping + 10 OCR detour + 3 blind guesses + ~22 flag/repeat noise.

Post-patch target: 35-40. Projected savings:
- -10 move steps (no pdf foot-gun, no habit formation)
- -10 OCR detour (LLM tries read first when it sees "pixel data embedded into context")
- -3 blind guesses (LLM sees captcha pixels, reads correct code first try)

## Coordination

@Jinjing Zhou 在 产研Lead 群 17:32 确认 pdf 工具需要保留（真 PDF 场景有），该 PR 只改文案不改能力。我在群里通知了先开干，revert 自由。

## Test plan
- [x] `grep "pixel data is embedded\|For non-PDF image files"` passes in live bundle after patch
- [x] PDF tool accepts a real PDF unchanged (no behaviour touched)
- [ ] Re-run lis8 e2e, verify `browser read <captcha.png>` appears in trace, `move *.png` absent, step count ≤ 45

🤖 Generated with [Claude Code](https://claude.com/claude-code)