### PR TITLE
fix(a11y): replace undefined text-t-error class with text-danger for dark mode contrast

### DIFF
--- a/src/renderer/pages/conversation/preview/components/renderers/PPTHtmlRenderer.tsx
+++ b/src/renderer/pages/conversation/preview/components/renderers/PPTHtmlRenderer.tsx
@@ -171,7 +171,7 @@ const PPTHtmlRenderer: React.FC<PPTHtmlRendererProps> = ({ filePath }) => {
       <div className='h-full w-full flex items-center justify-center bg-bg-1'>
         <div className='text-center max-w-400px'>
           <div className='text-48px mb-16px'>❌</div>
-          <div className='text-16px text-t-error font-medium mb-8px'>{t('preview.ppt.loadFailed')}</div>
+          <div className='text-16px text-danger font-medium mb-8px'>{t('preview.ppt.loadFailed')}</div>
           <div className='text-12px text-t-secondary mb-24px whitespace-pre-wrap'>{error}</div>
         </div>
         {messageContextHolder}

--- a/src/renderer/pages/conversation/preview/components/viewers/ExcelViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/ExcelViewer.tsx
@@ -487,7 +487,7 @@ const ExcelPreview: React.FC<ExcelPreviewProps> = ({ filePath, content: _content
     return (
       <div className='flex items-center justify-center h-full'>
         <div className='text-center'>
-          <div className='text-16px text-t-error mb-8px'>❌ {error}</div>
+          <div className='text-16px text-danger mb-8px'>❌ {error}</div>
           <div className='text-12px text-t-secondary'>{t('preview.excel.invalid')}</div>
         </div>
       </div>

--- a/src/renderer/pages/conversation/preview/components/viewers/PDFViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/PDFViewer.tsx
@@ -134,7 +134,7 @@ const PDFPreview: React.FC<PDFPreviewProps> = ({ filePath, content, hideToolbar 
       <div className='flex items-center justify-center h-full'>
         {messageContextHolder}
         <div className='text-center'>
-          <div className='text-16px text-t-error mb-8px'>❌ {error}</div>
+          <div className='text-16px text-danger mb-8px'>❌ {error}</div>
           <div className='text-12px text-t-secondary'>{t('preview.pdf.unableDisplay')}</div>
         </div>
       </div>

--- a/src/renderer/pages/conversation/preview/components/viewers/PPTViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/PPTViewer.tsx
@@ -261,7 +261,7 @@ const PPTPreview: React.FC<PPTPreviewProps> = ({ filePath, content, hideToolbar 
       <div className='flex items-center justify-center h-full'>
         {messageContextHolder}
         <div className='text-center'>
-          <div className='text-16px text-t-error mb-8px'>❌ {error}</div>
+          <div className='text-16px text-danger mb-8px'>❌ {error}</div>
           <div className='text-12px text-t-secondary'>{t('preview.ppt.invalid')}</div>
         </div>
       </div>

--- a/src/renderer/pages/conversation/preview/components/viewers/WordViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/WordViewer.tsx
@@ -317,7 +317,7 @@ const WordPreview: React.FC<WordPreviewProps> = ({ filePath, content, hideToolba
     return (
       <div className='flex items-center justify-center h-full'>
         <div className='text-center'>
-          <div className='text-16px text-t-error mb-8px'>❌ {error}</div>
+          <div className='text-16px text-danger mb-8px'>❌ {error}</div>
           <div className='text-12px text-t-secondary'>{t('preview.word.invalid')}</div>
         </div>
       </div>


### PR DESCRIPTION
Fixes #443

## Summary

- The `text-t-error` UnoCSS utility class was not defined in the theme config, resulting in no error color being applied to error messages in preview viewers.
- Replaced with `text-danger` which maps to `var(--danger)` — a properly theme-aware semantic color (#f53f3f light / #f76560 dark).
- Applied consistently across all 5 affected viewer components: WordViewer, ExcelViewer, PDFViewer, PPTViewer, PPTHtmlRenderer.

## Test plan

- [ ] Switch to dark mode and open an invalid/corrupted Word document — error text should be clearly visible in red
- [ ] Verify the same in light mode
- [ ] Check error states in Excel, PDF, and PPT viewers in both modes

Generated with [Claude Code](https://claude.ai/code)