### PR TITLE
fix(acp): emit connection status events to renderer after restart

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -1455,6 +1455,10 @@ This identity statement takes priority over the default identity in USER.md.
       }
       const shouldDisplayStatus = this.isFirstMessage || status === 'error' || status === 'disconnected';
       if (!shouldDisplayStatus) {
+        // Still emit agent_status to renderer so the connection status indicator
+        // (AgentStatusDot) updates in real time after restart/reconnect.
+        // Only skip adding to chat history to avoid visual clutter.
+        ipcBridge.acpConversation.responseStream.emit(message);
         return;
       }
     }


### PR DESCRIPTION
fix: ACP 连接状态显示延迟问题

点击「重启并连接」后，连接状态指示器永久停留在「连接中」，直到切换 session tab 再回来才正常。根因是 handleStreamEvent 过滤掉了重连时的 agent_status 事件，导致渲染进程收不到更新。

Closes #467