### PR TITLE
fix(e2e): pick sudowork Vite renderer tab, not a preview webview

### DIFF
--- a/tests/e2e/ops/connect.py
+++ b/tests/e2e/ops/connect.py
@@ -1,6 +1,19 @@
 """Connect to Sudowork via CDP."""
 
+import re
+
 from ai_dev_browser.core.connection import connect_browser
+
+
+# Sudowork's Vite dev server binds to a port in the 5170-5999 range (preferred
+# 5173, auto-detected fallbacks up to 5999 when earlier ports are in use on
+# Windows due to port reservations). Matching on the exact port range lets us
+# tell the sudowork renderer apart from any `<webview>` embeds that happen to
+# be on other ports, from third-party `localhost` services, and from the
+# DevTools pages that can also appear in `/json/list`.
+_SUDOWORK_RENDERER_RE = re.compile(
+    r"^https?://(127\.0\.0\.1|localhost):5\d{3}(?:/|$)", re.IGNORECASE
+)
 
 
 async def connect(port: int = 9232):
@@ -8,16 +21,39 @@ async def connect(port: int = 9232):
 
     Returns:
         tuple: (browser, tab)
+
+    The CDP target list on sudowork's Electron can contain more than just the
+    main renderer — conversations that previously referenced an external URL
+    spawn `<webview>` preview panes (via `src/renderer/.../URLViewer.tsx` and
+    `WebviewHost.tsx`) that each attach as their own `page` target. Those
+    previews commonly end up FIRST in `browser.tabs`, so a naive "grab the
+    first tab" fallback drives the wrong DOM — we observed this causing
+    mouse_click / type_text to miss the sudowork chat input and instead
+    interact with a lis8.sinosoft.ltd preview. Matching the Vite renderer's
+    URL pattern avoids that confusion.
     """
     browser = await connect_browser(port=port)
 
-    # Find the localhost renderer tab (skip devtools)
+    # Prefer an exact Vite-dev renderer match — stable against webview noise.
     for t in browser.tabs:
         url = getattr(t._target, "url", "") or ""
-        if "localhost" in url:
+        if _SUDOWORK_RENDERER_RE.match(url):
             return browser, t
 
-    if browser.tabs:
-        return browser, browser.tabs[0]
+    # Secondary: a more permissive localhost match. This covers packaged
+    # builds that might host the renderer on a non-Vite port, while still
+    # excluding `devtools://`, `chrome-extension://`, and external https
+    # webview previews.
+    for t in browser.tabs:
+        url = getattr(t._target, "url", "") or ""
+        if "localhost" in url or "127.0.0.1" in url:
+            return browser, t
+
+    # Last resort: first non-DevTools page. Better than blindly grabbing
+    # `tabs[0]` which could be a third-party https webview.
+    for t in browser.tabs:
+        url = getattr(t._target, "url", "") or ""
+        if not url.startswith("devtools://"):
+            return browser, t
 
     raise ConnectionError("No Sudowork tabs found")


### PR DESCRIPTION
## Summary

Fixes a subtle e2e runner bug: `connect.py` was using a loose `"localhost" in url` match, which accepts `<webview>` URL-preview panels alongside the main Vite renderer.

## Root cause

Sudowork's `URLViewer` (`src/renderer/pages/conversation/preview/components/viewers/URLViewer.tsx`) embeds any URL mentioned in a conversation as a `<webview>` — each of which attaches to the Electron CDP as its own `type=page` target.

When a conversation touches an external URL (lis8 e2e prompts always do), those webview previews end up in `/json/list` alongside the main renderer. On builds where the main renderer is transiently hidden from CDP (sandbox + multi-webview target-list interaction), the previous fallback to `browser.tabs[0]` would pick whichever preview came first — driving e.g. the `lis8.sinosoft.ltd` DOM instead of sudowork's chat input.

## Symptoms pre-fix

- `mouse_click text="新会话"` failed: button lives in sudowork's chat UI, not in the lis8 preview.
- `type_text` → `no_input`: lis8 form inputs have unpredictable focus/disabled state.
- `press_key Enter` did nothing meaningful: submitted lis8's login form, not sudowork's chat.
- `screenshot` returned lis8 pixels, making post-run audits misleading.

## Fix

Match sudowork's Vite dev renderer by URL pattern (`(127.0.0.1|localhost):5\d{3}`), fall through to broader `localhost` matches for packaged builds, last-resort to first non-DevTools page.

## Out of scope

A longer-term improvement is to make sudowork's Electron expose the main renderer reliably under all webview conditions (conditional `--disable-sandbox` in dev, or preload-level filtering of webview targets). Neither is critical path for product launch — sandbox-on is correct for end users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)