### PR TITLE
fix: add chcp 65001 encoding to spawnNpxBackend for Windows 10 compatibility

### DIFF
--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -254,7 +254,14 @@ export function spawnNpxBackend(backend: string, npxPackage: string, npxCommand:
   // detached: true creates a new session (setsid) so the child has no controlling terminal.
   // Required for backends (e.g. CodeBuddy) that write to /dev/tty — without it, SIGTTOU
   // would suspend the entire Electron process group and freeze the UI.
-  const child = spawn(npxCommand, spawnArgs, {
+  //
+  // chcp 65001: switch console code page to UTF-8 before launching the backend.
+  // On Chinese Windows 10 (default CP936/GBK), child processes inherit the system
+  // code page and UTF-8 output from the backend gets garbled into question marks
+  // or mojibake.  Windows 11 handles this natively, but older systems need the
+  // explicit switch.  This mirrors the same treatment in createGenericSpawnConfig.
+  const effectiveCommand = isWindows ? `chcp 65001 >nul && ${npxCommand}` : npxCommand;
+  const child = spawn(effectiveCommand, spawnArgs, {
     cwd: workingDir,
     stdio: ['pipe', 'pipe', 'pipe'],
     env: cleanEnv,


### PR DESCRIPTION
Fix garbled output (mojibake/question marks) on Chinese Windows 10 by adding `chcp 65001` code page switch to `spawnNpxBackend`, matching the existing treatment in `createGenericSpawnConfig`.

Closes #439

Generated with [Claude Code](https://claude.ai/code)