### PR TITLE
fix(e2e): adapt lis8 test to new GuidPage + fix type_text React compat

### DIFF
--- a/tests/e2e/cases/lis8-verify-patches.yaml
+++ b/tests/e2e/cases/lis8-verify-patches.yaml
@@ -6,11 +6,7 @@ steps:
   - op: wait_for_app_ready
     timeout: 300
 
-  # ── Phase 1: New conversation ──
-  - op: mouse_click
-    text: "新会话"
-  - op: pause
-    duration: 3000
+  # ── Phase 1: Verify home screen is ready ──
   - op: screenshot
     path: "screenshots/lis8-verify-00-home.png"
 

--- a/tests/e2e/ops/type_text.py
+++ b/tests/e2e/ops/type_text.py
@@ -19,7 +19,11 @@ async def type_text(tab, text: str, wait: float = 1) -> dict:
     js = """(() => {
         const el = document.querySelector('textarea, input:not([type="hidden"])');
         if (!el) return 'no_input';
-        
+
+        // Reset React's _valueTracker so it detects the change
+        const tracker = el._valueTracker;
+        if (tracker) tracker.setValue('');
+
         const proto = el.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
         const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
         setter.call(el, %s);

--- a/tests/e2e/ops/wait_for_app_ready.py
+++ b/tests/e2e/ops/wait_for_app_ready.py
@@ -21,7 +21,8 @@ async def wait_for_app_ready(tab, timeout: float = 300) -> dict:
             (function() {
                 var text = document.body.innerText || '';
                 if (text.includes('正在准备运行环境')) return 'pending';
-                if (text.includes('新会话') || text.includes('Hi')) return 'ready';
+                var hasInput = !!document.querySelector('textarea');
+                if (hasInput && (text.includes('新会话') || text.includes('Hi'))) return 'ready';
                 return 'unknown';
             })()
         """)


### PR DESCRIPTION
## Summary
- **wait_for_app_ready**: require `textarea` presence before declaring ready — prevents false positive when spinner page text matches "Hi"
- **lis8-verify-patches.yaml**: remove "新会话" button click step — new GuidPage is already the new-conversation view
- **type_text**: reset React `_valueTracker` before setting value so Arco Design controlled components properly detect the change

## Test plan
- [x] Ran `python runner.py --port 9230 --case lis8` — all 6 steps pass
- [x] Verified screenshots: home screen ready, message sent, agent executed 33 tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)