### PR TITLE
fix: delete assistant with associated conversations

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -442,11 +442,11 @@ export const openclawConversation = {
 export const database = {
   getConversationMessages: bridge.buildProvider<import('@/common/chatLib').TMessage[], { conversation_id: string; page?: number; pageSize?: number }>('database.get-conversation-messages'),
   getUserConversations: bridge.buildProvider<import('@/common/storage').TChatConversation[], { page?: number; pageSize?: number }>('database.get-user-conversations'),
-  /** 渠道对话创建/更新时，主进程通知渲染进程刷新对话列表 */
+  /** 渠道对话创建/更新/删除时，主进程通知渲染进程刷新对话列表 */
   conversationChanged: bridge.buildEmitter<{
     conversationId: string;
     source?: string;
-    action: 'created' | 'updated';
+    action: 'created' | 'updated' | 'deleted';
   }>('database.conversation-changed'),
 };
 

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -8,6 +8,7 @@ import type { IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail
 import { assistantManager } from '@/process/AssistantManager';
 import { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir } from '@/process/initStorage';
 import { skillManager } from '@/process/SkillManager';
+import { getDatabase } from '@/process/database';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import fs from 'fs/promises';
 import fsSync from 'fs';
@@ -248,7 +249,45 @@ export function initAssistantHubBridge(): void {
   });
 
   ipcBridge.assistantHub.uninstallAssistant.provider(async ({ name }) => {
+    // Delete associated conversations before uninstalling assistant
+    const deletedConversationIds: string[] = [];
+    try {
+      const db = getDatabase();
+      // The presetAssistantId stored in conversation.extra matches the assistant's name/id
+      // Try both the original name and with 'builtin-' prefix stripped
+      const presetAssistantId = name.startsWith('builtin-') ? name.slice('builtin-'.length) : name;
+      const deleteResult = db.deleteConversationsByPresetAssistantId(name);
+      if (!deleteResult.success) {
+        mainWarn('AssistantHub', `Failed to delete associated conversations: ${deleteResult.error}`);
+      } else if (deleteResult.data?.count > 0) {
+        mainLog('AssistantHub', `Deleted ${deleteResult.data.count} conversations associated with assistant ${name}`);
+        deletedConversationIds.push(...deleteResult.data.conversationIds);
+        // Also try deleting with stripped prefix if different
+        if (presetAssistantId !== name) {
+          const altResult = db.deleteConversationsByPresetAssistantId(presetAssistantId);
+          if (altResult.success && altResult.data?.count > 0) {
+            mainLog('AssistantHub', `Deleted additional ${altResult.data.count} conversations with stripped prefix ${presetAssistantId}`);
+            deletedConversationIds.push(...altResult.data.conversationIds);
+          }
+        }
+      }
+    } catch (dbError) {
+      mainWarn('AssistantHub', 'Error deleting associated conversations:', dbError);
+    }
+
     const result = await assistantManager.uninstallAssistant(name);
+
+    // Emit conversationChanged events to notify renderer to refresh conversation list
+    if (deletedConversationIds.length > 0) {
+      for (const conversationId of deletedConversationIds) {
+        ipcBridge.database.conversationChanged.emit({
+          conversationId,
+          source: 'aionui',
+          action: 'deleted',
+        });
+      }
+    }
+
     return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 

--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -1303,6 +1303,48 @@ export class AionUIDatabase {
   }
 
   /**
+   * Delete all conversations associated with a specific preset assistant.
+   * Used when deleting a custom assistant to cleanup related conversations.
+   *
+   * @param presetAssistantId - The assistant ID (UUID or name) to match against extra.presetAssistantId
+   * @returns Query result with the count of deleted conversations
+   */
+  deleteConversationsByPresetAssistantId(presetAssistantId: string): IQueryResult<{ count: number; conversationIds: string[] }> {
+    try {
+      // Find all conversations with this presetAssistantId
+      const findStmt = this.db.prepare(`SELECT id FROM conversations WHERE json_extract(extra, '$.presetAssistantId') = ?`);
+      const rows = findStmt.all(presetAssistantId) as Array<{ id: string }>;
+
+      if (rows.length === 0) {
+        return { success: true, data: { count: 0, conversationIds: [] } };
+      }
+
+      const conversationIds = rows.map((r) => r.id);
+      const now = Date.now();
+
+      // Delete messages first (foreign key constraint)
+      const deleteMessagesStmt = this.db.prepare('DELETE FROM messages WHERE conversation_id = ?');
+      // Delete conversations
+      const deleteConvStmt = this.db.prepare('DELETE FROM conversations WHERE id = ?');
+
+      const transaction = this.db.transaction(() => {
+        for (const id of conversationIds) {
+          deleteMessagesStmt.run(id);
+          deleteConvStmt.run(id);
+        }
+      });
+      transaction();
+
+      mainLog('Database', `Deleted ${conversationIds.length} conversations for assistant ${presetAssistantId}`);
+
+      return { success: true, data: { count: conversationIds.length, conversationIds } };
+    } catch (error: any) {
+      mainError('Database', 'Failed to delete conversations by presetAssistantId:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  /**
    * Get raw assistant plugin records for secret migration.
    * Returns original credential data from SQLite without going through Nexus.
    * Used by SecretMigrationCoordinator during initial migration.

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -172,7 +172,13 @@ const InstalledAssistantCard: React.FC<{
             <Shield size='15' />
           </div>
         ) : (
-          <Popconfirm title='确认删除该助手？' onOk={onDelete} okText='删除' cancelText='取消' okButtonProps={{ status: 'danger' }}>
+          <Popconfirm
+            title={t('settings.deleteAssistantConfirmTitle', { defaultValue: '删除该助手将会同步删除已关联该助手的会话，是否确认删除？' })}
+            onOk={onDelete}
+            okText={t('common.delete', { defaultValue: '删除' })}
+            cancelText={t('common.cancel', { defaultValue: '取消' })}
+            okButtonProps={{ status: 'danger' }}
+          >
             <div className='w-22px h-22px flex items-center justify-center text-t-tertiary hover:text-danger cursor-pointer transition-colors opacity-0 group-hover:opacity-100'>
               <Delete size='15' />
             </div>
@@ -1829,7 +1835,7 @@ const AgentModalContent: React.FC = () => {
 
       {/* Delete Confirmation Modal */}
       <Modal title={t('settings.deleteAssistantTitle', { defaultValue: 'Delete Assistant' })} visible={deleteConfirmVisible} onCancel={() => setDeleteConfirmVisible(false)} onOk={handleDeleteConfirm} okButtonProps={{ status: 'danger' }} okText={t('common.delete', { defaultValue: 'Delete' })} cancelText={t('common.cancel', { defaultValue: 'Cancel' })} className='w-[90vw] md:w-[400px]' wrapStyle={{ zIndex: 10000 }} maskStyle={{ zIndex: 9999 }}>
-        <p>{t('settings.deleteAssistantConfirm', { defaultValue: 'Are you sure you want to delete this assistant? This action cannot be undone.' })}</p>
+        <p>{t('settings.deleteAssistantConfirm', { defaultValue: 'Deleting this assistant will also synchronously delete all conversations associated with it. This action cannot be undone.' })}</p>
         {activeAssistant && (
           <div className='mt-12px p-12px bg-fill-2 rounded-lg flex items-center gap-12px'>
             <Avatar.Group size={32}>

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -1660,25 +1660,18 @@ const AgentModalContent: React.FC = () => {
         headerStyle={{ background: 'var(--color-bg-1)' }}
         bodyStyle={{ background: 'var(--color-bg-1)' }}
         footer={
-          <div className='flex items-center justify-between w-full'>
-            <div className='flex items-center gap-8px'>
-              <Button type='primary' onClick={handleSave} disabled={!isCreating && isReadonlyAssistant} className='w-[100px] rounded-[100px]'>
-                {isCreating ? t('common.create', { defaultValue: 'Create' }) : t('common.save', { defaultValue: 'Save' })}
-              </Button>
-              <Button
-                onClick={() => {
-                  setEditVisible(false);
-                }}
-                className='w-[100px] rounded-[100px] bg-fill-2'
-              >
-                {t('common.cancel', { defaultValue: 'Cancel' })}
-              </Button>
-            </div>
-            {!isCreating && !activeAssistant?.isBuiltin && !isExtensionAssistant(activeAssistant) && (
-              <Button status='danger' onClick={handleDeleteClick} className='rounded-[100px]' style={{ backgroundColor: 'rgb(var(--danger-1))' }}>
-                {t('common.delete', { defaultValue: 'Delete' })}
-              </Button>
-            )}
+          <div className='flex items-center gap-8px'>
+            <Button type='primary' onClick={handleSave} disabled={!isCreating && isReadonlyAssistant} className='w-[100px] rounded-[100px]'>
+              {isCreating ? t('common.create', { defaultValue: 'Create' }) : t('common.save', { defaultValue: 'Save' })}
+            </Button>
+            <Button
+              onClick={() => {
+                setEditVisible(false);
+              }}
+              className='w-[100px] rounded-[100px] bg-fill-2'
+            >
+              {t('common.cancel', { defaultValue: 'Cancel' })}
+            </Button>
           </div>
         }
       >
@@ -1834,8 +1827,8 @@ const AgentModalContent: React.FC = () => {
       </Drawer>
 
       {/* Delete Confirmation Modal */}
-      <Modal title={t('settings.deleteAssistantTitle', { defaultValue: 'Delete Assistant' })} visible={deleteConfirmVisible} onCancel={() => setDeleteConfirmVisible(false)} onOk={handleDeleteConfirm} okButtonProps={{ status: 'danger' }} okText={t('common.delete', { defaultValue: 'Delete' })} cancelText={t('common.cancel', { defaultValue: 'Cancel' })} className='w-[90vw] md:w-[400px]' wrapStyle={{ zIndex: 10000 }} maskStyle={{ zIndex: 9999 }}>
-        <p>{t('settings.deleteAssistantConfirm', { defaultValue: 'Deleting this assistant will also synchronously delete all conversations associated with it. This action cannot be undone.' })}</p>
+      <Modal title={t('settings.deleteAssistantTitle', { defaultValue: '删除助手' })} visible={deleteConfirmVisible} onCancel={() => setDeleteConfirmVisible(false)} onOk={handleDeleteConfirm} okButtonProps={{ status: 'danger' }} okText={t('common.delete', { defaultValue: '删除' })} cancelText={t('common.cancel', { defaultValue: '取消' })} className='w-[90vw] md:w-[400px]' wrapStyle={{ zIndex: 10000 }} maskStyle={{ zIndex: 9999 }}>
+        <p>{t('settings.deleteAssistantConfirm', { defaultValue: '删除该助手将会同步删除已关联该助手的会话，是否确认删除？' })}</p>
         {activeAssistant && (
           <div className='mt-12px p-12px bg-fill-2 rounded-lg flex items-center gap-12px'>
             <Avatar.Group size={32}>

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -46,7 +46,7 @@
   "promptPreview": "Preview",
   "promptPreviewEmpty": "No content to preview",
   "deleteAssistantTitle": "Delete Assistant",
-  "deleteAssistantConfirm": "Are you sure you want to delete this assistant? This action cannot be undone.",
+  "deleteAssistantConfirm": "Deleting this assistant will also synchronously delete all conversations associated with it. Do you want to proceed?",
   "cannotDeleteBuiltin": "Cannot delete builtin assistants",
   "duplicateAssistant": "Duplicate",
   "assistantMainAgent": "Main Agent",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -46,7 +46,7 @@
   "promptPreview": "预览",
   "promptPreviewEmpty": "暂无内容可预览",
   "deleteAssistantTitle": "删除助手",
-  "deleteAssistantConfirm": "确定要删除此助手吗？此操作无法撤销。",
+  "deleteAssistantConfirm": "删除该助手将会同步删除已关联该助手的会话，是否确认删除？",
   "cannotDeleteBuiltin": "无法删除内置助手",
   "duplicateAssistant": "复制新建",
   "assistantMainAgent": "主代理",

--- a/src/renderer/pages/conversation/context/ConversationTabsContext.tsx
+++ b/src/renderer/pages/conversation/context/ConversationTabsContext.tsx
@@ -6,6 +6,7 @@
 
 import type { TChatConversation } from '@/common/storage';
 import { STORAGE_KEYS } from '@/common/storageKeys';
+import { ipcBridge } from '@/common';
 import { addEventListener } from '@/renderer/utils/emitter';
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
@@ -238,6 +239,16 @@ export const ConversationTabsProvider: React.FC<{ children: React.ReactNode }> =
     return addEventListener('conversation.deleted', (conversationId) => {
       closeTab(conversationId);
     });
+  }, [closeTab]);
+
+  // 监听主进程的会话删除事件（如删除助手时批量删除会话）/ Listen to main process conversation deletion events (e.g., batch delete when removing assistant)
+  useEffect(() => {
+    const removeListener = ipcBridge.database.conversationChanged.on((data) => {
+      if (data.action === 'deleted') {
+        closeTab(data.conversationId);
+      }
+    });
+    return removeListener;
   }, [closeTab]);
 
   return (


### PR DESCRIPTION
## Summary
- Delete assistant will now synchronously delete all associated conversations
- Update confirmation message to warn users about conversation deletion
- Remove delete button from assistant detail drawer footer (delete only via card popconfirm)
- Refresh UI after assistant deletion

## Test plan
- [x] Delete an assistant from card and verify popconfirm shows correct warning message
- [x] Verify associated conversations are deleted after assistant deletion
- [x] Verify assistant list refreshes after deletion
- [x] Verify delete button is no longer in assistant detail drawer footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)