### PR TITLE
feat: add clickable agent connection status with restart control (#459)

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -56,6 +56,7 @@ export const conversation = {
   responseSearchWorkSpace: bridge.buildProvider<void, { file: number; dir: number; match?: IDirOrFile }>('conversation.response.search.workspace'),
   reloadContext: bridge.buildProvider<IBridgeResponse, { conversation_id: string }>('conversation.reload-context'),
   getConnectionStatus: bridge.buildProvider<IBridgeResponse<{ status: string | null }>, { conversation_id: string }>('conversation.get-connection-status'),
+  restartAndConnect: bridge.buildProvider<IBridgeResponse<{}>, { conversation_id: string }>('conversation.restart-and-connect'),
   syncWorkspaceSkills: bridge.buildProvider<IBridgeResponse<void>, { conversation_id: string }>('conversation.sync-workspace-skills'),
   // Flush all pending messages to database immediately (used before reading from DB)
   flushPendingMessages: bridge.buildProvider<void, { conversation_id: string }>('conversation.flush-pending-messages'),

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -739,6 +739,32 @@ export function initConversationBridge(): void {
     }
   });
 
+  // Restart the underlying agent/ACP connection and reconnect
+  // Disconnects current connection, clears bootstrap, then re-initializes
+  ipcBridge.conversation.restartAndConnect.provider(async ({ conversation_id }) => {
+    try {
+      const task = WorkerManage.getTaskById(conversation_id) as AcpAgent | OpenClawAgent | undefined;
+      if (!task) return { success: false, msg: 'conversation not found' };
+
+      if (task.type === 'acp') {
+        const acpTask = task as AcpAgent;
+        await acpTask.restartAndConnect();
+        return { success: true };
+      }
+
+      if (task.type === 'openclaw-gateway') {
+        const openclawTask = task as OpenClawAgent;
+        await openclawTask.restartGateway();
+        return { success: true };
+      }
+
+      return { success: false, msg: 'unsupported conversation type' };
+    } catch (error) {
+      mainWarn('[conversationBridge]', 'restartAndConnect failed:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
   // Abort controller for workspace reads: each new request aborts the previous one
   // to avoid stale results when the user navigates quickly.
   let lastGetWorkspaceAbortController: AbortController | undefined;

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -1019,6 +1019,25 @@ This identity statement takes priority over the default identity in USER.md.
       .finally(doKill);
   }
 
+  /**
+   * Restart the underlying ACP connection and reconnect.
+   * Disconnects current connection, clears bootstrap, then re-initializes.
+   */
+  async restartAndConnect(): Promise<void> {
+    // Disconnect current connection (kills process, clears session state)
+    await this.connection.disconnect();
+    // Clear bootstrap so initAgent creates a fresh connection
+    this.bootstrap = undefined;
+    // Clear pending state
+    this.pendingPermissions.clear();
+    this.permissionRequestMeta.clear();
+    this.approvalStore.clear();
+    this.pendingNavigationTools.clear();
+    this.statusMessageId = null;
+    // Re-initialize agent connection
+    await this.initAgent();
+  }
+
   async ensureYoloMode(): Promise<boolean> {
     if (this.options.yoloMode) {
       return true;

--- a/src/renderer/components/AgentStatusBanner.tsx
+++ b/src/renderer/components/AgentStatusBanner.tsx
@@ -7,9 +7,9 @@
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import { iconColors } from '@/renderer/theme/colors';
-import { Button, Tooltip } from '@arco-design/web-react';
-import { Connection } from '@icon-park/react';
-import React, { useEffect, useState } from 'react';
+import { Button, Dropdown, Menu, Message } from '@arco-design/web-react';
+import { Connection, Refresh } from '@icon-park/react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAddEventListener } from '@/renderer/utils/emitter';
 
@@ -37,6 +37,7 @@ function resolveGatewayHealthStatus(gatewayRunning: boolean): string {
 
 const AgentStatusDot: React.FC<{ conversation_id: string; conversationType?: TChatConversation['type'] }> = ({ conversation_id, conversationType }) => {
   const [status, setStatus] = useState('');
+  const [restarting, setRestarting] = useState(false);
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -85,20 +86,65 @@ const AgentStatusDot: React.FC<{ conversation_id: string; conversationType?: TCh
     [conversation_id, conversationType]
   );
 
+  const handleRestartAndConnect = useCallback(() => {
+    if (restarting) return;
+    setRestarting(true);
+
+    void ipcBridge.conversation.restartAndConnect
+      .invoke({ conversation_id })
+      .then((res) => {
+        if (res?.success) {
+          Message.success({
+            content: t('agentStatus.restartCommandSent', { defaultValue: '重启并连接命令已下发' }),
+            duration: 3000,
+          });
+        } else {
+          Message.error({
+            content: res?.msg || t('agentStatus.restartFailed', { defaultValue: '重启失败' }),
+            duration: 3000,
+          });
+        }
+      })
+      .catch((err) => {
+        Message.error({
+          content: err?.message || t('agentStatus.restartFailed', { defaultValue: '重启失败' }),
+          duration: 3000,
+        });
+      })
+      .finally(() => {
+        setRestarting(false);
+      });
+  }, [conversation_id, restarting, t]);
+
   if (!status) return null;
 
   const dotColor = DOT_COLORS[status] || '#86909c';
   const labelKey = STATUS_LABELS[status] || 'agentStatus.unknown';
 
+  const dropdownMenu = (
+    <Menu onClickMenuItem={(key) => {
+      if (key === 'restart') {
+        handleRestartAndConnect();
+      }
+    }}>
+      <Menu.Item key='restart' disabled={restarting}>
+        <span className='inline-flex items-center gap-6px'>
+          <Refresh theme='outline' size={14} fill='currentColor' className={restarting ? 'animate-spin' : ''} />
+          {t('agentStatus.restartAndConnect', { defaultValue: '重启并连接' })}
+        </span>
+      </Menu.Item>
+    </Menu>
+  );
+
   return (
-    <Tooltip content={t(labelKey, { defaultValue: status })}>
-      <Button type='text' size='small' className='!h-auto !w-auto !min-w-0 !px-0 !py-0 cursor-default'>
-        <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2'>
+    <Dropdown droplist={dropdownMenu} trigger='click' position='bl'>
+      <Button type='text' size='small' className='!h-auto !w-auto !min-w-0 !px-0 !py-0 cursor-pointer'>
+        <span className='inline-flex items-center gap-2px rounded-full px-8px py-2px bg-2' title={t(labelKey, { defaultValue: status })}>
           <Connection theme='outline' size={16} fill={iconColors.primary} />
           <span className='ml-4px w-8px h-8px rounded-full' style={{ backgroundColor: dotColor }} />
         </span>
       </Button>
-    </Tooltip>
+    </Dropdown>
   );
 };
 

--- a/src/renderer/i18n/locales/en-US/agentStatus.json
+++ b/src/renderer/i18n/locales/en-US/agentStatus.json
@@ -5,5 +5,8 @@
   "session_active": "Active",
   "disconnected": "Disconnected",
   "error": "Error",
-  "unknown": "Unknown"
+  "unknown": "Unknown",
+  "restartAndConnect": "Restart & Connect",
+  "restartCommandSent": "Restart command sent",
+  "restartFailed": "Restart failed"
 }

--- a/src/renderer/i18n/locales/ja-JP/agentStatus.json
+++ b/src/renderer/i18n/locales/ja-JP/agentStatus.json
@@ -5,5 +5,8 @@
   "session_active": "アクティブ",
   "disconnected": "切断",
   "error": "エラー",
-  "unknown": "不明"
+  "unknown": "不明",
+  "restartAndConnect": "再起動して接続",
+  "restartCommandSent": "再起動コマンドを送信しました",
+  "restartFailed": "再起動に失敗しました"
 }

--- a/src/renderer/i18n/locales/ko-KR/agentStatus.json
+++ b/src/renderer/i18n/locales/ko-KR/agentStatus.json
@@ -5,5 +5,8 @@
   "session_active": "활성",
   "disconnected": "연결 끊김",
   "error": "오류",
-  "unknown": "알 수 없음"
+  "unknown": "알 수 없음",
+  "restartAndConnect": "재시작 및 연결",
+  "restartCommandSent": "재시작 명령이 전송되었습니다",
+  "restartFailed": "재시작 실패"
 }

--- a/src/renderer/i18n/locales/tr-TR/agentStatus.json
+++ b/src/renderer/i18n/locales/tr-TR/agentStatus.json
@@ -5,5 +5,8 @@
   "session_active": "Aktif",
   "disconnected": "Bağlantı kesildi",
   "error": "Hata",
-  "unknown": "Bilinmiyor"
+  "unknown": "Bilinmiyor",
+  "restartAndConnect": "Yeniden başlat ve bağlan",
+  "restartCommandSent": "Yeniden başlatma komutu gönderildi",
+  "restartFailed": "Yeniden başlatma başarısız"
 }

--- a/src/renderer/i18n/locales/zh-CN/agentStatus.json
+++ b/src/renderer/i18n/locales/zh-CN/agentStatus.json
@@ -5,5 +5,8 @@
   "session_active": "会话活跃",
   "disconnected": "已断开",
   "error": "连接错误",
-  "unknown": "未知状态"
+  "unknown": "未知状态",
+  "restartAndConnect": "重启并连接",
+  "restartCommandSent": "重启并连接命令已下发",
+  "restartFailed": "重启失败"
 }

--- a/src/renderer/i18n/locales/zh-TW/agentStatus.json
+++ b/src/renderer/i18n/locales/zh-TW/agentStatus.json
@@ -5,5 +5,8 @@
   "session_active": "會話活躍",
   "disconnected": "已斷開",
   "error": "連線錯誤",
-  "unknown": "未知狀態"
+  "unknown": "未知狀態",
+  "restartAndConnect": "重啟並連線",
+  "restartCommandSent": "重啟並連線命令已下發",
+  "restartFailed": "重啟失敗"
 }


### PR DESCRIPTION
Closes #459

## Summary

Make the agent connection status indicator clickable with a dropdown menu providing a "Restart & Connect" option. The status continues to sync naturally from the backend.

- Add `restartAndConnect` IPC bridge and backend provider
- Add `AcpAgent.restartAndConnect()` method
- Replace Tooltip with Dropdown menu on AgentStatusDot
- Add i18n translations for all 6 locales

Generated with [Claude Code](https://claude.ai/code)