### PR TITLE
feat: support click-to-preview for readonly channel file messages

### DIFF
--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -5,11 +5,13 @@
  */
 
 import { Close } from '@icon-park/react';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import type { PreviewContentType } from '@/common/types/preview';
 import { getFileExtension } from '@/renderer/services/FileService';
 import { ipcBridge } from '@/common';
 import { Image } from '@arco-design/web-react';
 import fileIcon from '@/renderer/assets/file-icon.svg';
+import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
 
 const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg'];
 
@@ -25,6 +27,25 @@ const formatFileSize = (bytes: number): string => {
   if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)}KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`;
+};
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg', 'ico', 'tif', 'tiff', 'avif']);
+const OFFICE_EXTENSIONS: Record<string, PreviewContentType> = {
+  ppt: 'ppt', pptx: 'ppt', odp: 'ppt',
+  doc: 'word', docx: 'word', odt: 'word',
+  xls: 'excel', xlsx: 'excel', ods: 'excel',
+};
+
+const getContentTypeFromExt = (ext: string): PreviewContentType => {
+  const e = ext.toLowerCase();
+  if (e === 'md' || e === 'markdown') return 'markdown';
+  if (e === 'diff' || e === 'patch') return 'diff';
+  if (e === 'pdf') return 'pdf';
+  if (OFFICE_EXTENSIONS[e]) return OFFICE_EXTENSIONS[e];
+  if (e === 'csv') return 'code';
+  if (e === 'html' || e === 'htm') return 'html';
+  if (IMAGE_EXTENSIONS.has(e)) return 'image';
+  return 'code';
 };
 
 interface FilePreviewProps {
@@ -51,6 +72,19 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
   // remount and avoid spamming the backend with repeated IPC calls for a
   // file that doesn't exist.
   const [fileError, setFileError] = useState(false);
+  const { launchPreview, loading } = usePreviewLauncher();
+
+  const handlePreviewClick = useCallback(() => {
+    if (!readonly || loading || fileError) return;
+    const ext = getFileExtension(path).replace('.', '');
+    const contentType = getContentTypeFromExt(ext);
+    launchPreview({
+      originalPath: path,
+      fileName,
+      contentType,
+      editable: false,
+    });
+  }, [readonly, loading, fileError, path, fileName, launchPreview]);
 
   useEffect(() => {
     // bdpan:// paths are remote — skip local fs operations
@@ -115,7 +149,11 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
 
   return (
     <div className='relative inline-block mb-10px'>
-      <div className='h-60px flex items-center gap-12px px-12px rd-8px bg-bg-2 border border-solid' style={{ borderColor: 'var(--border-base)', boxShadow: 'var(--shadow-sm)' }}>
+      <div
+        className={readonly && !fileError ? 'h-60px flex items-center gap-12px px-12px rd-8px bg-bg-2 border border-solid cursor-pointer select-none' : 'h-60px flex items-center gap-12px px-12px rd-8px bg-bg-2 border border-solid'}
+        style={{ borderColor: 'var(--border-base)', boxShadow: 'var(--shadow-sm)' }}
+        onClick={handlePreviewClick}
+      >
         <div className='w-40px h-40px rd-8px flex items-center justify-center flex-shrink-0'>
           <img className='w-full h-full object-contain' src={fileIcon} alt='File Icon' />
         </div>


### PR DESCRIPTION
## Summary
- Enable clicking on file cards received from DingTalk/Lark/WeChat etc. to open the preview panel (Word/PDF/Excel/Code viewers), matching the draft-box click behavior
- Only activates in readonly mode (channel-received file messages), send-box file previews are unaffected
- Fix extension parsing bug: `getFileExtension` returns `.docx` but content type mapping expects `docx` without leading dot, causing Office files to render as raw text

## Test plan
- [ ] Send a .docx file from DingTalk client to sudoclaw, click the file card, verify Word preview opens correctly
- [ ] Send a .pdf file from DingTalk client, click to verify PDF preview
- [ ] Send an image file, verify existing click-to-zoom behavior unchanged
- [ ] Verify send-box file preview (non-readonly) still has no click handler
- [ ] Repeat above tests for Lark channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)