### PR TITLE
fix: 修复文件预览缓存未检测文件修改的问题

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -481,6 +481,8 @@ export const document = {
   libreOffice: {
     isAvailable: bridge.buildProvider<boolean, void>('document.libreoffice.is-available'),
   },
+  /** 获取文件最后修改时间 (mtime) / Get file last modification time */
+  getFileMtime: bridge.buildProvider<number, { filePath: string }>('document.get-file-mtime'),
 };
 
 export interface ICliStatus {

--- a/src/process/bridge/documentBridge.ts
+++ b/src/process/bridge/documentBridge.ts
@@ -145,6 +145,16 @@ export function initDocumentBridge(): void {
     return await conversionService.isLibreOfficeAvailable();
   });
 
+  // 获取文件最后修改时间 (mtime) / Get file last modification time
+  ipcBridge.document.getFileMtime.provider(async ({ filePath }) => {
+    try {
+      const stats = await fs.promises.stat(filePath);
+      return stats.mtimeMs; // 返回毫秒级时间戳
+    } catch {
+      return 0; // 文件不存在或无法访问时返回 0
+    }
+  });
+
   // 保存为 Word 文档接口 / Save as Word document endpoint
   ipcBridge.document.saveAsDocx.provider(async ({ markdown, conversationId, fileName }) => {
     try {

--- a/src/renderer/pages/conversation/preview/components/viewers/ExcelViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/ExcelViewer.tsx
@@ -22,7 +22,8 @@ interface ExcelPreviewProps {
 }
 
 // 缓存 Map / Cache Map
-const pdfCache = new Map<string, { pdfPath: string; timestamp: number }>();
+// 添加 mtime 字段以检测文件修改 / Added mtime field to detect file modifications
+const pdfCache = new Map<string, { pdfPath: string; timestamp: number; mtime: number }>();
 const CACHE_TIMEOUT = 5 * 60 * 1000; // 5 分钟
 
 // 宽表格列数阈值 / Wide table column threshold
@@ -129,8 +130,9 @@ const ExcelPreview: React.FC<ExcelPreviewProps> = ({ filePath, content: _content
           const response = await ipcBridge.document.convert.invoke({ filePath, to: 'libreoffice-pdf' });
           if (response.result.success && response.result.data) {
             setPdfPath(response.result.data as string);
-            // 保存到缓存 / Save to cache
-            pdfCache.set(filePath, { pdfPath: response.result.data as string, timestamp: Date.now() });
+            // 获取文件 mtime 并保存到缓存 / Get file mtime and save to cache
+            const mtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+            pdfCache.set(filePath, { pdfPath: response.result.data as string, timestamp: Date.now(), mtime });
           }
         } else {
           const response = await ipcBridge.document.convert.invoke({ filePath, to: 'excel-json' });
@@ -195,16 +197,21 @@ const ExcelPreview: React.FC<ExcelPreviewProps> = ({ filePath, content: _content
         return;
       }
 
-      // 检查缓存 / Check cache
+      // 检查缓存（同时检查文件修改时间）/ Check cache (also check file modification time)
       const cached = pdfCache.get(filePath);
-      if (cached && Date.now() - cached.timestamp < CACHE_TIMEOUT) {
-        console.log('[ExcelViewer] Cache hit:', filePath);
-        setUseLibreOffice(true); // 设置 LibreOffice 状态，因为缓存的是 PDF
-        setPdfPath(cached.pdfPath);
-        setLoading(false);
-        return;
-      }
       if (cached) {
+        // 获取当前文件的 mtime / Get current file mtime
+        const currentMtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+        // 缓存有效条件：mtime 未变化且未超时 / Cache valid if: mtime unchanged and not expired
+        if (cached.mtime === currentMtime && Date.now() - cached.timestamp < CACHE_TIMEOUT) {
+          console.log('[ExcelViewer] Cache hit:', filePath, 'mtime:', currentMtime);
+          setUseLibreOffice(true); // 设置 LibreOffice 状态，因为缓存的是 PDF
+          setPdfPath(cached.pdfPath);
+          setLoading(false);
+          return;
+        }
+        // mtime 变化或超时，清除缓存 / mtime changed or expired, clear cache
+        console.log('[ExcelViewer] Cache invalidated:', filePath, 'cached mtime:', cached.mtime, 'current mtime:', currentMtime);
         pdfCache.delete(filePath);
       }
 
@@ -257,9 +264,10 @@ const ExcelPreview: React.FC<ExcelPreviewProps> = ({ filePath, content: _content
 
             if (pdfResponse.result.success && pdfResponse.result.data) {
               setPdfPath(pdfResponse.result.data);
-              // 保存到缓存 / Save to cache
-              pdfCache.set(filePath, { pdfPath: pdfResponse.result.data, timestamp: Date.now() });
-              console.log('[ExcelViewer] Converted and cached:', filePath);
+              // 获取文件 mtime 并保存到缓存 / Get file mtime and save to cache
+              const mtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+              pdfCache.set(filePath, { pdfPath: pdfResponse.result.data, timestamp: Date.now(), mtime });
+              console.log('[ExcelViewer] Converted and cached:', filePath, 'mtime:', mtime);
             } else {
               // PDF 转换失败，回退到 JSON 渲染 / PDF conversion failed, fallback to JSON
               setUseLibreOffice(false);
@@ -472,13 +480,7 @@ const ExcelPreview: React.FC<ExcelPreviewProps> = ({ filePath, content: _content
   if (needsLibreOfficeInstall) {
     return (
       <div className='h-full w-full'>
-        <LibreOfficeInstallPrompt
-          fileType='excel'
-          installing={installingLibreOffice}
-          percent={installPercent}
-          phase={installPhase}
-          onInstall={handleInstallLibreOffice}
-        />
+        <LibreOfficeInstallPrompt fileType='excel' installing={installingLibreOffice} percent={installPercent} phase={installPhase} onInstall={handleInstallLibreOffice} />
       </div>
     );
   }

--- a/src/renderer/pages/conversation/preview/components/viewers/PPTViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/PPTViewer.tsx
@@ -21,7 +21,8 @@ interface PPTPreviewProps {
 }
 
 // 缓存 Map / Cache Map
-const pdfCache = new Map<string, { pdfPath: string; timestamp: number }>();
+// 添加 mtime 字段以检测文件修改 / Added mtime field to detect file modifications
+const pdfCache = new Map<string, { pdfPath: string; timestamp: number; mtime: number }>();
 const CACHE_TIMEOUT = 5 * 60 * 1000; // 5 分钟
 
 /**
@@ -135,8 +136,9 @@ const PPTPreview: React.FC<PPTPreviewProps> = ({ filePath, content, hideToolbar 
           const response = await ipcBridge.document.convert.invoke({ filePath, to: 'libreoffice-pdf' });
           if (response.result.success && response.result.data) {
             setPdfPath(response.result.data as string);
-            // 保存到缓存 / Save to cache
-            pdfCache.set(filePath, { pdfPath: response.result.data as string, timestamp: Date.now() });
+            // 获取文件 mtime 并保存到缓存 / Get file mtime and save to cache
+            const mtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+            pdfCache.set(filePath, { pdfPath: response.result.data as string, timestamp: Date.now(), mtime });
           }
         }
       } catch (err) {
@@ -160,16 +162,21 @@ const PPTPreview: React.FC<PPTPreviewProps> = ({ filePath, content, hideToolbar 
         return;
       }
 
-      // 检查缓存 / Check cache
+      // 检查缓存（同时检查文件修改时间）/ Check cache (also check file modification time)
       const cached = pdfCache.get(filePath);
-      if (cached && Date.now() - cached.timestamp < CACHE_TIMEOUT) {
-        console.log('[PPTViewer] Cache hit:', filePath);
-        setUseLibreOffice(true); // 设置 LibreOffice 状态，因为缓存的是 PDF
-        setPdfPath(cached.pdfPath);
-        setLoading(false);
-        return;
-      }
       if (cached) {
+        // 获取当前文件的 mtime / Get current file mtime
+        const currentMtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+        // 缓存有效条件：mtime 未变化且未超时 / Cache valid if: mtime unchanged and not expired
+        if (cached.mtime === currentMtime && Date.now() - cached.timestamp < CACHE_TIMEOUT) {
+          console.log('[PPTViewer] Cache hit:', filePath, 'mtime:', currentMtime);
+          setUseLibreOffice(true); // 设置 LibreOffice 状态，因为缓存的是 PDF
+          setPdfPath(cached.pdfPath);
+          setLoading(false);
+          return;
+        }
+        // mtime 变化或超时，清除缓存 / mtime changed or expired, clear cache
+        console.log('[PPTViewer] Cache invalidated:', filePath, 'cached mtime:', cached.mtime, 'current mtime:', currentMtime);
         pdfCache.delete(filePath);
       }
 
@@ -189,9 +196,10 @@ const PPTPreview: React.FC<PPTPreviewProps> = ({ filePath, content, hideToolbar 
 
           if (response.result.success && response.result.data) {
             setPdfPath(response.result.data);
-            // 保存到缓存 / Save to cache
-            pdfCache.set(filePath, { pdfPath: response.result.data, timestamp: Date.now() });
-            console.log('[PPTViewer] Converted and cached:', filePath);
+            // 获取文件 mtime 并保存到缓存 / Get file mtime and save to cache
+            const mtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+            pdfCache.set(filePath, { pdfPath: response.result.data, timestamp: Date.now(), mtime });
+            console.log('[PPTViewer] Converted and cached:', filePath, 'mtime:', mtime);
           } else {
             throw new Error(response.result.error || t('preview.ppt.loadFailed'));
           }
@@ -271,13 +279,7 @@ const PPTPreview: React.FC<PPTPreviewProps> = ({ filePath, content, hideToolbar 
   if (!useLibreOffice) {
     return (
       <div className='h-full w-full'>
-        <LibreOfficeInstallPrompt
-          fileType='ppt'
-          installing={installingLibreOffice}
-          percent={installPercent}
-          phase={installPhase}
-          onInstall={handleInstallLibreOffice}
-        />
+        <LibreOfficeInstallPrompt fileType='ppt' installing={installingLibreOffice} percent={installPercent} phase={installPhase} onInstall={handleInstallLibreOffice} />
       </div>
     );
   }

--- a/src/renderer/pages/conversation/preview/components/viewers/WordViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/WordViewer.tsx
@@ -22,7 +22,8 @@ interface WordPreviewProps {
 }
 
 // 缓存 Map / Cache Map
-const pdfCache = new Map<string, { pdfPath: string; timestamp: number }>();
+// 添加 mtime 字段以检测文件修改 / Added mtime field to detect file modifications
+const pdfCache = new Map<string, { pdfPath: string; timestamp: number; mtime: number }>();
 const CACHE_TIMEOUT = 5 * 60 * 1000; // 5 分钟
 
 /**
@@ -137,8 +138,9 @@ const WordPreview: React.FC<WordPreviewProps> = ({ filePath, content, hideToolba
         const response = await ipcBridge.document.convert.invoke({ filePath: currentFilePath, to: 'libreoffice-pdf' });
         if (response.result.success && response.result.data) {
           setPdfPath(response.result.data as string);
-          // 保存到缓存 / Save to cache
-          pdfCache.set(currentFilePath, { pdfPath: response.result.data as string, timestamp: Date.now() });
+          // 获取文件 mtime 并保存到缓存 / Get file mtime and save to cache
+          const mtime = await ipcBridge.document.getFileMtime.invoke({ filePath: currentFilePath });
+          pdfCache.set(currentFilePath, { pdfPath: response.result.data as string, timestamp: Date.now(), mtime });
         }
       } else {
         const response = await ipcBridge.document.convert.invoke({ filePath: currentFilePath, to: 'markdown' });
@@ -169,16 +171,21 @@ const WordPreview: React.FC<WordPreviewProps> = ({ filePath, content, hideToolba
         return;
       }
 
-      // 检查缓存 / Check cache
+      // 检查缓存（同时检查文件修改时间）/ Check cache (also check file modification time)
       const cached = pdfCache.get(filePath);
-      if (cached && Date.now() - cached.timestamp < CACHE_TIMEOUT) {
-        console.log('[WordViewer] Cache hit:', filePath);
-        setUseLibreOffice(true); // 设置 LibreOffice 状态，因为缓存的是 PDF
-        setPdfPath(cached.pdfPath);
-        setLoading(false);
-        return;
-      }
       if (cached) {
+        // 获取当前文件的 mtime / Get current file mtime
+        const currentMtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+        // 缓存有效条件：mtime 未变化且未超时 / Cache valid if: mtime unchanged and not expired
+        if (cached.mtime === currentMtime && Date.now() - cached.timestamp < CACHE_TIMEOUT) {
+          console.log('[WordViewer] Cache hit:', filePath, 'mtime:', currentMtime);
+          setUseLibreOffice(true); // 设置 LibreOffice 状态，因为缓存的是 PDF
+          setPdfPath(cached.pdfPath);
+          setLoading(false);
+          return;
+        }
+        // mtime 变化或超时，清除缓存 / mtime changed or expired, clear cache
+        console.log('[WordViewer] Cache invalidated:', filePath, 'cached mtime:', cached.mtime, 'current mtime:', currentMtime);
         pdfCache.delete(filePath);
       }
 
@@ -215,9 +222,10 @@ const WordPreview: React.FC<WordPreviewProps> = ({ filePath, content, hideToolba
 
           if (response.result.success && response.result.data) {
             setPdfPath(response.result.data);
-            // 保存到缓存 / Save to cache
-            pdfCache.set(filePath, { pdfPath: response.result.data, timestamp: Date.now() });
-            console.log('[WordViewer] Converted and cached:', filePath);
+            // 获取文件 mtime 并保存到缓存 / Get file mtime and save to cache
+            const mtime = await ipcBridge.document.getFileMtime.invoke({ filePath });
+            pdfCache.set(filePath, { pdfPath: response.result.data, timestamp: Date.now(), mtime });
+            console.log('[WordViewer] Converted and cached:', filePath, 'mtime:', mtime);
           } else {
             throw new Error(response.result.error || t('preview.word.loadFailed'));
           }
@@ -302,13 +310,7 @@ const WordPreview: React.FC<WordPreviewProps> = ({ filePath, content, hideToolba
   if (needsLibreOfficeInstall) {
     return (
       <div className='h-full w-full'>
-        <LibreOfficeInstallPrompt
-          fileType='word'
-          installing={installingLibreOffice}
-          percent={installPercent}
-          phase={installPhase}
-          onInstall={handleInstallLibreOffice}
-        />
+        <LibreOfficeInstallPrompt fileType='word' installing={installingLibreOffice} percent={installPercent} phase={installPhase} onInstall={handleInstallLibreOffice} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- 修复了 LibreOffice 文件预览缓存未检测文件修改的问题
- 当本地文件被修改后，预览时会因为缓存未失效而显示旧内容

## Problem
缓存仅以 `filePath` 作为键，当文件被本地修改后，`filePath` 保持不变，
导致在 5 分钟缓存有效期内返回旧的 PDF 内容。

## Solution
在缓存结构中添加 `mtime`（文件修改时间）字段：
- 每次检查缓存时，对比当前文件 mtime 与缓存的 mtime
- 若 mtime 不同，清除缓存并重新转换文件

## Changes
- `ipcBridge.ts`: 添加 `getFileMtime` IPC 方法定义
- `documentBridge.ts`: 实现 `getFileMtime` provider
- `WordViewer.tsx`: 缓存添加 mtime 检测
- `ExcelViewer.tsx`: 缓存添加 mtime 检测
- `PPTViewer.tsx`: 缓存添加 mtime 检测

## Test Plan
- [ ] 打开一个 Office 文件（Word/Excel/PPT）进行预览
- [ ] 在外部编辑器中修改该文件并保存
- [ ] 再次预览该文件，确认显示新内容而非旧缓存内容
- [ ] 点击刷新按钮，确认能重新转换并显示最新内容

🤖 Generated with [Claude Code](https://claude.com/claude-code)