### PR TITLE
feat(wecom): add file/image upload via WebSocket long connection

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -45,6 +45,33 @@ function isMediaContentType(type: string): boolean {
   return type === 'photo' || type === 'document' || type === 'voice' || type === 'audio' || type === 'video';
 }
 
+/**
+ * Validate a file path before sending - filter out invalid/truncated paths.
+ * Agent streaming can output partial paths (e.g., "/Users/y", "/Users/yobach/.nexus/channel")
+ * which are directories and cause EISDIR errors when WeComUploader tries to read them.
+ */
+function isValidFilePath(filePath: string): boolean {
+  // Skip empty paths
+  if (!filePath || filePath.trim().length === 0) return false;
+
+  // Skip paths that end with "/" (directory indicators)
+  if (filePath.endsWith('/')) return false;
+
+  // Skip paths that don't have a file extension (likely directories or truncated)
+  const ext = path.extname(filePath);
+  if (!ext || ext.length < 2) return false;
+
+  // Check if path exists and is a file (not a directory)
+  try {
+    if (!fs.existsSync(filePath)) return false;
+    const stats = fs.statSync(filePath);
+    if (stats.isDirectory()) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ==================== Platform-specific Helpers ====================
 
 /**
@@ -180,8 +207,7 @@ function convertTMessageToOutgoing(message: TMessage, platform: PluginType, isCo
       // Parse [[NEXUS_FILES]] marker to extract file paths for media attachments
       // This enables WeChat/Lark/etc to upload and send files to users
       const { cleanText, files } = parseNexusFilesMarker(rawText);
-      const text = cleanText.trim() ? cleanText : '...';
-
+      const text = cleanText.trim();
       // Determine imageUrl and fileUrl from extracted files
       // First image file -> imageUrl, first non-image file -> fileUrl
       const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp'];
@@ -703,6 +729,18 @@ export class ActionExecutor {
       // Track last text content to finalize AI Card even when last message is file/image
       let lastTextContent: IUnifiedOutgoingMessage | null = null;
 
+      // 跟踪已发送的文件，避免重复发送
+      // Track sent files to avoid duplicate sends
+      const sentFiles: Set<string> = new Set();
+
+      // 记录用户输入的文件，避免发回给用户
+      // Track user input files to avoid sending back to user
+      const userInputFiles: Set<string> = new Set(files || []);
+
+      // 缓存待发送的文件，等到流结束后再发送（保证文本先输出，文件最后发送）
+      // Buffer pending files to send after stream ends (ensure text outputs first, files last)
+      const pendingFilesToSend: IUnifiedOutgoingMessage[] = [];
+
       // 执行消息编辑的函数
       // Function to perform message edit
       const doEditMessage = async (msg: IUnifiedOutgoingMessage, forceThinkingTarget = false) => {
@@ -711,7 +749,7 @@ export class ActionExecutor {
         lastUpdateTime = Date.now();
         // When updating thinking message, always target thinkingMsgId directly
         // (not sentMessageIds[last], which may be a file/image message)
-        const targetMsgId = (forceThinkingTarget && thinkingMsgId) ? thinkingMsgId : (sentMessageIds[sentMessageIds.length - 1] || thinkingMsgId);
+        const targetMsgId = forceThinkingTarget && thinkingMsgId ? thinkingMsgId : sentMessageIds[sentMessageIds.length - 1] || thinkingMsgId;
         try {
           await context.editMessage(targetMsgId, msg);
         } catch {
@@ -730,6 +768,9 @@ export class ActionExecutor {
 
         // Skip desktop-only message types (agent_status, plan, etc.)
         if (!outgoingMessage) return;
+
+        // [DEBUG] Log outgoing message details
+        console.log(`[ActionExecutor] 📤 Outgoing: isInsert=${isInsert}, type=${outgoingMessage.type}, text="${outgoingMessage.text?.slice(0, 50)}...", imageUrl=${outgoingMessage.imageUrl || 'no'}, fileUrl=${outgoingMessage.fileUrl || 'no'}, fileName=${outgoingMessage.fileName || 'none'}`);
 
         // Strip replyMarkup during streaming to prevent premature card finalization.
         // Tool confirmation cards set replyMarkup (e.g., for Confirming status),
@@ -756,38 +797,98 @@ export class ActionExecutor {
           // First text streaming message: update thinking message instead of inserting
           // 第一个text流式消息：更新thinking消息而不是插入新消息
           thinkingUpdated = true;
-          pendingMessage = streamOutgoing;
 
-          if (now - lastUpdateTime >= UPDATE_THROTTLE_MS) {
-            if (pendingUpdateTimer) {
-              clearTimeout(pendingUpdateTimer);
-              pendingUpdateTimer = null;
-            }
-            await doEditMessage(streamOutgoing, true);
-          } else {
-            if (pendingUpdateTimer) {
-              clearTimeout(pendingUpdateTimer);
-            }
-            const delay = UPDATE_THROTTLE_MS - (now - lastUpdateTime);
-            pendingUpdateTimer = setTimeout(() => {
-              if (pendingMessage) {
-                void doEditMessage(pendingMessage, true);
-                pendingMessage = null;
-              }
-              pendingUpdateTimer = null;
-            }, delay);
+          // CRITICAL: First thinking update must be sent IMMEDIATELY without throttle delay.
+          // If we delay it with a timer, subsequent UPDATE messages will overwrite the content
+          // before the timer fires, and the first message content will be lost forever.
+          // 关键：第一个 thinking 更新必须立即发送，不能用节流延迟。
+          // 如果用定时器延迟，后续 UPDATE 会在定时器触发前覆盖内容，导致第一条消息永远丢失。
+          lastUpdateTime = Date.now();
+          try {
+            await context.editMessage(thinkingMsgId, streamOutgoing);
+          } catch {
+            // Ignore edit errors
           }
         } else if (isInsert) {
           // 新消息：发送新消息
           // New message: send new message
           if (supportsEdit) {
+            // 特殊处理 file_send 类型（Agent 生成的文件）
+            // WeCom: 缓存文件，等流结束后发送（保证文本先输出，文件最后）
+            // Lark/DingTalk/Telegram: 立即发送（保持原有行为）
+            // Special handling for file_send type (Agent-generated files)
+            // WeCom: buffer files to send after stream ends (text first, files last)
+            // Lark/DingTalk/Telegram: send immediately (keep original behavior)
+            if (streamOutgoing.type === 'image' || streamOutgoing.type === 'file') {
+              const isWeCom = context.platform === 'wecom';
+
+              // 检查是否是用户输入的文件，避免发回给用户
+              // Check if this is a user input file to avoid sending back to user
+              const fileUrl = streamOutgoing.fileUrl;
+              const imageUrl = streamOutgoing.imageUrl;
+              const isUserInputFile = (fileUrl && userInputFiles.has(fileUrl)) || (imageUrl && userInputFiles.has(imageUrl));
+
+              if (isUserInputFile) {
+                console.log(`[ActionExecutor] 📎 file_send SKIPPED (user input): type=${streamOutgoing.type}, fileUrl=${fileUrl || 'none'}, imageUrl=${imageUrl || 'none'}`);
+                // 记录到 sentFiles 防止后续重复发送
+                // Record to sentFiles to prevent duplicate sends later
+                if (fileUrl) sentFiles.add(fileUrl);
+                if (imageUrl) sentFiles.add(imageUrl);
+                // 标记 thinking 已更新
+                // Mark thinking as updated
+                if (!thinkingUpdated && thinkingMsgId) {
+                  thinkingUpdated = true;
+                }
+                return;
+              }
+
+              // 记录文件路径到 sentFiles，避免后续重复发送（仅记录有效路径）
+              // Record valid file paths to sentFiles to avoid duplicate sends later
+              if (streamOutgoing.fileUrl && isValidFilePath(streamOutgoing.fileUrl)) sentFiles.add(streamOutgoing.fileUrl);
+              if (streamOutgoing.imageUrl && isValidFilePath(streamOutgoing.imageUrl)) sentFiles.add(streamOutgoing.imageUrl);
+
+              if (isWeCom) {
+                // WeCom: 缓存文件，等流结束后发送
+                // WeCom: buffer file to send after stream ends
+                console.log(`[ActionExecutor] 📎 file_send buffered (WeCom): type=${streamOutgoing.type}, imageUrl=${imageUrl || 'none'}, fileUrl=${fileUrl || 'none'}`);
+                pendingFilesToSend.push(streamOutgoing);
+                // 标记 thinking 已更新，让后续文本 INSERT 转为 UPDATE 路径
+                // Mark thinking as updated so subsequent text INSERTs go to UPDATE path
+                if (!thinkingUpdated && thinkingMsgId) {
+                  thinkingUpdated = true;
+                }
+                return;
+              } else {
+                // Lark/DingTalk/Telegram: 立即发送文件（保持原有行为）
+                // Lark/DingTalk/Telegram: send file immediately (keep original behavior)
+                console.log(`[ActionExecutor] 📎 file_send immediate (${context.platform}): type=${streamOutgoing.type}, imageUrl=${imageUrl || 'none'}, fileUrl=${fileUrl || 'none'}`);
+                try {
+                  await context.sendMessage(streamOutgoing);
+                } catch {
+                  // Ignore file send errors
+                }
+                // 标记 thinking 已更新
+                // Mark thinking as updated
+                if (!thinkingUpdated && thinkingMsgId) {
+                  thinkingUpdated = true;
+                }
+                return;
+              }
+            }
+
+            // 记录文件路径到 sentFiles，避免后续重复发送（仅记录有效路径）
+            // Record valid file paths to sentFiles to avoid duplicate sends later
+            if (streamOutgoing.fileUrl && isValidFilePath(streamOutgoing.fileUrl)) sentFiles.add(streamOutgoing.fileUrl);
+            if (streamOutgoing.imageUrl && isValidFilePath(streamOutgoing.imageUrl)) sentFiles.add(streamOutgoing.imageUrl);
+            // [DEBUG] Log new message send with file tracking
+            const fileValid = streamOutgoing.fileUrl ? isValidFilePath(streamOutgoing.fileUrl) : false;
+            const imageValid = streamOutgoing.imageUrl ? isValidFilePath(streamOutgoing.imageUrl) : false;
+            console.log(`[ActionExecutor] 📥 NEW message: type=${streamOutgoing.type}, imageUrl=${streamOutgoing.imageUrl || 'none'}(valid=${imageValid}), fileUrl=${streamOutgoing.fileUrl || 'none'}(valid=${fileValid}), sentFiles now=${Array.from(sentFiles).join(',') || 'empty'}`);
             try {
               const newMsgId = await context.sendMessage(streamOutgoing);
-              // Don't push file/image IDs — they can't be edited and would pollute
-              // the edit target, preventing AI Card finalization
-              if (streamOutgoing.type !== 'file' && streamOutgoing.type !== 'image') {
-                sentMessageIds.push(newMsgId);
-              }
+              // image/file 已在上方特殊处理并 return，此处仅处理 text/buttons
+              // image/file already handled above with return, here only text/buttons
+              sentMessageIds.push(newMsgId);
             } catch {
               // Ignore send errors
             }
@@ -805,6 +906,82 @@ export class ActionExecutor {
           // 更新消息：使用定时器节流，确保最后一条消息能被发送
           // Update message: throttle with timer to ensure last message is sent
           if (supportsEdit) {
+            // 检查是否有文件附件需要发送（支持 edit 的平台如 WeCom 需要单独发送文件）
+            // Check if there are file attachments to send (edit-capable platforms like WeCom need separate file send)
+            // 排除用户输入的文件，避免发回给用户
+            // Exclude user input files to avoid sending back to user
+            // 验证路径有效性，过滤 Agent 流式输出的部分/截断路径（如 "/Users/y"，是目录而非文件）
+            // Validate path to filter out partial/truncated paths from Agent streaming (e.g., "/Users/y" is a directory)
+            const rawFileUrl = streamOutgoing.fileUrl;
+            const rawImageUrl = streamOutgoing.imageUrl;
+            const fileToSend = rawFileUrl && isValidFilePath(rawFileUrl) && !sentFiles.has(rawFileUrl) && !userInputFiles.has(rawFileUrl) ? rawFileUrl : null;
+            const imageToSend = rawImageUrl && isValidFilePath(rawImageUrl) && !sentFiles.has(rawImageUrl) && !userInputFiles.has(rawImageUrl) ? rawImageUrl : null;
+
+            // [DEBUG] Log file send decision with validation status
+            const fileValid = rawFileUrl ? isValidFilePath(rawFileUrl) : false;
+            const imageValid = rawImageUrl ? isValidFilePath(rawImageUrl) : false;
+            console.log(`[ActionExecutor] 📎 File check: fileUrl=${rawFileUrl || 'none'}(valid=${fileValid}), imageUrl=${rawImageUrl || 'none'}(valid=${imageValid}), sentFiles=${Array.from(sentFiles).join(',') || 'empty'}, userInputFiles=${Array.from(userInputFiles).join(',') || 'empty'}, fileToSend=${fileToSend || 'skip'}, imageToSend=${imageToSend || 'skip'}`);
+
+            // 处理文件发送：WeCom 缓存到流结束，其他渠道立即发送
+            // Handle file send: WeCom buffers until stream ends, other channels send immediately
+            const isWeCom = context.platform === 'wecom';
+
+            if (fileToSend) {
+              sentFiles.add(fileToSend);
+              if (isWeCom) {
+                // WeCom: 缓存文件，等流结束后发送
+                // WeCom: buffer file to send after stream ends
+                console.log(`[ActionExecutor] 📁 File buffered (WeCom): ${fileToSend}`);
+                pendingFilesToSend.push({
+                  type: 'file',
+                  text: '',
+                  fileUrl: fileToSend,
+                  fileName: streamOutgoing.fileName,
+                });
+              } else {
+                // Lark/DingTalk/Telegram: 立即发送文件
+                // Lark/DingTalk/Telegram: send file immediately
+                console.log(`[ActionExecutor] 📁 File sending immediately (${context.platform}): ${fileToSend}`);
+                try {
+                  await context.sendMessage({
+                    type: 'file',
+                    text: '',
+                    fileUrl: fileToSend,
+                    fileName: streamOutgoing.fileName,
+                  });
+                } catch {
+                  // Ignore file send errors
+                }
+              }
+            }
+
+            if (imageToSend) {
+              sentFiles.add(imageToSend);
+              if (isWeCom) {
+                // WeCom: 缓存图片，等流结束后发送
+                // WeCom: buffer image to send after stream ends
+                console.log(`[ActionExecutor] 🖼️ Image buffered (WeCom): ${imageToSend}`);
+                pendingFilesToSend.push({
+                  type: 'image',
+                  text: '',
+                  imageUrl: imageToSend,
+                });
+              } else {
+                // Lark/DingTalk/Telegram: 立即发送图片
+                // Lark/DingTalk/Telegram: send image immediately
+                console.log(`[ActionExecutor] 🖼️ Image sending immediately (${context.platform}): ${imageToSend}`);
+                try {
+                  await context.sendMessage({
+                    type: 'image',
+                    text: '',
+                    imageUrl: imageToSend,
+                  });
+                } catch {
+                  // Ignore image send errors
+                }
+              }
+            }
+
             pendingMessage = streamOutgoing;
 
             if (now - lastUpdateTime >= UPDATE_THROTTLE_MS) {
@@ -877,6 +1054,20 @@ export class ActionExecutor {
             await context.sendMessage(finalMessage);
           }
         }
+      }
+
+      // 流结束后发送缓存的文件（保证文本先输出完整，文件最后发送）
+      // Send buffered files after stream ends (ensure text outputs first, files last)
+      if (pendingFilesToSend.length > 0) {
+        console.log(`[ActionExecutor] 📁 Sending ${pendingFilesToSend.length} buffered files after stream ends`);
+        for (const fileMsg of pendingFilesToSend) {
+          try {
+            await context.sendMessage(fileMsg);
+          } catch {
+            // Ignore file send errors
+          }
+        }
+        pendingFilesToSend.length = 0; // Clear buffer
       }
     } catch (error: any) {
       console.error(`[ActionExecutor] Chat processing failed:`, error);

--- a/src/channels/plugins/wecom/WeComAdapter.ts
+++ b/src/channels/plugins/wecom/WeComAdapter.ts
@@ -99,7 +99,26 @@ export type WeComEventCallback = {
 /**
  * WeCom outgoing message types supported by aibot_respond_msg / aibot_send_msg
  */
-export type WeComOutgoingMsgType = 'text' | 'markdown' | 'stream' | 'template_card';
+export type WeComOutgoingMsgType = 'text' | 'markdown' | 'stream' | 'template_card' | 'image' | 'file' | 'voice' | 'video';
+
+/**
+ * WeCom media upload types for aibot_upload_media_init
+ */
+export type WeComUploadType = 'image' | 'file' | 'voice' | 'video';
+
+/**
+ * WeCom upload init response
+ */
+export interface WeComUploadInitResponse {
+  upload_id: string;
+}
+
+/**
+ * WeCom upload finish response
+ */
+export interface WeComUploadFinishResponse {
+  media_id: string;
+}
 
 // ==================== Incoming Message Conversion ====================
 

--- a/src/channels/plugins/wecom/WeComPlugin.ts
+++ b/src/channels/plugins/wecom/WeComPlugin.ts
@@ -11,8 +11,9 @@ import WebSocket from 'ws';
 import type { BotInfo, IChannelPluginConfig, IUnifiedOutgoingMessage, PluginType } from '../../types';
 import { BasePlugin } from '../BasePlugin';
 import { WECOM_MESSAGE_LIMIT, encodeChatId, getDefaultExtension, parseChatId, toUnifiedIncomingMessage, toWeComSendParams } from './WeComAdapter';
-import type { WeComMsgCallback, WeComEventCallback } from './WeComAdapter';
+import type { WeComMsgCallback, WeComEventCallback, WeComUploadType } from './WeComAdapter';
 import { downloadAndDecryptMedia } from './WeComCrypto';
+import { WeComUploader } from './WeComUploader';
 
 /**
  * Detect Office document type from ZIP content.
@@ -131,6 +132,9 @@ export class WeComPlugin extends BasePlugin {
   // Media download directory
   private mediaDir: string | null = null;
 
+  // Media uploader
+  private uploader: WeComUploader | null = null;
+
   /**
    * Initialize the WeCom client
    */
@@ -144,6 +148,9 @@ export class WeComPlugin extends BasePlugin {
 
     this.botId = botId as string;
     this.secret = secret as string;
+
+    // Initialize uploader with send function
+    this.uploader = new WeComUploader(this.send.bind(this), this.generateReqId.bind(this));
   }
 
   /**
@@ -188,6 +195,12 @@ export class WeComPlugin extends BasePlugin {
     this.streamSessions.clear();
     this.reqIdCache.clear();
     this.mediaDir = null;
+
+    // Clear uploader pending responses
+    if (this.uploader) {
+      this.uploader.clearPending();
+    }
+
     this.isConnected = false;
 
     console.log('[WeComPlugin] Stopped and cleaned up');
@@ -216,7 +229,35 @@ export class WeComPlugin extends BasePlugin {
    * Uses stream mode for real-time streaming responses
    */
   async sendMessage(chatId: string, message: IUnifiedOutgoingMessage): Promise<string> {
-    console.log(`[WeComPlugin] sendMessage: chatId=${chatId}, text=${message.text?.slice(0, 100)}`);
+    console.log(`[WeComPlugin] sendMessage: chatId=${chatId}, type=${message.type}, imageUrl=${message.imageUrl ? 'yes' : 'no'}, fileUrl=${message.fileUrl ? 'yes' : 'no'}, text=${message.text?.slice(0, 100)}`);
+
+    // Handle image attachment - upload and send
+    if (message.imageUrl) {
+      try {
+        const mediaId = await this.uploadMedia(message.imageUrl, 'image');
+        if (mediaId) {
+          await this.sendImageMessage(chatId, mediaId);
+          return `image_${mediaId}`;
+        }
+      } catch (error) {
+        console.error('[WeComPlugin] Failed to send image:', error);
+      }
+    }
+
+    // Handle file attachment - upload and send
+    if (message.fileUrl) {
+      try {
+        const mediaId = await this.uploadMedia(message.fileUrl, 'file');
+        if (mediaId) {
+          await this.sendFileMessage(chatId, mediaId, message.fileName);
+          return `file_${mediaId}`;
+        }
+      } catch (error) {
+        console.error('[WeComPlugin] Failed to send file:', error);
+      }
+    }
+
+    // Handle text message
     const { content } = toWeComSendParams(message);
     const reqId = this.reqIdCache.get(chatId);
 
@@ -314,6 +355,117 @@ export class WeComPlugin extends BasePlugin {
       // Mark as finished to prevent further attempts
       this.streamSessions.set(chatId, { ...session, isFinished: true });
     }
+  }
+
+  // ==================== Media Download ====================
+
+  // ==================== Media Upload ====================
+
+  /**
+   * Upload a media file to WeCom and return media_id
+   *
+   * @param filePath - Local file path to upload
+   * @param type - Upload type (image/file/voice/video)
+   * @returns media_id for use in message sending, or null on failure
+   */
+  private async uploadMedia(filePath: string, type: WeComUploadType): Promise<string | null> {
+    if (!this.uploader) {
+      console.error('[WeComPlugin] Uploader not initialized');
+      return null;
+    }
+
+    if (!fs.existsSync(filePath)) {
+      console.error(`[WeComPlugin] File not found: ${filePath}`);
+      return null;
+    }
+
+    try {
+      const mediaId = await this.uploader.uploadFile(filePath, type);
+      console.log(`[WeComPlugin] Uploaded media: type=${type}, path=${filePath}, media_id=${mediaId}`);
+      return mediaId;
+    } catch (error) {
+      console.error('[WeComPlugin] uploadMedia failed:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Send an image message to a chat
+   *
+   * @param chatId - Target chat ID
+   * @param mediaId - Media ID from upload
+   */
+  private async sendImageMessage(chatId: string, mediaId: string): Promise<void> {
+    const reqId = this.reqIdCache.get(chatId);
+
+    if (reqId) {
+      // Respond to incoming message
+      this.send({
+        cmd: 'aibot_respond_msg',
+        headers: { req_id: reqId },
+        body: {
+          msgtype: 'image',
+          image: { media_id: mediaId },
+        },
+      });
+    } else {
+      // Proactive push
+      const { type: chatType } = parseChatId(chatId);
+      const sendReqId = this.generateReqId();
+
+      this.send({
+        cmd: 'aibot_send_msg',
+        headers: { req_id: sendReqId },
+        body: {
+          chatid: chatId,
+          chat_type: chatType === 'group' ? 2 : 1,
+          msgtype: 'image',
+          image: { media_id: mediaId },
+        },
+      });
+    }
+
+    console.log(`[WeComPlugin] Sent image message: chatId=${chatId}, mediaId=${mediaId}`);
+  }
+
+  /**
+   * Send a file message to a chat
+   *
+   * @param chatId - Target chat ID
+   * @param mediaId - Media ID from upload
+   * @param fileName - File name to display
+   */
+  private async sendFileMessage(chatId: string, mediaId: string, fileName?: string): Promise<void> {
+    const reqId = this.reqIdCache.get(chatId);
+
+    if (reqId) {
+      // Respond to incoming message
+      this.send({
+        cmd: 'aibot_respond_msg',
+        headers: { req_id: reqId },
+        body: {
+          msgtype: 'file',
+          file: { media_id: mediaId },
+        },
+      });
+    } else {
+      // Proactive push
+      const { type: chatType } = parseChatId(chatId);
+      const sendReqId = this.generateReqId();
+
+      this.send({
+        cmd: 'aibot_send_msg',
+        headers: { req_id: sendReqId },
+        body: {
+          chatid: chatId,
+          chat_type: chatType === 'group' ? 2 : 1,
+          msgtype: 'file',
+          file: { media_id: mediaId },
+        },
+      });
+    }
+
+    console.log(`[WeComPlugin] Sent file message: chatId=${chatId}, mediaId=${mediaId}, fileName=${fileName}`);
   }
 
   // ==================== Media Download ====================
@@ -542,6 +694,14 @@ export class WeComPlugin extends BasePlugin {
     const cmd = msg.cmd as string;
     const errcode = msg.errcode as number | undefined;
     console.log(`[WeComPlugin] handleWsMessage: cmd=${cmd || 'none'}, errcode=${errcode}, full msg=${JSON.stringify(msg).slice(0, 500)}`);
+
+    // Check if this is an upload response (handled by uploader)
+    if (cmd?.startsWith('aibot_upload_media_') || (errcode !== undefined && !cmd)) {
+      if (this.uploader) {
+        this.uploader.handleResponse(msg);
+      }
+      return;
+    }
 
     switch (cmd) {
       case 'aibot_msg_callback':

--- a/src/channels/plugins/wecom/WeComUploader.ts
+++ b/src/channels/plugins/wecom/WeComUploader.ts
@@ -1,0 +1,298 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { WeComUploadType } from './WeComAdapter';
+
+/**
+ * WeComUploader - Handles file upload via WeCom WebSocket long connection
+ *
+ * Implements three-step chunked upload:
+ * 1. aibot_upload_media_init - Get upload_id
+ * 2. aibot_upload_media_chunk - Upload base64 data (multiple chunks, ≤512KB each)
+ * 3. aibot_upload_media_finish - Get media_id
+ *
+ * Reference: https://developer.work.weixin.qq.com/document/path/101463
+ */
+
+// Maximum chunk size before base64 encoding (512KB)
+const MAX_CHUNK_SIZE = 512 * 1024;
+
+// Maximum number of chunks (100)
+const MAX_CHUNKS = 100;
+
+// File size limits by type
+const SIZE_LIMITS: Record<WeComUploadType, number> = {
+  image: 10 * 1024 * 1024, // 10MB
+  voice: 2 * 1024 * 1024, // 2MB
+  video: 10 * 1024 * 1024, // 10MB
+  file: 20 * 1024 * 1024, // 20MB
+};
+
+// Supported file formats by type
+const SUPPORTED_FORMATS: Record<WeComUploadType, Set<string>> = {
+  image: new Set(['.png', '.jpg', '.jpeg', '.gif']),
+  voice: new Set(['.amr']),
+  video: new Set(['.mp4']),
+  file: new Set(), // All formats supported
+};
+
+/**
+ * WebSocket message response handler
+ */
+interface WsResponse {
+  errcode: number;
+  errmsg: string;
+  body?: {
+    upload_id?: string;
+    media_id?: string;
+  };
+}
+
+/**
+ * WeComUploader class
+ */
+export class WeComUploader {
+  private pendingResponses: Map<string, { resolve: (value: WsResponse) => void; reject: (error: Error) => void }> = new Map();
+  private responseTimeout = 30000; // 30 seconds
+
+  constructor(
+    private send: (data: Record<string, unknown>) => void,
+    private generateReqId: () => string
+  ) {}
+
+  /**
+   * Handle WebSocket response for upload commands
+   * Called by WeComPlugin when receiving upload-related responses
+   */
+  handleResponse(msg: Record<string, unknown>): void {
+    const reqId = (msg.headers as Record<string, unknown>)?.req_id as string;
+    if (!reqId) return;
+
+    const pending = this.pendingResponses.get(reqId);
+    if (!pending) return;
+
+    const errcode = msg.errcode as number;
+    const errmsg = (msg.errmsg as string) || '';
+
+    if (errcode === 0) {
+      pending.resolve({
+        errcode,
+        errmsg,
+        body: msg.body as { upload_id?: string; media_id?: string } | undefined,
+      });
+    } else {
+      pending.reject(new Error(`WeCom upload error: ${errmsg} (errcode=${errcode})`));
+    }
+
+    this.pendingResponses.delete(reqId);
+  }
+
+  /**
+   * Upload a file to WeCom and return media_id
+   *
+   * @param filePath - Local file path
+   * @param type - Upload type (image/file/voice/video)
+   * @returns media_id for use in message sending
+   */
+  async uploadFile(filePath: string, type: WeComUploadType): Promise<string> {
+    // Validate file
+    this.validateFile(filePath, type);
+
+    // Read file content
+    const content = fs.readFileSync(filePath);
+    const totalSize = content.length;
+    const filename = path.basename(filePath);
+
+    // Calculate MD5
+    const md5 = crypto.createHash('md5').update(content).digest('hex');
+
+    // Split into chunks
+    const chunks = this.splitFile(content);
+    const totalChunks = chunks.length;
+
+    console.log(`[WeComUploader] Uploading: file=${filename}, type=${type}, size=${totalSize}, chunks=${totalChunks}, md5=${md5}`);
+
+    // Step 1: Initialize upload
+    const uploadId = await this.initUpload(type, filename, totalSize, totalChunks, md5);
+
+    // Step 2: Upload chunks
+    for (let i = 0; i < chunks.length; i++) {
+      await this.uploadChunk(uploadId, i, chunks[i]);
+      console.log(`[WeComUploader] Chunk ${i + 1}/${totalChunks} uploaded`);
+    }
+
+    // Step 3: Finish upload
+    const mediaId = await this.finishUpload(uploadId);
+
+    console.log(`[WeComUploader] Upload complete: media_id=${mediaId}`);
+    return mediaId;
+  }
+
+  /**
+   * Validate file before upload
+   */
+  private validateFile(filePath: string, type: WeComUploadType): void {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+
+    const stat = fs.statSync(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    const sizeLimit = SIZE_LIMITS[type];
+    const supportedFormats = SUPPORTED_FORMATS[type];
+
+    // Check size
+    if (stat.size > sizeLimit) {
+      throw new Error(`File too large: ${stat.size} bytes exceeds ${sizeLimit} limit for type ${type}`);
+    }
+
+    // Check format
+    if (supportedFormats.size > 0 && !supportedFormats.has(ext)) {
+      throw new Error(`Unsupported format: ${ext} for type ${type}. Supported: ${Array.from(supportedFormats).join(', ')}`);
+    }
+
+    // Check minimum size (5 bytes per API doc)
+    if (stat.size < 5) {
+      throw new Error(`File too small: minimum 5 bytes required`);
+    }
+  }
+
+  /**
+   * Split file content into chunks
+   */
+  private splitFile(content: Buffer): Buffer[] {
+    const chunks: Buffer[] = [];
+    let offset = 0;
+
+    while (offset < content.length) {
+      const chunkSize = Math.min(MAX_CHUNK_SIZE, content.length - offset);
+      chunks.push(content.subarray(offset, offset + chunkSize));
+      offset += chunkSize;
+    }
+
+    if (chunks.length > MAX_CHUNKS) {
+      throw new Error(`Too many chunks: ${chunks.length} exceeds ${MAX_CHUNKS} limit. File is too large.`);
+    }
+
+    return chunks;
+  }
+
+  /**
+   * Step 1: Initialize upload
+   */
+  private async initUpload(type: WeComUploadType, filename: string, totalSize: number, totalChunks: number, md5: string): Promise<string> {
+    const reqId = this.generateReqId();
+
+    const request = {
+      cmd: 'aibot_upload_media_init',
+      headers: { req_id: reqId },
+      body: {
+        type,
+        filename,
+        total_size: totalSize,
+        total_chunks: totalChunks,
+        md5,
+      },
+    };
+
+    const response = await this.sendAndWait(reqId, request);
+    const uploadId = response.body?.upload_id;
+
+    if (!uploadId) {
+      throw new Error('WeCom upload init failed: no upload_id returned');
+    }
+
+    return uploadId;
+  }
+
+  /**
+   * Step 2: Upload a chunk
+   */
+  private async uploadChunk(uploadId: string, chunkIndex: number, chunk: Buffer): Promise<void> {
+    const reqId = this.generateReqId();
+
+    // Base64 encode the chunk
+    const base64Data = chunk.toString('base64');
+
+    const request = {
+      cmd: 'aibot_upload_media_chunk',
+      headers: { req_id: reqId },
+      body: {
+        upload_id: uploadId,
+        chunk_index: chunkIndex,
+        base64_data: base64Data,
+      },
+    };
+
+    await this.sendAndWait(reqId, request);
+  }
+
+  /**
+   * Step 3: Finish upload
+   */
+  private async finishUpload(uploadId: string): Promise<string> {
+    const reqId = this.generateReqId();
+
+    const request = {
+      cmd: 'aibot_upload_media_finish',
+      headers: { req_id: reqId },
+      body: {
+        upload_id: uploadId,
+      },
+    };
+
+    const response = await this.sendAndWait(reqId, request);
+    const mediaId = response.body?.media_id;
+
+    if (!mediaId) {
+      throw new Error('WeCom upload finish failed: no media_id returned');
+    }
+
+    return mediaId;
+  }
+
+  /**
+   * Send request and wait for response
+   */
+  private sendAndWait(reqId: string, request: Record<string, unknown>): Promise<WsResponse> {
+    return new Promise((resolve, reject) => {
+      // Set up timeout
+      const timeout = setTimeout(() => {
+        this.pendingResponses.delete(reqId);
+        reject(new Error(`WeCom upload timeout: no response for req_id=${reqId}`));
+      }, this.responseTimeout);
+
+      // Store pending response handler
+      this.pendingResponses.set(reqId, {
+        resolve: (value) => {
+          clearTimeout(timeout);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+
+      // Send request
+      this.send(request);
+    });
+  }
+
+  /**
+   * Clear all pending responses (for cleanup)
+   */
+  clearPending(): void {
+    for (const [reqId, pending] of this.pendingResponses) {
+      pending.reject(new Error('WeComUploader cleared'));
+    }
+    this.pendingResponses.clear();
+  }
+}

--- a/src/channels/plugins/wecom/index.ts
+++ b/src/channels/plugins/wecom/index.ts
@@ -7,3 +7,4 @@
 export { WeComPlugin } from './WeComPlugin';
 export * from './WeComAdapter';
 export * from './WeComCrypto';
+export { WeComUploader } from './WeComUploader';


### PR DESCRIPTION
- Implement three-step chunked upload (init → chunk → finish)
- Add WeComUploader class for media upload with AES decryption
- Add path validation to filter truncated/directory paths
- Buffer files until stream ends for WeCom (text first, files last)
- Other channels (Lark/DingTalk/Telegram) send files immediately
- Skip user input files to avoid sending back to user
- Fix first thinking update to send immediately without throttle

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
