### PR TITLE
feat: support sending images and files to DingTalk channel

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -699,6 +699,10 @@ export class ActionExecutor {
       // Track last message content for adding action buttons after stream ends
       let lastMessageContent: IUnifiedOutgoingMessage | null = null;
 
+      // 跟踪最后一条文本消息内容，用于文件消息后仍能正确 finalize AI Card
+      // Track last text content to finalize AI Card even when last message is file/image
+      let lastTextContent: IUnifiedOutgoingMessage | null = null;
+
       // 执行消息编辑的函数
       // Function to perform message edit
       const doEditMessage = async (msg: IUnifiedOutgoingMessage, forceThinkingTarget = false) => {
@@ -736,6 +740,9 @@ export class ActionExecutor {
         // 保存最后一条消息内容（不含 replyMarkup，最终消息会单独添加）
         // Save last message content (without replyMarkup, final message adds it separately)
         lastMessageContent = streamOutgoing;
+        if (streamOutgoing.type === 'text') {
+          lastTextContent = streamOutgoing;
+        }
 
         // IMPORTANT: Treat first text streaming message as update to thinking message
         // This prevents async race condition where first insert's sendMessage takes time
@@ -776,7 +783,11 @@ export class ActionExecutor {
           if (supportsEdit) {
             try {
               const newMsgId = await context.sendMessage(streamOutgoing);
-              sentMessageIds.push(newMsgId);
+              // Don't push file/image IDs — they can't be edited and would pollute
+              // the edit target, preventing AI Card finalization
+              if (streamOutgoing.type !== 'file' && streamOutgoing.type !== 'image') {
+                sentMessageIds.push(newMsgId);
+              }
             } catch {
               // Ignore send errors
             }
@@ -846,7 +857,14 @@ export class ActionExecutor {
         // Skip edit for non-text messages (file/image) — these were already sent via sendMessage
         // and cannot be edited (LarkPlugin.editMessage only supports card messages)
         if (lastMessageContent.type === 'file' || lastMessageContent.type === 'image') {
-          // No action needed; file/image messages were already sent correctly via sendMessage
+          // File/image was the last message — still need to finalize the AI Card
+          // with the last text content so it stops spinning
+          if (lastTextContent && supportsEdit && sentMessageIds.length > 0) {
+            const responseMarkup = getResponseActionsMarkup(context.platform as PluginType, lastTextContent.text);
+            const finalMessage: IUnifiedOutgoingMessage = { ...lastTextContent, replyMarkup: responseMarkup };
+            const lastMsgId = sentMessageIds[sentMessageIds.length - 1];
+            await context.editMessage(lastMsgId, finalMessage);
+          }
         } else {
           const responseMarkup = getResponseActionsMarkup(context.platform as PluginType, lastMessageContent.text);
           const finalMessage: IUnifiedOutgoingMessage = { ...lastMessageContent, replyMarkup: responseMarkup };

--- a/src/channels/plugins/dingtalk/DingTalkAdapter.ts
+++ b/src/channels/plugins/dingtalk/DingTalkAdapter.ts
@@ -677,3 +677,44 @@ export function extractCardAction(params: Record<string, string>): IMessageActio
     params: actionParams,
   };
 }
+
+// ==================== Media Upload Helpers ====================
+
+/**
+ * DingTalk upload API supported image extensions
+ * https://open.dingtalk.com/document/orgapp/upload-media-files
+ */
+const DINGTALK_UPLOAD_IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'gif', 'png', 'bmp']);
+
+/**
+ * Map file extension to DingTalk sampleFile fileType parameter.
+ * https://open.dingtalk.com/document/development/robot-message-type
+ * Official supported: xlsx, pdf, zip, rar, doc, docx
+ */
+const DINGTALK_FILE_TYPE_MAP: Record<string, string> = {
+  pdf: 'pdf',
+  doc: 'doc', docx: 'doc',
+  xls: 'xlsx', xlsx: 'xlsx',
+  ppt: 'ppt', pptx: 'ppt',
+  zip: 'zip',
+  rar: 'rar',
+};
+
+/**
+ * Determine upload media type based on file extension.
+ * Only returns 'image' for extensions DingTalk upload API explicitly supports as image type.
+ * All other extensions default to 'file'.
+ */
+export function getUploadMediaType(fileName: string): 'image' | 'file' {
+  const ext = fileName.split('.').pop()?.toLowerCase() || '';
+  return DINGTALK_UPLOAD_IMAGE_EXTENSIONS.has(ext) ? 'image' : 'file';
+}
+
+/**
+ * Map file extension to DingTalk sampleFile fileType parameter.
+ * Falls back to 'pdf' for unknown extensions.
+ */
+export function getDingTalkFileType(fileName: string): string {
+  const ext = fileName.split('.').pop()?.toLowerCase() || '';
+  return DINGTALK_FILE_TYPE_MAP[ext] || 'pdf';
+}

--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -12,7 +12,7 @@ import https from 'https';
 
 import type { BotInfo, IChannelPluginConfig, IUnifiedOutgoingMessage, PluginType } from '../../types';
 import { BasePlugin } from '../BasePlugin';
-import { DINGTALK_MESSAGE_LIMIT, encodeChatId, extractCardAction, parseChatId, toDingTalkSendParams, toUnifiedIncomingMessage, convertHtmlToDingTalkMarkdown, getDefaultExtension, getDefaultMimeType, extractMediaDownloadInfo, setMediaLocalPath } from './DingTalkAdapter';
+import { DINGTALK_MESSAGE_LIMIT, encodeChatId, extractCardAction, parseChatId, toDingTalkSendParams, toUnifiedIncomingMessage, convertHtmlToDingTalkMarkdown, getDefaultExtension, getDefaultMimeType, extractMediaDownloadInfo, setMediaLocalPath, getUploadMediaType, getDingTalkFileType } from './DingTalkAdapter';
 import { mainLog, mainWarn, mainError } from '@/process/utils/mainLogger';
 import type { DingTalkStreamMessage } from './DingTalkAdapter';
 
@@ -220,8 +220,34 @@ export class DingTalkPlugin extends BasePlugin {
   async sendMessage(chatId: string, message: IUnifiedOutgoingMessage): Promise<string> {
     await this.ensureAccessToken();
 
-    const { contentType, content, rawText } = toDingTalkSendParams(message);
     const { type: chatType, id } = parseChatId(chatId);
+
+    // Handle image messages - upload then send via API
+    if (message.type === 'image' && message.imageUrl) {
+      try {
+        const uploadType = getUploadMediaType(message.imageUrl);
+        const mediaId = await this.uploadMedia(message.imageUrl, uploadType);
+        return this.sendMediaViaAPI(chatType, id, 'image', mediaId);
+      } catch (error) {
+        mainError('DingTalkPlugin', 'Failed to send image', error);
+        throw error;
+      }
+    }
+
+    // Handle file messages - upload then send via API
+    if (message.type === 'file' && message.fileUrl && message.fileName) {
+      try {
+        const uploadType = getUploadMediaType(message.fileName);
+        const mediaId = await this.uploadMedia(message.fileUrl, uploadType);
+        const fileType = getDingTalkFileType(message.fileName);
+        return this.sendMediaViaAPI(chatType, id, 'file', mediaId, message.fileName, fileType);
+      } catch (error) {
+        mainError('DingTalkPlugin', 'Failed to send file', error);
+        throw error;
+      }
+    }
+
+    const { contentType, content, rawText } = toDingTalkSendParams(message);
 
     // Try AI Card streaming for text/markdown messages
     if (contentType === 'markdown' && rawText !== undefined) {
@@ -940,5 +966,133 @@ export class DingTalkPlugin extends BasePlugin {
         error: error.message || 'Failed to connect to DingTalk API',
       };
     }
+  }
+
+  // ==================== Media Upload & Send ====================
+
+  // DingTalk old API base for media upload (multipart/form-data)
+  private static readonly DINGTALK_OAPI_BASE = 'https://oapi.dingtalk.com';
+
+  /**
+   * Upload a media file to DingTalk and return media_id.
+   * Uses the old oapi endpoint with access_token as query parameter.
+   */
+  private async uploadMedia(filePath: string, uploadType: 'image' | 'file'): Promise<string> {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+
+    const token = await this.getAccessToken();
+    const fileBuffer = fs.readFileSync(filePath);
+    const fileName = path.basename(filePath);
+
+    const boundary = `----DingTalkBoundary${Date.now()}`;
+    const CRLF = '\r\n';
+    const fileData = fileBuffer.toString('binary');
+
+    // Build multipart/form-data body
+    const body =
+      `--${boundary}${CRLF}` +
+      `Content-Disposition: form-data; name="media"; filename="${fileName}"${CRLF}` +
+      `Content-Type: application/octet-stream${CRLF}` +
+      CRLF +
+      fileData +
+      CRLF +
+      `--${boundary}--${CRLF}`;
+
+    const url = `${DingTalkPlugin.DINGTALK_OAPI_BASE}/media/upload?access_token=${encodeURIComponent(token)}&type=${uploadType}`;
+
+    return new Promise((resolve, reject) => {
+      const urlObj = new URL(url);
+      const bodyBuffer = Buffer.from(body, 'binary');
+
+      const options = {
+        hostname: urlObj.hostname,
+        port: urlObj.port || 443,
+        path: urlObj.pathname + urlObj.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+          'Content-Length': bodyBuffer.length,
+        },
+      };
+
+      const req = https.request(options, (res) => {
+        let responseData = '';
+        res.on('data', (chunk) => {
+          responseData += chunk;
+        });
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(responseData);
+            if (parsed.errcode && parsed.errcode !== 0) {
+              reject(new Error(`DingTalk upload failed: errcode=${parsed.errcode}, errmsg=${parsed.errmsg}`));
+              return;
+            }
+            if (!parsed.media_id) {
+              reject(new Error('DingTalk upload failed: no media_id in response'));
+              return;
+            }
+            resolve(parsed.media_id);
+          } catch {
+            reject(new Error(`Invalid upload response: ${responseData}`));
+          }
+        });
+      });
+
+      req.on('error', reject);
+      req.setTimeout(30000, () => {
+        req.destroy(new Error('Upload timed out'));
+      });
+      req.write(bodyBuffer);
+      req.end();
+    });
+  }
+
+  /**
+   * Send image or file message via DingTalk robot API.
+   * Uses the new api.dingtalk.com endpoint with header-based auth.
+   */
+  private async sendMediaViaAPI(
+    chatType: 'user' | 'group',
+    id: string,
+    mediaType: 'image' | 'file',
+    mediaId: string,
+    fileName?: string,
+    fileType?: string,
+  ): Promise<string> {
+    const token = await this.getAccessToken();
+
+    let msgKey: string;
+    let msgParam: string;
+
+    if (mediaType === 'image') {
+      msgKey = 'sampleImageMsg';
+      msgParam = JSON.stringify({ photoURL: mediaId });
+    } else {
+      msgKey = 'sampleFile';
+      msgParam = JSON.stringify({ mediaId, fileName, fileType });
+    }
+
+    if (chatType === 'user') {
+      const body: Record<string, unknown> = {
+        robotCode: this.clientId,
+        userIds: [id],
+        msgKey,
+        msgParam,
+      };
+      const response = await this.apiRequest('POST', '/v1.0/robot/oToMessages/batchSend', token, body);
+      return response?.processQueryKey || `api_media_${Date.now()}`;
+    }
+
+    // Group chat
+    const body: Record<string, unknown> = {
+      robotCode: this.clientId,
+      openConversationId: id,
+      msgKey,
+      msgParam,
+    };
+    const response = await this.apiRequest('POST', '/v1.0/robot/groupMessages/send', token, body);
+    return response?.processQueryKey || `api_media_${Date.now()}`;
   }
 }

--- a/tests/unit/channels/dingtalkAdapter.test.ts
+++ b/tests/unit/channels/dingtalkAdapter.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { getDefaultExtension, getDefaultMimeType, extractMediaDownloadInfo, setMediaLocalPath, toUnifiedIncomingMessage } from '@/channels/plugins/dingtalk/DingTalkAdapter';
+import { getDefaultExtension, getDefaultMimeType, extractMediaDownloadInfo, setMediaLocalPath, toUnifiedIncomingMessage, getUploadMediaType, getDingTalkFileType } from '@/channels/plugins/dingtalk/DingTalkAdapter';
 import type { DingTalkStreamMessage } from '@/channels/plugins/dingtalk/DingTalkAdapter';
 
 // ==================== getDefaultExtension ====================
@@ -763,5 +763,239 @@ describe('DingTalkAdapter richText message handling', () => {
       expect(result!.content.type).toBe('text');
       expect(result!.content.text).toBe('line1line2line3');
     });
+  });
+});
+
+// ==================== getUploadMediaType ====================
+
+describe('getUploadMediaType', () => {
+  // DingTalk upload API explicitly supports these as image type
+  it('returns image for jpg', () => {
+    expect(getUploadMediaType('photo.jpg')).toBe('image');
+  });
+
+  it('returns image for jpeg', () => {
+    expect(getUploadMediaType('photo.jpeg')).toBe('image');
+  });
+
+  it('returns image for png', () => {
+    expect(getUploadMediaType('icon.png')).toBe('image');
+  });
+
+  it('returns image for gif', () => {
+    expect(getUploadMediaType('anim.gif')).toBe('image');
+  });
+
+  it('returns image for bmp', () => {
+    expect(getUploadMediaType('bitmap.bmp')).toBe('image');
+  });
+
+  // NOT supported by DingTalk upload API as image type
+  it('returns file for webp (not in DingTalk image list)', () => {
+    expect(getUploadMediaType('photo.webp')).toBe('file');
+  });
+
+  it('returns file for svg (not in DingTalk image list)', () => {
+    expect(getUploadMediaType('icon.svg')).toBe('file');
+  });
+
+  it('returns file for tiff (not in DingTalk image list)', () => {
+    expect(getUploadMediaType('scan.tiff')).toBe('file');
+  });
+
+  it('returns file for avif (not in DingTalk image list)', () => {
+    expect(getUploadMediaType('photo.avif')).toBe('file');
+  });
+
+  it('returns file for ico (not in DingTalk image list)', () => {
+    expect(getUploadMediaType('favicon.ico')).toBe('file');
+  });
+
+  // Document types
+  it('returns file for pdf', () => {
+    expect(getUploadMediaType('doc.pdf')).toBe('file');
+  });
+
+  it('returns file for docx', () => {
+    expect(getUploadMediaType('report.docx')).toBe('file');
+  });
+
+  it('returns file for xlsx', () => {
+    expect(getUploadMediaType('data.xlsx')).toBe('file');
+  });
+
+  it('returns file for pptx', () => {
+    expect(getUploadMediaType('slides.pptx')).toBe('file');
+  });
+
+  it('returns file for zip', () => {
+    expect(getUploadMediaType('archive.zip')).toBe('file');
+  });
+
+  it('returns file for rar', () => {
+    expect(getUploadMediaType('archive.rar')).toBe('file');
+  });
+
+  // Other types
+  it('returns file for csv', () => {
+    expect(getUploadMediaType('data.csv')).toBe('file');
+  });
+
+  it('returns file for txt', () => {
+    expect(getUploadMediaType('note.txt')).toBe('file');
+  });
+
+  it('returns file for md', () => {
+    expect(getUploadMediaType('readme.md')).toBe('file');
+  });
+
+  it('returns file for json', () => {
+    expect(getUploadMediaType('config.json')).toBe('file');
+  });
+
+  // Edge cases
+  it('returns file for empty string', () => {
+    expect(getUploadMediaType('')).toBe('file');
+  });
+
+  it('returns file for filename without extension', () => {
+    expect(getUploadMediaType('Makefile')).toBe('file');
+  });
+
+  it('returns file for hidden file with dot prefix', () => {
+    expect(getUploadMediaType('.gitignore')).toBe('file');
+  });
+
+  it('takes last extension from multi-dot filename', () => {
+    expect(getUploadMediaType('archive.tar.gz')).toBe('file');
+  });
+
+  // Case insensitivity
+  it('returns image for uppercase PNG', () => {
+    expect(getUploadMediaType('photo.PNG')).toBe('image');
+  });
+
+  it('returns image for mixed case JpEg', () => {
+    expect(getUploadMediaType('photo.JpEg')).toBe('image');
+  });
+
+  it('returns file for uppercase PDF', () => {
+    expect(getUploadMediaType('doc.PDF')).toBe('file');
+  });
+
+  it('returns file for mixed case DocX', () => {
+    expect(getUploadMediaType('doc.DocX')).toBe('file');
+  });
+
+  it('returns image for uppercase GIF', () => {
+    expect(getUploadMediaType('anim.GIF')).toBe('image');
+  });
+
+  it('returns image for uppercase BMP', () => {
+    expect(getUploadMediaType('bitmap.BMP')).toBe('image');
+  });
+});
+
+// ==================== getDingTalkFileType ====================
+
+describe('getDingTalkFileType', () => {
+  // Exact mappings
+  it('maps pdf → pdf', () => {
+    expect(getDingTalkFileType('doc.pdf')).toBe('pdf');
+  });
+
+  it('maps doc → doc', () => {
+    expect(getDingTalkFileType('letter.doc')).toBe('doc');
+  });
+
+  it('maps docx → doc', () => {
+    expect(getDingTalkFileType('report.docx')).toBe('doc');
+  });
+
+  it('maps xls → xlsx', () => {
+    expect(getDingTalkFileType('data.xls')).toBe('xlsx');
+  });
+
+  it('maps xlsx → xlsx', () => {
+    expect(getDingTalkFileType('data.xlsx')).toBe('xlsx');
+  });
+
+  it('maps ppt → ppt', () => {
+    expect(getDingTalkFileType('slides.ppt')).toBe('ppt');
+  });
+
+  it('maps pptx → ppt', () => {
+    expect(getDingTalkFileType('slides.pptx')).toBe('ppt');
+  });
+
+  it('maps zip → zip', () => {
+    expect(getDingTalkFileType('archive.zip')).toBe('zip');
+  });
+
+  it('maps rar → rar', () => {
+    expect(getDingTalkFileType('archive.rar')).toBe('rar');
+  });
+
+  // Unknown extensions → default 'pdf'
+  it('maps csv → pdf (unknown, defaults to pdf)', () => {
+    expect(getDingTalkFileType('data.csv')).toBe('pdf');
+  });
+
+  it('maps txt → pdf (unknown, defaults to pdf)', () => {
+    expect(getDingTalkFileType('note.txt')).toBe('pdf');
+  });
+
+  it('maps md → pdf (unknown, defaults to pdf)', () => {
+    expect(getDingTalkFileType('readme.md')).toBe('pdf');
+  });
+
+  it('maps json → pdf (unknown, defaults to pdf)', () => {
+    expect(getDingTalkFileType('config.json')).toBe('pdf');
+  });
+
+  it('maps odt → pdf (unknown, defaults to pdf)', () => {
+    expect(getDingTalkFileType('doc.odt')).toBe('pdf');
+  });
+
+  it('maps png → pdf (image extension, defaults to pdf)', () => {
+    expect(getDingTalkFileType('photo.png')).toBe('pdf');
+  });
+
+  // Edge cases
+  it('returns pdf for empty string', () => {
+    expect(getDingTalkFileType('')).toBe('pdf');
+  });
+
+  it('returns pdf for filename without extension', () => {
+    expect(getDingTalkFileType('Makefile')).toBe('pdf');
+  });
+
+  it('returns pdf for hidden file', () => {
+    expect(getDingTalkFileType('.gitignore')).toBe('pdf');
+  });
+
+  it('takes last extension from multi-dot filename', () => {
+    expect(getDingTalkFileType('report.final.pdf')).toBe('pdf');
+  });
+
+  it('takes last extension for multi-dot docx', () => {
+    expect(getDingTalkFileType('draft.v2.docx')).toBe('doc');
+  });
+
+  // Case insensitivity
+  it('maps PDF → pdf', () => {
+    expect(getDingTalkFileType('doc.PDF')).toBe('pdf');
+  });
+
+  it('maps DOCX → doc', () => {
+    expect(getDingTalkFileType('doc.DOCX')).toBe('doc');
+  });
+
+  it('maps XLSX → xlsx', () => {
+    expect(getDingTalkFileType('data.XLSX')).toBe('xlsx');
+  });
+
+  it('maps PPTX → ppt', () => {
+    expect(getDingTalkFileType('slides.PPTX')).toBe('ppt');
   });
 });

--- a/tests/unit/channels/dingtalkPluginMedia.test.ts
+++ b/tests/unit/channels/dingtalkPluginMedia.test.ts
@@ -1,0 +1,562 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests for DingTalkPlugin media upload and send functionality.
+ *
+ * Strategy: Mock `https` and `fs` modules via vi.doMock, then use
+ * vi.resetModules() + dynamic import() to load DingTalkPlugin with mocks.
+ * Access private methods via (instance as any).
+ */
+
+// ---- Shared mock state (set before each loadPluginWithMocks call) ----
+let mockUploadResponse: any;
+let mockApiRequestResponse: any;
+let mockRequestError: Error | null;
+let mockFsExistsSync: boolean;
+let fsReadFileSyncMock: ReturnType<typeof vi.fn>;
+
+// ---- Captured request data ----
+interface CapturedRequest {
+  options: any;
+  writeData: Buffer[];
+  endCalled: boolean;
+  responseCallback: ((res: any) => void) | null;
+}
+let capturedRequests: CapturedRequest[];
+
+/**
+ * Create a mock https.request that captures requests and auto-responds.
+ */
+function createMockHttpsRequest() {
+  capturedRequests = [];
+
+  return (optionsOrUrl: any, responseCallback?: (res: any) => void) => {
+    const writeData: Buffer[] = [];
+    const req: CapturedRequest = {
+      options: optionsOrUrl,
+      writeData,
+      endCalled: false,
+      responseCallback: responseCallback || null,
+    };
+    capturedRequests.push(req);
+
+    const mockReq = {
+      on: vi.fn((_event: string, _handler: (...args: any[]) => void) => mockReq),
+      setTimeout: vi.fn((_ms: number, _handler: () => void) => {}),
+      write: vi.fn((data: any) => {
+        writeData.push(typeof data === 'string' ? Buffer.from(data, 'utf-8') : data);
+      }),
+      end: vi.fn(() => {
+        req.endCalled = true;
+        if (req.responseCallback) {
+          // Determine response based on request path (options.path, not full URL)
+          const reqPath = optionsOrUrl.path || '';
+          let responseData: string;
+
+          if (reqPath.includes('/media/upload')) {
+            responseData = JSON.stringify(mockUploadResponse);
+          } else {
+            responseData = JSON.stringify(mockApiRequestResponse);
+          }
+
+          const mockRes = {
+            statusCode: 200,
+            on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+              if (event === 'data') handler(responseData);
+              if (event === 'end') handler();
+            }),
+          };
+
+          req.responseCallback(mockRes);
+        }
+      }),
+      destroy: vi.fn(),
+    };
+
+    if (mockRequestError) {
+      setTimeout(() => {
+        const errorCall = mockReq.on.mock.calls.find((c: any[]) => c[0] === 'error');
+        if (errorCall) errorCall[1](mockRequestError);
+      }, 0);
+    }
+
+    return mockReq;
+  };
+}
+
+async function loadPluginWithMocks() {
+  vi.resetModules();
+
+  mockFsExistsSync = true;
+  fsReadFileSyncMock = vi.fn(() => Buffer.from('fake-file-content'));
+  mockUploadResponse = { errcode: 0, media_id: '@test_media_id_123', type: 'image' };
+  mockApiRequestResponse = { processQueryKey: 'test_process_key' };
+  mockRequestError = null;
+
+  const mockHttpsRequest = createMockHttpsRequest();
+
+  vi.doMock('fs', () => ({
+    default: {
+      existsSync: vi.fn(() => mockFsExistsSync),
+      readFileSync: fsReadFileSyncMock,
+      writeFileSync: vi.fn(),
+    },
+    existsSync: vi.fn(() => mockFsExistsSync),
+    readFileSync: fsReadFileSyncMock,
+    writeFileSync: vi.fn(),
+  }));
+
+  vi.doMock('https', () => ({
+    default: { request: mockHttpsRequest },
+    request: mockHttpsRequest,
+  }));
+
+  vi.doMock('dingtalk-stream', () => ({
+    DWClient: vi.fn(),
+    TOPIC_ROBOT: 'TOPIC_ROBOT',
+    TOPIC_CARD: 'TOPIC_CARD',
+    EventAck: { SUCCESS: 'SUCCESS' },
+  }));
+
+  vi.doMock('@/process/utils/mainLogger', () => ({
+    mainLog: vi.fn(),
+    mainWarn: vi.fn(),
+    mainError: vi.fn(),
+  }));
+
+  vi.doMock('@/channels/plugins/dingtalk/DingTalkAdapter', () => ({
+    DINGTALK_MESSAGE_LIMIT: 20000,
+    encodeChatId: vi.fn(),
+    extractCardAction: vi.fn(),
+    parseChatId: vi.fn((chatId: string) => {
+      if (chatId.startsWith('user:')) return { type: 'user' as const, id: chatId.slice(5) };
+      if (chatId.startsWith('group:')) return { type: 'group' as const, id: chatId.slice(6) };
+      return { type: 'user' as const, id: chatId };
+    }),
+    toDingTalkSendParams: vi.fn(() => ({
+      contentType: 'markdown',
+      content: { title: 'Message', text: 'test' },
+      rawText: 'test',
+    })),
+    toUnifiedIncomingMessage: vi.fn(),
+    convertHtmlToDingTalkMarkdown: vi.fn((s: string) => s),
+    getDefaultExtension: vi.fn(),
+    getDefaultMimeType: vi.fn(),
+    extractMediaDownloadInfo: vi.fn(),
+    setMediaLocalPath: vi.fn(),
+    getUploadMediaType: vi.fn((fileName: string) => {
+      const ext = fileName.split('.').pop()?.toLowerCase() || '';
+      return ['jpg', 'jpeg', 'gif', 'png', 'bmp'].includes(ext) ? 'image' : 'file';
+    }),
+    getDingTalkFileType: vi.fn((fileName: string) => {
+      const ext = fileName.split('.').pop()?.toLowerCase() || '';
+      const map: Record<string, string> = {
+        pdf: 'pdf', doc: 'doc', docx: 'doc',
+        xls: 'xlsx', xlsx: 'xlsx', ppt: 'ppt', pptx: 'ppt',
+        zip: 'zip', rar: 'rar',
+      };
+      return map[ext] || 'pdf';
+    }),
+  }));
+
+  vi.doMock('@/channels/plugins/BasePlugin', () => {
+    class BasePlugin {
+      type = 'dingtalk';
+      protected _status = 'created';
+      protected config: any = null;
+      protected messageHandler: any = null;
+      protected confirmHandler: any = null;
+      getStatus() { return this._status; }
+      getConfig() { return this.config; }
+      setMessageHandler(h: any) { this.messageHandler = h; }
+      setConfirmHandler(h: any) { this.confirmHandler = h; }
+    }
+    return { BasePlugin };
+  });
+
+  return await import('@/channels/plugins/dingtalk/DingTalkPlugin');
+}
+
+// ==================== uploadMedia ====================
+
+describe('DingTalkPlugin uploadMedia', () => {
+  it('uploads image file and returns media_id', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-access-token', expiresAt: Date.now() + 3600000 };
+
+    const result = await (plugin as any).uploadMedia('/tmp/photo.jpg', 'image');
+
+    expect(result).toBe('@test_media_id_123');
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeDefined();
+    expect(uploadReq!.options.path).toContain('access_token=test-access-token');
+    expect(uploadReq!.options.path).toContain('type=image');
+    expect(uploadReq!.options.method).toBe('POST');
+    expect(uploadReq!.options.headers['Content-Type']).toContain('multipart/form-data');
+    expect(uploadReq!.options.headers['Content-Type']).toContain('boundary=');
+    expect(uploadReq!.endCalled).toBe(true);
+    expect(fsReadFileSyncMock).toHaveBeenCalledWith('/tmp/photo.jpg');
+  });
+
+  it('uploads file with type=file parameter', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+
+    await (plugin as any).uploadMedia('/tmp/report.pdf', 'file');
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeDefined();
+    expect(uploadReq!.options.path).toContain('type=file');
+  });
+
+  it('throws error when file does not exist', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    mockFsExistsSync = false;
+
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+
+    await expect(
+      (plugin as any).uploadMedia('/tmp/nonexistent.jpg', 'image')
+    ).rejects.toThrow('File not found');
+  });
+
+  it('throws error when upload API returns errcode != 0', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    mockUploadResponse = { errcode: 40004, errmsg: '不合法的媒体文件类型' };
+
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+
+    await expect(
+      (plugin as any).uploadMedia('/tmp/bad.jpg', 'image')
+    ).rejects.toThrow('errcode=40004');
+  });
+
+  it('throws error when upload response has no media_id', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    mockUploadResponse = { errcode: 0, errmsg: 'ok', type: 'image' };
+
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+
+    await expect(
+      (plugin as any).uploadMedia('/tmp/empty.jpg', 'image')
+    ).rejects.toThrow('no media_id');
+  });
+
+  it('multipart body contains filename in Content-Disposition', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+
+    await (plugin as any).uploadMedia('/tmp/my_photo.jpg', 'image');
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeDefined();
+
+    const bodyStr = Buffer.concat(uploadReq!.writeData).toString('utf-8');
+    expect(bodyStr).toContain('filename="my_photo.jpg"');
+    expect(bodyStr).toContain('name="media"');
+  });
+
+  it('multipart body contains file content', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+
+    await (plugin as any).uploadMedia('/tmp/photo.jpg', 'image');
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeDefined();
+
+    const bodyStr = Buffer.concat(uploadReq!.writeData).toString('binary');
+    expect(bodyStr).toContain('fake-file-content');
+  });
+
+  it('encodes access_token with special characters in URL', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'token=special&chars', expiresAt: Date.now() + 3600000 };
+
+    await (plugin as any).uploadMedia('/tmp/photo.jpg', 'image');
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeDefined();
+    expect(uploadReq!.options.path).toContain('access_token=');
+    // Special chars should be encoded
+    expect(uploadReq!.options.path).not.toContain('token=special&chars');
+  });
+});
+
+// ==================== sendMediaViaAPI ====================
+
+describe('DingTalkPlugin sendMediaViaAPI', () => {
+  async function createPlugin() {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+    return plugin;
+  }
+
+  it('sends image via user chat with sampleImageMsg', async () => {
+    const plugin = await createPlugin();
+
+    const result = await (plugin as any).sendMediaViaAPI('user', 'user123', 'image', '@media_abc');
+
+    expect(result).toBe('test_process_key');
+
+    const apiReq = capturedRequests.find((r) =>
+      r.options.path?.includes('oToMessages/batchSend')
+    );
+    expect(apiReq).toBeDefined();
+
+    const body = JSON.parse(Buffer.concat(apiReq!.writeData).toString('utf-8'));
+    expect(body.msgKey).toBe('sampleImageMsg');
+    expect(body.robotCode).toBe('test-client-id');
+    expect(body.userIds).toEqual(['user123']);
+
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.photoURL).toBe('@media_abc');
+  });
+
+  it('sends file via user chat with sampleFile', async () => {
+    const plugin = await createPlugin();
+
+    const result = await (plugin as any).sendMediaViaAPI('user', 'user123', 'file', '@media_xyz', 'report.pdf', 'pdf');
+
+    expect(result).toBe('test_process_key');
+
+    const apiReq = capturedRequests.find((r) =>
+      r.options.path?.includes('oToMessages/batchSend')
+    );
+    expect(apiReq).toBeDefined();
+
+    const body = JSON.parse(Buffer.concat(apiReq!.writeData).toString('utf-8'));
+    expect(body.msgKey).toBe('sampleFile');
+    expect(body.robotCode).toBe('test-client-id');
+    expect(body.userIds).toEqual(['user123']);
+
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.mediaId).toBe('@media_xyz');
+    expect(msgParam.fileName).toBe('report.pdf');
+    expect(msgParam.fileType).toBe('pdf');
+  });
+
+  it('sends image via group chat with groupMessages/send', async () => {
+    const plugin = await createPlugin();
+
+    await (plugin as any).sendMediaViaAPI('group', 'group456', 'image', '@media_abc');
+
+    const apiReq = capturedRequests.find((r) =>
+      r.options.path?.includes('groupMessages/send')
+    );
+    expect(apiReq).toBeDefined();
+
+    const body = JSON.parse(Buffer.concat(apiReq!.writeData).toString('utf-8'));
+    expect(body.msgKey).toBe('sampleImageMsg');
+    expect(body.openConversationId).toBe('group456');
+    expect(body.robotCode).toBe('test-client-id');
+
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.photoURL).toBe('@media_abc');
+  });
+
+  it('sends file via group chat with correct fileType', async () => {
+    const plugin = await createPlugin();
+
+    await (plugin as any).sendMediaViaAPI('group', 'group456', 'file', '@media_xyz', 'data.xlsx', 'xlsx');
+
+    const apiReq = capturedRequests.find((r) =>
+      r.options.path?.includes('groupMessages/send')
+    );
+    expect(apiReq).toBeDefined();
+
+    const body = JSON.parse(Buffer.concat(apiReq!.writeData).toString('utf-8'));
+    expect(body.msgKey).toBe('sampleFile');
+
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.mediaId).toBe('@media_xyz');
+    expect(msgParam.fileName).toBe('data.xlsx');
+    expect(msgParam.fileType).toBe('xlsx');
+  });
+
+  it('uses x-acs-dingtalk-access-token header', async () => {
+    const plugin = await createPlugin();
+
+    await (plugin as any).sendMediaViaAPI('user', 'user123', 'image', '@media_abc');
+
+    const apiReq = capturedRequests.find((r) =>
+      r.options.path?.includes('oToMessages/batchSend')
+    );
+    expect(apiReq).toBeDefined();
+    expect(apiReq!.options.headers['x-acs-dingtalk-access-token']).toBe('test-token');
+    expect(apiReq!.options.headers['Content-Type']).toBe('application/json');
+  });
+});
+
+// ==================== sendMessage routing ====================
+
+describe('DingTalkPlugin sendMessage routing', () => {
+  async function createPlugin() {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+    (plugin as any).ensureAccessToken = vi.fn(async () => {});
+    return plugin;
+  }
+
+  it('routes image message to upload + sendMediaViaAPI', async () => {
+    const plugin = await createPlugin();
+
+    await plugin.sendMessage('user:user123', {
+      type: 'image',
+      imageUrl: '/tmp/photo.jpg',
+    });
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    const sendReq = capturedRequests.find((r) =>
+      r.options.path?.includes('oToMessages/batchSend')
+    );
+    expect(uploadReq).toBeDefined();
+    expect(sendReq).toBeDefined();
+
+    const body = JSON.parse(Buffer.concat(sendReq!.writeData).toString('utf-8'));
+    expect(body.msgKey).toBe('sampleImageMsg');
+  });
+
+  it('routes file message to upload + sendMediaViaAPI', async () => {
+    const plugin = await createPlugin();
+
+    await plugin.sendMessage('user:user123', {
+      type: 'file',
+      fileUrl: '/tmp/report.pdf',
+      fileName: 'report.pdf',
+    });
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    const sendReq = capturedRequests.find((r) =>
+      r.options.path?.includes('oToMessages/batchSend')
+    );
+    expect(uploadReq).toBeDefined();
+    expect(sendReq).toBeDefined();
+
+    const body = JSON.parse(Buffer.concat(sendReq!.writeData).toString('utf-8'));
+    expect(body.msgKey).toBe('sampleFile');
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.fileName).toBe('report.pdf');
+    expect(msgParam.fileType).toBe('pdf');
+  });
+
+  it('skips image send when imageUrl is empty - no upload request made', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+    (plugin as any).ensureAccessToken = vi.fn(async () => {});
+    (plugin as any).createAndDeliverAICard = vi.fn(() => Promise.reject(new Error('no AI card')));
+    (plugin as any).webhookCache = new Map();
+
+    // imageUrl is empty → skip image branch, fall through to existing markdown path
+    // The existing path will succeed via mocked API send
+    await plugin.sendMessage('user:user123', { type: 'image' });
+
+    // Verify no upload request was made
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeUndefined();
+  });
+
+  it('skips file send when fileUrl is missing - no upload request made', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+    (plugin as any).ensureAccessToken = vi.fn(async () => {});
+    (plugin as any).createAndDeliverAICard = vi.fn(() => Promise.reject(new Error('no AI card')));
+    (plugin as any).webhookCache = new Map();
+
+    await plugin.sendMessage('user:user123', { type: 'file', fileName: 'test.pdf' });
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeUndefined();
+  });
+
+  it('skips file send when fileName is missing - no upload request made', async () => {
+    const { DingTalkPlugin } = await loadPluginWithMocks();
+    const plugin = new DingTalkPlugin();
+    (plugin as any).clientId = 'test-client-id';
+    (plugin as any).tokenCache = { accessToken: 'test-token', expiresAt: Date.now() + 3600000 };
+    (plugin as any).ensureAccessToken = vi.fn(async () => {});
+    (plugin as any).createAndDeliverAICard = vi.fn(() => Promise.reject(new Error('no AI card')));
+    (plugin as any).webhookCache = new Map();
+
+    await plugin.sendMessage('user:user123', { type: 'file', fileUrl: '/tmp/test.pdf' });
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    expect(uploadReq).toBeUndefined();
+  });
+
+  it('routes group chat file message correctly', async () => {
+    const plugin = await createPlugin();
+
+    await plugin.sendMessage('group:group789', {
+      type: 'file',
+      fileUrl: '/tmp/data.xlsx',
+      fileName: 'data.xlsx',
+    });
+
+    const uploadReq = capturedRequests.find((r) =>
+      r.options.path?.includes('/media/upload')
+    );
+    const sendReq = capturedRequests.find((r) =>
+      r.options.path?.includes('groupMessages/send')
+    );
+    expect(uploadReq).toBeDefined();
+    expect(sendReq).toBeDefined();
+
+    const body = JSON.parse(Buffer.concat(sendReq!.writeData).toString('utf-8'));
+    expect(body.openConversationId).toBe('group789');
+    expect(body.msgKey).toBe('sampleFile');
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.fileType).toBe('xlsx');
+  });
+});

--- a/tests/unit/channels/streamFinalization.test.ts
+++ b/tests/unit/channels/streamFinalization.test.ts
@@ -1,0 +1,341 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// ============================================================================
+// Extracted stream callback pattern — mirrors ActionExecutor.handleChatMessage
+// streaming logic (lines ~700-880).
+//
+// This tests the EXACT pattern that caused two bugs:
+//   Bug 1: AI Card stuck spinning when file sent during streaming
+//   Bug 2: Unwanted Copy/Regenerate/Continue buttons on fallback plain message
+//
+// Root cause: file/image message IDs polluted sentMessageIds, preventing
+// AI Card finalization and triggering sendPlainMessage fallback.
+// ============================================================================
+
+interface SimMessage {
+  type: 'text' | 'file' | 'image';
+  text?: string;
+  fileName?: string;
+  isInsert: boolean;
+}
+
+interface SimResult {
+  sentMessageIds: string[];
+  editCalls: Array<{ targetId: string; msgType: string; hasReplyMarkup: boolean }>;
+  plainMessageCalls: Array<{ text: string }>;
+}
+
+/**
+ * Simulates the stream callback logic from ActionExecutor.handleChatMessage.
+ * Returns call traces so tests can assert on exact behavior.
+ *
+ * This is a faithful reproduction of the logic — if this function's behavior
+ * diverges from ActionExecutor, the test loses value. Keep in sync.
+ */
+function simulateStream(messages: SimMessage[], platform: 'dingtalk' | 'telegram' | 'lark' = 'dingtalk'): SimResult {
+  const sentMessageIds: string[] = ['aicard_thinking_123']; // thinkingMsgId
+  let lastMessageContent: SimMessage | null = null;
+  let lastTextContent: SimMessage | null = null;
+  let thinkingUpdated = false;
+  let msgIdCounter = 100;
+
+  const editCalls: SimResult['editCalls'] = [];
+  const plainMessageCalls: SimResult['plainMessageCalls'] = [];
+
+  const doEditMessage = (msg: SimMessage, forceThinkingTarget = false) => {
+    const targetId = forceThinkingTarget
+      ? sentMessageIds[0]
+      : (sentMessageIds[sentMessageIds.length - 1] || sentMessageIds[0]);
+    editCalls.push({ targetId, msgType: msg.type, hasReplyMarkup: false });
+  };
+
+  // ---- Stream callback (mirrors ActionExecutor lines ~738-824) ----
+  for (const msg of messages) {
+    const streamOutgoing = msg;
+    lastMessageContent = streamOutgoing;
+    if (streamOutgoing.type === 'text') {
+      lastTextContent = streamOutgoing;
+    }
+
+    if (msg.isInsert && !thinkingUpdated && streamOutgoing.type === 'text') {
+      // First text insert: edit thinking message in-place
+      thinkingUpdated = true;
+      doEditMessage(streamOutgoing, true);
+    } else if (msg.isInsert) {
+      // Non-first insert: send new message
+      const newMsgId = `msg_${++msgIdCounter}`;
+      // KEY FIX: Don't push file/image IDs
+      if (streamOutgoing.type !== 'file' && streamOutgoing.type !== 'image') {
+        sentMessageIds.push(newMsgId);
+      }
+    } else {
+      // Update: edit last sentMessageId
+      doEditMessage(streamOutgoing);
+    }
+  }
+
+  // ---- After stream ends (mirrors ActionExecutor lines ~856-880) ----
+  if (lastMessageContent) {
+    if (lastMessageContent.type === 'file' || lastMessageContent.type === 'image') {
+      // FIX: Still finalize the AI Card with lastTextContent
+      if (lastTextContent && sentMessageIds.length > 0) {
+        const lastMsgId = sentMessageIds[sentMessageIds.length - 1];
+        editCalls.push({
+          targetId: lastMsgId,
+          msgType: 'text', // using lastTextContent
+          hasReplyMarkup: platform === 'dingtalk',
+        });
+      }
+      // If lastTextContent is null (no text before file): no action — no crash
+    } else {
+      // Normal text finalization
+      const lastMsgId = sentMessageIds[sentMessageIds.length - 1];
+      editCalls.push({
+        targetId: lastMsgId,
+        msgType: lastMessageContent.type,
+        hasReplyMarkup: platform === 'dingtalk',
+      });
+    }
+  }
+
+  return { sentMessageIds, editCalls, plainMessageCalls };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Stream finalization when file/image is sent', () => {
+  // -------------------------------------------------------------------------
+  // Bug 1: AI Card stuck spinning
+  // -------------------------------------------------------------------------
+  describe('sentMessageIds should not contain file/image IDs', () => {
+    it('should NOT push file message ID to sentMessageIds', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Hello', isInsert: true },
+        { type: 'file', fileName: 'doc.docx', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      // Only the thinkingMsgId should be present — file ID was NOT pushed
+      expect(result.sentMessageIds).toEqual(['aicard_thinking_123']);
+      // No file ID (like processQueryKey) pollutes the array
+      expect(result.sentMessageIds).not.toContainEqual(expect.stringContaining('file'));
+    });
+
+    it('should NOT push image message ID to sentMessageIds', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Hello', isInsert: true },
+        { type: 'image', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      expect(result.sentMessageIds).toEqual(['aicard_thinking_123']);
+    });
+
+    it('should still push text insert IDs to sentMessageIds', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'First block', isInsert: true },
+        { type: 'file', fileName: 'doc.docx', isInsert: true },
+        { type: 'text', text: 'Second block', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      // thinkingMsgId + second text block ID
+      expect(result.sentMessageIds).toHaveLength(2);
+      expect(result.sentMessageIds[0]).toBe('aicard_thinking_123');
+      expect(result.sentMessageIds[1]).toMatch(/^msg_\d+$/);
+    });
+
+    it('should handle multiple file sends without polluting sentMessageIds', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Generating files...', isInsert: true },
+        { type: 'file', fileName: 'file1.pdf', isInsert: true },
+        { type: 'file', fileName: 'file2.xlsx', isInsert: true },
+        { type: 'image', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      // Only thinkingMsgId — zero file/image IDs
+      expect(result.sentMessageIds).toEqual(['aicard_thinking_123']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug 2: AI Card finalization target
+  // -------------------------------------------------------------------------
+  describe('editMessage should target AI Card ID (not file ID)', () => {
+    it('should call editMessage with AI Card ID when last message is file', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Here is your document', isInsert: true },
+        { type: 'text', text: 'Here is your document (updated)', isInsert: false },
+        { type: 'file', fileName: 'report.docx', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      // Find the final edit call (stream end finalization)
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      // Must target the AI Card ID, NOT a file processQueryKey
+      expect(finalEdits[0].targetId).toBe('aicard_thinking_123');
+    });
+
+    it('should call editMessage with AI Card ID when last message is image', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Here is the image', isInsert: true },
+        { type: 'image', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      expect(finalEdits[0].targetId).toBe('aicard_thinking_123');
+    });
+
+    it('should finalize with text type, not file type', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Complete response', isInsert: true },
+        { type: 'file', fileName: 'output.docx', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      // Finalization uses lastTextContent, so msgType should be 'text'
+      expect(finalEdits[0].msgType).toBe('text');
+    });
+
+    it('should include replyMarkup to trigger isFinal in DingTalkPlugin.editMessage', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Response', isInsert: true },
+        { type: 'file', fileName: 'f.docx', isInsert: true },
+      ];
+      const result = simulateStream(messages, 'dingtalk');
+
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      expect(finalEdits[0].hasReplyMarkup).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: normal text-only flow must not change
+  // -------------------------------------------------------------------------
+  describe('text-only flow should be unchanged', () => {
+    it('should finalize with last sentMessageId for text-only stream', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Hello', isInsert: true },
+        { type: 'text', text: 'Hello world', isInsert: false },
+        { type: 'text', text: 'Hello world!', isInsert: false },
+      ];
+      const result = simulateStream(messages);
+
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      expect(finalEdits[0].targetId).toBe('aicard_thinking_123');
+    });
+
+    it('should have replyMarkup for DingTalk platform', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Hi', isInsert: true },
+      ];
+      const result = simulateStream(messages, 'dingtalk');
+
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits[0].hasReplyMarkup).toBe(true);
+    });
+
+    it('should NOT have replyMarkup for Telegram platform', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Hi', isInsert: true },
+      ];
+      const result = simulateStream(messages, 'telegram');
+
+      // Final edit call exists but without replyMarkup (Telegram doesn't use action buttons)
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(0);
+      // But the finalization edit call itself should still exist
+      const allEdits = result.editCalls;
+      expect(allEdits.length).toBeGreaterThanOrEqual(1);
+      const lastEdit = allEdits[allEdits.length - 1];
+      expect(lastEdit.hasReplyMarkup).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+  describe('edge cases', () => {
+    it('should NOT crash when only file is sent (no text before file)', () => {
+      const messages: SimMessage[] = [
+        { type: 'file', fileName: 'output.docx', isInsert: true },
+      ];
+      // Should not throw
+      expect(() => simulateStream(messages)).not.toThrow();
+    });
+
+    it('should NOT call editMessage for finalization when only file is sent', () => {
+      const messages: SimMessage[] = [
+        { type: 'file', fileName: 'output.docx', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      // lastTextContent is null, so no finalization edit should happen
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(0);
+    });
+
+    it('should track correct lastTextContent when text appears after file', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'First', isInsert: true },
+        { type: 'file', fileName: 'doc.docx', isInsert: true },
+        { type: 'text', text: 'Second block', isInsert: true },
+        { type: 'text', text: 'Second block (updated)', isInsert: false },
+      ];
+      const result = simulateStream(messages);
+
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      // Should target the second text block's ID (msg_101), not thinkingMsgId
+      expect(finalEdits[0].targetId).toMatch(/^msg_\d+$/);
+    });
+
+    it('should use the LAST text content for finalization, not the first', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'First text', isInsert: true },
+        { type: 'text', text: 'First text updated', isInsert: false },
+        { type: 'file', fileName: 'doc.docx', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      // lastTextContent should be 'First text updated', not 'First text'
+      expect(finalEdits[0].msgType).toBe('text');
+    });
+
+    it('should handle file between two text blocks', () => {
+      const messages: SimMessage[] = [
+        { type: 'text', text: 'Block 1', isInsert: true },
+        { type: 'file', fileName: 'data.csv', isInsert: true },
+        { type: 'text', text: 'Block 2', isInsert: true },
+        { type: 'text', text: 'Block 2 updated', isInsert: false },
+        { type: 'file', fileName: 'result.pdf', isInsert: true },
+      ];
+      const result = simulateStream(messages);
+
+      // sentMessageIds: [thinkingMsgId, msg_101 (Block 2)]
+      expect(result.sentMessageIds).toHaveLength(2);
+      // Finalization should target Block 2's ID
+      const finalEdits = result.editCalls.filter(e => e.hasReplyMarkup);
+      expect(finalEdits).toHaveLength(1);
+      expect(finalEdits[0].targetId).toMatch(/^msg_\d+$/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Support sending images and files to DingTalk channel via media upload and robot API
- Fix AI Card stuck spinning and unwanted Copy/Regenerate/Continue buttons when file is sent during streaming

## Test plan
- [x] Unit tests for DingTalk media upload/send (dingtalkPluginMedia.test.ts)
- [x] Unit tests for stream finalization with file messages (streamFinalization.test.ts)
- [x] Unit tests for DingTalk adapter media type detection (dingtalkAdapter.test.ts)
- [ ] Manual verification: send a message to DingTalk bot that triggers file generation
- [ ] Verify: AI Card shows complete text, no spinner
- [ ] Verify: File appears correctly
- [ ] Verify: No Copy/Regenerate/Continue buttons on plain message card

🤖 Generated with [Claude Code](https://claude.com/claude-code)