### PR TITLE
fix(cdp): disable renderer sandbox in dev so main renderer is visible

### DIFF
--- a/src/utils/configureChromium.ts
+++ b/src/utils/configureChromium.ts
@@ -286,6 +286,36 @@ if (cdpStartupEnabled) {
   cdpPort = port;
   registerInstance(port);
 
+  // Dev-only: disable the Chromium renderer sandbox when CDP is enabled.
+  //
+  // Motivation: with sandbox on, Electron hides the main renderer
+  // from `/json/list` as soon as any `<webview>` guest WebContents
+  // is alive in the same session (URL previews via WebviewHost /
+  // URLViewer are the common trigger). The e2e runner's `connect.py`
+  // iterates the target list looking for the Vite tab; when the
+  // main renderer isn't there, it falls back to the first visible
+  // target — which for lis8-style prompts ends up being the
+  // embedded `lis8.sinosoft.ltd` preview, and every subsequent
+  // click / type / screenshot hits that page instead of sudowork's
+  // chat UI.
+  //
+  // Sandbox-on is the right default for packaged builds (renderer
+  // isolation is a real security benefit). It's only the CDP
+  // visibility quirk that gates dev-time automated testing, so we
+  // narrow the opt-out to CDP-enabled startups in non-packaged
+  // builds. Packaged production builds default to CDP disabled and
+  // therefore never hit this branch — sandbox stays on for users.
+  //
+  // The gate here is `!app.isPackaged` rather than
+  // `NODE_ENV==='development'` because the latter isn't consistently
+  // set across our dev tooling (electron-vite vs direct node launch
+  // vs --webui). `app.isPackaged === false` is the canonical
+  // "this is a dev/source launch" signal Electron itself uses.
+  if (!app.isPackaged) {
+    app.commandLine.appendSwitch('no-sandbox');
+    console.log('[CDP] Dev mode: renderer sandbox disabled so `/json/list` exposes the main Vite tab alongside any webview guests');
+  }
+
   // Log CDP initialization
   console.log('[CDP] Chrome DevTools Protocol enabled');
   console.log(`[CDP] Remote debugging port: ${port}`);


### PR DESCRIPTION
## Summary

Dev-only `--no-sandbox` flag when CDP is enabled. Fixes a persistent e2e harness bug where the main renderer vanishes from Electron's `/json/list` enumeration as soon as any `<webview>` guest exists in the session — leaving the e2e runner driving preview panels instead of the sudowork chat UI.

## Root cause

Electron's CDP `/json/list` de-duplicates target enumeration when sandbox is on and child webContents (including `<webview>`s) are present. Empirically observed:

- Fresh dev, no convs with external URLs: `localhost:5173/#/guid` shows up ✓
- Dev with any conv containing a URL (lis8 e2e prompts always do): main renderer disappears, only webview previews remain

The e2e runner's `connect.py` iterates `browser.tabs` looking for the Vite URL; with the main renderer invisible, all fallbacks miss and it drives the first webview preview instead. Every click/type/screenshot silently hits the wrong DOM, producing "0 passed, 0 failed" noise.

## Fix

`src/utils/configureChromium.ts`: when CDP is enabled **and** the build is unpackaged, also `--no-sandbox`. Packaged production defaults to CDP disabled, so the sandbox-off branch is skipped for real users.

## Verification

- Before: `curl :9230/json` → only `[page] https://lis8.sinosoft.ltd/` webview previews
- After: `[page] http://localhost:5173/` (the real Vite renderer) + any webview guests
- E2e runner lands on sudowork chat DOM; screenshots show SudoClaw UI, not lis8

## Scope boundaries

- Sandbox-on stays the default for packaged production (security best practice)
- Only affects unpackaged dev launches with CDP enabled
- No change to Electron preload / webPreferences — sandbox is disabled at the command-line switch level only

🤖 Generated with [Claude Code](https://claude.com/claude-code)