### PR TITLE
fix: normalize Windows backslash paths in markdown image syntax

### DIFF
--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -587,8 +587,17 @@ export const handleImageGenerationWithWorkspace = (message: TMessage, workspace:
     content: {
       ...message.content,
       content: message.content.content.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, imagePath) => {
-        // 如果是绝对路径、http链接或data URL，保持不变
-        if (imagePath.startsWith('http') || imagePath.startsWith('data:') || imagePath.startsWith('/') || imagePath.startsWith('file:') || imagePath.startsWith('\\') || /^[A-Za-z]:/.test(imagePath)) {
+        // 如果是绝对路径、http链接或data URL，保持不变（但需要处理Windows路径的反斜杠）
+        if (imagePath.startsWith('http') || imagePath.startsWith('data:') || imagePath.startsWith('file:')) {
+          return match;
+        }
+        // Windows 绝对路径：标准化反斜杠为正斜杠
+        if (/^[A-Za-z]:/.test(imagePath) || imagePath.startsWith('\\')) {
+          const normalizedPath = imagePath.replace(/\\/g, '/');
+          return `![${alt}](${normalizedPath})`;
+        }
+        // Unix 绝对路径，保持不变
+        if (imagePath.startsWith('/')) {
           return match;
         }
         // 如果是相对路径，与workspace拼接

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -50,7 +50,7 @@ import { hasCronCommands } from './CronCommandDetector';
 import { detectChannelQueryIntent, executeChannelInfoCommand, type ChannelQueryCommand } from './ChannelInfoDetector';
 import { extractTextFromMessage, processCronInMessage } from './MessageMiddleware';
 import { processAtFileReferences } from './acp/AcpAtFileProcessor';
-import { StreamTextBuffer, CronTextAccumulator, filterThinkTagsFromMessage } from './acp/AcpMessagePipeline';
+import { StreamTextBuffer, CronTextAccumulator, filterThinkTagsFromMessage, preprocessContentMessage } from './acp/AcpMessagePipeline';
 import { saveAcpSessionId, saveSessionMode, saveModelId, saveContextUsage } from './acp/AcpPersistence';
 import { resolveImageConfig, callImagesGenerations, callImagesEdits, saveImageResult, resolveChatModel, callChatCompletionsWithImage, readSudorouterCredentials } from '../bridge/imageGenerationBridge';
 import { resolveWorkspaceSkillsDir } from '../utils/workspaceSkillsDir';
@@ -1491,7 +1491,7 @@ This identity statement takes priority over the default identity in USER.md.
       }
     }
 
-    const filteredMessage = filterThinkTagsFromMessage(message as IResponseMessage);
+    const filteredMessage = preprocessContentMessage(message as IResponseMessage);
 
     ipcBridge.acpConversation.responseStream.emit(filteredMessage);
 

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -27,6 +27,7 @@ import BaseAgent from '@process/task/BaseAgent';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { resolveImageConfig, callImagesGenerations, callImagesEdits, saveImageResult, resolveChatModel, callChatCompletionsWithImage, readSudorouterCredentials } from '../bridge/imageGenerationBridge';
 import { buildDraftsInstruction, hasMcpServersConfigured, buildMcporterCommandHint } from './agentUtils';
+import { normalizeWindowsImagePaths } from './acp/AcpMessagePipeline';
 import { cleanupIntermediateFiles, cleanupMisplacedFiles } from './draftsCleanup';
 import { inferToolFailure } from '@/agent/acp/inferToolFailure';
 import { createHash } from 'node:crypto';
@@ -1169,7 +1170,11 @@ ${draftsInstruction}`;
 
   /** Handle stream messages: DB persist + UI emit + channel emit */
   private handleStreamMessage(message: IResponseMessage): void {
-    const msg = { ...message, conversation_id: this.conversation_id };
+    // Normalize Windows backslash paths in content messages before emission
+    let msg: IResponseMessage = { ...message, conversation_id: this.conversation_id };
+    if (msg.type === 'content' && typeof msg.data === 'string') {
+      msg = { ...msg, data: normalizeWindowsImagePaths(msg.data) };
+    }
 
     // Mark as finished when content is output
     const contentTypes = ['content', 'agent_status', 'acp_tool_call', 'plan'];

--- a/src/process/task/acp/AcpMessagePipeline.ts
+++ b/src/process/task/acp/AcpMessagePipeline.ts
@@ -117,3 +117,50 @@ export function filterThinkTagsFromMessage(message: IResponseMessage): IResponse
     data: cleanedContent,
   };
 }
+
+// ========== Windows Path Normalization ==========
+
+/**
+ * Normalize Windows-style backslash paths in markdown image syntax to forward slashes.
+ *
+ * When agents return markdown with Windows paths like `![alt](C:\Users\...\image.png)`,
+ * the backslashes are interpreted as escape characters by the markdown parser (remark),
+ * corrupting the path (e.g. `\.` becomes `.`). This function converts such paths to
+ * forward slashes before the content reaches the frontend markdown renderer.
+ */
+export function normalizeWindowsImagePaths(content: string): string {
+  // Match markdown image syntax where the path starts with a Windows drive letter (e.g. C:\)
+  return content.replace(
+    /!\[([^\]]*)\]\(([A-Za-z]:\\[^)]+)\)/g,
+    (_match, alt: string, imagePath: string) => {
+      const normalizedPath = imagePath.replace(/\\/g, '/');
+      return `![${alt}](${normalizedPath})`;
+    },
+  );
+}
+
+/**
+ * Apply all content message preprocessing: think tag filtering + Windows path normalization.
+ * This is the main entry point for message preprocessing before emission to the frontend.
+ */
+export function preprocessContentMessage(message: IResponseMessage): IResponseMessage {
+  if (message.type !== 'content' || typeof message.data !== 'string') {
+    return message;
+  }
+
+  let data = message.data;
+
+  // 1. Filter think tags
+  if (/<\s*\/?\s*think(?:ing)?\s*>/i.test(data)) {
+    data = stripThinkTags(data);
+  }
+
+  // 2. Normalize Windows image paths
+  data = normalizeWindowsImagePaths(data);
+
+  if (data === message.data) {
+    return message;
+  }
+
+  return { ...message, data };
+}

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -552,6 +552,13 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeS
   const normalizedChildren = useMemo(() => {
     if (typeof childrenProp === 'string') {
       let text = childrenProp.replace(/file:\/\//g, '');
+      // Normalize Windows backslash paths in markdown image syntax to forward slashes.
+      // Without this, the markdown parser treats backslashes as escape characters,
+      // corrupting paths like C:\Users\...\image.png (e.g. \. becomes just .)
+      text = text.replace(
+        /!\[([^\]]*)\]\(([A-Za-z]:\\[^)]+)\)/g,
+        (_match, alt: string, imagePath: string) => `![${alt}](${imagePath.replace(/\\/g, '/')})`,
+      );
       text = convertLatexDelimiters(text);
       return text;
     }

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs, vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
@@ -582,6 +582,15 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeS
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath, remarkBreaks]}
             rehypePlugins={allowHtml ? [rehypeRaw, rehypeKatex] : [rehypeKatex]}
+            urlTransform={(url) => {
+              // Allow Windows absolute paths like C:/Users/... or D:\docs\...
+              // defaultUrlTransform treats the drive letter (e.g. "C") as an unknown
+              // protocol scheme and sanitizes the URL to empty string.
+              if (/^[A-Za-z]:[/\\]/.test(url)) {
+                return url;
+              }
+              return defaultUrlTransform(url);
+            }}
             components={{
               span: ({ node: _node, className, children, ...props }) => {
                 return (

--- a/tests/unit/windowsImagePaths.test.ts
+++ b/tests/unit/windowsImagePaths.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { normalizeWindowsImagePaths, preprocessContentMessage } from '@process/task/acp/AcpMessagePipeline';
+import { defaultUrlTransform } from 'react-markdown';
 
 describe('normalizeWindowsImagePaths', () => {
   it('should normalize Windows backslash paths in markdown image syntax', () => {
@@ -73,6 +74,31 @@ describe('normalizeWindowsImagePaths', () => {
     const input = '![](c:\\users\\test\\image.png)';
     const expected = '![](c:/users/test/image.png)';
     expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should not modify paths that already use forward slashes', () => {
+    const input = '![](C:/Users/16674/.nexus/sudoclaw/workspace/shaobing.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(input);
+  });
+});
+
+describe('defaultUrlTransform sanitization (root cause of empty src)', () => {
+  it('should sanitize Windows drive letter paths as unknown protocol', () => {
+    // This demonstrates the root cause: react-markdown treats "C:" as a protocol
+    // and sanitizes it to empty string because "C" is not in the safe protocol list
+    expect(defaultUrlTransform('C:/Users/16674/.nexus/sudoclaw/workspace/shaobing.png')).toBe('');
+  });
+
+  it('should allow http/https URLs', () => {
+    expect(defaultUrlTransform('https://example.com/image.png')).toBe('https://example.com/image.png');
+  });
+
+  it('should allow relative paths', () => {
+    expect(defaultUrlTransform('./images/photo.png')).toBe('./images/photo.png');
+  });
+
+  it('should allow Unix absolute paths', () => {
+    expect(defaultUrlTransform('/home/user/image.png')).toBe('/home/user/image.png');
   });
 });
 

--- a/tests/unit/windowsImagePaths.test.ts
+++ b/tests/unit/windowsImagePaths.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeWindowsImagePaths, preprocessContentMessage } from '@process/task/acp/AcpMessagePipeline';
+
+describe('normalizeWindowsImagePaths', () => {
+  it('should normalize Windows backslash paths in markdown image syntax', () => {
+    const input = '![alt](C:\\Users\\16674\\.nexus\\sudoclaw\\workspace\\shaobing.png)';
+    const expected = '![alt](C:/Users/16674/.nexus/sudoclaw/workspace/shaobing.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should handle empty alt text', () => {
+    const input = '![](C:\\Users\\16674\\Desktop\\image.png)';
+    const expected = '![](C:/Users/16674/Desktop/image.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should handle Chinese alt text', () => {
+    const input = '![热腾腾的芝麻烧饼](C:\\Users\\16674\\.nexus\\sudoclaw\\workspace\\sudoclaw-temp-1776762459099\\shaobing.png)';
+    const expected = '![热腾腾的芝麻烧饼](C:/Users/16674/.nexus/sudoclaw/workspace/sudoclaw-temp-1776762459099/shaobing.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should handle multiple images in content', () => {
+    const input = 'Here are two images:\n![img1](D:\\photos\\a.png)\n![img2](E:\\docs\\b.jpg)';
+    const expected = 'Here are two images:\n![img1](D:/photos/a.png)\n![img2](E:/docs/b.jpg)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should not modify http/https URLs', () => {
+    const input = '![alt](https://example.com/image.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(input);
+  });
+
+  it('should not modify Unix absolute paths', () => {
+    const input = '![alt](/home/user/image.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(input);
+  });
+
+  it('should not modify relative paths', () => {
+    const input = '![alt](./images/photo.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(input);
+  });
+
+  it('should not modify data URLs', () => {
+    const input = '![alt](data:image/png;base64,iVBOR...)';
+    expect(normalizeWindowsImagePaths(input)).toBe(input);
+  });
+
+  it('should handle mixed content with Windows paths and regular text', () => {
+    const input = '给你画好了：\n\n![](C:\\Users\\16674\\.nexus\\sudoclaw\\workspace\\sudoclaw-temp-1776762459099\\shaobing.png)\n\n这是一个烧饼。';
+    const expected = '给你画好了：\n\n![](C:/Users/16674/.nexus/sudoclaw/workspace/sudoclaw-temp-1776762459099/shaobing.png)\n\n这是一个烧饼。';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should handle paths with spaces', () => {
+    const input = '![](C:\\Users\\My User\\Documents\\image.png)';
+    const expected = '![](C:/Users/My User/Documents/image.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should return unchanged content when no images present', () => {
+    const input = 'Hello, this is just plain text with no images.';
+    expect(normalizeWindowsImagePaths(input)).toBe(input);
+  });
+
+  it('should handle lowercase drive letters', () => {
+    const input = '![](c:\\users\\test\\image.png)';
+    const expected = '![](c:/users/test/image.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+});
+
+describe('preprocessContentMessage', () => {
+  it('should normalize Windows paths in content messages', () => {
+    const message = {
+      type: 'content' as const,
+      conversation_id: 'test-conv',
+      msg_id: 'test-msg',
+      data: '![](C:\\Users\\test\\image.png)',
+    };
+    const result = preprocessContentMessage(message);
+    expect(result.data).toBe('![](C:/Users/test/image.png)');
+  });
+
+  it('should not modify non-content messages', () => {
+    const message = {
+      type: 'start' as const,
+      conversation_id: 'test-conv',
+      msg_id: 'test-msg',
+      data: null,
+    };
+    const result = preprocessContentMessage(message);
+    expect(result).toBe(message);
+  });
+
+  it('should handle both think tags and Windows paths', () => {
+    const message = {
+      type: 'content' as const,
+      conversation_id: 'test-conv',
+      msg_id: 'test-msg',
+      data: '<think>thinking...</think>![](C:\\Users\\test\\image.png)',
+    };
+    const result = preprocessContentMessage(message);
+    expect(result.data).toBe('![](C:/Users/test/image.png)');
+  });
+
+  it('should return same message if no changes needed', () => {
+    const message = {
+      type: 'content' as const,
+      conversation_id: 'test-conv',
+      msg_id: 'test-msg',
+      data: 'Hello world, no paths here.',
+    };
+    const result = preprocessContentMessage(message);
+    expect(result).toBe(message);
+  });
+});


### PR DESCRIPTION
Fix Windows file path display issue where agent response images with backslash paths were not rendering.

Backslashes in Windows paths like `C:\Users\...\image.png` were being interpreted as escape characters by the markdown parser, corrupting the path and making `src` empty in LocalImageView.

Normalizes Windows paths to forward slashes in both backend message pipeline and frontend markdown renderer.

Closes #441

Generated with [Claude Code](https://claude.ai/code)