### PR TITLE
feat: support file/image sending to Lark channel

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -170,7 +170,7 @@ function getConfirmationPrompt(details: { type: string; title?: string; [key: st
  * 将 TMessage 转换为 IUnifiedOutgoingMessage
  * Convert TMessage to IUnifiedOutgoingMessage for platform
  */
-function convertTMessageToOutgoing(message: TMessage, platform: PluginType, isComplete = false): IUnifiedOutgoingMessage {
+function convertTMessageToOutgoing(message: TMessage, platform: PluginType, isComplete = false): IUnifiedOutgoingMessage | null {
   switch (message.type) {
     case 'text': {
       // 根据平台格式化文本
@@ -262,6 +262,14 @@ function convertTMessageToOutgoing(message: TMessage, platform: PluginType, isCo
         parseMode: 'HTML',
       };
     }
+
+    case 'agent_status':
+    case 'acp_tool_call':
+    case 'codex_tool_call':
+    case 'plan':
+    case 'available_commands':
+      // Desktop-only UI state messages — skip for channel clients
+      return null;
 
     case 'acp_permission':
     case 'codex_permission': {
@@ -684,17 +692,22 @@ export class ActionExecutor {
       // Track sent message IDs for new inserted messages
       const sentMessageIds: string[] = thinkingMsgId ? [thinkingMsgId] : [];
 
+      // Track whether thinking message has been updated by first text message
+      let thinkingUpdated = false;
+
       // 跟踪最后一条消息内容，用于流结束后添加操作按钮
       // Track last message content for adding action buttons after stream ends
       let lastMessageContent: IUnifiedOutgoingMessage | null = null;
 
       // 执行消息编辑的函数
       // Function to perform message edit
-      const doEditMessage = async (msg: IUnifiedOutgoingMessage) => {
+      const doEditMessage = async (msg: IUnifiedOutgoingMessage, forceThinkingTarget = false) => {
         if (!supportsEdit) return; // WeChat doesn't support edit
 
         lastUpdateTime = Date.now();
-        const targetMsgId = sentMessageIds[sentMessageIds.length - 1] || thinkingMsgId;
+        // When updating thinking message, always target thinkingMsgId directly
+        // (not sentMessageIds[last], which may be a file/image message)
+        const targetMsgId = (forceThinkingTarget && thinkingMsgId) ? thinkingMsgId : (sentMessageIds[sentMessageIds.length - 1] || thinkingMsgId);
         try {
           await context.editMessage(targetMsgId, msg);
         } catch {
@@ -711,6 +724,9 @@ export class ActionExecutor {
         // Convert message format (based on platform)
         const outgoingMessage = convertTMessageToOutgoing(message, context.platform as PluginType, false);
 
+        // Skip desktop-only message types (agent_status, plan, etc.)
+        if (!outgoingMessage) return;
+
         // Strip replyMarkup during streaming to prevent premature card finalization.
         // Tool confirmation cards set replyMarkup (e.g., for Confirming status),
         // but DingTalk interprets replyMarkup as "stream complete" and finishes the AI Card.
@@ -721,14 +737,18 @@ export class ActionExecutor {
         // Save last message content (without replyMarkup, final message adds it separately)
         lastMessageContent = streamOutgoing;
 
-        // IMPORTANT: Always treat first streaming message as update to thinking message
+        // IMPORTANT: Treat first text streaming message as update to thinking message
         // This prevents async race condition where first insert's sendMessage takes time
         // while subsequent messages arrive and get processed as updates
-        // 重要：始终将第一个流式消息视为更新thinking消息
-        // 这可以防止异步竞态条件：第一个insert的sendMessage耗时时，后续消息已到达并被当作update处理
-        if (isInsert && sentMessageIds.length === 1 && thinkingMsgId && supportsEdit) {
-          // First streaming message: update thinking message instead of inserting
-          // 第一个流式消息：更新thinking消息而不是插入新消息
+        // Use thinkingUpdated flag instead of sentMessageIds.length to handle cases
+        // where file/image messages are sent before text (e.g., doc generation)
+        // 重要：始终将第一个text流式消息视为更新thinking消息
+        // 使用 thinkingUpdated 标志而非 sentMessageIds.length，
+        // 以处理 file/image 在 text 之前发送的情况（如文档生成）
+        if (isInsert && !thinkingUpdated && thinkingMsgId && supportsEdit && streamOutgoing.type === 'text') {
+          // First text streaming message: update thinking message instead of inserting
+          // 第一个text流式消息：更新thinking消息而不是插入新消息
+          thinkingUpdated = true;
           pendingMessage = streamOutgoing;
 
           if (now - lastUpdateTime >= UPDATE_THROTTLE_MS) {
@@ -736,7 +756,7 @@ export class ActionExecutor {
               clearTimeout(pendingUpdateTimer);
               pendingUpdateTimer = null;
             }
-            await doEditMessage(streamOutgoing);
+            await doEditMessage(streamOutgoing, true);
           } else {
             if (pendingUpdateTimer) {
               clearTimeout(pendingUpdateTimer);
@@ -744,7 +764,7 @@ export class ActionExecutor {
             const delay = UPDATE_THROTTLE_MS - (now - lastUpdateTime);
             pendingUpdateTimer = setTimeout(() => {
               if (pendingMessage) {
-                void doEditMessage(pendingMessage);
+                void doEditMessage(pendingMessage, true);
                 pendingMessage = null;
               }
               pendingUpdateTimer = null;
@@ -823,15 +843,21 @@ export class ActionExecutor {
       // 流结束后，更新最后一条消息添加操作按钮（保留原内容）
       // After stream ends, update last message with action buttons (keep original content)
       if (lastMessageContent) {
-        const responseMarkup = getResponseActionsMarkup(context.platform as PluginType, lastMessageContent.text);
-        const finalMessage: IUnifiedOutgoingMessage = { ...lastMessageContent, replyMarkup: responseMarkup };
-
-        if (supportsEdit && sentMessageIds.length > 0) {
-          const lastMsgId = sentMessageIds[sentMessageIds.length - 1];
-          await context.editMessage(lastMsgId, finalMessage);
+        // Skip edit for non-text messages (file/image) — these were already sent via sendMessage
+        // and cannot be edited (LarkPlugin.editMessage only supports card messages)
+        if (lastMessageContent.type === 'file' || lastMessageContent.type === 'image') {
+          // No action needed; file/image messages were already sent correctly via sendMessage
         } else {
-          // For WeChat or if no message was sent yet, send the final content as a new message
-          await context.sendMessage(finalMessage);
+          const responseMarkup = getResponseActionsMarkup(context.platform as PluginType, lastMessageContent.text);
+          const finalMessage: IUnifiedOutgoingMessage = { ...lastMessageContent, replyMarkup: responseMarkup };
+
+          if (supportsEdit && sentMessageIds.length > 0) {
+            const lastMsgId = sentMessageIds[sentMessageIds.length - 1];
+            await context.editMessage(lastMsgId, finalMessage);
+          } else {
+            // For WeChat or if no message was sent yet, send the final content as a new message
+            await context.sendMessage(finalMessage);
+          }
         }
       }
     } catch (error: any) {

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -274,6 +274,14 @@ function convertTMessageToOutgoing(message: TMessage, platform: PluginType, isCo
       };
     }
 
+    case 'file_send': {
+      const { filePath, fileName, fileType } = message.content;
+      if (fileType === 'image') {
+        return { type: 'image' as const, imageUrl: filePath };
+      }
+      return { type: 'file' as const, fileUrl: filePath, fileName };
+    }
+
     default:
       // 其他类型暂不支持，显示通用消息
       // Other types not supported yet, show generic message

--- a/src/channels/plugins/lark/LarkAdapter.ts
+++ b/src/channels/plugins/lark/LarkAdapter.ts
@@ -342,6 +342,22 @@ export function toLarkSendParams(message: IUnifiedOutgoingMessage): {
     };
   }
 
+  // Handle image messages
+  if (message.type === 'image' && message.imageUrl) {
+    return {
+      contentType: 'image',
+      content: { image: message.imageUrl },
+    };
+  }
+
+  // Handle file messages
+  if (message.type === 'file' && message.fileUrl && message.fileName) {
+    return {
+      contentType: 'file',
+      content: { file: message.fileUrl, file_name: message.fileName },
+    };
+  }
+
   // Default to text message - return raw text, caller will format
   const text = message.text || '';
   return {

--- a/src/channels/plugins/lark/LarkPlugin.ts
+++ b/src/channels/plugins/lark/LarkPlugin.ts
@@ -5,8 +5,11 @@
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
+import * as fs from 'fs';
+import * as path from 'path';
 
-import type { BotInfo, IChannelPluginConfig, IUnifiedOutgoingMessage, PluginType } from '../../types';
+import { getDataPath } from '@/process/utils';
+import type { BotInfo, IChannelPluginConfig, IUnifiedIncomingMessage, IUnifiedOutgoingMessage, PluginType } from '../../types';
 import { BasePlugin } from '../BasePlugin';
 import { extractCardAction, LARK_MESSAGE_LIMIT, toLarkSendParams, toUnifiedIncomingMessage } from './LarkAdapter';
 
@@ -383,6 +386,11 @@ export class LarkPlugin extends BasePlugin {
       // Convert to unified message
       const unifiedMessage = toUnifiedIncomingMessage(event);
       if (unifiedMessage && this.messageHandler) {
+        // Download media attachments (image_key/file_key → local files)
+        // before forwarding so downstream code can read them as local paths
+        if (unifiedMessage.content.attachments?.length) {
+          await this.downloadMediaAttachments(unifiedMessage, eventId || '');
+        }
         // Check for menu button commands first
         if (unifiedMessage.content.type === 'text' && unifiedMessage.content.text) {
           const buttonAction = this.getMenuButtonAction(unifiedMessage.content.text);
@@ -402,6 +410,55 @@ export class LarkPlugin extends BasePlugin {
       }
     } catch (error) {
       console.error('[LarkPlugin] Error processing message event:', error);
+    }
+  }
+
+  /**
+   * Download media attachments from Feishu to local files.
+   * Replaces Feishu keys (image_key, file_key) in attachment.fileId with local file paths
+   * so that downstream code (ActionExecutor → Agent) can read them as local files.
+   */
+  private async downloadMediaAttachments(unifiedMessage: IUnifiedIncomingMessage, messageId: string): Promise<void> {
+    if (!this.client || !unifiedMessage.content.attachments?.length) {
+      return;
+    }
+
+    const mediaDir = path.join(getDataPath(), 'channel-media', 'lark');
+    fs.mkdirSync(mediaDir, { recursive: true });
+
+    for (const attachment of unifiedMessage.content.attachments) {
+      if (!attachment.fileId) continue;
+
+      // Map attachment type to Feishu resource type for the API
+      const resourceType = attachment.type === 'photo' ? 'image'
+        : attachment.type === 'audio' ? 'audio'
+        : attachment.type === 'video' ? 'video'
+        : 'file';
+
+      try {
+        const response = await this.client.im.messageResource.get({
+          params: { type: resourceType },
+          path: { message_id: messageId, file_key: attachment.fileId },
+        });
+
+        if (!response) {
+          console.warn(`[LarkPlugin] Failed to download resource: ${attachment.fileId}, no response`);
+          continue;
+        }
+
+        // Determine file extension based on attachment type
+        const ext = attachment.type === 'photo' ? '.png'
+          : attachment.fileName ? path.extname(attachment.fileName)
+          : attachment.type === 'audio' ? '.ogg'
+          : attachment.type === 'video' ? '.mp4'
+          : '.bin';
+
+        const localPath = path.join(mediaDir, `${attachment.fileId}${ext}`);
+        await response.writeFile(localPath);
+        attachment.fileId = localPath;
+      } catch (error) {
+        console.warn(`[LarkPlugin] Failed to download media ${attachment.fileId}:`, error);
+      }
     }
   }
 

--- a/src/channels/plugins/lark/LarkPlugin.ts
+++ b/src/channels/plugins/lark/LarkPlugin.ts
@@ -197,8 +197,47 @@ export class LarkPlugin extends BasePlugin {
 
     await this.ensureAccessToken();
 
-    const { contentType, content, rawText } = toLarkSendParams(message);
     const receiveIdType = this.getReceiveIdType(chatId);
+
+    // Handle image messages - upload then send
+    if (message.type === 'image' && message.imageUrl) {
+      try {
+        const imageKey = await this.uploadImage(message.imageUrl);
+        const response = await this.client.im.message.create({
+          params: { receive_id_type: receiveIdType },
+          data: {
+            receive_id: chatId,
+            msg_type: 'image',
+            content: JSON.stringify({ image_key: imageKey }),
+          },
+        });
+        return response.data?.message_id || '';
+      } catch (error) {
+        console.error('[LarkPlugin] Failed to send image:', error);
+        throw error;
+      }
+    }
+
+    // Handle file messages - upload then send
+    if (message.type === 'file' && message.fileUrl && message.fileName) {
+      try {
+        const fileKey = await this.uploadFile(message.fileUrl, message.fileName);
+        const response = await this.client.im.message.create({
+          params: { receive_id_type: receiveIdType },
+          data: {
+            receive_id: chatId,
+            msg_type: 'file',
+            content: JSON.stringify({ file_key: fileKey }),
+          },
+        });
+        return response.data?.message_id || '';
+      } catch (error) {
+        console.error('[LarkPlugin] Failed to send file:', error);
+        throw error;
+      }
+    }
+
+    const { contentType, content, rawText } = toLarkSendParams(message);
 
     // Handle text messages - send as card for streaming support
     // Lark only allows editing card messages, not text messages
@@ -463,7 +502,70 @@ export class LarkPlugin extends BasePlugin {
   }
 
   /**
-   * Map menu action strings to action info
+   * Upload an image file to Lark and return image_key.
+   * Max 10MB, supports JPEG/PNG/WEBP/GIF/TIFF/BMP/ICO.
+   */
+  private async uploadImage(filePath: string): Promise<string> {
+    if (!this.client) throw new Error('Client not initialized');
+    if (!fs.existsSync(filePath)) throw new Error(`Image file not found: ${filePath}`);
+
+    const imageBuffer = fs.readFileSync(filePath);
+    const response = await this.client.im.image.create({
+      data: {
+        image_type: 'message',
+        image: imageBuffer,
+      },
+    });
+
+    if (!response?.image_key) {
+      throw new Error('Failed to upload image: no image_key returned');
+    }
+    return response.image_key;
+  }
+
+  /**
+   * Upload a file to Lark and return file_key.
+   * Max 30MB, file_type must match the file format.
+   */
+  private async uploadFile(filePath: string, fileName: string): Promise<string> {
+    if (!this.client) throw new Error('Client not initialized');
+    if (!fs.existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
+
+    const fileBuffer = fs.readFileSync(filePath);
+    const file_type = this.toLarkFileType(fileName);
+
+    const response = await this.client.im.file.create({
+      data: {
+        file_type,
+        file_name: fileName,
+        file: fileBuffer,
+      },
+    });
+
+    if (!response?.file_key) {
+      throw new Error('Failed to upload file: no file_key returned');
+    }
+    return response.file_key;
+  }
+
+  /**
+   * Map file extension to Lark file_type for upload API.
+   * Returns 'stream' as catch-all for unsupported types.
+   */
+  private toLarkFileType(fileName: string): 'opus' | 'mp4' | 'pdf' | 'doc' | 'xls' | 'ppt' | 'stream' {
+    const ext = path.extname(fileName).toLowerCase();
+    const map: Record<string, 'opus' | 'mp4' | 'pdf' | 'doc' | 'xls' | 'ppt'> = {
+      '.pdf': 'pdf',
+      '.doc': 'doc', '.docx': 'doc',
+      '.xls': 'xls', '.xlsx': 'xls', '.csv': 'xls',
+      '.ppt': 'ppt', '.pptx': 'ppt',
+      '.mp3': 'opus', '.opus': 'opus', '.ogg': 'opus',
+      '.mp4': 'mp4',
+    };
+    return map[ext] || 'stream';
+  }
+
+  /**
    * These are the action strings configured in Feishu bot custom menu
    */
   private getMenuButtonAction(text: string): { type: string; action: string } | null {

--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -54,7 +54,7 @@ export const joinPath = (basePath: string, relativePath: string): string => {
  * @description 跟对话相关的消息类型申明 及相关处理
  */
 
-type TMessageType = 'text' | 'tips' | 'tool_call' | 'tool_group' | 'agent_status' | 'acp_permission' | 'acp_tool_call' | 'codex_permission' | 'codex_tool_call' | 'plan' | 'available_commands';
+type TMessageType = 'text' | 'tips' | 'tool_call' | 'tool_group' | 'agent_status' | 'acp_permission' | 'acp_tool_call' | 'codex_permission' | 'codex_tool_call' | 'plan' | 'available_commands' | 'file_send';
 
 interface IMessage<T extends TMessageType, Content extends Record<string, any>> {
   /**
@@ -284,8 +284,17 @@ export type IMessageAvailableCommands = IMessage<
   }
 >;
 
+/** Data for file_send messages — used by channels to send files to IM clients */
+export interface IFileSendData {
+  filePath: string;
+  fileName: string;
+  fileType: 'image' | 'file';
+}
+
+export type IMessageFileSend = IMessage<'file_send', IFileSendData>;
+
 // eslint-disable-next-line max-len
-export type TMessage = IMessageText | IMessageTips | IMessageToolCall | IMessageToolGroup | IMessageAgentStatus | IMessageAcpPermission | IMessageAcpToolCall | IMessageCodexPermission | IMessageCodexToolCall | IMessagePlan | IMessageAvailableCommands;
+export type TMessage = IMessageText | IMessageTips | IMessageToolCall | IMessageToolGroup | IMessageAgentStatus | IMessageAcpPermission | IMessageAcpToolCall | IMessageCodexPermission | IMessageCodexToolCall | IMessagePlan | IMessageAvailableCommands | IMessageFileSend;
 
 // 统一所有需要用户交互的用户类型
 export interface IConfirmation<Option extends any = any> {
@@ -414,6 +423,16 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
         position: 'left',
         conversation_id: message.conversation_id,
         content: message.data as any,
+      };
+    }
+    case 'file_send': {
+      return {
+        id: uuid(),
+        type: 'file_send',
+        msg_id: message.msg_id,
+        position: 'left',
+        conversation_id: message.conversation_id,
+        content: message.data as IFileSendData,
       };
     }
     // Disabled: available_commands messages are too noisy and distracting in the chat UI

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -458,10 +458,6 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
           createdAt: Date.now(),
         };
         addMessage(this.conversation_id, userMessage);
-
-        // Emit user_content event so the desktop renderer can display the message in real-time.
-        // For desktop-originated messages, the SendBox already added the message locally with
-        // the same msg_id, so addOrUpdateMessage's dedup logic will skip the duplicate.
         const userResponseMessage: IResponseMessage = {
           type: 'user_content',
           conversation_id: this.conversation_id,

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -14,6 +14,7 @@ import { ipcBridge } from '@/common';
 import type { IConfirmation, TMessage } from '@/common/chatLib';
 import { transformMessage } from '@/common/chatLib';
 import { NavigationInterceptor } from '@/common/navigation';
+import * as fs from 'node:fs';
 import type { IResponseMessage } from '@/common/ipcBridge';
 import { uuid } from '@/common/utils';
 import type { AcpBackendAll, AcpResult, ToolCallUpdate } from '@/types/acpTypes';
@@ -674,6 +675,21 @@ ${draftsInstruction}`;
           ipcBridge.conversation.responseStream.emit(contentMsg);
           const tMessage = transformMessage(contentMsg);
           if (tMessage) addOrUpdateMessage(this.conversation_id, tMessage);
+
+          // Send generated images to channel clients (e.g., Lark) as actual image files
+          for (const { imgUrl, relativePath } of savedImages) {
+            const fileMessage: IResponseMessage = {
+              type: 'file_send',
+              conversation_id: this.conversation_id,
+              msg_id: uuid(),
+              data: {
+                filePath: imgUrl,
+                fileName: relativePath,
+                fileType: 'image' as const,
+              },
+            };
+            this.handleStreamMessage(fileMessage);
+          }
         }
       }
     } catch (error) {
@@ -1593,6 +1609,24 @@ ${draftsInstruction}`;
       }
     }
 
+    // Intercept file-creation tool calls: send generated files to channel clients (e.g., Lark)
+    if (status === 'completed') {
+      const filePath = this.extractFilePathFromToolCall(toolName, acpUpdate.update.rawInput);
+      if (filePath) {
+        const fileMessage: IResponseMessage = {
+          type: 'file_send',
+          conversation_id: this.conversation_id,
+          msg_id: uuid(),
+          data: {
+            filePath,
+            fileName: nodePath.basename(filePath),
+            fileType: this.classifyFileType(filePath),
+          },
+        };
+        this.handleStreamMessage(fileMessage);
+      }
+    }
+
     const messages = this.adapter.convertSessionUpdate(acpUpdate);
     for (const message of messages) {
       this.emitTMessage(message);
@@ -1607,6 +1641,47 @@ ${draftsInstruction}`;
     if (/write|edit|create|delete|patch|update|insert|remove/.test(n)) return 'edit';
     if (/exec|run|bash|shell|terminal/.test(n)) return 'execute';
     return null;
+  }
+
+  /** Document extensions that should trigger file sending to channel clients */
+  private static readonly DOCUMENT_EXTENSIONS = new Set([
+    '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.csv', '.txt', '.md', '.html',
+  ]);
+
+  /** Image extensions */
+  private static readonly IMAGE_EXTENSIONS = new Set([
+    '.jpg', '.jpeg', '.png', '.webp', '.gif', '.tiff', '.bmp', '.ico', '.svg',
+  ]);
+
+  /**
+   * Extract file path from a tool call if it represents a file-creation operation.
+   * Returns null if the tool call is not a file-creation operation or the file doesn't exist.
+   */
+  private extractFilePathFromToolCall(toolName: string, rawInput?: Record<string, unknown>): string | null {
+    if (!rawInput) return null;
+    const n = toolName.toLowerCase();
+    if (!/write|edit|create/.test(n)) return null;
+
+    const filePath = (rawInput.path || rawInput.file_path || rawInput.filename) as string | undefined;
+    if (!filePath || typeof filePath !== 'string') return null;
+
+    const ext = nodePath.extname(filePath).toLowerCase();
+    if (!OpenClawAgent.DOCUMENT_EXTENSIONS.has(ext) && !OpenClawAgent.IMAGE_EXTENSIONS.has(ext)) return null;
+
+    // Verify the file actually exists on disk
+    try {
+      if (!fs.existsSync(filePath)) return null;
+    } catch {
+      return null;
+    }
+
+    return filePath;
+  }
+
+  /** Classify a file path as 'image' or 'file' based on its extension */
+  private classifyFileType(filePath: string): 'image' | 'file' {
+    const ext = nodePath.extname(filePath).toLowerCase();
+    return OpenClawAgent.IMAGE_EXTENSIONS.has(ext) ? 'image' : 'file';
   }
 }
 

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -169,6 +169,9 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
   private expectReconnectOnClose = false;
   private hasEmittedTerminalConnectionError = false;
 
+  /** Snapshot of known deliverable files and their mtime, used to detect new files created by Bash/execute tools */
+  private workspaceFileSnapshot: Map<string, number> = new Map();
+
   constructor(data: OpenClawAgentData) {
     super('openclaw-gateway', data);
     this.conversation_id = data.conversation_id;
@@ -515,6 +518,10 @@ All file operations, bash commands, and output (when calling write() tool) MUST 
 
 ${draftsInstruction}`;
         processedContent = `${workspaceDirective}\n\n${processedContent}`;
+
+        // Initialize workspace file snapshot before sending message,
+        // so we can detect new files created during this turn
+        this.refreshWorkspaceFileSnapshot();
       }
 
       // Process file references
@@ -1611,6 +1618,7 @@ ${draftsInstruction}`;
 
     // Intercept file-creation tool calls: send generated files to channel clients (e.g., Lark)
     if (status === 'completed') {
+      // Strategy 1: Direct file-creation tools (Write/Edit/Create) — extract path from tool args
       const filePath = this.extractFilePathFromToolCall(toolName, acpUpdate.update.rawInput);
       if (filePath) {
         const fileMessage: IResponseMessage = {
@@ -1624,6 +1632,29 @@ ${draftsInstruction}`;
           },
         };
         this.handleStreamMessage(fileMessage);
+        // Refresh snapshot so Strategy 2 won't re-detect this file
+        this.refreshWorkspaceFileSnapshot();
+      }
+
+      // Strategy 2: Execute-class tools (Bash/Shell) — scan workspace for new/modified files
+      // Covers cases like: Write tool creates .js script -> Bash runs "node xxx.js" -> script writes .docx
+      if (kind === 'execute') {
+        const newFiles = this.detectNewFilesFromWorkspace();
+        for (const newFile of newFiles) {
+          const fileMessage: IResponseMessage = {
+            type: 'file_send',
+            conversation_id: this.conversation_id,
+            msg_id: uuid(),
+            data: {
+              filePath: newFile,
+              fileName: nodePath.basename(newFile),
+              fileType: this.classifyFileType(newFile),
+            },
+          };
+          this.handleStreamMessage(fileMessage);
+        }
+        // Refresh snapshot immediately to avoid re-sending same files on next execute tool
+        this.refreshWorkspaceFileSnapshot();
       }
     }
 
@@ -1641,6 +1672,74 @@ ${draftsInstruction}`;
     if (/write|edit|create|delete|patch|update|insert|remove/.test(n)) return 'edit';
     if (/exec|run|bash|shell|terminal/.test(n)) return 'execute';
     return null;
+  }
+
+  /**
+   * Build or refresh the workspace file snapshot.
+   * Scans the workspace root (non-recursive, depth=1) and records each deliverable file's mtime.
+   * Files inside .drafts/ directory are excluded.
+   */
+  private refreshWorkspaceFileSnapshot(): void {
+    this.workspaceFileSnapshot.clear();
+    if (!this.workspace) return;
+
+    try {
+      const entries = fs.readdirSync(this.workspace, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        if (entry.name === '.drafts') continue;
+
+        const ext = nodePath.extname(entry.name).toLowerCase();
+        if (!OpenClawAgent.DOCUMENT_EXTENSIONS.has(ext) && !OpenClawAgent.IMAGE_EXTENSIONS.has(ext)) continue;
+
+        const fullPath = nodePath.join(this.workspace, entry.name);
+        try {
+          const stat = fs.statSync(fullPath);
+          this.workspaceFileSnapshot.set(entry.name, stat.mtimeMs);
+        } catch {
+          // stat failed (file deleted between readdir and stat), skip
+        }
+      }
+    } catch {
+      // workspace not readable, skip silently
+    }
+  }
+
+  /**
+   * After an execute-class tool completes, scan workspace for newly created or modified deliverable files.
+   * Returns absolute paths of files that are new or have a newer mtime than the snapshot.
+   */
+  private detectNewFilesFromWorkspace(): string[] {
+    if (!this.workspace) return [];
+    const newFiles: string[] = [];
+
+    try {
+      const entries = fs.readdirSync(this.workspace, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        if (entry.name === '.drafts') continue;
+
+        const ext = nodePath.extname(entry.name).toLowerCase();
+        if (!OpenClawAgent.DOCUMENT_EXTENSIONS.has(ext) && !OpenClawAgent.IMAGE_EXTENSIONS.has(ext)) continue;
+
+        const fullPath = nodePath.join(this.workspace, entry.name);
+        try {
+          const stat = fs.statSync(fullPath);
+          const prevMtime = this.workspaceFileSnapshot.get(entry.name);
+
+          // New file (not in snapshot) or modified file (mtime changed)
+          if (prevMtime === undefined || stat.mtimeMs > prevMtime) {
+            newFiles.push(fullPath);
+          }
+        } catch {
+          // stat failed, skip
+        }
+      }
+    } catch {
+      // workspace not readable, skip
+    }
+
+    return newFiles;
   }
 
   /** Document extensions that should trigger file sending to channel clients */

--- a/src/renderer/messages/MessageFileSend.tsx
+++ b/src/renderer/messages/MessageFileSend.tsx
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IMessageFileSend } from '@/common/chatLib';
+import { FileText, Picture } from '@icon-park/react';
+import React from 'react';
+
+const FILE_TYPE_LABELS: Record<string, string> = {
+  '.pdf': 'PDF 文档',
+  '.doc': 'Word 文档',
+  '.docx': 'Word 文档',
+  '.xls': 'Excel 表格',
+  '.xlsx': 'Excel 表格',
+  '.ppt': 'PowerPoint 演示文稿',
+  '.pptx': 'PowerPoint 演示文稿',
+  '.csv': 'CSV 文件',
+  '.txt': '文本文件',
+  '.md': 'Markdown 文件',
+  '.html': 'HTML 文件',
+  '.jpg': 'JPEG 图片',
+  '.jpeg': 'JPEG 图片',
+  '.png': 'PNG 图片',
+  '.webp': 'WebP 图片',
+  '.gif': 'GIF 图片',
+  '.tiff': 'TIFF 图片',
+  '.bmp': 'BMP 图片',
+  '.svg': 'SVG 图片',
+};
+
+const MessageFileSend: React.FC<{ message: IMessageFileSend }> = ({ message }) => {
+  const { fileName, fileType } = message.content;
+  const ext = fileName ? '.' + fileName.split('.').pop()?.toLowerCase() : '';
+  const typeLabel = FILE_TYPE_LABELS[ext] || '文件';
+
+  if (fileType === 'image') {
+    return (
+      <div className='w-full'>
+        <div className='bg-message-tips rd-8px p-x-12px p-y-8px flex items-center gap-8px'>
+          <Picture theme='filled' size='18' className='flex-shrink-0 text-t-secondary' />
+          <span className='text-t-secondary text-13px'>{fileName}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='w-full'>
+      <div className='bg-message-tips rd-8px p-x-12px p-y-8px flex items-center gap-8px'>
+        <FileText theme='filled' size='18' className='flex-shrink-0 text-t-secondary' />
+        <div className='flex flex-col gap-2px'>
+          <span className='text-t-primary text-14px'>{fileName}</span>
+          <span className='text-t-tertiary text-12px'>{typeLabel}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MessageFileSend;

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -25,6 +25,7 @@ import HOC from '../utils/HOC';
 import MessageCodexToolCall from './codex/MessageCodexToolCall';
 import type { FileChangeInfo } from './codex/MessageFileChanges';
 import MessageFileChanges, { parseDiff } from './codex/MessageFileChanges';
+import MessageFileSend from './MessageFileSend';
 import { useMessageList } from './hooks';
 import MessagePlan from './MessagePlan';
 import MessageTips from './MessageTips';
@@ -118,6 +119,8 @@ const MessageItem: React.FC<{ message: TMessage; isStreaming?: boolean }> = Reac
         return <MessageCodexToolCall message={message}></MessageCodexToolCall>;
       case 'plan':
         return <MessagePlan message={message}></MessagePlan>;
+      case 'file_send':
+        return <MessageFileSend message={message}></MessageFileSend>;
       case 'available_commands':
         return null;
       default:


### PR DESCRIPTION
## Summary
- 支持飞书渠道发送图片和文件（.docx/.pdf/.xlsx 等），用户通过飞书对话生成的文档可直接下载
- 新增 workspace 文件快照机制，检测 Bash/execute 工具间接生成的文件（如 docx skill 通过 `node xxx.js` 写入的文件）
- 修复渠道流式回调路由：file/image 消息走 sendMessage 而非 editMessage
- 修复文件重复发送、Thinking 卡片未更新、桌面端"未知消息类型：file_send"等问题
- 跳过桌面端专用消息类型（agent_status/acp_tool_call/plan 等），避免飞书出现多余 Processing 卡片

## Changes
- `OpenClawAgent.ts`: 新增 Strategy 2（workspace 文件扫描检测新文件）+ 快照机制防止重复发送
- `ActionExecutor.ts`: convertTMessageToOutgoing 补全缺失 case + thinkingUpdated 标志修复 Thinking 卡片 + file/image 跳过 edit
- `MessageFileSend.tsx`: 新建文件消息渲染组件
- `MessageList.tsx`: 注册 file_send case

## Test plan
- [ ] 飞书发送图片生成 Word 文档，验证收到一个可下载文件
- [ ] 飞书发送文档转换请求，验证只收到目标文件无重复
- [ ] 验证飞书不再出现多余 Processing 卡片
- [ ] 验证桌面端不再显示"未知消息类型：file_send"
- [ ] 验证普通文本消息的流式更新行为不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)