### PR TITLE
feat(wechat): support agent reply images and files in markdown

### DIFF
--- a/src/channels/plugins/wechat/WeChatAdapter.ts
+++ b/src/channels/plugins/wechat/WeChatAdapter.ts
@@ -252,6 +252,54 @@ export function toWeChatSendPayload(userId: string, message: IUnifiedOutgoingMes
 }
 
 /**
+ * Extract all image URLs from markdown text.
+ * Matches `![alt](url)` patterns and returns the URLs.
+ *
+ * @param text - Markdown text that may contain image references
+ * @returns Array of image URLs found in the markdown
+ */
+export function extractMarkdownImageUrls(text: string): string[] {
+  const imageRegex = /!\[[^\]]*\]\(([^)]+)\)/g;
+  const urls: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = imageRegex.exec(text)) !== null) {
+    const url = match[1].trim();
+    if (url) urls.push(url);
+  }
+  return urls;
+}
+
+/**
+ * Extract all file URLs from markdown links that point to downloadable files.
+ * Matches `[text](url)` patterns where the URL ends with a known file extension.
+ * Excludes image links (which are handled by extractMarkdownImageUrls).
+ *
+ * @param text - Markdown text that may contain file links
+ * @returns Array of { url, fileName } for files found in the markdown
+ */
+export function extractMarkdownFileUrls(text: string): Array<{ url: string; fileName: string }> {
+  // Match [text](url) but NOT ![text](url)
+  const linkRegex = /(?<!!)\[([^\]]*)\]\(([^)]+)\)/g;
+  const fileExtensions = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.zip', '.rar', '.7z', '.tar', '.gz', '.csv', '.txt', '.json', '.xml', '.yaml', '.yml', '.mp3', '.wav', '.mp4', '.avi', '.mov'];
+  const files: Array<{ url: string; fileName: string }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = linkRegex.exec(text)) !== null) {
+    const linkText = match[1].trim();
+    const url = match[2].trim();
+    if (!url) continue;
+    // Check if URL ends with a known file extension
+    const urlLower = url.toLowerCase().split('?')[0]; // Remove query params for extension check
+    const hasFileExt = fileExtensions.some((ext) => urlLower.endsWith(ext));
+    if (hasFileExt) {
+      // Use link text as filename if available, otherwise extract from URL
+      const fileName = linkText || url.split('/').pop()?.split('?')[0] || 'file';
+      files.push({ url, fileName });
+    }
+  }
+  return files;
+}
+
+/**
  * Strip HTML/Markdown markup to plain text.
  */
 export function stripMarkdownToPlain(text: string): string {

--- a/src/channels/plugins/wechat/WeChatAdapter.ts
+++ b/src/channels/plugins/wechat/WeChatAdapter.ts
@@ -292,7 +292,8 @@ export function extractMarkdownFileUrls(text: string): Array<{ url: string; file
     const hasFileExt = fileExtensions.some((ext) => urlLower.endsWith(ext));
     if (hasFileExt) {
       // Use link text as filename if available, otherwise extract from URL
-      const fileName = linkText || url.split('/').pop()?.split('?')[0] || 'file';
+      // Split on both / and \ to handle Windows paths (e.g., C:\Users\docs\report.pdf)
+      const fileName = linkText || url.split(/[/\\]/).pop()?.split('?')[0] || 'file';
       files.push({ url, fileName });
     }
   }

--- a/src/channels/plugins/wechat/WeChatPlugin.ts
+++ b/src/channels/plugins/wechat/WeChatPlugin.ts
@@ -225,10 +225,68 @@ export class WeChatPlugin extends BasePlugin {
   }
 
   /**
-   * Download a remote media file to local workspace for uploading.
-   * Supports both HTTP(S) URLs and local file paths.
+   * Resolve a local file path from a markdown-extracted URL/path.
+   * Handles file:// protocol, Windows paths (backslashes, drive letters),
+   * and relative paths (resolved against workspace directory).
    *
-   * @param url - Remote URL or local file path
+   * @param rawPath - Raw path string from markdown (may be file:// URL, Windows path, or relative path)
+   * @returns Resolved absolute path, or null if the file doesn't exist
+   */
+  private resolveLocalFilePath(rawPath: string): string | null {
+    let filePath = rawPath;
+
+    // Handle file:// protocol (e.g., file:///C:/Users/image.jpg or file:///home/user/image.jpg)
+    if (filePath.startsWith('file://')) {
+      try {
+        // Use URL API to properly parse file:// URLs
+        const fileUrl = new URL(filePath);
+        filePath = fileUrl.pathname;
+        // On Windows, file:///C:/path becomes /C:/path — strip the leading slash
+        if (/^\/[A-Za-z]:/.test(filePath)) {
+          filePath = filePath.slice(1);
+        }
+      } catch {
+        // Fallback: simple strip of file:// prefix
+        filePath = filePath.replace(/^file:\/\/\/?/, '');
+      }
+    }
+
+    // Normalize path separators: replace backslashes with forward slashes, then use path.normalize
+    // This handles Windows paths like C:\Users\file.jpg, C:\\Users\\file.jpg, mixed slashes
+    filePath = path.normalize(filePath.replace(/\\/g, path.sep));
+
+    // Check if it's an absolute path (Unix: /path, Windows: C:\path, C:/path)
+    if (path.isAbsolute(filePath)) {
+      if (fs.existsSync(filePath)) {
+        return filePath;
+      }
+      console.warn(`[WeChatPlugin] Local file not found (absolute): ${filePath}`);
+      return null;
+    }
+
+    // Relative path: try resolving against workspace directory, then cwd
+    const candidates = [
+      this.mediaDir ? path.resolve(this.mediaDir, filePath) : null,
+      path.resolve(process.cwd(), filePath),
+    ].filter(Boolean) as string[];
+
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        console.log(`[WeChatPlugin] Resolved relative path: ${rawPath} -> ${candidate}`);
+        return candidate;
+      }
+    }
+
+    console.warn(`[WeChatPlugin] Local file not found (relative): ${rawPath}, tried: ${candidates.join(', ')}`);
+    return null;
+  }
+
+  /**
+   * Download a remote media file to local workspace for uploading.
+   * Supports HTTP(S) URLs, file:// URLs, local file paths (absolute and relative),
+   * and Windows-style paths (backslashes, drive letters).
+   *
+   * @param url - Remote URL, file:// URL, or local file path
    * @param defaultExt - Default file extension if not determinable from URL
    * @param fileName - Optional desired file name
    * @returns Local file path, or null on failure
@@ -242,12 +300,16 @@ export class WeChatPlugin extends BasePlugin {
         fs.mkdirSync(this.mediaDir, { recursive: true });
       }
 
-      // If it's already a local file path, return directly if it exists
-      if (!url.startsWith('http://') && !url.startsWith('https://')) {
-        if (fs.existsSync(url)) {
-          return url;
+      // Determine if this is a remote URL (HTTP/HTTPS) or a local path
+      // Local paths include: absolute paths, relative paths, file:// URLs, Windows drive paths (C:\...)
+      const isRemoteUrl = url.startsWith('http://') || url.startsWith('https://');
+
+      if (!isRemoteUrl) {
+        // Handle local file path (absolute, relative, file://, Windows paths)
+        const localPath = this.resolveLocalFilePath(url);
+        if (localPath) {
+          return localPath;
         }
-        console.warn(`[WeChatPlugin] Local file not found: ${url}`);
         return null;
       }
 

--- a/src/channels/plugins/wechat/WeChatPlugin.ts
+++ b/src/channels/plugins/wechat/WeChatPlugin.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { randomBytes } from 'node:crypto';
 import type { BotInfo, IChannelPluginConfig, IUnifiedOutgoingMessage, PluginType } from '../../types';
 import { BasePlugin } from '../BasePlugin';
-import { getDefaultExtension, getMediaExtract, splitMessage, stripMarkdownToPlain, toUnifiedIncomingMessage, toWeChatSendPayload } from './WeChatAdapter';
+import { extractMarkdownFileUrls, extractMarkdownImageUrls, getDefaultExtension, getMediaExtract, splitMessage, stripMarkdownToPlain, toUnifiedIncomingMessage, toWeChatSendPayload } from './WeChatAdapter';
 import { WeChatApiClient } from './WeChatApiClient';
 import { WeChatContextTokenStore } from './WeChatContextTokenStore';
 import { encryptAesEcb, generateAesKey } from './WeChatCrypto';
@@ -121,25 +121,34 @@ export class WeChatPlugin extends BasePlugin {
       return `wechat_no_token_${Date.now()}`;
     }
 
-    // Build message items
+    // Build message items from explicit attachments
     const items: WeChatMessageItem[] = [];
 
-    // Handle image attachment
+    // Handle explicit image attachment
     if (message.imageUrl) {
       const imageItem = await this.uploadMedia(message.imageUrl, UploadMediaType.IMAGE, userId);
       if (imageItem) items.push(imageItem);
     }
 
-    // Handle file attachment
+    // Handle explicit file attachment
     if (message.fileUrl) {
       const fileItem = await this.uploadMedia(message.fileUrl, UploadMediaType.FILE, userId);
       if (fileItem) items.push(fileItem);
     }
 
-    // Handle text content
-    const text = stripMarkdownToPlain(message.text || '');
+    // Extract images and files embedded in markdown text BEFORE stripping
+    const rawText = message.text || '';
+    const markdownImageUrls = extractMarkdownImageUrls(rawText);
+    const markdownFileUrls = extractMarkdownFileUrls(rawText);
 
-    // Send each item as its own request (text first, then media)
+    if (markdownImageUrls.length > 0 || markdownFileUrls.length > 0) {
+      console.log(`[WeChatPlugin] Found ${markdownImageUrls.length} images and ${markdownFileUrls.length} files in markdown`);
+    }
+
+    // Strip markdown to plain text (images/links are removed)
+    const text = stripMarkdownToPlain(rawText);
+
+    // Send text first, then media (text → explicit attachments → markdown images → markdown files)
     // Reference: photon-hq/wechat-ilink-client/src/media/send.ts
     if (text.trim()) {
       const chunks = splitMessage(text, WECHAT_MESSAGE_LIMIT);
@@ -149,29 +158,139 @@ export class WeChatPlugin extends BasePlugin {
       }
     }
 
-    // Send each media item separately
+    // Send explicit media items
     for (const item of items) {
-      const clientId = `sudowork-wechat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const mediaPayload = {
-        msg: {
-          from_user_id: '',
-          to_user_id: userId,
-          client_id: clientId,
-          context_token: contextToken,
-          message_type: 2, // MessageType.BOT
-          message_state: 2, // MessageState.FINISH
-          item_list: [item],
-        },
-      };
-      console.log('[WeChatPlugin] sendMessage media item:', JSON.stringify(mediaPayload, null, 2));
-      await this.apiClient.sendMessage(mediaPayload);
+      await this.sendMediaItem(item, userId, contextToken);
     }
 
-    if (items.length === 0 && !text.trim()) {
+    // Download and send images extracted from markdown
+    for (const imageUrl of markdownImageUrls) {
+      try {
+        const localPath = await this.downloadRemoteMedia(imageUrl, '.jpg');
+        if (localPath) {
+          const imageItem = await this.uploadMedia(localPath, UploadMediaType.IMAGE, userId);
+          if (imageItem) {
+            await this.sendMediaItem(imageItem, userId, contextToken);
+            console.log(`[WeChatPlugin] Sent markdown image: ${imageUrl}`);
+          }
+        }
+      } catch (error) {
+        console.warn(`[WeChatPlugin] Failed to send markdown image ${imageUrl}:`, error);
+      }
+    }
+
+    // Download and send files extracted from markdown
+    for (const { url: fileUrl, fileName } of markdownFileUrls) {
+      try {
+        const ext = path.extname(fileName) || '';
+        const localPath = await this.downloadRemoteMedia(fileUrl, ext, fileName);
+        if (localPath) {
+          const fileItem = await this.uploadMedia(localPath, UploadMediaType.FILE, userId);
+          if (fileItem) {
+            await this.sendMediaItem(fileItem, userId, contextToken);
+            console.log(`[WeChatPlugin] Sent markdown file: ${fileUrl}`);
+          }
+        }
+      } catch (error) {
+        console.warn(`[WeChatPlugin] Failed to send markdown file ${fileUrl}:`, error);
+      }
+    }
+
+    if (items.length === 0 && markdownImageUrls.length === 0 && markdownFileUrls.length === 0 && !text.trim()) {
       return `wechat_empty_${Date.now()}`;
     }
 
     return `wechat_${Date.now()}`;
+  }
+
+  /**
+   * Send a single media item as a separate message.
+   */
+  private async sendMediaItem(item: WeChatMessageItem, userId: string, contextToken: string): Promise<void> {
+    if (!this.apiClient) return;
+    const clientId = `sudowork-wechat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const mediaPayload = {
+      msg: {
+        from_user_id: '',
+        to_user_id: userId,
+        client_id: clientId,
+        context_token: contextToken,
+        message_type: 2, // MessageType.BOT
+        message_state: 2, // MessageState.FINISH
+        item_list: [item],
+      },
+    };
+    console.log('[WeChatPlugin] sendMessage media item:', JSON.stringify(mediaPayload, null, 2));
+    await this.apiClient.sendMessage(mediaPayload);
+  }
+
+  /**
+   * Download a remote media file to local workspace for uploading.
+   * Supports both HTTP(S) URLs and local file paths.
+   *
+   * @param url - Remote URL or local file path
+   * @param defaultExt - Default file extension if not determinable from URL
+   * @param fileName - Optional desired file name
+   * @returns Local file path, or null on failure
+   */
+  private async downloadRemoteMedia(url: string, defaultExt: string, fileName?: string): Promise<string | null> {
+    try {
+      // Ensure media directory exists
+      if (!this.mediaDir) {
+        const { getDataPath } = await import('@/process/utils');
+        this.mediaDir = path.join(getDataPath(), 'channel-media', 'wechat');
+        fs.mkdirSync(this.mediaDir, { recursive: true });
+      }
+
+      // If it's already a local file path, return directly if it exists
+      if (!url.startsWith('http://') && !url.startsWith('https://')) {
+        if (fs.existsSync(url)) {
+          return url;
+        }
+        console.warn(`[WeChatPlugin] Local file not found: ${url}`);
+        return null;
+      }
+
+      // Download remote file
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 30_000);
+      try {
+        const response = await fetch(url, {
+          method: 'GET',
+          signal: controller.signal,
+        });
+        clearTimeout(timer);
+
+        if (!response.ok) {
+          console.warn(`[WeChatPlugin] Remote media download failed: HTTP ${response.status} for ${url}`);
+          return null;
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        const data = Buffer.from(arrayBuffer);
+
+        // Determine file name and extension
+        const urlPath = new URL(url).pathname;
+        const urlExt = path.extname(urlPath);
+        const ext = urlExt || defaultExt;
+        const baseName = fileName || `wechat_dl_${Date.now()}_${Math.random().toString(36).slice(2, 8)}${ext}`;
+        const filePath = path.join(this.mediaDir, baseName);
+
+        fs.writeFileSync(filePath, data);
+        console.log(`[WeChatPlugin] Downloaded remote media: ${url} -> ${filePath} (${data.length} bytes)`);
+        return filePath;
+      } catch (error) {
+        clearTimeout(timer);
+        if (error instanceof Error && error.name === 'AbortError') {
+          console.warn(`[WeChatPlugin] Remote media download timed out: ${url}`);
+          return null;
+        }
+        throw error;
+      }
+    } catch (error) {
+      console.error(`[WeChatPlugin] downloadRemoteMedia failed for ${url}:`, error);
+      return null;
+    }
   }
 
   async editMessage(_chatId: string, _messageId: string, _message: IUnifiedOutgoingMessage): Promise<void> {

--- a/tests/unit/channels/wechatAdapter.test.ts
+++ b/tests/unit/channels/wechatAdapter.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { getDefaultExtension, getMediaUrl, getMediaExtract, toUnifiedIncomingMessage, toWeChatSendPayload, splitMessage, stripMarkdownToPlain } from '@/channels/plugins/wechat/WeChatAdapter';
+import { extractMarkdownFileUrls, extractMarkdownImageUrls, getDefaultExtension, getMediaUrl, getMediaExtract, toUnifiedIncomingMessage, toWeChatSendPayload, splitMessage, stripMarkdownToPlain } from '@/channels/plugins/wechat/WeChatAdapter';
 import type { WeChatMessage, WeChatMessageItem } from '@/channels/plugins/wechat/types';
 import { MessageItemType, MessageType } from '@/channels/plugins/wechat/types';
 
@@ -441,6 +441,93 @@ describe('WeChatAdapter', () => {
 
     it('strips headers', () => {
       expect(stripMarkdownToPlain('## Header')).toBe('Header');
+    });
+  });
+
+  describe('extractMarkdownImageUrls', () => {
+    it('extracts single image URL', () => {
+      const text = 'Here is an image: ![alt text](https://example.com/image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['https://example.com/image.png']);
+    });
+
+    it('extracts multiple image URLs', () => {
+      const text = '![img1](https://example.com/a.jpg) some text ![img2](https://example.com/b.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['https://example.com/a.jpg', 'https://example.com/b.png']);
+    });
+
+    it('returns empty array when no images', () => {
+      const text = 'No images here, just a [link](https://example.com)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual([]);
+    });
+
+    it('handles empty alt text', () => {
+      const text = '![](https://example.com/image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['https://example.com/image.png']);
+    });
+
+    it('handles local file paths', () => {
+      const text = '![screenshot](/tmp/screenshots/image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['/tmp/screenshots/image.png']);
+    });
+
+    it('extracts images from complex markdown', () => {
+      const text = `# Report
+Here is the chart:
+![Chart](https://cdn.example.com/chart.png)
+
+And some **bold** text with a [link](https://example.com).
+
+Another image:
+![Photo](https://cdn.example.com/photo.jpg)`;
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['https://cdn.example.com/chart.png', 'https://cdn.example.com/photo.jpg']);
+    });
+  });
+
+  describe('extractMarkdownFileUrls', () => {
+    it('extracts file links with known extensions', () => {
+      const text = 'Download the [report](https://example.com/report.pdf)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toEqual([{ url: 'https://example.com/report.pdf', fileName: 'report' }]);
+    });
+
+    it('extracts multiple file links', () => {
+      const text = '[spreadsheet](https://example.com/data.xlsx) and [archive](https://example.com/files.zip)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(2);
+      expect(files[0].url).toBe('https://example.com/data.xlsx');
+      expect(files[1].url).toBe('https://example.com/files.zip');
+    });
+
+    it('ignores image links', () => {
+      const text = '![image](https://example.com/image.jpg) and [doc](https://example.com/doc.pdf)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].url).toBe('https://example.com/doc.pdf');
+    });
+
+    it('ignores links without file extensions', () => {
+      const text = '[website](https://example.com) and [page](https://example.com/about)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toEqual([]);
+    });
+
+    it('handles URLs with query parameters', () => {
+      const text = '[download](https://example.com/file.pdf?token=abc123)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].url).toBe('https://example.com/file.pdf?token=abc123');
+    });
+
+    it('returns empty array for text without links', () => {
+      const text = 'Just some plain text without any links.';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toEqual([]);
     });
   });
 });

--- a/tests/unit/channels/wechatAdapter.test.ts
+++ b/tests/unit/channels/wechatAdapter.test.ts
@@ -475,6 +475,48 @@ describe('WeChatAdapter', () => {
       expect(urls).toEqual(['/tmp/screenshots/image.png']);
     });
 
+    it('handles relative file paths', () => {
+      const text = '![screenshot](./images/screenshot.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['./images/screenshot.png']);
+    });
+
+    it('handles relative paths without dot prefix', () => {
+      const text = '![chart](output/charts/chart.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['output/charts/chart.png']);
+    });
+
+    it('handles Windows absolute paths with backslashes', () => {
+      const text = '![img](C:\\Users\\user\\Documents\\image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['C:\\Users\\user\\Documents\\image.png']);
+    });
+
+    it('handles Windows paths with forward slashes', () => {
+      const text = '![img](C:/Users/user/Documents/image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['C:/Users/user/Documents/image.png']);
+    });
+
+    it('handles Windows paths with double backslashes', () => {
+      const text = '![img](C:\\\\Users\\\\user\\\\image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['C:\\\\Users\\\\user\\\\image.png']);
+    });
+
+    it('handles file:// protocol URLs', () => {
+      const text = '![local](file:///home/user/image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['file:///home/user/image.png']);
+    });
+
+    it('handles file:// protocol with Windows path', () => {
+      const text = '![local](file:///C:/Users/user/image.png)';
+      const urls = extractMarkdownImageUrls(text);
+      expect(urls).toEqual(['file:///C:/Users/user/image.png']);
+    });
+
     it('extracts images from complex markdown', () => {
       const text = `# Report
 Here is the chart:
@@ -528,6 +570,51 @@ Another image:
       const text = 'Just some plain text without any links.';
       const files = extractMarkdownFileUrls(text);
       expect(files).toEqual([]);
+    });
+
+    it('handles local Unix file paths', () => {
+      const text = '[report](/home/user/documents/report.pdf)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].url).toBe('/home/user/documents/report.pdf');
+      expect(files[0].fileName).toBe('report');
+    });
+
+    it('handles relative file paths', () => {
+      const text = '[data](./output/data.csv)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].url).toBe('./output/data.csv');
+      expect(files[0].fileName).toBe('data');
+    });
+
+    it('handles Windows paths with backslashes and extracts filename', () => {
+      const text = '[report](C:\\Users\\user\\Documents\\report.pdf)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].url).toBe('C:\\Users\\user\\Documents\\report.pdf');
+      expect(files[0].fileName).toBe('report');
+    });
+
+    it('extracts filename from Windows path with backslashes when no link text', () => {
+      const text = '[](C:\\Users\\user\\Documents\\report.pdf)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].fileName).toBe('report.pdf');
+    });
+
+    it('handles Windows paths with forward slashes', () => {
+      const text = '[data](C:/Users/user/data.xlsx)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].url).toBe('C:/Users/user/data.xlsx');
+    });
+
+    it('handles file:// protocol URLs', () => {
+      const text = '[report](file:///home/user/report.pdf)';
+      const files = extractMarkdownFileUrls(text);
+      expect(files).toHaveLength(1);
+      expect(files[0].url).toBe('file:///home/user/report.pdf');
     });
   });
 });


### PR DESCRIPTION
Closes #451

## Summary
- Extract images and file links from markdown in agent responses
- Send prettified plain text first, then download and send each image/file separately
- Add comprehensive unit tests (48 tests passing)

## Test Plan
- [ ] Verify markdown with embedded images sends text + images separately
- [ ] Verify markdown with file links sends text + files separately
- [ ] Verify plain text messages still work as before
- [ ] Verify explicit imageUrl/fileUrl attachments still work

Generated with [Claude Code](https://claude.ai/claude-code)