### PR TITLE
fix: 数字助手主代理下拉框锁定为 SudoClaw，禁止切换

### DIFF
--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -1130,7 +1130,7 @@ const AgentModalContent: React.FC = () => {
             nameI18n: { 'zh-CN': customName },
             descriptionI18n: duplicateAssistant.description ? { 'zh-CN': duplicateAssistant.description } : undefined,
             avatar: duplicateAssistant.avatar || duplicateAssistant.emoji,
-            presetAgentType: duplicateAssistant.preset_agent_type || 'sudoclaw',
+            presetAgentType: 'sudoclaw',
             enabled: true,
             source_type: 'custom',
             enabledSkills: duplicateAssistant.skills || [],
@@ -1169,7 +1169,7 @@ const AgentModalContent: React.FC = () => {
             nameI18n: { 'zh-CN': customName },
             descriptionI18n: duplicateInstalledAssistant.descriptionI18n || (duplicateInstalledAssistant.description ? { 'zh-CN': duplicateInstalledAssistant.description } : undefined),
             avatar: duplicateInstalledAssistant.avatar,
-            presetAgentType: duplicateInstalledAssistant.presetAgentType || 'sudoclaw',
+            presetAgentType: 'sudoclaw',
             enabled: true,
             source_type: 'custom',
             enabledSkills: duplicateInstalledAssistant.enabledSkills || [],
@@ -1347,7 +1347,7 @@ const AgentModalContent: React.FC = () => {
             nameI18n: { 'zh-CN': editName },
             descriptionI18n: editDescription ? { 'zh-CN': editDescription } : undefined,
             avatar: editAvatar,
-            presetAgentType: editAgent,
+            presetAgentType: 'sudoclaw',
             enabled: true,
             source_type: 'custom',
             enabledSkills: sanitizeAssistantEnabledSkills(selectedSkills, installedSkills),
@@ -1361,14 +1361,14 @@ const AgentModalContent: React.FC = () => {
         if (!activeAssistant) return;
         const lookupName = resolveAssistantName(activeAssistant.id);
 
-        // For custom assistants, save all fields
+        // For custom assistants, save all fields (presetAgentType always locked to sudoclaw)
         await ipcBridge.assistantHub.updateAssistantMeta.invoke({
           name: lookupName,
           updates: {
             nameI18n: { 'zh-CN': editName },
             descriptionI18n: editDescription ? { 'zh-CN': editDescription } : undefined,
             avatar: editAvatar,
-            presetAgentType: editAgent,
+            presetAgentType: 'sudoclaw',
             enabledSkills: sanitizeAssistantEnabledSkills(selectedSkills, installedSkills),
           },
         });
@@ -1710,39 +1710,13 @@ const AgentModalContent: React.FC = () => {
               <Input className='mt-10px rounded-4px bg-bg-1' value={editDescription} onChange={(value) => setEditDescription(value)} disabled={activeAssistant?.isBuiltin || isReadonlyAssistant} placeholder={t('settings.assistantDescriptionPlaceholder', { defaultValue: 'What can this assistant help with?' })} />
             </div>
 
-            {/* Main Agent */}
+            {/* Main Agent - locked to SudoClaw */}
             <div className='flex-shrink-0'>
               <Typography.Text bold>{t('settings.assistantMainAgent', { defaultValue: 'Main Agent' })}</Typography.Text>
-              <Select className='mt-10px w-full rounded-4px' value={editAgent} onChange={(value) => setEditAgent(value as string)} disabled={isReadonlyAssistant}>
-                {[
-                  { value: 'gemini', label: 'Gemini CLI' },
-                  { value: 'claude', label: 'Claude Code' },
-                  { value: 'qwen', label: 'Qwen Code' },
-                  { value: 'codex', label: 'Codex' },
-                  { value: 'codebuddy', label: 'CodeBuddy' },
-                  { value: 'opencode', label: 'OpenCode' },
-                  { value: 'sudoclaw', label: 'SudoClaw', backendId: 'openclaw-gateway' },
-                ]
-                  .filter((opt) => availableBackends.has(opt.backendId || opt.value))
-                  .map((opt) => (
-                    <Select.Option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </Select.Option>
-                  ))}
-                {extensionAcpAdapters?.map((adapter) => {
-                  const id = adapter.id as string;
-                  const name = (adapter.name as string) || id;
-                  return (
-                    <Select.Option key={id} value={id}>
-                      <span className='flex items-center gap-6px'>
-                        {name}
-                        <Tag size='small' color='arcoblue'>
-                          ext
-                        </Tag>
-                      </span>
-                    </Select.Option>
-                  );
-                })}
+              <Select className='mt-10px w-full rounded-4px' value='sudoclaw' disabled>
+                <Select.Option key='sudoclaw' value='sudoclaw'>
+                  SudoClaw
+                </Select.Option>
               </Select>
             </div>
 

--- a/src/renderer/pages/guid/components/AssistantAgentDropdown.tsx
+++ b/src/renderer/pages/guid/components/AssistantAgentDropdown.tsx
@@ -41,7 +41,9 @@ type AssistantAgentDropdownProps = {
   disabled?: boolean;
 };
 
-const AssistantAgentDropdown: React.FC<AssistantAgentDropdownProps> = ({ availableAgents, currentAgentType, onSelectAgent, disabled }) => {
+const AssistantAgentDropdown: React.FC<AssistantAgentDropdownProps> = ({ availableAgents, currentAgentType, onSelectAgent, disabled: _disabled }) => {
+  // Main agent dropdown is always disabled - only SudoClaw is supported
+  const disabled = true;
   const [visible, setVisible] = useState(false);
 
   // Build set of available backends from detected agents

--- a/src/renderer/pages/guid/components/AssistantEditDrawer.tsx
+++ b/src/renderer/pages/guid/components/AssistantEditDrawer.tsx
@@ -235,14 +235,14 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
       // Use assistantHub.updateAssistantMeta to save to _sudowork_meta.json
       const lookupName = resolveAssistantName(assistant.id);
 
-      // For custom assistants, save all fields
+      // For custom assistants, save all fields (presetAgentType always locked to sudoclaw)
       await ipcBridge.assistantHub.updateAssistantMeta.invoke({
         name: lookupName,
         updates: {
           nameI18n: { 'zh-CN': editName },
           descriptionI18n: editDescription ? { 'zh-CN': editDescription } : undefined,
           avatar: editAvatar,
-          presetAgentType: editAgent,
+          presetAgentType: 'sudoclaw',
           enabledSkills: selectedSkills,
         },
       });
@@ -369,22 +369,20 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
             />
           </div>
 
-          {/* Main Agent */}
+          {/* Main Agent - locked to SudoClaw */}
           <div className='flex-shrink-0'>
             <Typography.Text bold>
               {t('settings.assistantMainAgent', {
                 defaultValue: 'Main Agent',
               })}
             </Typography.Text>
-            <Select className='mt-10px w-full rounded-4px' value={editAgent} onChange={(value) => setEditAgent(value as string)} disabled={isReadonly}>
-              {AGENT_OPTIONS.filter((opt) => availableBackends.has(opt.backendId || opt.value)).map((opt) => (
-                <Select.Option key={opt.value} value={opt.value}>
-                  <span className='flex items-center gap-6px'>
-                    {getAgentLogo(opt.backendId || opt.value) && <img src={getAgentLogo(opt.backendId || opt.value) || undefined} alt='' width={16} height={16} style={{ objectFit: 'contain' }} />}
-                    {opt.label}
-                  </span>
-                </Select.Option>
-              ))}
+            <Select className='mt-10px w-full rounded-4px' value='sudoclaw' disabled>
+              <Select.Option key='sudoclaw' value='sudoclaw'>
+                <span className='flex items-center gap-6px'>
+                  {getAgentLogo('openclaw-gateway') && <img src={getAgentLogo('openclaw-gateway') || undefined} alt='' width={16} height={16} style={{ objectFit: 'contain' }} />}
+                  SudoClaw
+                </span>
+              </Select.Option>
             </Select>
           </div>
 


### PR DESCRIPTION
Closes #480

## Summary
- 将数字助手创建/修改时的主代理(Main Agent)下拉框设为始终禁用状态，仅支持 SudoClaw
- 涉及三处修改：AgentModalContent、AssistantEditDrawer、AssistantAgentDropdown

## Test plan
- [ ] 创建新助手，确认主代理下拉框显示 SudoClaw 且不可点击
- [ ] 编辑现有助手，确认主代理下拉框禁用
- [ ] 复制助手，确认复制后的主代理为 sudoclaw
- [ ] GUID 页面头部的代理切换下拉框不可点击

Generated with [Claude Code](https://claude.ai/code)