### PR TITLE
feat(acp): add ai_dev_browser PYTHONPATH for nexus browser tool

### DIFF
--- a/hook/python/pythonpath/hook/file/file.py
+++ b/hook/python/pythonpath/hook/file/file.py
@@ -44,7 +44,7 @@ class FileInterceptor:
         """
         original_open = builtins.open
 
-        def open_(file: FileDescriptorOrPath, mode, *args, **kwargs):
+        def open_(file: FileDescriptorOrPath, mode='r', *args, **kwargs):
             # Build FileData with the absolute path and parsed flags for policy check
             reason = self.callback(FileData(path=Path(file).absolute(), flags=parse_flags(mode)))
             if reason:

--- a/hook/python/src/hook/file/file.py
+++ b/hook/python/src/hook/file/file.py
@@ -44,7 +44,7 @@ class FileInterceptor:
         """
         original_open = builtins.open
 
-        def open_(file: FileDescriptorOrPath, mode, *args, **kwargs):
+        def open_(file: FileDescriptorOrPath, mode='r', *args, **kwargs):
             # Build FileData with the absolute path and parsed flags for policy check
             reason = self.callback(FileData(path=Path(file).absolute(), flags=parse_flags(mode)))
             if reason:

--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -122,6 +122,15 @@ export function prepareCleanEnv(): Record<string, string | undefined> {
     console.log(`[ACP] Injecting python safety hook via PYTHONPATH: ${pythonpath}`);
   }
 
+  // PYTHONPATH for ai_dev_browser module resolution (browser tool).
+  // The browser skill dir contains ai_dev_browser (symlinked from vendor).
+  // Python silently ignores non-existent entries, so no existence check needed.
+  const browserSkillDir = path.join(os.homedir(), '.nexus', 'skills', '_system', 'browser');
+  const prevPythonPath = cleanEnv.PYTHONPATH || '';
+  cleanEnv.PYTHONPATH = prevPythonPath
+    ? `${browserSkillDir}${path.delimiter}${prevPythonPath}`
+    : browserSkillDir;
+
   return cleanEnv;
 }
 


### PR DESCRIPTION
## Summary
- Prepend `~/.nexus/skills/_system/browser` to `PYTHONPATH` in `prepareCleanEnv()` so the nexus process can resolve `ai_dev_browser.core` for the new `BrowserTool`
- Merges correctly with existing `PYTHONPATH` (safety hook pythonpath when enabled)
- Pairs with nexi-lab/nexus#3866 which adds BrowserTool as nexus's 7th Tier A built-in tool

## Test plan
- [ ] Start sudowork dev, select Nexus agent on GuidPage
- [ ] Send "open https://google.com and screenshot" → browser tool_call appears in UI
- [ ] Full lis8 flow: login + captcha + navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)