### PR TITLE
chore(browser+e2e): bump to v0.8.4 + db_audit framework + dev sandbox fix

### DIFF
--- a/tests/e2e/cases/lis8-verify-patches.yaml
+++ b/tests/e2e/cases/lis8-verify-patches.yaml
@@ -35,3 +35,20 @@ steps:
   # ── Phase 4: Final screenshot ──
   - op: screenshot
     path: "screenshots/lis8-verify-01-result.png"
+
+  # ── Phase 5: DB audit (外援 verification, not UI-drive) ──
+  # Counts agent tool calls since case_start and asserts on v0.8.3/v0.8.4 markers.
+  # max_tool_calls is a soft-ish budget — past runs: v0.8.0=29, v0.8.1=65, v0.8.3=4
+  # (last was a cheat — browser was pre-logged-in). 50 gives headroom for a real
+  # lis8 run without rewarding regressions.
+  - op: db_audit
+    max_tool_calls: 50
+    assert_metrics:
+      # v0.8.4 rich-return actually reaches the trace when js_evaluate is used.
+      # We don't assert js_evaluate_calls > 0 because if the LLM steers via
+      # find_by_text / click_by_ref (the desired path), 0 is correct.
+      js_evaluate_with_navigated: ">= 0"
+      js_evaluate_with_console: ">= 0"
+      # Fallback python scripts (navigate.py cascade) should be 0 post-v0.8.0.
+      python_scripts: "== 0"
+

--- a/tests/e2e/ops/db_audit.py
+++ b/tests/e2e/ops/db_audit.py
@@ -96,16 +96,25 @@ def _count_metrics(rows):
 
         if '"hint"' in out:
             m["hint_field_seen"] += 1
-        if re.search(r"browser find_by_text", cmd_s):
+        # Match both `browser X` (CLI wrapper) and
+        # `python -m ai_dev_browser.tools.X` (direct module invocation).
+        # LLM uses both forms interchangeably, so treat them the same.
+        def tool_ran(name: str) -> bool:
+            return bool(re.search(
+                rf"(?:^|\s)browser {name}\b|ai_dev_browser\.tools\.{name}\b",
+                cmd_s,
+            ))
+
+        if tool_ran("find_by_text"):
             m["find_by_text_calls"] += 1
             if '"found": true' in out or '"found":true' in out:
                 m["find_by_text_found"] += 1
-        if re.search(r"browser click_by_text", cmd_s):
+        if tool_ran("click_by_text"):
             if '"clicked": false' in out or '"clicked":false' in out:
                 m["click_by_text_fails"] += 1
-        if re.search(r"browser click_by_ref", cmd_s):
+        if tool_ran("click_by_ref"):
             m["click_by_ref_calls"] += 1
-        if re.search(r"browser js_evaluate", cmd_s):
+        if tool_ran("js_evaluate"):
             m["js_evaluate_calls"] += 1
             if '"navigated"' in out:
                 m["js_evaluate_with_navigated"] += 1
@@ -113,11 +122,11 @@ def _count_metrics(rows):
                 m["js_evaluate_with_console"] += 1
             if '"error"' in out and re.search(r'"error"\s*:\s*\{', out):
                 m["js_evaluate_with_error"] += 1
-        if re.search(r"browser mouse_click", cmd_s):
+        if tool_ran("mouse_click"):
             m["mouse_click_coord"] += 1
-        if re.search(r"browser browser_start", cmd_s):
+        if tool_ran("browser_start"):
             m["browser_start_calls"] += 1
-        if re.search(r"browser page_screenshot", cmd_s):
+        if tool_ran("page_screenshot"):
             m["page_screenshot_calls"] += 1
         if re.search(r"python\b.*\.py", cmd_s):
             m["python_scripts"] += 1

--- a/tests/e2e/ops/db_audit.py
+++ b/tests/e2e/ops/db_audit.py
@@ -1,0 +1,244 @@
+"""Post-run DB audit — count agent tool calls and assert thresholds.
+
+App-specific e2e verification op. Reads ~/.nexus/sudowork.db after the
+agent finishes responding and counts tool-call patterns that matter for
+whatever we're testing (anti-pattern regressions, v0.8.x feature reach).
+
+Sits in the "叫外援" slot at the END of a yaml case — it's not part of the
+human UI drive-through, it's external ground-truth verification. Shape
+matches judge.py ({pass, reason, ...}) so runner.py can count it as a
+verification step.
+
+WAL note: the DB is WAL-mode; reading the bare .db file misses in-flight
+writes. We copy .db + .db-wal + .db-shm to a tmpdir before opening.
+"""
+
+import json
+import operator
+import re
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import state
+
+
+_CMP = {">=": operator.ge, "<=": operator.le, "==": operator.eq,
+        "!=": operator.ne, ">": operator.gt, "<": operator.lt}
+_RULE_RE = re.compile(r"^(>=|<=|==|!=|>|<)\s*(-?\d+)$")
+
+
+def _copy_wal_snapshot(src_dir: Path) -> Path:
+    """Copy .db + .db-wal + .db-shm to a tmpdir and return the tmp .db path."""
+    dst = Path(tempfile.mkdtemp(prefix="sudowork_audit_"))
+    for name in ("sudowork.db", "sudowork.db-wal", "sudowork.db-shm"):
+        s = src_dir / name
+        if s.exists():
+            shutil.copy2(s, dst / name)
+    return dst / "sudowork.db"
+
+
+def _extract_tool_output_text(content) -> str:
+    """Pull the text payload out of an acp_tool_call content array."""
+    if not isinstance(content, list):
+        return ""
+    for c in content:
+        inner = c.get("content") if isinstance(c, dict) else None
+        if isinstance(inner, dict) and inner.get("type") == "text":
+            return inner.get("text", "") or ""
+    return ""
+
+
+def _count_metrics(rows):
+    """rows: list of (id, type, content, status, created_at) tuples.
+
+    Returns (counts_dict, trace_lines).
+    """
+    m = {
+        "total_messages": 0,
+        "tool_calls": 0,
+        "hint_field_seen": 0,          # v0.8.3 Failure: auto-inject
+        "click_by_text_fails": 0,
+        "find_by_text_calls": 0,
+        "find_by_text_found": 0,
+        "click_by_ref_calls": 0,
+        "js_evaluate_calls": 0,
+        "js_evaluate_with_navigated": 0,  # v0.8.4 rich-return usage
+        "js_evaluate_with_console": 0,
+        "js_evaluate_with_error": 0,
+        "mouse_click_coord": 0,
+        "python_scripts": 0,
+        "browser_start_calls": 0,
+        "page_screenshot_calls": 0,
+        "read_calls": 0,
+    }
+    trace_lines = []
+    for idx, (_id, rtype, content, status, _ts) in enumerate(rows):
+        m["total_messages"] += 1
+        if rtype != "acp_tool_call":
+            snip = (content or "").replace("\n", " ")[:160]
+            trace_lines.append(f"[#{idx} {rtype}] {snip}")
+            continue
+        try:
+            payload = json.loads(content or "{}")
+        except Exception:
+            trace_lines.append(f"[#{idx} parse-err]")
+            continue
+
+        m["tool_calls"] += 1
+        update = payload.get("update") or {}
+        raw = update.get("rawInput") or {}
+        cmd = (raw.get("command") or raw.get("path")
+               or raw.get("file_path") or "")
+        cmd_s = str(cmd)
+        out = _extract_tool_output_text(update.get("content", []))
+
+        if '"hint"' in out:
+            m["hint_field_seen"] += 1
+        if re.search(r"browser find_by_text", cmd_s):
+            m["find_by_text_calls"] += 1
+            if '"found": true' in out or '"found":true' in out:
+                m["find_by_text_found"] += 1
+        if re.search(r"browser click_by_text", cmd_s):
+            if '"clicked": false' in out or '"clicked":false' in out:
+                m["click_by_text_fails"] += 1
+        if re.search(r"browser click_by_ref", cmd_s):
+            m["click_by_ref_calls"] += 1
+        if re.search(r"browser js_evaluate", cmd_s):
+            m["js_evaluate_calls"] += 1
+            if '"navigated"' in out:
+                m["js_evaluate_with_navigated"] += 1
+            if '"console"' in out:
+                m["js_evaluate_with_console"] += 1
+            if '"error"' in out and re.search(r'"error"\s*:\s*\{', out):
+                m["js_evaluate_with_error"] += 1
+        if re.search(r"browser mouse_click", cmd_s):
+            m["mouse_click_coord"] += 1
+        if re.search(r"browser browser_start", cmd_s):
+            m["browser_start_calls"] += 1
+        if re.search(r"browser page_screenshot", cmd_s):
+            m["page_screenshot_calls"] += 1
+        if re.search(r"python\b.*\.py", cmd_s):
+            m["python_scripts"] += 1
+        _title = update.get("title", "") or ""
+        if _title == "read" or _title.startswith("read "):
+            m["read_calls"] += 1
+
+        title = update.get("title", "?")
+        st = update.get("status", "?")
+        out_snip = out[:120].replace("\n", " ")
+        trace_lines.append(
+            f"[#{idx} {title} {st}] CMD: {cmd_s[:120]} | OUT: {out_snip}"
+        )
+    return m, trace_lines
+
+
+def _check_rule(value: int, rule: str) -> tuple:
+    mat = _RULE_RE.match(str(rule).strip())
+    if not mat:
+        return False, f"bad rule '{rule}'"
+    op, n = mat.group(1), int(mat.group(2))
+    ok = _CMP[op](value, n)
+    return ok, f"{value} {op} {n}"
+
+
+async def db_audit(
+    tab,
+    conversation: str = "latest",
+    since: str = "case_start",
+    max_tool_calls: int = None,
+    assert_metrics: dict = None,
+    print_trace: bool = True,
+    nexus_dir: str = None,
+) -> dict:
+    """Query sudowork DB, count metrics since cutoff, assert thresholds.
+
+    Args:
+        tab: Browser tab (unused — DB is source of truth; kept for op-signature parity)
+        conversation: "latest" (default, picks most recently active) or
+            an explicit conversation_id (exact match)
+        since: "case_start" (uses state.CASE_START_MS set by runner) or
+            an explicit ms-epoch as a string
+        max_tool_calls: if set, fail when tool_calls > this
+        assert_metrics: dict of {metric_name: rule_str}, e.g.
+            {"hint_field_seen": ">= 1", "click_by_text_fails": "== 0"}
+        print_trace: dump per-tool-call trace to stdout
+        nexus_dir: override DB dir (default ~/.nexus)
+
+    Returns:
+        {"pass": bool, "reason": str, "counts": dict, "trace": str}
+    """
+    src = Path(nexus_dir) if nexus_dir else (Path.home() / ".nexus")
+    if not (src / "sudowork.db").exists():
+        return {"pass": False,
+                "reason": f"DB not found at {src / 'sudowork.db'}",
+                "counts": {}, "trace": ""}
+
+    if since == "case_start":
+        if state.CASE_START_MS == 0:
+            return {"pass": False,
+                    "reason": "state.CASE_START_MS is 0 — runner didn't mark case start",
+                    "counts": {}, "trace": ""}
+        cutoff_ms = state.CASE_START_MS
+    else:
+        cutoff_ms = int(since)
+
+    db_path = _copy_wal_snapshot(src)
+    con = sqlite3.connect(str(db_path))
+    cur = con.cursor()
+
+    if conversation == "latest":
+        row = cur.execute(
+            "SELECT conversation_id, MAX(created_at) FROM messages "
+            "GROUP BY conversation_id ORDER BY 2 DESC LIMIT 1"
+        ).fetchone()
+        if not row:
+            con.close()
+            return {"pass": False, "reason": "no conversations in DB",
+                    "counts": {}, "trace": ""}
+        conv_id = row[0]
+    else:
+        conv_id = conversation
+
+    rows = cur.execute(
+        "SELECT id, type, content, status, created_at FROM messages "
+        "WHERE conversation_id = ? AND created_at > ? ORDER BY created_at ASC",
+        (conv_id, cutoff_ms),
+    ).fetchall()
+    con.close()
+
+    counts, trace_lines = _count_metrics(rows)
+    counts["conversation_id"] = conv_id
+    counts["cutoff_ms"] = cutoff_ms
+
+    failures = []
+    if max_tool_calls is not None and counts["tool_calls"] > max_tool_calls:
+        failures.append(
+            f"tool_calls={counts['tool_calls']} > max_tool_calls={max_tool_calls}"
+        )
+    if assert_metrics:
+        for metric, rule in assert_metrics.items():
+            if metric not in counts:
+                failures.append(f"unknown metric: {metric}")
+                continue
+            ok, desc = _check_rule(counts[metric], rule)
+            if not ok:
+                failures.append(f"{metric}: {desc}")
+
+    passed = len(failures) == 0
+
+    if print_trace:
+        print("\n--- db_audit trace ---")
+        for line in trace_lines:
+            print("  " + line)
+        print(f"--- counts: {json.dumps({k: v for k, v in counts.items() if k != 'conversation_id'})}")
+        print(f"--- conversation: {conv_id}")
+
+    reason = "all assertions passed" if passed else "; ".join(failures)
+    return {
+        "pass": passed,
+        "reason": reason,
+        "counts": counts,
+        "trace": "\n".join(trace_lines),
+    }

--- a/tests/e2e/ops/wait_for_response.py
+++ b/tests/e2e/ops/wait_for_response.py
@@ -1,13 +1,22 @@
 """Wait for agent to finish responding.
 
-Two modes:
-- programmatic (default): checks for UI loading indicator absence + text stability
-- llm: periodically screenshots and asks the conversation agent to judge completion
+Three modes:
+- db (default): poll sudowork.db for activity gap + no in_progress tool_call
+- programmatic: DOM-based (text stability + loading indicator) — legacy,
+  false-positive when spinner blinks between tool calls
+- llm: send screenshot to conversation agent for completion judgment
 """
 
 import asyncio
+import shutil
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
 
 from ai_dev_browser.core.page import js_evaluate
+
+import state
 
 from .screenshot import screenshot
 
@@ -17,31 +26,133 @@ async def _get_page_text(tab) -> str:
     return r.get("result", "")
 
 
-async def wait_for_response(tab, timeout: float = 120, mode: str = "programmatic",
-                            expect: str = None) -> dict:
+def _copy_wal(nexus_dir: Path) -> Path:
+    """Copy .db + .db-wal + .db-shm to tmpdir and return tmp .db path."""
+    dst = Path(tempfile.mkdtemp(prefix="sudowork_wait_"))
+    for name in ("sudowork.db", "sudowork.db-wal", "sudowork.db-shm"):
+        s = nexus_dir / name
+        if s.exists():
+            shutil.copy2(s, dst / name)
+    return dst / "sudowork.db"
+
+
+async def wait_for_response(tab, timeout: float = 120, mode: str = "db",
+                            expect: str = None, idle_seconds: float = 30,
+                            poll_interval: float = 3) -> dict:
     """Wait for agent to finish responding.
 
     Args:
         tab: Browser tab
         timeout: Max seconds to wait
-        mode: "programmatic" (UI indicator + text stability) or
-              "llm" (send screenshot to conversation agent for judgment)
-        expect: For llm mode — what completion looks like (sent to agent as judgment prompt)
+        mode: "db" (default — polls sudowork.db for activity),
+              "programmatic" (legacy DOM-based), or
+              "llm" (send screenshot to conversation agent)
+        expect: For llm mode — what completion looks like
+        idle_seconds: DB mode — consider done after this long with no new messages
+        poll_interval: DB mode — seconds between DB snapshots
 
     Returns:
-        {"done": True/False, "mode": str, "text": str}
+        {"done": True/False, "mode": str, ...}
     """
     if mode == "llm":
         return await _wait_llm(tab, timeout, expect)
-    return await _wait_programmatic(tab, timeout)
+    if mode == "programmatic":
+        return await _wait_programmatic(tab, timeout)
+    return await _wait_db(timeout, idle_seconds, poll_interval)
+
+
+async def _wait_db(timeout: float, idle_seconds: float,
+                   poll_interval: float) -> dict:
+    """Poll sudowork.db for activity. Done when:
+      (a) no new messages in the latest conversation for `idle_seconds`, AND
+      (b) no acp_tool_call message has status 'in_progress'.
+
+    Stronger than DOM text stability because it's the DB's own state —
+    the UI indicator can blink between tool calls but the DB tells the
+    truth about what the agent is doing.
+
+    Uses state.CASE_START_MS as the lower bound when picking "which
+    conversation is this test run in." Falls back to "latest activity"
+    if state is unset (e.g. run_op.py direct invocation).
+    """
+    if state.CASE_START_MS == 0:
+        return {"timeout": True, "mode": "db",
+                "error": "state.CASE_START_MS is 0 — wait_for_response needs runner context"}
+
+    nexus_dir = Path.home() / ".nexus"
+    deadline = time.time() + timeout
+    last_max_ts = state.CASE_START_MS
+    idle_start = None
+    conv_id = None
+    poll_count = 0
+
+    while time.time() < deadline:
+        await asyncio.sleep(poll_interval)
+        poll_count += 1
+
+        db_path = _copy_wal(nexus_dir)
+        try:
+            con = sqlite3.connect(str(db_path))
+            cur = con.cursor()
+
+            # Pick the conversation carrying this run's messages — pinned
+            # to the first one we see, so late side-activity in other
+            # convs (notifications etc) doesn't confuse us.
+            if conv_id is None:
+                row = cur.execute(
+                    "SELECT conversation_id, MAX(created_at) FROM messages "
+                    "WHERE created_at > ? "
+                    "GROUP BY conversation_id ORDER BY 2 DESC LIMIT 1",
+                    (state.CASE_START_MS,),
+                ).fetchone()
+                if row:
+                    conv_id = row[0]
+
+            if conv_id is None:
+                con.close()
+                continue  # agent hasn't written anything yet
+
+            latest = cur.execute(
+                "SELECT MAX(created_at) FROM messages WHERE conversation_id = ?",
+                (conv_id,),
+            ).fetchone()
+            latest_ts = latest[0] if latest and latest[0] else state.CASE_START_MS
+
+            in_progress = cur.execute(
+                "SELECT 1 FROM messages WHERE conversation_id = ? "
+                "AND type = 'acp_tool_call' AND status = 'in_progress' LIMIT 1",
+                (conv_id,),
+            ).fetchone()
+            con.close()
+        finally:
+            shutil.rmtree(db_path.parent, ignore_errors=True)
+
+        if in_progress:
+            idle_start = None
+            last_max_ts = latest_ts
+            continue
+
+        if latest_ts > last_max_ts:
+            last_max_ts = latest_ts
+            idle_start = None
+            continue
+
+        if idle_start is None:
+            idle_start = time.time()
+        elif time.time() - idle_start >= idle_seconds:
+            return {"done": True, "mode": "db", "conversation_id": conv_id,
+                    "idle_seconds": round(time.time() - idle_start, 1),
+                    "polls": poll_count}
+
+    return {"timeout": True, "mode": "db", "conversation_id": conv_id,
+            "polls": poll_count}
 
 
 async def _wait_programmatic(tab, timeout: float) -> dict:
-    """Check loading indicator + require text stability (no changes for 10s).
+    """Legacy DOM-based wait. Kept for cases where DB isn't available.
 
-    Detects both Sudoclaw ("正在处理中") and Nexus (CSS spinner) loading states.
-    Only considers text stable when loading indicators are absent AND the
-    conversation area contains at least one agent reply (not just the user message).
+    False-positives when the loading spinner blinks between tool calls,
+    which is why db mode is the new default.
     """
     prev_text = ""
     stable_count = 0
@@ -53,7 +164,6 @@ async def _wait_programmatic(tab, timeout: float) -> dict:
         has_loading = "正在处理中" in text
         has_permission = "Always Allow" in text and "Reject" in text
 
-        # Check for CSS-based loading spinner (Nexus uses animation, not text)
         spinner_check = await js_evaluate(tab, """(() => {
             const spinner = document.querySelector('.loading-spinner, .ant-spin, [class*="spinner"], [class*="loading"]');
             const sendBtn = document.querySelector('[class*="send"]');
@@ -73,7 +183,6 @@ async def _wait_programmatic(tab, timeout: float) -> dict:
             stable_count = 0
             prev_text = text
 
-        # Stable for 3 consecutive checks (9 seconds) with no loading
         if stable_count >= 3:
             return {"done": True, "mode": "programmatic", "text": text}
 
@@ -85,14 +194,12 @@ async def _wait_llm(tab, timeout: float, expect: str = None) -> dict:
     from .type_text import type_text
     from .press_key import press_key
 
-    # First wait for initial response to start (programmatic)
     for _ in range(10):
         await asyncio.sleep(3)
         text = await _get_page_text(tab)
         if "正在处理中" not in text:
             break
 
-    # Take screenshot and ask agent to judge completion
     ss = await screenshot(tab)
     import os
     abs_path = os.path.abspath(ss.get("path", ""))
@@ -107,7 +214,6 @@ async def _wait_llm(tab, timeout: float, expect: str = None) -> dict:
     await type_text(tab, judgment_prompt, wait=0.5)
     await press_key(tab, key='Enter', wait=15)
 
-    # Read response
     text = await _get_page_text(tab)
     if "DONE" in text[-500:]:
         return {"done": True, "mode": "llm", "text": text}

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -12,10 +12,12 @@ Usage:
 import argparse
 import asyncio
 import sys
+import time
 from pathlib import Path
 
 import yaml
 
+import state
 from ops.registry import discover_ops, invoke_op
 
 OPS = discover_ops()
@@ -38,6 +40,10 @@ async def run_case(tab, case_path: Path) -> dict:
     passed = 0
     failed = 0
 
+    # Mark case start so ops like db_audit can filter messages "since this run"
+    state.CASE_START_MS = int(time.time() * 1000)
+    state.CASE_NAME = name
+
     print(f"\n{'='*60}")
     print(f"  {name}")
     print(f"{'='*60}")
@@ -55,7 +61,7 @@ async def run_case(tab, case_path: Path) -> dict:
         result = await invoke_op(tab, op_name, OPS, **kwargs)
 
         # Check result
-        if op_name == "judge":
+        if op_name in ("judge", "db_audit"):
             if result.get("pass"):
                 passed += 1
                 status = "PASS"

--- a/tests/e2e/state.py
+++ b/tests/e2e/state.py
@@ -1,0 +1,10 @@
+"""Shared state between runner and ops (case boundaries etc).
+
+Module-level — runner writes, ops read. Kept separate from ops/ because
+ops/ is meant to be the pure action surface; runner state leaking in
+would muddy that. CASE_START_MS is set by runner.run_case before the
+first step of each case so db_audit can filter messages "since this run".
+"""
+
+CASE_START_MS: int = 0  # epoch ms — runner sets per case
+CASE_NAME: str = ""


### PR DESCRIPTION
Bundles four independent but related improvements from the lis8 debugging arc.

## What landed

- **browser: v0.8.2 → v0.8.3 (`c21c4500`)** — auto-hint on failure via `Failure:` docstring section. Bypasses `browser --list` first-line truncation for reactive steering.
- **browser: v0.8.3 → v0.8.4 (`6cb336b0`)** — `js_evaluate` rich return shape `{result, console, url_before, url_after, navigated, title_after, error}`. Raw `.click()`→`null` leaves LLM without signal; v0.8.4 closes that chain.
- **cdp: dev sandbox off (`c9533760`)** — packaged builds keep sandbox, dev disables it so the main renderer is visible to CDP. Fixes e2e runner picking webview preview instead of sudowork tab.
- **e2e: db_audit op + DB `wait_for_response` (`b2afaaf0`)** — see below.

## e2e framework changes

`ops/` stays "human meta-operations" (pure UI drive). New `db_audit` op is the "叫外援" verification slot at case end — reads sudowork.db ground truth to count agent tool calls and assert thresholds.

- `state.py`: runner sets `CASE_START_MS` per case, ops read as cutoff
- `ops/db_audit.py`: WAL-safe DB snapshot, metric counting (tool_calls, hint_field_seen, js_evaluate rich-return usage, click_by_text_fails / find_by_text_found / click_by_ref, python_scripts anti-pattern, etc.), assertion DSL (`"hint_field_seen: >= 1"`), judge-shape return
- `ops/wait_for_response.py`: new default mode `db` polls messages table for activity gap + no `in_progress` acp_tool_call. First lis8 run exposed programmatic mode false-positive (returned "done" while agent still mid-flight); db mode is truth-based.
- `runner.py`: wires `CASE_START_MS` + extends judge-style pass/fail branch to `db_audit`
- `lis8-verify-patches.yaml`: final `db_audit` step with anti-regression thresholds

## Test plan

- [x] db_audit validated against live DB — correct cutoff filtering, WAL snapshot, metric counts, assertion DSL
- [x] wait_for_response db mode validated — idle detection + conv pinning correct
- [x] First lis8 run with bundle exposed useful regression (LLM wrote python-script anti-pattern; find_by_text never reached; js_evaluate rich-return never exercised)
- [ ] Re-run lis8 after browser ai ships v0.8.5 + v0.9.0 (non-breaking + breaking core API fixes for the 3 frictions this PR's data surfaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)