### PR TITLE
fix: enable click-to-preview for file_send messages

### DIFF
--- a/src/renderer/messages/MessageFileSend.tsx
+++ b/src/renderer/messages/MessageFileSend.tsx
@@ -5,8 +5,10 @@
  */
 
 import type { IMessageFileSend } from '@/common/chatLib';
+import type { PreviewContentType } from '@/common/types/preview';
+import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
 import { FileText, Picture } from '@icon-park/react';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 const FILE_TYPE_LABELS: Record<string, string> = {
   '.pdf': 'PDF 文档',
@@ -30,15 +32,50 @@ const FILE_TYPE_LABELS: Record<string, string> = {
   '.svg': 'SVG 图片',
 };
 
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg', 'ico', 'tif', 'tiff', 'avif']);
+const OFFICE_EXTENSIONS: Record<string, PreviewContentType> = {
+  ppt: 'ppt', pptx: 'ppt', odp: 'ppt',
+  doc: 'word', docx: 'word', odt: 'word',
+  xls: 'excel', xlsx: 'excel', ods: 'excel',
+};
+
+export const getContentTypeFromExt = (ext: string): PreviewContentType => {
+  const e = ext.toLowerCase();
+  if (e === 'md' || e === 'markdown') return 'markdown';
+  if (e === 'diff' || e === 'patch') return 'diff';
+  if (e === 'pdf') return 'pdf';
+  if (OFFICE_EXTENSIONS[e]) return OFFICE_EXTENSIONS[e];
+  if (e === 'csv') return 'code';
+  if (e === 'html' || e === 'htm') return 'html';
+  if (IMAGE_EXTENSIONS.has(e)) return 'image';
+  return 'code';
+};
+
 const MessageFileSend: React.FC<{ message: IMessageFileSend }> = ({ message }) => {
-  const { fileName, fileType } = message.content;
-  const ext = fileName ? '.' + fileName.split('.').pop()?.toLowerCase() : '';
-  const typeLabel = FILE_TYPE_LABELS[ext] || '文件';
+  const { filePath, fileName, fileType } = message.content;
+  const ext = fileName ? fileName.split('.').pop()?.toLowerCase() || '' : '';
+  const typeLabel = FILE_TYPE_LABELS['.' + ext] || '文件';
+  const { launchPreview, loading } = usePreviewLauncher();
+
+  const handleClick = useCallback(() => {
+    if (!filePath || loading) return;
+    const contentType = fileType === 'image' ? 'image' : getContentTypeFromExt(ext);
+    launchPreview({
+      originalPath: filePath,
+      fileName,
+      contentType,
+      editable: false,
+    });
+  }, [filePath, fileName, fileType, ext, launchPreview, loading]);
+
+  const clickableProps = filePath
+    ? { className: 'cursor-pointer select-none', onClick: handleClick }
+    : {};
 
   if (fileType === 'image') {
     return (
       <div className='w-full'>
-        <div className='bg-message-tips rd-8px p-x-12px p-y-8px flex items-center gap-8px'>
+        <div className='bg-message-tips rd-8px p-x-12px p-y-8px flex items-center gap-8px' {...clickableProps}>
           <Picture theme='filled' size='18' className='flex-shrink-0 text-t-secondary' />
           <span className='text-t-secondary text-13px'>{fileName}</span>
         </div>
@@ -48,7 +85,7 @@ const MessageFileSend: React.FC<{ message: IMessageFileSend }> = ({ message }) =
 
   return (
     <div className='w-full'>
-      <div className='bg-message-tips rd-8px p-x-12px p-y-8px flex items-center gap-8px'>
+      <div className='bg-message-tips rd-8px p-x-12px p-y-8px flex items-center gap-8px' {...clickableProps}>
         <FileText theme='filled' size='18' className='flex-shrink-0 text-t-secondary' />
         <div className='flex flex-col gap-2px'>
           <span className='text-t-primary text-14px'>{fileName}</span>

--- a/tests/unit/messageFileSend.test.ts
+++ b/tests/unit/messageFileSend.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getContentTypeFromExt } from '@/renderer/messages/MessageFileSend';
+
+// --- getContentTypeFromExt 纯函数测试 ---
+
+describe('getContentTypeFromExt', () => {
+  // 文档类型
+  it('maps pdf → pdf', () => {
+    expect(getContentTypeFromExt('pdf')).toBe('pdf');
+  });
+
+  it('maps docx → word, doc → word, odt → word', () => {
+    expect(getContentTypeFromExt('docx')).toBe('word');
+    expect(getContentTypeFromExt('doc')).toBe('word');
+    expect(getContentTypeFromExt('odt')).toBe('word');
+  });
+
+  it('maps xlsx → excel, xls → excel, ods → excel', () => {
+    expect(getContentTypeFromExt('xlsx')).toBe('excel');
+    expect(getContentTypeFromExt('xls')).toBe('excel');
+    expect(getContentTypeFromExt('ods')).toBe('excel');
+  });
+
+  it('maps pptx → ppt, ppt → ppt, odp → ppt', () => {
+    expect(getContentTypeFromExt('pptx')).toBe('ppt');
+    expect(getContentTypeFromExt('ppt')).toBe('ppt');
+    expect(getContentTypeFromExt('odp')).toBe('ppt');
+  });
+
+  // Markdown
+  it('maps md → markdown, markdown → markdown', () => {
+    expect(getContentTypeFromExt('md')).toBe('markdown');
+    expect(getContentTypeFromExt('markdown')).toBe('markdown');
+  });
+
+  // 图片类型
+  it('maps common image extensions to image', () => {
+    const imageExts = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg', 'ico', 'tif', 'tiff', 'avif'];
+    for (const ext of imageExts) {
+      expect(getContentTypeFromExt(ext)).toBe('image');
+    }
+  });
+
+  // 代码类型
+  it('maps code extensions to code', () => {
+    const codeExts = ['ts', 'tsx', 'js', 'jsx', 'py', 'java', 'go', 'rs', 'c', 'cpp', 'json', 'yaml', 'txt', 'sh'];
+    for (const ext of codeExts) {
+      expect(getContentTypeFromExt(ext)).toBe('code');
+    }
+  });
+
+  // 特殊类型
+  it('maps csv → code (not excel)', () => {
+    expect(getContentTypeFromExt('csv')).toBe('code');
+  });
+
+  it('maps html → html, htm → html', () => {
+    expect(getContentTypeFromExt('html')).toBe('html');
+    expect(getContentTypeFromExt('htm')).toBe('html');
+  });
+
+  it('maps diff → diff, patch → diff', () => {
+    expect(getContentTypeFromExt('diff')).toBe('diff');
+    expect(getContentTypeFromExt('patch')).toBe('diff');
+  });
+
+  // 边界情况
+  it('returns code for unknown extensions', () => {
+    expect(getContentTypeFromExt('xyz')).toBe('code');
+    expect(getContentTypeFromExt('rar')).toBe('code');
+    expect(getContentTypeFromExt('zip')).toBe('code');
+  });
+
+  it('returns code for empty string', () => {
+    expect(getContentTypeFromExt('')).toBe('code');
+  });
+
+  it('is case-insensitive', () => {
+    expect(getContentTypeFromExt('PNG')).toBe('image');
+    expect(getContentTypeFromExt('Pdf')).toBe('pdf');
+    expect(getContentTypeFromExt('DOCX')).toBe('word');
+    expect(getContentTypeFromExt('MD')).toBe('markdown');
+    expect(getContentTypeFromExt('TS')).toBe('code');
+  });
+});


### PR DESCRIPTION
## Summary
- `file_send` messages (AI generated files sent to channel clients like Lark) were display-only in the desktop UI — only showed filename with no click interaction
- Added click handler to `MessageFileSend` component that opens the built-in preview panel via existing `usePreviewLauncher` hook, consistent with draft box (草稿箱) single-click behavior
- Handles all file types: documents (PDF/Word/Excel/PPT), images, code, markdown, etc.

## Test plan
- [x] Unit tests for `getContentTypeFromExt` — 13 cases covering document/image/code/special types, empty/unknown extensions, case-insensitivity
- [ ] Manual: verify clicking a file_send message opens the preview panel in the desktop UI
- [ ] Manual: verify clicking during loading state does not trigger duplicate preview
- [ ] Manual: verify file_send messages without filePath are not clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)