### PR TITLE
fix: DingTalk picture+text message streaming fixes

### DIFF
--- a/src/channels/plugins/dingtalk/DingTalkAdapter.ts
+++ b/src/channels/plugins/dingtalk/DingTalkAdapter.ts
@@ -86,6 +86,8 @@ export interface DingTalkStreamMessage {
     duration?: string;
     recognition?: string;
     _localPath?: string;
+    /** richText message items (DingTalk places richText array here for richText msgtype) */
+    richText?: DingTalkRichTextItem[];
   };
   sessionWebhook?: string;
   robotCode?: string;
@@ -113,12 +115,59 @@ export interface DingTalkCardActionData {
 const DINGTALK_MEDIA_TYPES = new Set(['picture', 'audio', 'video', 'file']);
 
 /**
+ * A single item in a DingTalk richText message.
+ * Items can be text or picture type.
+ * Per DingTalk docs, picture items include downloadCode/pictureDownloadCode.
+ */
+export interface DingTalkRichTextItem {
+  text?: string;
+  downloadCode?: string;
+  pictureDownloadCode?: string;
+  type?: string; // 'text' | 'picture'
+}
+
+/**
+ * Extract richText items from a DingTalk message, trying multiple data paths:
+ * 1. content.richText (DingTalk Stream API actual path per official docs)
+ * 2. richText.richTextList (legacy/alternative path)
+ * 3. richText as a direct array
+ */
+function getRichTextItems(data: DingTalkStreamMessage): DingTalkRichTextItem[] {
+  if (data.content?.richText && Array.isArray(data.content.richText)) {
+    return data.content.richText;
+  }
+  if (data.richText?.richTextList) {
+    return data.richText.richTextList;
+  }
+  if (Array.isArray((data as any).richText)) {
+    return (data as any).richText;
+  }
+  return [];
+}
+
+/**
  * Extract downloadCode and fileName from a DingTalk message if it contains media.
  * Returns null for non-media message types.
  */
 export function extractMediaDownloadInfo(data: DingTalkStreamMessage): { downloadCode: string; fileName?: string } | null {
   const msgtype = data.msgtype;
-  if (!msgtype || !DINGTALK_MEDIA_TYPES.has(msgtype)) {
+  if (!msgtype) {
+    return null;
+  }
+
+  // richText messages may contain picture items with downloadCode
+  if (msgtype === 'richText') {
+    const items = getRichTextItems(data);
+    const pictureItem = items.find(
+      (item) => item.downloadCode && (item.type === 'picture' || !!item.pictureDownloadCode),
+    );
+    if (pictureItem?.downloadCode) {
+      return { downloadCode: pictureItem.downloadCode };
+    }
+    return null;
+  }
+
+  if (!DINGTALK_MEDIA_TYPES.has(msgtype)) {
     return null;
   }
 
@@ -153,6 +202,9 @@ export function extractMediaDownloadInfo(data: DingTalkStreamMessage): { downloa
  */
 export function setMediaLocalPath(data: DingTalkStreamMessage, localPath: string): void {
   switch (data.msgtype) {
+    case 'richText':
+      if (data.content) data.content._localPath = localPath;
+      break;
     case 'picture':
       if (data.picture) data.picture._localPath = localPath;
       if (data.content) data.content._localPath = localPath;
@@ -179,6 +231,8 @@ export function getDefaultExtension(msgtype: string | undefined): string {
   switch (msgtype) {
     case 'picture':
       return '.jpg';
+    case 'richText':
+      return '.jpg'; // richText with picture items
     case 'audio':
       return '.amr';
     case 'video':
@@ -313,11 +367,33 @@ function extractMessageContent(data: DingTalkStreamMessage): IUnifiedMessageCont
     }
 
     case 'richText': {
-      const textParts = (data.richText?.richTextList || []).filter((item) => item.type === 'text').map((item) => item.text || '');
+      const items = getRichTextItems(data);
+      const textParts: string[] = [];
+      const pictureCodes: Array<{ downloadCode: string }> = [];
+
+      for (const item of items) {
+        if (item.text) {
+          textParts.push(item.text);
+        }
+        if (item.downloadCode && (item.type === 'picture' || !!item.pictureDownloadCode)) {
+          pictureCodes.push({ downloadCode: item.downloadCode });
+        }
+      }
+
       let text = textParts.join('');
       if (data.conversationType === '2') {
         text = text.replace(/@\S+\s*/g, '').trim();
       }
+
+      if (pictureCodes.length > 0) {
+        const fileId = data.content?._localPath || pictureCodes[0].downloadCode;
+        return {
+          type: 'photo',
+          text,
+          attachments: [{ type: 'photo', fileId }],
+        };
+      }
+
       return { type: 'text', text };
     }
 

--- a/src/channels/plugins/dingtalk/DingTalkAdapter.ts
+++ b/src/channels/plugins/dingtalk/DingTalkAdapter.ts
@@ -57,21 +57,35 @@ export interface DingTalkStreamMessage {
   picture?: {
     downloadCode?: string;
     photoURL?: string;
+    _localPath?: string;
   };
   audio?: {
     downloadCode?: string;
     duration?: string;
     recognition?: string;
+    _localPath?: string;
   };
   video?: {
     downloadCode?: string;
     duration?: string;
     videoType?: string;
+    _localPath?: string;
   };
   file?: {
     downloadCode?: string;
     fileName?: string;
     fileSize?: string;
+    _localPath?: string;
+  };
+  /** Stream callback content field (actual location of media downloadCode in newer API) */
+  content?: {
+    downloadCode?: string;
+    pictureDownloadCode?: string;
+    fileName?: string;
+    fileSize?: string;
+    duration?: string;
+    recognition?: string;
+    _localPath?: string;
   };
   sessionWebhook?: string;
   robotCode?: string;
@@ -92,6 +106,107 @@ export interface DingTalkCardActionData {
 }
 
 // ==================== Incoming Message Conversion ====================
+
+/**
+ * Media message types supported by DingTalk robot.
+ */
+const DINGTALK_MEDIA_TYPES = new Set(['picture', 'audio', 'video', 'file']);
+
+/**
+ * Extract downloadCode and fileName from a DingTalk message if it contains media.
+ * Returns null for non-media message types.
+ */
+export function extractMediaDownloadInfo(data: DingTalkStreamMessage): { downloadCode: string; fileName?: string } | null {
+  const msgtype = data.msgtype;
+  if (!msgtype || !DINGTALK_MEDIA_TYPES.has(msgtype)) {
+    return null;
+  }
+
+  let downloadCode: string | undefined;
+  let fileName: string | undefined;
+
+  switch (msgtype) {
+    case 'picture':
+      downloadCode = data.picture?.downloadCode || data.content?.downloadCode || data.content?.pictureDownloadCode;
+      break;
+    case 'audio':
+      downloadCode = data.audio?.downloadCode || data.content?.downloadCode;
+      break;
+    case 'video':
+      downloadCode = data.video?.downloadCode || data.content?.downloadCode;
+      break;
+    case 'file':
+      downloadCode = data.file?.downloadCode || data.content?.downloadCode;
+      fileName = data.file?.fileName || data.content?.fileName;
+      break;
+  }
+
+  if (!downloadCode) {
+    return null;
+  }
+
+  return { downloadCode, fileName };
+}
+
+/**
+ * Set _localPath on the appropriate media field of a DingTalk message.
+ */
+export function setMediaLocalPath(data: DingTalkStreamMessage, localPath: string): void {
+  switch (data.msgtype) {
+    case 'picture':
+      if (data.picture) data.picture._localPath = localPath;
+      if (data.content) data.content._localPath = localPath;
+      break;
+    case 'audio':
+      if (data.audio) data.audio._localPath = localPath;
+      if (data.content) data.content._localPath = localPath;
+      break;
+    case 'video':
+      if (data.video) data.video._localPath = localPath;
+      if (data.content) data.content._localPath = localPath;
+      break;
+    case 'file':
+      if (data.file) data.file._localPath = localPath;
+      if (data.content) data.content._localPath = localPath;
+      break;
+  }
+}
+
+/**
+ * Map a DingTalk msgtype to a default file extension.
+ */
+export function getDefaultExtension(msgtype: string | undefined): string {
+  switch (msgtype) {
+    case 'picture':
+      return '.jpg';
+    case 'audio':
+      return '.amr';
+    case 'video':
+      return '.mp4';
+    case 'file':
+      return '';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Map a DingTalk msgtype to a default MIME type.
+ */
+export function getDefaultMimeType(msgtype: string | undefined): string {
+  switch (msgtype) {
+    case 'picture':
+      return 'image/jpeg';
+    case 'audio':
+      return 'audio/amr';
+    case 'video':
+      return 'video/mp4';
+    case 'file':
+      return 'application/octet-stream';
+    default:
+      return 'application/octet-stream';
+  }
+}
 
 /**
  * Encode chatId based on conversation type
@@ -213,7 +328,7 @@ function extractMessageContent(data: DingTalkStreamMessage): IUnifiedMessageCont
         attachments: [
           {
             type: 'photo',
-            fileId: data.picture?.downloadCode || '',
+            fileId: data.picture?._localPath || data.content?._localPath || data.picture?.downloadCode || data.content?.downloadCode || '',
           },
         ],
       };
@@ -221,12 +336,12 @@ function extractMessageContent(data: DingTalkStreamMessage): IUnifiedMessageCont
     case 'audio':
       return {
         type: 'audio',
-        text: data.audio?.recognition || '',
+        text: data.audio?.recognition || data.content?.recognition || '',
         attachments: [
           {
             type: 'audio',
-            fileId: data.audio?.downloadCode || '',
-            duration: data.audio?.duration ? parseInt(data.audio.duration, 10) : undefined,
+            fileId: data.audio?._localPath || data.content?._localPath || data.audio?.downloadCode || data.content?.downloadCode || '',
+            duration: data.audio?.duration ? parseInt(data.audio.duration, 10) : data.content?.duration ? parseInt(data.content.duration, 10) : undefined,
           },
         ],
       };
@@ -238,8 +353,8 @@ function extractMessageContent(data: DingTalkStreamMessage): IUnifiedMessageCont
         attachments: [
           {
             type: 'video',
-            fileId: data.video?.downloadCode || '',
-            duration: data.video?.duration ? parseInt(data.video.duration, 10) : undefined,
+            fileId: data.video?._localPath || data.content?._localPath || data.video?.downloadCode || data.content?.downloadCode || '',
+            duration: data.video?.duration ? parseInt(data.video.duration, 10) : data.content?.duration ? parseInt(data.content.duration, 10) : undefined,
           },
         ],
       };
@@ -251,9 +366,9 @@ function extractMessageContent(data: DingTalkStreamMessage): IUnifiedMessageCont
         attachments: [
           {
             type: 'document',
-            fileId: data.file?.downloadCode || '',
-            fileName: data.file?.fileName,
-            size: data.file?.fileSize ? parseInt(data.file.fileSize, 10) : undefined,
+            fileId: data.file?._localPath || data.content?._localPath || data.file?.downloadCode || data.content?.downloadCode || '',
+            fileName: data.file?.fileName || data.content?.fileName,
+            size: data.file?.fileSize ? parseInt(data.file.fileSize, 10) : data.content?.fileSize ? parseInt(data.content.fileSize, 10) : undefined,
           },
         ],
       };

--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -6,11 +6,14 @@
 
 import { DWClient, TOPIC_ROBOT, TOPIC_CARD, EventAck } from 'dingtalk-stream';
 import type { DWClientDownStream } from 'dingtalk-stream';
+import fs from 'fs';
+import path from 'path';
 import https from 'https';
 
 import type { BotInfo, IChannelPluginConfig, IUnifiedOutgoingMessage, PluginType } from '../../types';
 import { BasePlugin } from '../BasePlugin';
-import { DINGTALK_MESSAGE_LIMIT, encodeChatId, extractCardAction, parseChatId, toDingTalkSendParams, toUnifiedIncomingMessage, convertHtmlToDingTalkMarkdown } from './DingTalkAdapter';
+import { DINGTALK_MESSAGE_LIMIT, encodeChatId, extractCardAction, parseChatId, toDingTalkSendParams, toUnifiedIncomingMessage, convertHtmlToDingTalkMarkdown, getDefaultExtension, getDefaultMimeType, extractMediaDownloadInfo, setMediaLocalPath } from './DingTalkAdapter';
+import { mainLog, mainWarn, mainError } from '@/process/utils/mainLogger';
 import type { DingTalkStreamMessage } from './DingTalkAdapter';
 
 /**
@@ -83,6 +86,9 @@ export class DingTalkPlugin extends BasePlugin {
   // Store sessionWebhook per chatId for fallback sending
   private webhookCache: Map<string, string> = new Map();
 
+  // Local directory for downloaded media files (lazy-initialized)
+  private mediaDir: string | null = null;
+
   /**
    * Initialize the DingTalk client
    */
@@ -127,10 +133,10 @@ export class DingTalkPlugin extends BasePlugin {
         try {
           const data: DingTalkStreamMessage = JSON.parse(msg.data);
           void this.handleRobotMessage(data, msg.headers.messageId).catch((error) => {
-            console.error('[DingTalkPlugin] Error handling robot message:', error);
+            mainError('DingTalkPlugin', 'Error handling robot message', error);
           });
         } catch (error) {
-          console.error('[DingTalkPlugin] Failed to parse robot message:', error);
+          mainError('DingTalkPlugin', 'Failed to parse robot message', error);
         }
       });
 
@@ -143,10 +149,10 @@ export class DingTalkPlugin extends BasePlugin {
         try {
           const data = JSON.parse(msg.data);
           void this.handleCardCallback(data, msg.headers.messageId).catch((error) => {
-            console.error('[DingTalkPlugin] Error handling card callback:', error);
+            mainError('DingTalkPlugin', 'Error handling card callback', error);
           });
         } catch (error) {
-          console.error('[DingTalkPlugin] Failed to parse card callback:', error);
+          mainError('DingTalkPlugin', 'Failed to parse card callback', error);
         }
       });
 
@@ -157,9 +163,9 @@ export class DingTalkPlugin extends BasePlugin {
       // Start event cache cleanup timer
       this.startEventCleanup();
 
-      console.log(`[DingTalkPlugin] Started for client ${this.clientId}`);
+      mainLog('DingTalkPlugin', `Started for client ${this.clientId}`);
     } catch (error) {
-      console.error('[DingTalkPlugin] Failed to start:', error);
+      mainError('DingTalkPlugin', 'Failed to start', error);
       throw error;
     }
   }
@@ -186,7 +192,7 @@ export class DingTalkPlugin extends BasePlugin {
     this.webhookCache.clear();
     this.isConnected = false;
 
-    console.log('[DingTalkPlugin] Stopped and cleaned up');
+    mainLog('DingTalkPlugin', 'Stopped and cleaned up');
   }
 
   /**
@@ -223,7 +229,7 @@ export class DingTalkPlugin extends BasePlugin {
         const cardMessageId = await this.createAndDeliverAICard(chatType, id, rawText);
         return cardMessageId;
       } catch (error) {
-        console.warn('[DingTalkPlugin] AI Card failed, falling back to webhook:', error);
+        mainWarn('DingTalkPlugin', 'AI Card failed, falling back to webhook', error);
       }
     }
 
@@ -234,7 +240,7 @@ export class DingTalkPlugin extends BasePlugin {
         const msgId = await this.sendViaWebhook(webhook, contentType, content, rawText);
         return msgId;
       } catch (error) {
-        console.error('[DingTalkPlugin] Webhook send failed:', error);
+        mainError('DingTalkPlugin', 'Webhook send failed', error);
         throw error;
       }
     }
@@ -244,7 +250,7 @@ export class DingTalkPlugin extends BasePlugin {
       const msgId = await this.sendViaAPI(chatType, id, contentType, content, rawText);
       return msgId;
     } catch (error) {
-      console.error('[DingTalkPlugin] API send failed:', error);
+      mainError('DingTalkPlugin', 'API send failed', error);
       throw error;
     }
   }
@@ -286,7 +292,7 @@ export class DingTalkPlugin extends BasePlugin {
       if (errorMsg.includes('not modified') || errorMsg.includes('not found')) {
         return;
       }
-      console.error('[DingTalkPlugin] Failed to update AI Card:', error);
+      mainError('DingTalkPlugin', 'Failed to update AI Card', error);
 
       // Mark card as finished to prevent further failed streaming attempts
       this.aiCardSessions.set(messageId, { ...cardSession, isFinished: true });
@@ -327,6 +333,9 @@ export class DingTalkPlugin extends BasePlugin {
         this.webhookCache.set(chatId, data.sessionWebhook);
       }
 
+      // Download media files to local workspace before converting
+      await this.downloadMediaItems(data);
+
       // Convert to unified message
       const unifiedMessage = toUnifiedIncomingMessage(data);
       if (unifiedMessage && this.messageHandler) {
@@ -346,16 +355,16 @@ export class DingTalkPlugin extends BasePlugin {
                 name: buttonAction.action,
               },
             };
-            void this.emitMessage(actionMessage).catch((error) => console.error('[DingTalkPlugin] Error handling message:', error));
+            void this.emitMessage(actionMessage).catch((error) => mainError('DingTalkPlugin', 'Error handling message', error));
             return;
           }
         }
 
         // Process in background to avoid blocking
-        void this.emitMessage(unifiedMessage).catch((error) => console.error('[DingTalkPlugin] Error handling message:', error));
+        void this.emitMessage(unifiedMessage).catch((error) => mainError('DingTalkPlugin', 'Error handling message', error));
       }
     } catch (error) {
-      console.error('[DingTalkPlugin] Error processing robot message:', error);
+      mainError('DingTalkPlugin', 'Error processing robot message', error);
     }
   }
 
@@ -386,7 +395,7 @@ export class DingTalkPlugin extends BasePlugin {
       if (actionInfo.name === 'system.confirm' && actionInfo.params?.callId && actionInfo.params?.value) {
         if (this.confirmHandler) {
           void this.confirmHandler(userId, 'dingtalk', actionInfo.params.callId, actionInfo.params.value).catch((error) => {
-            console.error('[DingTalkPlugin] Confirm handler error:', error);
+            mainError('DingTalkPlugin', 'Confirm handler error', error);
           });
         }
         return;
@@ -403,10 +412,10 @@ export class DingTalkPlugin extends BasePlugin {
 
       const unifiedMessage = toUnifiedIncomingMessage(mockData, actionInfo);
       if (unifiedMessage && this.messageHandler) {
-        void this.emitMessage(unifiedMessage).catch((error) => console.error('[DingTalkPlugin] Error handling card action:', error));
+        void this.emitMessage(unifiedMessage).catch((error) => mainError('DingTalkPlugin', 'Error handling card action', error));
       }
     } catch (error) {
-      console.error('[DingTalkPlugin] Error processing card callback:', error);
+      mainError('DingTalkPlugin', 'Error processing card callback', error);
     }
   }
 
@@ -555,7 +564,7 @@ export class DingTalkPlugin extends BasePlugin {
       // Fall back to DingTalk API
       await this.sendViaAPI(chatType, id, contentType, content, rawText);
     } catch (error) {
-      console.error('[DingTalkPlugin] Fallback plain message send failed:', error);
+      mainError('DingTalkPlugin', 'Fallback plain message send failed', error);
     }
   }
 
@@ -617,6 +626,103 @@ export class DingTalkPlugin extends BasePlugin {
     return response?.processQueryKey || `api_${Date.now()}`;
   }
 
+  // ==================== Media Download ====================
+
+  /**
+   * Ensure the media directory exists and return its path.
+   */
+  private async ensureMediaDir(): Promise<string> {
+    if (!this.mediaDir) {
+      const { getDataPath } = await import('@/process/utils');
+      this.mediaDir = path.join(getDataPath(), 'channel-media', 'dingtalk');
+    }
+    fs.mkdirSync(this.mediaDir, { recursive: true });
+    return this.mediaDir;
+  }
+
+  /**
+   * Download a file from URL using https.request (consistent with the rest of DingTalkPlugin).
+   * Returns the file content as a Buffer.
+   */
+  private downloadFile(url: string, timeoutMs = 30_000): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const urlObj = new URL(url);
+      const req = https.request(
+        {
+          hostname: urlObj.hostname,
+          port: urlObj.port || 443,
+          path: urlObj.pathname + urlObj.search,
+          method: 'GET',
+          timeout: timeoutMs,
+        },
+        (res) => {
+          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            // Follow redirects
+            this.downloadFile(res.headers.location, timeoutMs).then(resolve, reject);
+            return;
+          }
+          if (res.statusCode && res.statusCode >= 400) {
+            reject(new Error(`Download failed: HTTP ${res.statusCode}`));
+            return;
+          }
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => resolve(Buffer.concat(chunks)));
+        }
+      );
+      req.on('error', reject);
+      req.on('timeout', () => {
+        req.destroy(new Error('Download timed out'));
+      });
+      req.end();
+    });
+  }
+
+  /**
+   * Download media files (picture/audio/video/file) from DingTalk to local workspace.
+   * Sets `_localPath` on the message data for each successfully downloaded item.
+   * Failures are logged but do not block message processing.
+   */
+  private async downloadMediaItems(data: DingTalkStreamMessage): Promise<void> {
+    const mediaInfo = extractMediaDownloadInfo(data);
+    if (!mediaInfo) {
+      return;
+    }
+
+    const { downloadCode, fileName } = mediaInfo;
+    const msgtype = data.msgtype!;
+
+    try {
+      const token = await this.getAccessToken();
+      const response = await this.apiRequest('POST', '/v1.0/robot/messageFiles/download', token, {
+        downloadCode,
+        robotCode: this.clientId,
+      });
+
+      const downloadUrl = response?.downloadUrl;
+      if (!downloadUrl) {
+        mainError('DingTalkPlugin', `No downloadUrl in response for downloadCode: ${downloadCode}`);
+        return;
+      }
+
+      // Download file content using https.request (same as other DingTalk HTTP calls)
+      const fileData = await this.downloadFile(downloadUrl);
+
+      // Save directly to mediaDir (no double nesting)
+      const mediaDir = await this.ensureMediaDir();
+      const ext = fileName ? path.extname(fileName) : getDefaultExtension(msgtype);
+      const baseName = fileName || `dingtalk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}${ext}`;
+      const localPath = path.join(mediaDir, baseName);
+      fs.writeFileSync(localPath, fileData);
+
+      setMediaLocalPath(data, localPath);
+
+      mainLog('DingTalkPlugin', `Downloaded media: type=${msgtype}, size=${fileData.length}, path=${localPath}`);
+    } catch (error) {
+      mainError('DingTalkPlugin', `Failed to download media for type=${msgtype}, downloadCode=${downloadCode}`, error);
+    }
+  }
+
   // ==================== Access Token Management ====================
 
   /**
@@ -657,7 +763,7 @@ export class DingTalkPlugin extends BasePlugin {
         throw new Error('No access token in response');
       }
     } catch (error) {
-      console.error('[DingTalkPlugin] Failed to refresh access token:', error);
+      mainError('DingTalkPlugin', 'Failed to refresh access token', error);
       throw error;
     }
   }

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -158,6 +158,8 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
   private currentStreamMsgId: string | null = null;
   private accumulatedAssistantText = '';
   private agentAssistantFallbackText = '';
+  /** When true, accumulated text matches a prefix of "NO_REPLY" and is buffered pending more tokens */
+  private noReplyBuffering = false;
   private statusMessageId: string | null = null;
   private connectionTipMessageId: string | null = null;
   private _lastConnectionStatus: string | null = null;
@@ -780,6 +782,7 @@ ${draftsInstruction}`;
       case 'delta': {
         const cumulative = this.extractTextFromMessage(event.message);
         if (!cumulative) return;
+
         this.agentAssistantFallbackText = '';
 
         if (!this.currentStreamMsgId) {
@@ -798,6 +801,25 @@ ${draftsInstruction}`;
 
         if (!delta) return;
 
+        // Filter out NO_REPLY — internal agent protocol signal (e.g. memory flush response), not user-facing.
+        // Buffer partial prefixes ("N", "NO", "NO_", ...) to handle multi-token splitting by the LLM.
+        const trimmed = this.accumulatedAssistantText.trim();
+        if ('NO_REPLY'.startsWith(trimmed)) {
+          this.noReplyBuffering = true;
+          if (trimmed === 'NO_REPLY') {
+            this.currentStreamMsgId = null;
+            this.accumulatedAssistantText = '';
+            this.noReplyBuffering = false;
+          }
+          return;
+        }
+
+        // If we were buffering a NO_REPLY prefix but text diverged, emit full accumulated text
+        if (this.noReplyBuffering) {
+          this.noReplyBuffering = false;
+          delta = this.accumulatedAssistantText;
+        }
+
         this.handleStreamMessage({
           type: 'content',
           conversation_id: this.conversation_id,
@@ -810,6 +832,14 @@ ${draftsInstruction}`;
       case 'final': {
         if (event.message) {
           const finalText = this.extractTextFromMessage(event.message);
+          // Filter out NO_REPLY — internal agent protocol signal, not user-facing
+          if (finalText?.trim() === 'NO_REPLY') {
+            this.noReplyBuffering = false;
+            this.currentStreamMsgId = null;
+            this.accumulatedAssistantText = '';
+            this.handleEndTurn();
+            break;
+          }
           if (finalText && finalText.length > this.accumulatedAssistantText.length) {
             if (!this.currentStreamMsgId) {
               this.currentStreamMsgId = uuid();
@@ -851,6 +881,16 @@ ${draftsInstruction}`;
         break;
 
       case 'error':
+        mainError('OpenClawAgent', '[DIAG] ChatEvent error received:', JSON.stringify({
+          runId: event.runId,
+          sessionKey: event.sessionKey,
+          seq: event.seq,
+          state: event.state,
+          stopReason: event.stopReason,
+          errorMessage: event.errorMessage,
+          message: event.message,
+          usage: event.usage,
+        }, null, 2));
         this.emitErrorMessage(event.errorMessage || 'Unknown error');
         this.handleEndTurn();
         break;
@@ -908,7 +948,7 @@ ${draftsInstruction}`;
       case 'assistant': {
         if (!event.data) break;
         const text = (event.data.text as string) || '';
-        if (text) {
+        if (text && text.trim() !== 'NO_REPLY') {
           this.agentAssistantFallbackText = text;
         }
         break;
@@ -1010,9 +1050,21 @@ ${draftsInstruction}`;
   }
 
   private handleEndTurn(): void {
+    // Flush any content that was buffered for NO_REPLY prefix detection
+    // (e.g. "NO" that turned out to be a real response, not NO_REPLY)
+    if (this.noReplyBuffering && this.accumulatedAssistantText && this.currentStreamMsgId) {
+      this.handleStreamMessage({
+        type: 'content',
+        conversation_id: this.conversation_id,
+        msg_id: this.currentStreamMsgId,
+        data: this.accumulatedAssistantText,
+      });
+    }
+
     this.currentStreamMsgId = null;
     this.accumulatedAssistantText = '';
     this.agentAssistantFallbackText = '';
+    this.noReplyBuffering = false;
 
     const msg: IResponseMessage = {
       type: 'finish',

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -456,6 +456,17 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
           createdAt: Date.now(),
         };
         addMessage(this.conversation_id, userMessage);
+
+        // Emit user_content event so the desktop renderer can display the message in real-time.
+        // For desktop-originated messages, the SendBox already added the message locally with
+        // the same msg_id, so addOrUpdateMessage's dedup logic will skip the duplicate.
+        const userResponseMessage: IResponseMessage = {
+          type: 'user_content',
+          conversation_id: this.conversation_id,
+          msg_id: data.msg_id,
+          data: userMessage.content.content,
+        };
+        ipcBridge.openclawConversation.responseStream.emit(userResponseMessage);
       }
 
       // Reset streaming state

--- a/tests/integration/channels/dingtalkMediaFlow.test.ts
+++ b/tests/integration/channels/dingtalkMediaFlow.test.ts
@@ -1,0 +1,273 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for DingTalk media download flow.
+ *
+ * Tests the full chain: DingTalkStreamMessage -> extractMediaDownloadInfo -> download -> setMediaLocalPath -> toUnifiedIncomingMessage
+ * using mock HTTP and real adapter logic.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractMediaDownloadInfo, getDefaultExtension, setMediaLocalPath, toUnifiedIncomingMessage } from '@/channels/plugins/dingtalk/DingTalkAdapter';
+import type { DingTalkStreamMessage } from '@/channels/plugins/dingtalk/DingTalkAdapter';
+
+// ==================== Integration: full media download flow ====================
+
+describe('DingTalk media download flow (integration)', () => {
+  const tmpDir = path.join('/tmp', `dingtalk-media-test-${Date.now()}`);
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  /**
+   * Simulates the full download flow that DingTalkPlugin.downloadMediaItems performs:
+   * 1. extractMediaDownloadInfo to get downloadCode/fileName
+   * 2. Mock API call to get downloadUrl
+   * 3. Write file directly to mediaDir (same as DingTalkPlugin)
+   * 4. setMediaLocalPath to update message data
+   * 5. toUnifiedIncomingMessage to verify fileId is local path
+   */
+  async function simulateFullFlow(
+    data: DingTalkStreamMessage,
+    mockDownloadUrl: string,
+    fileContent: Buffer,
+  ): Promise<{ localPath: string; unified: ReturnType<typeof toUnifiedIncomingMessage> }> {
+    // Step 1: Extract download info
+    const mediaInfo = extractMediaDownloadInfo(data);
+    if (!mediaInfo) {
+      throw new Error('No media info extracted');
+    }
+
+    // Step 2: (Mocked in real plugin - API call to get downloadUrl)
+    // In this test we use the mockDownloadUrl directly
+
+    // Step 3: Save file directly to mediaDir (mirrors DingTalkPlugin.downloadMediaItems)
+    const ext = mediaInfo.fileName ? path.extname(mediaInfo.fileName) : getDefaultExtension(data.msgtype);
+    const baseName = mediaInfo.fileName || `dingtalk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}${ext}`;
+    const localPath = path.join(tmpDir, baseName);
+    fs.writeFileSync(localPath, fileContent);
+
+    // Step 4: Set local path on message data
+    setMediaLocalPath(data, localPath);
+
+    // Step 5: Convert to unified message and verify
+    const unified = toUnifiedIncomingMessage(data);
+
+    return { localPath, unified };
+  }
+
+  describe('picture message - full flow', () => {
+    it('downloads picture and produces local fileId in unified message', async () => {
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_pic_1',
+        senderStaffId: 'staff1',
+        senderNick: 'User1',
+        conversationType: '1',
+        createAt: 1000,
+        msgtype: 'picture',
+        picture: { downloadCode: 'pic_download_code_123' },
+      };
+
+      const fakeImageData = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]); // JPEG magic bytes
+      const { localPath, unified } = await simulateFullFlow(data, 'https://dt.example.com/file.jpg', fakeImageData);
+
+      expect(fs.existsSync(localPath)).toBe(true);
+      expect(fs.readFileSync(localPath)).toEqual(fakeImageData);
+      expect(unified).not.toBeNull();
+      expect(unified!.content.type).toBe('photo');
+      expect(unified!.content.attachments![0].fileId).toBe(localPath);
+      expect(unified!.content.attachments![0].fileId).not.toContain('pic_download_code_123');
+    });
+  });
+
+  describe('audio message - full flow', () => {
+    it('downloads audio and produces local fileId in unified message', async () => {
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_audio_1',
+        senderStaffId: 'staff2',
+        senderNick: 'User2',
+        conversationType: '1',
+        createAt: 2000,
+        msgtype: 'audio',
+        audio: { downloadCode: 'audio_download_code_456', duration: '5000', recognition: 'recognized text' },
+      };
+
+      const fakeAudioData = Buffer.from([0x23, 0x21, 0x41, 0x4d, 0x52]); // AMR magic bytes
+      const { localPath, unified } = await simulateFullFlow(data, 'https://dt.example.com/file.amr', fakeAudioData);
+
+      expect(fs.existsSync(localPath)).toBe(true);
+      expect(unified).not.toBeNull();
+      expect(unified!.content.type).toBe('audio');
+      expect(unified!.content.attachments![0].fileId).toBe(localPath);
+      expect(unified!.content.attachments![0].duration).toBe(5000);
+      expect(unified!.content.text).toBe('recognized text');
+    });
+  });
+
+  describe('video message - full flow', () => {
+    it('downloads video and produces local fileId in unified message', async () => {
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_video_1',
+        senderStaffId: 'staff3',
+        senderNick: 'User3',
+        conversationType: '1',
+        createAt: 3000,
+        msgtype: 'video',
+        video: { downloadCode: 'video_download_code_789', duration: '30000' },
+      };
+
+      const fakeVideoData = Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]); // MP4 magic bytes
+      const { localPath, unified } = await simulateFullFlow(data, 'https://dt.example.com/file.mp4', fakeVideoData);
+
+      expect(fs.existsSync(localPath)).toBe(true);
+      expect(unified).not.toBeNull();
+      expect(unified!.content.type).toBe('video');
+      expect(unified!.content.attachments![0].fileId).toBe(localPath);
+      expect(unified!.content.attachments![0].duration).toBe(30000);
+    });
+  });
+
+  describe('file message - full flow', () => {
+    it('downloads file with original fileName and produces local fileId', async () => {
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_file_1',
+        senderStaffId: 'staff4',
+        senderNick: 'User4',
+        conversationType: '1',
+        createAt: 4000,
+        msgtype: 'file',
+        file: { downloadCode: 'file_download_code_101', fileName: 'quarterly-report.pdf', fileSize: '102400' },
+      };
+
+      const fakeFileData = Buffer.from('%PDF-1.4 fake content');
+      const { localPath, unified } = await simulateFullFlow(data, 'https://dt.example.com/file.pdf', fakeFileData);
+
+      expect(fs.existsSync(localPath)).toBe(true);
+      expect(localPath).toContain('quarterly-report.pdf');
+      expect(unified).not.toBeNull();
+      expect(unified!.content.type).toBe('document');
+      expect(unified!.content.attachments![0].fileId).toBe(localPath);
+      expect(unified!.content.attachments![0].fileName).toBe('quarterly-report.pdf');
+      expect(unified!.content.attachments![0].size).toBe(102400);
+    });
+
+    it('downloads file without fileName using generated name with default extension', async () => {
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_file_2',
+        senderStaffId: 'staff5',
+        senderNick: 'User5',
+        conversationType: '1',
+        createAt: 5000,
+        msgtype: 'file',
+        file: { downloadCode: 'file_download_code_202' },
+      };
+
+      const fakeFileData = Buffer.from('some binary data');
+      const { localPath, unified } = await simulateFullFlow(data, 'https://dt.example.com/file.bin', fakeFileData);
+
+      expect(fs.existsSync(localPath)).toBe(true);
+      // file type has no default extension, so file name is generated without extension
+      expect(localPath).toContain(path.join(tmpDir, 'dingtalk'));
+      expect(unified).not.toBeNull();
+      expect(unified!.content.attachments![0].fileId).toBe(localPath);
+    });
+  });
+
+  describe('download failure - graceful degradation', () => {
+    it('falls back to downloadCode as fileId when download is skipped', () => {
+      // Simulate: download failed, _localPath was never set
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_fail_1',
+        senderStaffId: 'staff6',
+        senderNick: 'User6',
+        conversationType: '1',
+        createAt: 6000,
+        msgtype: 'picture',
+        picture: { downloadCode: 'expired_code_xyz' },
+      };
+
+      // Without calling setMediaLocalPath, _localPath is never set
+      const unified = toUnifiedIncomingMessage(data);
+      expect(unified).not.toBeNull();
+      expect(unified!.content.attachments![0].fileId).toBe('expired_code_xyz');
+    });
+
+    it('falls back to downloadCode when extractMediaDownloadInfo returns null (empty downloadCode)', () => {
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_fail_2',
+        senderStaffId: 'staff7',
+        senderNick: 'User7',
+        conversationType: '1',
+        createAt: 7000,
+        msgtype: 'audio',
+        audio: { downloadCode: '' },
+      };
+
+      // extractMediaDownloadInfo returns null for empty downloadCode
+      expect(extractMediaDownloadInfo(data)).toBeNull();
+
+      // Message still converts to unified format (with empty fileId)
+      const unified = toUnifiedIncomingMessage(data);
+      expect(unified).not.toBeNull();
+      expect(unified!.content.type).toBe('audio');
+      expect(unified!.content.attachments![0].fileId).toBe('');
+    });
+
+    it('non-media messages pass through without any download logic', () => {
+      const textData: DingTalkStreamMessage = {
+        msgId: 'msg_text_1',
+        senderStaffId: 'staff8',
+        senderNick: 'User8',
+        conversationType: '1',
+        createAt: 8000,
+        msgtype: 'text',
+        text: { content: 'Hello bot' },
+      };
+
+      expect(extractMediaDownloadInfo(textData)).toBeNull();
+
+      const unified = toUnifiedIncomingMessage(textData);
+      expect(unified).not.toBeNull();
+      expect(unified!.content.type).toBe('text');
+      expect(unified!.content.text).toBe('Hello bot');
+    });
+  });
+
+  describe('group chat scenario', () => {
+    it('handles picture in group chat with @bot removed and local fileId', async () => {
+      const data: DingTalkStreamMessage = {
+        msgId: 'msg_group_pic_1',
+        senderStaffId: 'staff9',
+        senderNick: 'User9',
+        conversationType: '2',
+        conversationId: 'group123',
+        createAt: 9000,
+        msgtype: 'picture',
+        picture: { downloadCode: 'group_pic_code' },
+      };
+
+      const fakeImageData = Buffer.from([0xff, 0xd8, 0xff, 0xe1]);
+      const { localPath, unified } = await simulateFullFlow(data, 'https://dt.example.com/group_pic.jpg', fakeImageData);
+
+      expect(unified).not.toBeNull();
+      expect(unified!.chatId).toBe('group:group123');
+      expect(unified!.content.type).toBe('photo');
+      expect(unified!.content.attachments![0].fileId).toBe(localPath);
+    });
+  });
+});

--- a/tests/unit/channels/dingtalkAdapter.test.ts
+++ b/tests/unit/channels/dingtalkAdapter.test.ts
@@ -1,0 +1,552 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getDefaultExtension, getDefaultMimeType, extractMediaDownloadInfo, setMediaLocalPath, toUnifiedIncomingMessage } from '@/channels/plugins/dingtalk/DingTalkAdapter';
+import type { DingTalkStreamMessage } from '@/channels/plugins/dingtalk/DingTalkAdapter';
+
+// ==================== getDefaultExtension ====================
+
+describe('DingTalkAdapter getDefaultExtension', () => {
+  it('returns .jpg for picture', () => {
+    expect(getDefaultExtension('picture')).toBe('.jpg');
+  });
+
+  it('returns .amr for audio', () => {
+    expect(getDefaultExtension('audio')).toBe('.amr');
+  });
+
+  it('returns .mp4 for video', () => {
+    expect(getDefaultExtension('video')).toBe('.mp4');
+  });
+
+  it('returns empty string for file (uses original fileName)', () => {
+    expect(getDefaultExtension('file')).toBe('');
+  });
+
+  it('returns empty string for text', () => {
+    expect(getDefaultExtension('text')).toBe('');
+  });
+
+  it('returns empty string for richText', () => {
+    expect(getDefaultExtension('richText')).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(getDefaultExtension(undefined)).toBe('');
+  });
+
+  it('returns empty string for unknown type', () => {
+    expect(getDefaultExtension('sticker')).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(getDefaultExtension('')).toBe('');
+  });
+});
+
+// ==================== getDefaultMimeType ====================
+
+describe('DingTalkAdapter getDefaultMimeType', () => {
+  it('returns image/jpeg for picture', () => {
+    expect(getDefaultMimeType('picture')).toBe('image/jpeg');
+  });
+
+  it('returns audio/amr for audio', () => {
+    expect(getDefaultMimeType('audio')).toBe('audio/amr');
+  });
+
+  it('returns video/mp4 for video', () => {
+    expect(getDefaultMimeType('video')).toBe('video/mp4');
+  });
+
+  it('returns application/octet-stream for file', () => {
+    expect(getDefaultMimeType('file')).toBe('application/octet-stream');
+  });
+
+  it('returns application/octet-stream for text', () => {
+    expect(getDefaultMimeType('text')).toBe('application/octet-stream');
+  });
+
+  it('returns application/octet-stream for undefined', () => {
+    expect(getDefaultMimeType(undefined)).toBe('application/octet-stream');
+  });
+
+  it('returns application/octet-stream for unknown type', () => {
+    expect(getDefaultMimeType('sticker')).toBe('application/octet-stream');
+  });
+});
+
+// ==================== extractMediaDownloadInfo ====================
+
+describe('DingTalkAdapter extractMediaDownloadInfo', () => {
+  it('returns downloadCode for picture message', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      picture: { downloadCode: 'pic_code_123' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('pic_code_123');
+    expect(result!.fileName).toBeUndefined();
+  });
+
+  it('returns downloadCode from content field for picture message (Stream API)', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      content: { pictureDownloadCode: 'pic_dl_code_abc', downloadCode: 'generic_dl_code' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('generic_dl_code');
+  });
+
+  it('falls back to content.downloadCode when pictureDownloadCode is absent', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      content: { downloadCode: 'generic_dl_code' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('generic_dl_code');
+  });
+
+  it('prefers picture field over content field', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      picture: { downloadCode: 'pic_field_code' },
+      content: { downloadCode: 'content_field_code' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('pic_field_code');
+  });
+
+  it('returns downloadCode for audio message', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'audio',
+      audio: { downloadCode: 'audio_code_456', duration: '3000' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('audio_code_456');
+    expect(result!.fileName).toBeUndefined();
+  });
+
+  it('returns downloadCode from content field for audio message (Stream API)', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'audio',
+      content: { downloadCode: 'audio_content_code', duration: '5000', recognition: 'hello' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('audio_content_code');
+  });
+
+  it('returns downloadCode for video message', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'video',
+      video: { downloadCode: 'video_code_789' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('video_code_789');
+    expect(result!.fileName).toBeUndefined();
+  });
+
+  it('returns downloadCode from content field for video message (Stream API)', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'video',
+      content: { downloadCode: 'video_content_code', duration: '10000' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('video_content_code');
+  });
+
+  it('returns downloadCode and fileName for file message', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'file',
+      file: { downloadCode: 'file_code_101', fileName: 'report.pdf', fileSize: '50000' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('file_code_101');
+    expect(result!.fileName).toBe('report.pdf');
+  });
+
+  it('returns downloadCode and fileName from content field for file message (Stream API)', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'file',
+      content: { downloadCode: 'file_content_code', fileName: 'doc.xlsx', fileSize: '102400' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('file_content_code');
+    expect(result!.fileName).toBe('doc.xlsx');
+  });
+
+  it('returns null for text message', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'text',
+      text: { content: 'hello' },
+    };
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns null for richText message', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'richText',
+      richText: { richTextList: [{ text: 'hello', type: 'text' }] },
+    };
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns null when msgtype is undefined', () => {
+    const data: DingTalkStreamMessage = {};
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns null when msgtype is empty string', () => {
+    const data: DingTalkStreamMessage = { msgtype: '' };
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns null when msgtype is unknown', () => {
+    const data: DingTalkStreamMessage = { msgtype: 'sticker' };
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns null when downloadCode is empty string', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      picture: { downloadCode: '' },
+    };
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns null when downloadCode is undefined', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      picture: {},
+    };
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns null when media field is undefined', () => {
+    const data: DingTalkStreamMessage = { msgtype: 'picture' };
+    expect(extractMediaDownloadInfo(data)).toBeNull();
+  });
+
+  it('returns fileName as undefined for file message without fileName', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'file',
+      file: { downloadCode: 'file_code_no_name' },
+    };
+    const result = extractMediaDownloadInfo(data);
+    expect(result).not.toBeNull();
+    expect(result!.downloadCode).toBe('file_code_no_name');
+    expect(result!.fileName).toBeUndefined();
+  });
+});
+
+// ==================== setMediaLocalPath ====================
+
+describe('DingTalkAdapter setMediaLocalPath', () => {
+  it('sets _localPath on picture field', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      picture: { downloadCode: 'code1' },
+    };
+    setMediaLocalPath(data, '/tmp/photo.jpg');
+    expect(data.picture!._localPath).toBe('/tmp/photo.jpg');
+  });
+
+  it('sets _localPath on audio field', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'audio',
+      audio: { downloadCode: 'code2' },
+    };
+    setMediaLocalPath(data, '/tmp/voice.amr');
+    expect(data.audio!._localPath).toBe('/tmp/voice.amr');
+  });
+
+  it('sets _localPath on video field', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'video',
+      video: { downloadCode: 'code3' },
+    };
+    setMediaLocalPath(data, '/tmp/video.mp4');
+    expect(data.video!._localPath).toBe('/tmp/video.mp4');
+  });
+
+  it('sets _localPath on file field', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'file',
+      file: { downloadCode: 'code4', fileName: 'doc.pdf' },
+    };
+    setMediaLocalPath(data, '/tmp/doc.pdf');
+    expect(data.file!._localPath).toBe('/tmp/doc.pdf');
+  });
+
+  it('does not throw when media field is undefined for picture', () => {
+    const data: DingTalkStreamMessage = { msgtype: 'picture' };
+    expect(() => setMediaLocalPath(data, '/tmp/photo.jpg')).not.toThrow();
+  });
+
+  it('does not throw when media field is undefined for audio', () => {
+    const data: DingTalkStreamMessage = { msgtype: 'audio' };
+    expect(() => setMediaLocalPath(data, '/tmp/voice.amr')).not.toThrow();
+  });
+
+  it('does not throw when media field is undefined for video', () => {
+    const data: DingTalkStreamMessage = { msgtype: 'video' };
+    expect(() => setMediaLocalPath(data, '/tmp/video.mp4')).not.toThrow();
+  });
+
+  it('does not throw when media field is undefined for file', () => {
+    const data: DingTalkStreamMessage = { msgtype: 'file' };
+    expect(() => setMediaLocalPath(data, '/tmp/doc.pdf')).not.toThrow();
+  });
+
+  it('does not throw when msgtype is undefined', () => {
+    const data: DingTalkStreamMessage = {};
+    expect(() => setMediaLocalPath(data, '/tmp/anything')).not.toThrow();
+  });
+
+  it('overwrites existing _localPath', () => {
+    const data: DingTalkStreamMessage = {
+      msgtype: 'picture',
+      picture: { downloadCode: 'code', _localPath: '/old/path.jpg' },
+    };
+    setMediaLocalPath(data, '/new/path.jpg');
+    expect(data.picture!._localPath).toBe('/new/path.jpg');
+  });
+});
+
+// ==================== toUnifiedIncomingMessage - media _localPath priority ====================
+
+describe('DingTalkAdapter extractMessageContent _localPath priority', () => {
+  const baseMessage: DingTalkStreamMessage = {
+    msgId: 'msg1',
+    senderStaffId: 'staff1',
+    senderNick: 'TestUser',
+    conversationType: '1',
+    createAt: 1000,
+  };
+
+  // --- picture ---
+
+  describe('picture message', () => {
+    it('uses _localPath when available', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'picture',
+        picture: {
+          downloadCode: 'code_abc',
+          _localPath: '/tmp/channel-media/dingtalk/photo_123.jpg',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('photo');
+      expect(result!.content.attachments![0].fileId).toBe('/tmp/channel-media/dingtalk/photo_123.jpg');
+    });
+
+    it('falls back to downloadCode when _localPath is absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'picture',
+        picture: {
+          downloadCode: 'code_abc',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('code_abc');
+    });
+
+    it('returns empty fileId when both _localPath and downloadCode are absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'picture',
+        picture: {},
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('');
+    });
+
+    it('returns empty fileId when picture is undefined', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'picture',
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('');
+    });
+  });
+
+  // --- audio ---
+
+  describe('audio message', () => {
+    it('uses _localPath when available', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'audio',
+        audio: {
+          downloadCode: 'audio_code',
+          duration: '3000',
+          recognition: 'hello world',
+          _localPath: '/tmp/channel-media/dingtalk/voice_456.amr',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('audio');
+      expect(result!.content.attachments![0].fileId).toBe('/tmp/channel-media/dingtalk/voice_456.amr');
+      expect(result!.content.attachments![0].duration).toBe(3000);
+      expect(result!.content.text).toBe('hello world');
+    });
+
+    it('falls back to downloadCode when _localPath is absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'audio',
+        audio: {
+          downloadCode: 'audio_code',
+          duration: '5000',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('audio_code');
+      expect(result!.content.attachments![0].duration).toBe(5000);
+    });
+
+    it('returns empty fileId and undefined duration when both are absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'audio',
+        audio: {},
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('');
+      expect(result!.content.attachments![0].duration).toBeUndefined();
+    });
+  });
+
+  // --- video ---
+
+  describe('video message', () => {
+    it('uses _localPath when available', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'video',
+        video: {
+          downloadCode: 'video_code',
+          duration: '10000',
+          _localPath: '/tmp/channel-media/dingtalk/video_789.mp4',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('video');
+      expect(result!.content.attachments![0].fileId).toBe('/tmp/channel-media/dingtalk/video_789.mp4');
+      expect(result!.content.attachments![0].duration).toBe(10000);
+    });
+
+    it('falls back to downloadCode when _localPath is absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'video',
+        video: {
+          downloadCode: 'video_code',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('video_code');
+    });
+
+    it('returns empty fileId when both are absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'video',
+        video: {},
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('');
+    });
+  });
+
+  // --- file ---
+
+  describe('file message', () => {
+    it('uses _localPath when available', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'file',
+        file: {
+          downloadCode: 'file_code',
+          fileName: 'report.pdf',
+          fileSize: '50000',
+          _localPath: '/tmp/channel-media/dingtalk/report.pdf',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('document');
+      expect(result!.content.attachments![0].fileId).toBe('/tmp/channel-media/dingtalk/report.pdf');
+      expect(result!.content.attachments![0].fileName).toBe('report.pdf');
+      expect(result!.content.attachments![0].size).toBe(50000);
+    });
+
+    it('falls back to downloadCode when _localPath is absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'file',
+        file: {
+          downloadCode: 'file_code',
+          fileName: 'doc.docx',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('file_code');
+      expect(result!.content.attachments![0].fileName).toBe('doc.docx');
+    });
+
+    it('returns empty fileId and preserves fileName when both are absent', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'file',
+        file: {
+          fileName: 'note.txt',
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('');
+      expect(result!.content.attachments![0].fileName).toBe('note.txt');
+    });
+
+    it('returns empty fileId and undefined fileName when file is empty object', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'file',
+        file: {},
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.attachments![0].fileId).toBe('');
+      expect(result!.content.attachments![0].fileName).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/channels/dingtalkAdapter.test.ts
+++ b/tests/unit/channels/dingtalkAdapter.test.ts
@@ -31,8 +31,8 @@ describe('DingTalkAdapter getDefaultExtension', () => {
     expect(getDefaultExtension('text')).toBe('');
   });
 
-  it('returns empty string for richText', () => {
-    expect(getDefaultExtension('richText')).toBe('');
+  it('returns .jpg for richText (contains picture items)', () => {
+    expect(getDefaultExtension('richText')).toBe('.jpg');
   });
 
   it('returns empty string for undefined', () => {
@@ -547,6 +547,221 @@ describe('DingTalkAdapter extractMessageContent _localPath priority', () => {
       expect(result).not.toBeNull();
       expect(result!.content.attachments![0].fileId).toBe('');
       expect(result!.content.attachments![0].fileName).toBeUndefined();
+    });
+  });
+});
+
+// ==================== richText message handling ====================
+
+describe('DingTalkAdapter richText message handling', () => {
+  const baseMessage: DingTalkStreamMessage = {
+    msgId: 'msg1',
+    senderStaffId: 'staff1',
+    senderNick: 'TestUser',
+    conversationType: '1',
+    createAt: 1000,
+  };
+
+  // --- extractMediaDownloadInfo for richText ---
+
+  describe('extractMediaDownloadInfo for richText', () => {
+    it('returns downloadCode for richText with picture item (content.richText path)', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {
+          richText: [
+            { text: 'hello' },
+            { downloadCode: 'pic_dl_123', pictureDownloadCode: 'pic_pc_123', type: 'picture' },
+          ],
+        },
+      };
+      const result = extractMediaDownloadInfo(data);
+      expect(result).not.toBeNull();
+      expect(result!.downloadCode).toBe('pic_dl_123');
+    });
+
+    it('returns downloadCode for richText with picture item (richText.richTextList fallback)', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        richText: {
+          richTextList: [
+            { text: 'hello' },
+            { downloadCode: 'pic_dl_456', pictureDownloadCode: 'pic_pc_456', type: 'picture' },
+          ],
+        },
+      };
+      const result = extractMediaDownloadInfo(data);
+      expect(result).not.toBeNull();
+      expect(result!.downloadCode).toBe('pic_dl_456');
+    });
+
+    it('returns null for richText with text-only items', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {
+          richText: [{ text: 'hello' }, { text: 'world' }],
+        },
+      };
+      expect(extractMediaDownloadInfo(data)).toBeNull();
+    });
+
+    it('returns null for richText with empty content', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {},
+      };
+      expect(extractMediaDownloadInfo(data)).toBeNull();
+    });
+  });
+
+  // --- setMediaLocalPath for richText ---
+
+  describe('setMediaLocalPath for richText', () => {
+    it('sets _localPath on content field for richText', () => {
+      const data: DingTalkStreamMessage = {
+        msgtype: 'richText',
+        content: { richText: [{ text: 'hello' }] },
+      };
+      setMediaLocalPath(data, '/tmp/rich_photo.jpg');
+      expect(data.content!._localPath).toBe('/tmp/rich_photo.jpg');
+    });
+
+    it('does not throw when content is undefined for richText', () => {
+      const data: DingTalkStreamMessage = { msgtype: 'richText' };
+      expect(() => setMediaLocalPath(data, '/tmp/anything.jpg')).not.toThrow();
+    });
+  });
+
+  // --- toUnifiedIncomingMessage for richText ---
+
+  describe('toUnifiedIncomingMessage for richText', () => {
+    it('returns photo type for richText with text+picture (content.richText path)', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {
+          richText: [
+            { text: 'hello' },
+            { downloadCode: 'pic_dl_789', pictureDownloadCode: 'pic_pc_789', type: 'picture' },
+          ],
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('photo');
+      expect(result!.content.text).toBe('hello');
+      expect(result!.content.attachments).toBeDefined();
+      expect(result!.content.attachments!.length).toBe(1);
+      expect(result!.content.attachments![0].type).toBe('photo');
+      expect(result!.content.attachments![0].fileId).toBe('pic_dl_789');
+    });
+
+    it('returns photo type for richText with text+picture (richText.richTextList fallback)', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        richText: {
+          richTextList: [
+            { text: 'hello' },
+            { downloadCode: 'pic_dl_abc', pictureDownloadCode: 'pic_pc_abc', type: 'picture' },
+          ],
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('photo');
+      expect(result!.content.text).toBe('hello');
+      expect(result!.content.attachments![0].fileId).toBe('pic_dl_abc');
+    });
+
+    it('uses _localPath when available for richText picture', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {
+          _localPath: '/tmp/channel-media/dingtalk/rich_photo.jpg',
+          richText: [
+            { text: 'hello' },
+            { downloadCode: 'pic_dl_xyz', type: 'picture' },
+          ],
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('photo');
+      expect(result!.content.attachments![0].fileId).toBe('/tmp/channel-media/dingtalk/rich_photo.jpg');
+    });
+
+    it('returns text type for richText with text only', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {
+          richText: [{ text: 'hello' }, { text: ' world' }],
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('text');
+      expect(result!.content.text).toBe('hello world');
+    });
+
+    it('returns photo type for richText with picture only (no text)', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {
+          richText: [
+            { downloadCode: 'pic_only_code', pictureDownloadCode: 'pic_only_pc', type: 'picture' },
+          ],
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('photo');
+      expect(result!.content.text).toBe('');
+      expect(result!.content.attachments![0].fileId).toBe('pic_only_code');
+    });
+
+    it('returns text type with empty text for richText with empty array', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: { richText: [] },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('text');
+      expect(result!.content.text).toBe('');
+    });
+
+    it('returns text type for richText with no content field', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('text');
+      expect(result!.content.text).toBe('');
+    });
+
+    it('joins multiple text items for richText', () => {
+      const data: DingTalkStreamMessage = {
+        ...baseMessage,
+        msgtype: 'richText',
+        content: {
+          richText: [{ text: 'line1' }, { text: 'line2' }, { text: 'line3' }],
+        },
+      };
+      const result = toUnifiedIncomingMessage(data);
+      expect(result).not.toBeNull();
+      expect(result!.content.type).toBe('text');
+      expect(result!.content.text).toBe('line1line2line3');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Download DingTalk media files before message conversion to ensure images are available when building the agent payload
- Emit `user_content` IPC event in OpenClawAgent for real-time message display in the desktop UI
- Handle DingTalk richText (picture+text) messages correctly by extracting picture items from `content.richText` path
- Filter `NO_REPLY` internal protocol signal from DingTalk streaming — the OpenClaw agent sends `NO_REPLY` after memory flush tool calls, which was being streamed to DingTalk as user-visible text, overwriting the real response content. Buffer partial prefixes to handle multi-token LLM splitting.

## Test plan
- [ ] Send picture+text (richText) message from DingTalk, verify model responds with actual content (not "NO_REPLY" or "No")
- [ ] Send pure text message from DingTalk, verify normal response
- [ ] Send picture-only message from DingTalk, verify image is processed correctly
- [ ] Verify desktop UI still shows user messages in real-time
- [ ] Verify no regression in other channels (Telegram, Lark, WeChat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)