### PR TITLE
fix: 修复数字助手通过左tab添加后使用不能生效的问题

### DIFF
--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -1052,6 +1052,8 @@ const AgentModalContent: React.FC = () => {
           }
           await fetchInstalledAssistantNames();
           await loadAssistants();
+          // Refresh agent detection so GuidPage's useGuidAgentSelection picks up the new assistant
+          await refreshAgentDetection();
           setHubDetailVisible(false);
         } else {
           Message.error(t('settings.assistant.installFailed', { msg: res.msg || 'Unknown error', defaultValue: `安装失败: ${res.msg || '未知错误'}` }));
@@ -1064,15 +1066,17 @@ const AgentModalContent: React.FC = () => {
         setInstallProgress(0);
       }
     },
-    [hubAssistantList, fetchInstalledAssistantNames, loadAssistants, t]
+    [hubAssistantList, fetchInstalledAssistantNames, loadAssistants, refreshAgentDetection, t]
   );
 
   // Go use installed assistant (navigate to guid page)
-  const handleGoUseHubAssistant = useCallback(() => {
+  const handleGoUseHubAssistant = useCallback(async () => {
     if (!hubDetailAssistant) return;
     setHubDetailVisible(false);
+    // Refresh agent detection before navigating so GuidPage's customAgents are up-to-date
+    await refreshAgentDetection();
     void navigate(`/guid?assistant=${encodeURIComponent(hubDetailAssistant.name)}`);
-  }, [hubDetailAssistant, navigate]);
+  }, [hubDetailAssistant, navigate, refreshAgentDetection]);
 
   // Open duplicate confirm modal for hub assistant
   const handleOpenDuplicateModal = useCallback((assistant: IAssistantHubSkill) => {

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -209,9 +209,11 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
     }
   }, [availableAgentsData]);
 
-  // Load last selected agent
+  // Load last selected agent (skip when URL parameter takes priority)
   useEffect(() => {
     if (!availableAgents || availableAgents.length === 0) return;
+    // Skip restoring persisted agent when a URL parameter explicitly specifies the assistant
+    if (assistantFromUrl) return;
 
     let cancelled = false;
 
@@ -238,7 +240,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
     return () => {
       cancelled = true;
     };
-  }, [availableAgents]);
+  }, [availableAgents, assistantFromUrl]);
 
   // Load custom agents + extension-contributed assistants
   useEffect(() => {


### PR DESCRIPTION
Closes #460

## Summary
- 安装助手后刷新 SWR 缓存，确保 GuidPage 能获取到新安装的助手
- “去使用”导航前先刷新 agent detection
- 修复异步 effect 竞争导致 URL 参数指定的助手选择被覆盖的问题

Generated with [Claude Code](https://claude.ai/code)