### PR TITLE
feat(avatar): MVP-0 floating window with capability-isolated bridge

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -127,7 +127,12 @@ export default defineConfig(({ mode }) => {
       build: {
         sourcemap: false,
         reportCompressedSize: false,
-        rollupOptions: { input: { index: resolve('src/preload.ts') } },
+        rollupOptions: {
+          input: {
+            index: resolve('src/preload.ts'),
+            avatar: resolve('src/preload-avatar.ts'),
+          },
+        },
       },
     },
 
@@ -167,7 +172,10 @@ export default defineConfig(({ mode }) => {
         chunkSizeWarningLimit: 1500,
         cssCodeSplit: true,
         rollupOptions: {
-          input: { index: resolve('src/renderer/index.html') },
+          input: {
+            index: resolve('src/renderer/index.html'),
+            avatar: resolve('src/renderer/avatar/index.html'),
+          },
           external: ['node:crypto', 'crypto'],
           output: {
             manualChunks(id: string) {

--- a/src/adapter/main.ts
+++ b/src/adapter/main.ts
@@ -9,6 +9,7 @@ import { ipcMain } from 'electron';
 
 import { bridge } from '@office-ai/platform';
 import { ADAPTER_BRIDGE_EVENT_KEY } from './constant';
+import { forwardBroadcastToAvatars } from '../process/avatarBroadcast';
 
 /**
  * Bridge event data structure for IPC communication
@@ -77,7 +78,12 @@ bridge.adapter({
         win.webContents.send(ADAPTER_BRIDGE_EVENT_KEY, JSON.stringify({ name, data }));
       }
     }
-    // 2. 同时广播到所有 WebSocket 客户端 / Also broadcast to all WebSocket clients
+    // 2. 选择性投递到 avatar 窗口（独立 channel + 主进程白名单，capability isolation）
+    //    Selectively forward to avatar windows via a dedicated channel + main-side
+    //    allowlist. Avatar windows are not in adapterWindowList — see
+    //    src/process/avatarBroadcast.ts.
+    forwardBroadcastToAvatars(name, data);
+    // 3. 同时广播到所有 WebSocket 客户端 / Also broadcast to all WebSocket clients
     for (const broadcast of webSocketBroadcasters) {
       try {
         broadcast(name, data);

--- a/src/common/avatarBridge.ts
+++ b/src/common/avatarBridge.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared types between the avatar preload, the avatar renderer, and the
+ * main-process avatar broadcast forwarder.
+ *
+ * The avatar window uses a dedicated IPC channel (AVATAR_BRIDGE_CHANNEL)
+ * separate from the generic main bridge mega-channel
+ * (ADAPTER_BRIDGE_EVENT_KEY). See src/process/avatarBroadcast.ts for the
+ * capability-isolation rationale.
+ */
+
+export const AVATAR_BRIDGE_CHANNEL = 'avatar:bridge';
+
+export type AvatarBridgeMessage = {
+  name: string;
+  data: unknown;
+};

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -700,6 +700,10 @@ export const windowControls = {
 export const systemSettings = {
   getCloseToTray: bridge.buildProvider<boolean, void>('system-settings:get-close-to-tray'),
   setCloseToTray: bridge.buildProvider<void, { enabled: boolean }>('system-settings:set-close-to-tray'),
+  // Floating desktop avatar window — independent transparent BrowserWindow
+  // that reflects active ACP conversation state. See src/process/avatarWindow.ts.
+  getAvatarEnabled: bridge.buildProvider<boolean, void>('system-settings:get-avatar-enabled'),
+  setAvatarEnabled: bridge.buildProvider<void, { enabled: boolean }>('system-settings:set-avatar-enabled'),
   changeLanguage: bridge.buildProvider<void, { language: string }>('system-settings:change-language'),
   // Broadcast language change to all renderers (desktop + WebUI) for real-time sync
   languageChanged: bridge.buildEmitter<{ language: string }>('system-settings:language-changed'),

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -86,6 +86,8 @@ export interface IConfigStorageRefer {
   'system.closeToTray'?: boolean;
   // 桌面 avatar 浮窗开关 / Floating desktop avatar window enabled
   'avatar.enabled'?: boolean;
+  // Avatar 浮窗最近一次的位置（屏幕坐标）/ Last-known avatar window bounds (screen coords)
+  'avatar.bounds'?: { x: number; y: number; width: number; height: number };
   // 内置资源最后复制的版本号，用于优化启动速度 / Last copied version of builtin resources for startup optimization
   'system.lastBuiltinResourcesVersion'?: string;
   /**

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -84,6 +84,8 @@ export interface IConfigStorageRefer {
   'migration.skillSubdirectoriesMigrated'?: boolean;
   // 关闭窗口时最小化到系统托盘 / Minimize to system tray when closing window
   'system.closeToTray'?: boolean;
+  // 桌面 avatar 浮窗开关 / Floating desktop avatar window enabled
+  'avatar.enabled'?: boolean;
   // 内置资源最后复制的版本号，用于优化启动速度 / Last copied version of builtin resources for startup optimization
   'system.lastBuiltinResourcesVersion'?: string;
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
 import 'v8-compile-cache';
 
 import './utils/configureChromium';
-import { app, BrowserWindow, globalShortcut, Menu, nativeImage, net, powerMonitor, protocol, screen, Tray } from 'electron';
+import { app, BrowserWindow, Menu, nativeImage, net, powerMonitor, protocol, screen, Tray } from 'electron';
 import fixPath from 'fix-path';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -357,22 +357,6 @@ function closeAvatarWindow(): void {
   avatarWindow = null;
 }
 
-/**
- * Toggle avatar visibility from a global hotkey. Mirrors what the user
- * would get by flipping the Settings switch: opens or closes the window
- * AND persists `avatar.enabled` so the choice survives a restart.
- */
-function toggleAvatarFromHotkey(): void {
-  const isOpen = avatarWindow !== null && !avatarWindow.isDestroyed();
-  const target = !isOpen;
-  if (target) openAvatarWindow();
-  else closeAvatarWindow();
-  void ProcessConfig.set('avatar.enabled', target).catch((error: unknown) => {
-    mainError('App', 'Failed to persist avatar.enabled from hotkey:', error);
-  });
-}
-
-const AVATAR_HOTKEY = 'CommandOrControl+Shift+A';
 let isQuitting = false;
 let closeToTrayEnabled = false;
 let quitCleanupInProgress = false;
@@ -922,16 +906,6 @@ const handleAppReady = async (): Promise<void> => {
       else closeAvatarWindow();
     });
 
-    // 注册全局快捷键 / Register global hotkey for avatar toggle
-    try {
-      const registered = globalShortcut.register(AVATAR_HOTKEY, toggleAvatarFromHotkey);
-      if (!registered) {
-        mainError('App', `Failed to register avatar hotkey ${AVATAR_HOTKEY} (likely conflict with another app)`);
-      }
-    } catch (error) {
-      mainError('App', 'Avatar hotkey registration threw:', error);
-    }
-
     // Flush pending deep-link URL (received before window was ready)
     if (pendingDeepLinkUrl) {
       const url = pendingDeepLinkUrl;
@@ -1089,15 +1063,7 @@ app.on('before-quit', (event) => {
   })();
 });
 
-app.on('will-quit', () => {
-  // Release global hotkeys so a relaunch can re-register them and so we
-  // don't leave the system shortcut bound when the app exits.
-  try {
-    globalShortcut.unregisterAll();
-  } catch (error) {
-    mainError('App', 'globalShortcut.unregisterAll failed:', error);
-  }
-});
+app.on('will-quit', () => {});
 
 app.on('quit', (_event, exitCode) => {});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { initMainAdapterWithWindow } from './adapter/main';
+import { createAvatarWindow } from './process/avatarWindow';
 import { ipcBridge } from './common';
 import { AION_ASSET_PROTOCOL } from './extensions/assetProtocol';
 import { initializeProcess } from './process';
@@ -323,6 +324,7 @@ const isVersionMode = hasCommand('--version') || hasCommand('-v');
 let isExplicitQuit = false;
 
 let mainWindow: BrowserWindow;
+let avatarWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let isQuitting = false;
 let closeToTrayEnabled = false;
@@ -563,6 +565,26 @@ const createWindow = (): void => {
   setupApplicationMenu();
   void applyZoomToWindow(mainWindow);
   registerWindowMaximizeListeners(mainWindow);
+
+  // Avatar window (development preview, gated by env var until the user-facing
+  // Settings toggle and persistence land in a follow-up commit). When the
+  // main window closes, the avatar follows.
+  // 桌面悬浮 avatar 窗口（开发期预览）：用环境变量开关，等后续 commit 落
+  // 设置 UI / 持久化后切到用户开关。主窗关闭时 avatar 随之关闭。
+  const avatarDevEnabled = process.env['SUDOWORK_AVATAR_DEV'] === '1' || process.env['SUDOWORK_AVATAR_DEV'] === 'true';
+  if (avatarDevEnabled) {
+    try {
+      avatarWindow = createAvatarWindow();
+      mainWindow.on('closed', () => {
+        if (avatarWindow && !avatarWindow.isDestroyed()) {
+          avatarWindow.close();
+        }
+        avatarWindow = null;
+      });
+    } catch (error) {
+      mainError('App', 'Failed to create avatar window:', error);
+    }
+  }
 
   // Initialize auto-updater service (skip when disabled via env, e.g. E2E / CI, or nightly builds)
   // 初始化自动更新服务（通过环境变量禁用时跳过，例如 E2E / CI 场景；nightly 版本也跳过自动更新提醒）

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
 import 'v8-compile-cache';
 
 import './utils/configureChromium';
-import { app, BrowserWindow, Menu, nativeImage, net, powerMonitor, protocol, screen, Tray } from 'electron';
+import { app, BrowserWindow, globalShortcut, Menu, nativeImage, net, powerMonitor, protocol, screen, Tray } from 'electron';
 import fixPath from 'fix-path';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -356,6 +356,23 @@ function closeAvatarWindow(): void {
   }
   avatarWindow = null;
 }
+
+/**
+ * Toggle avatar visibility from a global hotkey. Mirrors what the user
+ * would get by flipping the Settings switch: opens or closes the window
+ * AND persists `avatar.enabled` so the choice survives a restart.
+ */
+function toggleAvatarFromHotkey(): void {
+  const isOpen = avatarWindow !== null && !avatarWindow.isDestroyed();
+  const target = !isOpen;
+  if (target) openAvatarWindow();
+  else closeAvatarWindow();
+  void ProcessConfig.set('avatar.enabled', target).catch((error: unknown) => {
+    mainError('App', 'Failed to persist avatar.enabled from hotkey:', error);
+  });
+}
+
+const AVATAR_HOTKEY = 'CommandOrControl+Shift+A';
 let isQuitting = false;
 let closeToTrayEnabled = false;
 let quitCleanupInProgress = false;
@@ -905,6 +922,16 @@ const handleAppReady = async (): Promise<void> => {
       else closeAvatarWindow();
     });
 
+    // 注册全局快捷键 / Register global hotkey for avatar toggle
+    try {
+      const registered = globalShortcut.register(AVATAR_HOTKEY, toggleAvatarFromHotkey);
+      if (!registered) {
+        mainError('App', `Failed to register avatar hotkey ${AVATAR_HOTKEY} (likely conflict with another app)`);
+      }
+    } catch (error) {
+      mainError('App', 'Avatar hotkey registration threw:', error);
+    }
+
     // Flush pending deep-link URL (received before window was ready)
     if (pendingDeepLinkUrl) {
       const url = pendingDeepLinkUrl;
@@ -1062,7 +1089,15 @@ app.on('before-quit', (event) => {
   })();
 });
 
-app.on('will-quit', () => {});
+app.on('will-quit', () => {
+  // Release global hotkeys so a relaunch can re-register them and so we
+  // don't leave the system shortcut bound when the app exits.
+  try {
+    globalShortcut.unregisterAll();
+  } catch (error) {
+    mainError('App', 'globalShortcut.unregisterAll failed:', error);
+  }
+});
 
 app.on('quit', (_event, exitCode) => {});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { ProcessConfig } from './process/initStorage';
 import { loadShellEnvironmentAsync, mergePaths } from './process/utils/shellEnv';
 import { initializeAcpDetector } from './process/bridge';
 import { registerWindowMaximizeListeners } from './process/bridge/windowControlsBridge';
-import { onCloseToTrayChanged, onLanguageChanged } from './process/bridge/systemSettingsBridge';
+import { onAvatarEnabledChanged, onCloseToTrayChanged, onLanguageChanged } from './process/bridge/systemSettingsBridge';
 import WorkerManage from './process/WorkerManage';
 import { setupApplicationMenu } from './utils/appMenu';
 import { startWebServer } from './webserver';
@@ -326,6 +326,36 @@ let isExplicitQuit = false;
 let mainWindow: BrowserWindow;
 let avatarWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
+
+/**
+ * SUDOWORK_AVATAR_DEV=1 fast-path for dev iteration: opens the avatar
+ * window immediately without waiting for the persisted user setting
+ * read. Persisted setting still drives behavior at init time and via
+ * the runtime listener below.
+ */
+function isAvatarDevEnvSet(): boolean {
+  const v = process.env['SUDOWORK_AVATAR_DEV'];
+  return v === '1' || v === 'true';
+}
+
+function openAvatarWindow(): void {
+  if (avatarWindow && !avatarWindow.isDestroyed()) return;
+  try {
+    avatarWindow = createAvatarWindow();
+    avatarWindow.on('closed', () => {
+      avatarWindow = null;
+    });
+  } catch (error) {
+    mainError('App', 'Failed to create avatar window:', error);
+  }
+}
+
+function closeAvatarWindow(): void {
+  if (avatarWindow && !avatarWindow.isDestroyed()) {
+    avatarWindow.close();
+  }
+  avatarWindow = null;
+}
 let isQuitting = false;
 let closeToTrayEnabled = false;
 let quitCleanupInProgress = false;
@@ -566,25 +596,18 @@ const createWindow = (): void => {
   void applyZoomToWindow(mainWindow);
   registerWindowMaximizeListeners(mainWindow);
 
-  // Avatar window (development preview, gated by env var until the user-facing
-  // Settings toggle and persistence land in a follow-up commit). When the
-  // main window closes, the avatar follows.
-  // 桌面悬浮 avatar 窗口（开发期预览）：用环境变量开关，等后续 commit 落
-  // 设置 UI / 持久化后切到用户开关。主窗关闭时 avatar 随之关闭。
-  const avatarDevEnabled = process.env['SUDOWORK_AVATAR_DEV'] === '1' || process.env['SUDOWORK_AVATAR_DEV'] === 'true';
-  if (avatarDevEnabled) {
-    try {
-      avatarWindow = createAvatarWindow();
-      mainWindow.on('closed', () => {
-        if (avatarWindow && !avatarWindow.isDestroyed()) {
-          avatarWindow.close();
-        }
-        avatarWindow = null;
-      });
-    } catch (error) {
-      mainError('App', 'Failed to create avatar window:', error);
-    }
+  // Avatar fast-path: SUDOWORK_AVATAR_DEV=1 opens the floating window
+  // immediately (before backend init), useful for dev iteration. The
+  // persisted user setting is honored separately after initializeProcess()
+  // completes — see the post-init block below.
+  // SUDOWORK_AVATAR_DEV=1 在 init 完成前就打开 avatar，方便开发迭代；
+  // 持久化的用户设置由 init 完成后的逻辑读取。
+  if (isAvatarDevEnvSet()) {
+    openAvatarWindow();
   }
+  mainWindow.on('closed', () => {
+    closeAvatarWindow();
+  });
 
   // Initialize auto-updater service (skip when disabled via env, e.g. E2E / CI, or nightly builds)
   // 初始化自动更新服务（通过环境变量禁用时跳过，例如 E2E / CI 场景；nightly 版本也跳过自动更新提醒）
@@ -862,6 +885,24 @@ const handleAppReady = async (): Promise<void> => {
     // 监听语言变更，刷新托盘菜单文案 / Listen for language changes to refresh tray menu labels
     onLanguageChanged(() => {
       refreshTrayMenu();
+    });
+
+    // 初始化 avatar 浮窗：读持久化设置；SUDOWORK_AVATAR_DEV 开发覆盖在窗口创建时已生效
+    // Initialize floating avatar from persisted setting (SUDOWORK_AVATAR_DEV
+    // override is already applied at window creation time)
+    try {
+      const savedAvatarEnabled = await ProcessConfig.get('avatar.enabled');
+      if (savedAvatarEnabled === true) {
+        openAvatarWindow();
+      }
+    } catch (error) {
+      mainError('App', 'Failed to read avatar.enabled setting:', error);
+    }
+    // 监听 avatar 开关变更（用户在设置 UI 切换时立即生效）
+    // Listen for avatar toggle changes (apply immediately when user toggles in Settings)
+    onAvatarEnabledChanged((enabled) => {
+      if (enabled) openAvatarWindow();
+      else closeAvatarWindow();
     });
 
     // Flush pending deep-link URL (received before window was ready)

--- a/src/preload-avatar.ts
+++ b/src/preload-avatar.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { contextBridge, ipcRenderer } from 'electron';
+import { AVATAR_BRIDGE_CHANNEL, type AvatarBridgeMessage } from './common/avatarBridge';
+
+/**
+ * Avatar window preload — minimal capability surface.
+ *
+ * The avatar BrowserWindow is sandboxed and contextIsolated. It MUST NOT
+ * have access to the generic main bridge mega-channel
+ * (ADAPTER_BRIDGE_EVENT_KEY) — that would allow a prompt-injected LLM to
+ * observe arbitrary bridge events and potentially exfiltrate sensitive
+ * state via JS-layer leaks.
+ *
+ * Instead the avatar subscribes to a dedicated channel populated by
+ * src/process/avatarBroadcast.ts, gated by an explicit allowlist on the
+ * main process side. The renderer here can ONLY:
+ *
+ *   - subscribe to allowlisted bridge events via avatarApi.onBridge
+ *
+ * It explicitly cannot:
+ *
+ *   - emit arbitrary bridge messages (no electronAPI.emit equivalent)
+ *   - reach generic ipcRenderer (contextIsolation: true keeps it out of
+ *     the renderer's reach)
+ *   - touch Node.js APIs (sandbox: true)
+ *
+ * MVP-1 will add avatarApi.sendMessage via a dedicated 'avatar:sendMessage'
+ * IPC handle that hardcodes the underlying bridge call to
+ * conversation.sendMessage; arbitrary names will continue to be rejected
+ * at the IPC layer.
+ */
+
+type AvatarApi = {
+  onBridge: (callback: (msg: AvatarBridgeMessage) => void) => () => void;
+};
+
+const avatarApi: AvatarApi = {
+  onBridge: (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, msg: AvatarBridgeMessage): void => {
+      callback(msg);
+    };
+    ipcRenderer.on(AVATAR_BRIDGE_CHANNEL, handler);
+    return () => {
+      ipcRenderer.off(AVATAR_BRIDGE_CHANNEL, handler);
+    };
+  },
+};
+
+contextBridge.exposeInMainWorld('avatarApi', avatarApi);

--- a/src/process/avatarBroadcast.ts
+++ b/src/process/avatarBroadcast.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BrowserWindow } from 'electron';
+import { AVATAR_BRIDGE_CHANNEL } from '../common/avatarBridge';
+
+/**
+ * Bridge message names that are allowed to flow from the main bridge into
+ * avatar windows. Any name not in this Set is dropped — avatar windows are
+ * deliberately NOT registered with initMainAdapterWithWindow, so this Set
+ * is the sole gate for what avatar can observe.
+ *
+ * Adding a new permitted event MUST be an explicit edit here. This prevents
+ * ambient drift where new bridge events accidentally leak into avatar
+ * sandbox.
+ *
+ * Empty in the scaffold commit; populated as MVP-0 / MVP-1 wires up
+ * specific events (e.g. 'chat.response.stream').
+ */
+const AVATAR_ALLOWED_BROADCAST_NAMES: ReadonlySet<string> = new Set<string>();
+
+const avatarWindows: BrowserWindow[] = [];
+
+/**
+ * Register an avatar window to receive allowlisted bridge broadcasts.
+ *
+ * Avatar windows MUST NOT also be registered via
+ * initMainAdapterWithWindow — doing so would defeat the capability
+ * isolation by exposing the generic mega-channel
+ * (ADAPTER_BRIDGE_EVENT_KEY) to the avatar process.
+ *
+ * Returns an unregister function (also wired to win.on('closed')).
+ */
+export function registerAvatarWindow(win: BrowserWindow): () => void {
+  avatarWindows.push(win);
+  const off = (): void => {
+    const idx = avatarWindows.indexOf(win);
+    if (idx > -1) avatarWindows.splice(idx, 1);
+  };
+  win.on('closed', off);
+  return off;
+}
+
+/**
+ * Forward a bridge broadcast to all registered avatar windows, gated by
+ * the allowlist. Called from src/adapter/main.ts after the existing
+ * fan-out loop.
+ */
+export function forwardBroadcastToAvatars(name: string, data: unknown): void {
+  if (!AVATAR_ALLOWED_BROADCAST_NAMES.has(name)) return;
+  for (const win of avatarWindows) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(AVATAR_BRIDGE_CHANNEL, { name, data });
+    }
+  }
+}

--- a/src/process/avatarBroadcast.ts
+++ b/src/process/avatarBroadcast.ts
@@ -20,7 +20,12 @@ import { AVATAR_BRIDGE_CHANNEL } from '../common/avatarBridge';
  * Empty in the scaffold commit; populated as MVP-0 / MVP-1 wires up
  * specific events (e.g. 'chat.response.stream').
  */
-const AVATAR_ALLOWED_BROADCAST_NAMES: ReadonlySet<string> = new Set<string>();
+const AVATAR_ALLOWED_BROADCAST_NAMES: ReadonlySet<string> = new Set<string>([
+  // ACP per-message stream — drives the avatar's visual FSM (idle / thinking
+  // / error in MVP-0; expanded to 7 states in MVP-1). Channel is named via
+  // ipcBridge.acpConversation.responseStream definition in src/common/ipcBridge.ts.
+  'chat.response.stream',
+]);
 
 const avatarWindows: BrowserWindow[] = [];
 

--- a/src/process/avatarWindow.ts
+++ b/src/process/avatarWindow.ts
@@ -7,10 +7,44 @@
 import { BrowserWindow, app, screen } from 'electron';
 import * as path from 'path';
 import { registerAvatarWindow } from './avatarBroadcast';
+import { ProcessConfig } from './initStorage';
+import { mainError } from './utils/mainLogger';
 
 const AVATAR_WIDTH = 220;
 const AVATAR_HEIGHT = 220;
 const SCREEN_MARGIN = 16;
+
+type AvatarBounds = { x: number; y: number; width: number; height: number };
+
+/**
+ * Validate that a saved bounds rectangle is still on a connected display.
+ * Returns the bounds when usable, or null when the user changed monitors
+ * and the saved position is now off-screen.
+ */
+function pickRestoreBounds(saved: AvatarBounds | undefined): AvatarBounds | null {
+  if (!saved) return null;
+  if (typeof saved.x !== 'number' || typeof saved.y !== 'number' || typeof saved.width !== 'number' || typeof saved.height !== 'number') return null;
+  // Confirm the rect intersects at least one display so the avatar isn't
+  // restored into an invisible region (e.g. after a monitor unplug).
+  const display = screen.getDisplayMatching({
+    x: saved.x,
+    y: saved.y,
+    width: saved.width,
+    height: saved.height,
+  });
+  if (!display) return null;
+  return saved;
+}
+
+function defaultBottomRightBounds(): AvatarBounds {
+  const workArea = screen.getPrimaryDisplay().workArea;
+  return {
+    x: workArea.x + workArea.width - AVATAR_WIDTH - SCREEN_MARGIN,
+    y: workArea.y + workArea.height - AVATAR_HEIGHT - SCREEN_MARGIN,
+    width: AVATAR_WIDTH,
+    height: AVATAR_HEIGHT,
+  };
+}
 
 /**
  * Create the floating avatar BrowserWindow.
@@ -37,16 +71,23 @@ const SCREEN_MARGIN = 16;
  * avatarBroadcast.ts for the rationale.
  */
 export function createAvatarWindow(): BrowserWindow {
-  const primaryDisplay = screen.getPrimaryDisplay();
-  const workArea = primaryDisplay.workArea;
-  const initialX = workArea.x + workArea.width - AVATAR_WIDTH - SCREEN_MARGIN;
-  const initialY = workArea.y + workArea.height - AVATAR_HEIGHT - SCREEN_MARGIN;
+  // Resolve initial bounds: prefer the saved last-known position when
+  // it still maps to a connected display; otherwise place at the
+  // bottom-right above the taskbar.
+  // ProcessConfig.get is async — we instantiate the window synchronously
+  // with the default position and snap to persisted bounds once they
+  // resolve (typically before paint, so the user does not see a jump).
+  const initialBounds = defaultBottomRightBounds();
+  const persistedBoundsPromise = ProcessConfig.get('avatar.bounds').catch((error: unknown): undefined => {
+    mainError('Avatar', 'Failed to read avatar.bounds:', error);
+    return undefined;
+  });
 
   const win = new BrowserWindow({
-    width: AVATAR_WIDTH,
-    height: AVATAR_HEIGHT,
-    x: initialX,
-    y: initialY,
+    width: initialBounds.width,
+    height: initialBounds.height,
+    x: initialBounds.x,
+    y: initialBounds.y,
     frame: false,
     transparent: true,
     hasShadow: false,
@@ -63,6 +104,25 @@ export function createAvatarWindow(): BrowserWindow {
   });
 
   registerAvatarWindow(win);
+
+  // If persisted bounds resolve before the window paints, snap to them.
+  void persistedBoundsPromise.then((saved): void => {
+    const restored = pickRestoreBounds(saved as AvatarBounds | undefined);
+    if (restored && !win.isDestroyed()) {
+      win.setBounds(restored);
+    }
+  });
+
+  // Persist the last-known bounds on close so the next launch restores
+  // the user's preferred position. 'close' fires before the window is
+  // destroyed and getBounds() is still valid.
+  win.on('close', () => {
+    if (win.isDestroyed()) return;
+    const current = win.getBounds();
+    void ProcessConfig.set('avatar.bounds', current).catch((error) => {
+      mainError('Avatar', 'Failed to persist avatar.bounds:', error);
+    });
+  });
 
   win.once('ready-to-show', () => {
     if (!win.isDestroyed()) win.show();

--- a/src/process/avatarWindow.ts
+++ b/src/process/avatarWindow.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BrowserWindow, app, screen } from 'electron';
+import * as path from 'path';
+import { registerAvatarWindow } from './avatarBroadcast';
+
+const AVATAR_WIDTH = 220;
+const AVATAR_HEIGHT = 220;
+const SCREEN_MARGIN = 16;
+
+/**
+ * Create the floating avatar BrowserWindow.
+ *
+ * Security posture (MVP-0):
+ *   - sandbox: true              renderer has no Node API
+ *   - contextIsolation: true     renderer cannot reach Electron internals
+ *   - nodeIntegration: false     defense in depth
+ *   - dedicated preload          exposes only avatarApi.onBridge for now
+ *
+ * Window posture:
+ *   - transparent + frameless    visual is the SVG orb only, no chrome
+ *   - alwaysOnTop                overlay above all other windows
+ *   - skipTaskbar                does not clutter taskbar / dock
+ *   - hasShadow: false           pure transparency, no rectangular shadow
+ *   - resizable: false           fixed 220x220 footprint
+ *
+ * Initial position: bottom-right corner above the taskbar, similar to an
+ * input method floating window. workArea already excludes the taskbar.
+ *
+ * Avatar windows are registered with avatarBroadcast.ts which provides
+ * capability-gated bridge event forwarding via a dedicated AVATAR_BRIDGE_CHANNEL.
+ * Avatar windows are NOT added to the main bridge adapterWindowList — see
+ * avatarBroadcast.ts for the rationale.
+ */
+export function createAvatarWindow(): BrowserWindow {
+  const primaryDisplay = screen.getPrimaryDisplay();
+  const workArea = primaryDisplay.workArea;
+  const initialX = workArea.x + workArea.width - AVATAR_WIDTH - SCREEN_MARGIN;
+  const initialY = workArea.y + workArea.height - AVATAR_HEIGHT - SCREEN_MARGIN;
+
+  const win = new BrowserWindow({
+    width: AVATAR_WIDTH,
+    height: AVATAR_HEIGHT,
+    x: initialX,
+    y: initialY,
+    frame: false,
+    transparent: true,
+    hasShadow: false,
+    alwaysOnTop: true,
+    resizable: false,
+    skipTaskbar: true,
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/avatar.js'),
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  registerAvatarWindow(win);
+
+  win.once('ready-to-show', () => {
+    if (!win.isDestroyed()) win.show();
+  });
+
+  // Load the avatar renderer. In dev, electron-vite serves multi-HTML
+  // entries under ELECTRON_RENDERER_URL with the input key as the path.
+  // In production, the build emits a directory matching the input key.
+  const rendererUrl = process.env['ELECTRON_RENDERER_URL'];
+  if (!app.isPackaged && rendererUrl) {
+    void win.loadURL(`${rendererUrl}/src/renderer/avatar/index.html`);
+  } else {
+    void win.loadFile(path.join(__dirname, '../renderer/src/renderer/avatar/index.html'));
+  }
+
+  return win;
+}

--- a/src/process/avatarWindow.ts
+++ b/src/process/avatarWindow.ts
@@ -128,14 +128,15 @@ export function createAvatarWindow(): BrowserWindow {
     if (!win.isDestroyed()) win.show();
   });
 
-  // Load the avatar renderer. In dev, electron-vite serves multi-HTML
-  // entries under ELECTRON_RENDERER_URL with the input key as the path.
-  // In production, the build emits a directory matching the input key.
+  // Load the avatar renderer. electron-vite sets the renderer's vite root
+  // to `src/renderer/`, so URLs are relative to that root: the dev server
+  // serves `src/renderer/avatar/index.html` at /avatar/index.html, and the
+  // production build emits to out/renderer/avatar/index.html.
   const rendererUrl = process.env['ELECTRON_RENDERER_URL'];
   if (!app.isPackaged && rendererUrl) {
-    void win.loadURL(`${rendererUrl}/src/renderer/avatar/index.html`);
+    void win.loadURL(`${rendererUrl}/avatar/index.html`);
   } else {
-    void win.loadFile(path.join(__dirname, '../renderer/src/renderer/avatar/index.html'));
+    void win.loadFile(path.join(__dirname, '../renderer/avatar/index.html'));
   }
 
   return win;

--- a/src/process/bridge/systemSettingsBridge.ts
+++ b/src/process/bridge/systemSettingsBridge.ts
@@ -23,6 +23,9 @@ let _changeListener: CloseToTrayChangeListener | null = null;
 type LanguageChangeListener = () => void;
 let _languageChangeListener: LanguageChangeListener | null = null;
 
+type AvatarEnabledChangeListener = (enabled: boolean) => void;
+let _avatarEnabledChangeListener: AvatarEnabledChangeListener | null = null;
+
 /**
  * 注册关闭到托盘设置变更监听器（供主进程 index.ts 使用）
  * Register a listener for close-to-tray setting changes (used by main process index.ts)
@@ -39,6 +42,15 @@ export function onLanguageChanged(listener: LanguageChangeListener): void {
   _languageChangeListener = listener;
 }
 
+/**
+ * 注册 avatar 浮窗开关变更监听器（供主进程 index.ts 使用，控制 avatar 窗口生命周期）
+ * Register a listener for avatar-enabled setting changes (used by main process
+ * index.ts to create / destroy the floating avatar BrowserWindow at runtime).
+ */
+export function onAvatarEnabledChanged(listener: AvatarEnabledChangeListener): void {
+  _avatarEnabledChangeListener = listener;
+}
+
 export function initSystemSettingsBridge(): void {
   // 获取"关闭到托盘"设置 / Get "close to tray" setting
   ipcBridge.systemSettings.getCloseToTray.provider(async () => {
@@ -53,6 +65,19 @@ export function initSystemSettingsBridge(): void {
     await ProcessConfig.set('system.closeToTray', enabled);
     // 然后通知主进程更新托盘状态
     _changeListener?.(enabled);
+  });
+
+  // 获取 avatar 浮窗开关 / Get floating avatar window enabled setting
+  ipcBridge.systemSettings.getAvatarEnabled.provider(async () => {
+    const value = await ProcessConfig.get('avatar.enabled');
+    return value ?? false;
+  });
+
+  // 设置 avatar 浮窗开关，先持久化再通知主进程切换窗口
+  // Set avatar enabled, persist first then notify main process to toggle window
+  ipcBridge.systemSettings.setAvatarEnabled.provider(async ({ enabled }) => {
+    await ProcessConfig.set('avatar.enabled', enabled);
+    _avatarEnabledChangeListener?.(enabled);
   });
 
   // 语言变更通知，同步主进程 i18n 并通知托盘重建

--- a/src/renderer/avatar/App.css
+++ b/src/renderer/avatar/App.css
@@ -11,11 +11,37 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
+  transition:
+    background 150ms ease-out,
+    box-shadow 150ms ease-out,
+    transform 150ms ease-out;
+}
+
+/* idle: gentle blue breathing */
+.orb-idle {
   background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.85) 0%, rgba(120, 180, 255, 0.85) 25%, rgba(50, 100, 200, 0.6) 70%, rgba(30, 60, 140, 0.4) 100%);
   box-shadow:
     0 0 32px 8px rgba(80, 140, 220, 0.4),
     0 0 12px 2px rgba(255, 255, 255, 0.3) inset;
   animation: orb-breathe 4s ease-in-out infinite;
+}
+
+/* thinking: brighter cyan, faster pulse */
+.orb-thinking {
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.95) 0%, rgba(140, 220, 255, 0.95) 20%, rgba(60, 160, 230, 0.75) 65%, rgba(30, 100, 180, 0.5) 100%);
+  box-shadow:
+    0 0 40px 10px rgba(100, 180, 255, 0.55),
+    0 0 16px 3px rgba(255, 255, 255, 0.4) inset;
+  animation: orb-pulse 1.6s ease-in-out infinite;
+}
+
+/* error: red, brief shake then settle */
+.orb-error {
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 150, 150, 0.85) 25%, rgba(220, 60, 60, 0.7) 70%, rgba(140, 30, 30, 0.5) 100%);
+  box-shadow:
+    0 0 36px 8px rgba(220, 80, 80, 0.55),
+    0 0 12px 2px rgba(255, 255, 255, 0.3) inset;
+  animation: orb-shake 600ms ease-out 1;
 }
 
 @keyframes orb-breathe {
@@ -27,5 +53,36 @@
   50% {
     transform: scale(1.08);
     opacity: 1;
+  }
+}
+
+@keyframes orb-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.14);
+    opacity: 0.85;
+  }
+}
+
+@keyframes orb-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-6px);
+  }
+  40% {
+    transform: translateX(6px);
+  }
+  60% {
+    transform: translateX(-4px);
+  }
+  80% {
+    transform: translateX(4px);
   }
 }

--- a/src/renderer/avatar/App.css
+++ b/src/renderer/avatar/App.css
@@ -1,0 +1,31 @@
+.orb-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-app-region: drag;
+}
+
+.orb {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.85) 0%, rgba(120, 180, 255, 0.85) 25%, rgba(50, 100, 200, 0.6) 70%, rgba(30, 60, 140, 0.4) 100%);
+  box-shadow:
+    0 0 32px 8px rgba(80, 140, 220, 0.4),
+    0 0 12px 2px rgba(255, 255, 255, 0.3) inset;
+  animation: orb-breathe 4s ease-in-out infinite;
+}
+
+@keyframes orb-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.92;
+  }
+  50% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}

--- a/src/renderer/avatar/App.tsx
+++ b/src/renderer/avatar/App.tsx
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+/**
+ * Avatar root component — MVP-0 placeholder orb.
+ *
+ * Renders a transparent breathing orb in the center of the avatar window.
+ * Subsequent commits will:
+ *   - subscribe to avatarApi.onBridge for chat.response.stream events
+ *   - drive a 3-state FSM (idle / thinking / error) over orb visuals
+ */
+const App: React.FC = () => {
+  return (
+    <div className='orb-container'>
+      <div className='orb' />
+    </div>
+  );
+};
+
+export default App;

--- a/src/renderer/avatar/App.tsx
+++ b/src/renderer/avatar/App.tsx
@@ -4,20 +4,102 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 /**
- * Avatar root component — MVP-0 placeholder orb.
+ * Avatar root component — MVP-0 placeholder orb with a 3-state FSM driven
+ * by the ACP response stream forwarded over the dedicated avatar:bridge
+ * channel.
  *
- * Renders a transparent breathing orb in the center of the avatar window.
- * Subsequent commits will:
- *   - subscribe to avatarApi.onBridge for chat.response.stream events
- *   - drive a 3-state FSM (idle / thinking / error) over orb visuals
+ * State machine (MVP-0 simplified — MVP-1 expands to 7 states):
+ *   - idle      Initial state; resumed 1s after a 'finish' event
+ *   - thinking  Entered on 'start' / 'thought' / 'content' / 'tool_call'
+ *               / 'acp_tool_call'
+ *   - error     Entered on 'error'; sticks until the next 'start'
+ *
+ * Visual differentiation lives in CSS classes (.orb-idle / .orb-thinking
+ * / .orb-error). Transitions are <150ms.
  */
+
+type AvatarFsmState = 'idle' | 'thinking' | 'error';
+
+const FINISH_TO_IDLE_DEBOUNCE_MS = 1000;
+
+/**
+ * Minimal subset of ACP IResponseMessage shape this renderer cares about.
+ * The full type lives in src/common/ipcBridge.ts and is intentionally NOT
+ * imported here to keep the avatar renderer bundle lean and decoupled from
+ * the main renderer's typings.
+ */
+type AcpResponseMessage = {
+  type: string;
+};
+
+const isAcpResponseMessage = (data: unknown): data is AcpResponseMessage => {
+  return typeof data === 'object' && data !== null && 'type' in data && typeof (data as { type: unknown }).type === 'string';
+};
+
 const App: React.FC = () => {
+  const [fsmState, setFsmState] = useState<AvatarFsmState>('idle');
+
+  useEffect(() => {
+    const api = window.avatarApi;
+    if (!api) {
+      // Preload not loaded (e.g. dev mode mismatch). Stay in idle and log
+      // for diagnostic purposes; the orb still renders so the window is
+      // visibly alive.
+      console.warn('[Avatar] window.avatarApi missing; preload may not be wired');
+      return;
+    }
+
+    let finishDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearDebounce = (): void => {
+      if (finishDebounceTimer !== null) {
+        clearTimeout(finishDebounceTimer);
+        finishDebounceTimer = null;
+      }
+    };
+
+    const unsubscribe = api.onBridge((msg) => {
+      if (msg.name !== 'chat.response.stream') return;
+      if (!isAcpResponseMessage(msg.data)) return;
+
+      const eventType = msg.data.type;
+      switch (eventType) {
+        case 'start':
+        case 'thought':
+        case 'content':
+        case 'tool_call':
+        case 'acp_tool_call':
+          clearDebounce();
+          setFsmState('thinking');
+          break;
+        case 'finish':
+          clearDebounce();
+          finishDebounceTimer = setTimeout(() => {
+            setFsmState('idle');
+            finishDebounceTimer = null;
+          }, FINISH_TO_IDLE_DEBOUNCE_MS);
+          break;
+        case 'error':
+          clearDebounce();
+          setFsmState('error');
+          break;
+        default:
+          // Ignore other event types in MVP-0; MVP-1 expands the FSM.
+          break;
+      }
+    });
+
+    return () => {
+      clearDebounce();
+      unsubscribe();
+    };
+  }, []);
+
   return (
     <div className='orb-container'>
-      <div className='orb' />
+      <div className={`orb orb-${fsmState}`} data-state={fsmState} />
     </div>
   );
 };

--- a/src/renderer/avatar/index.html
+++ b/src/renderer/avatar/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sudowork Avatar</title>
+    <style>
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        background: transparent;
+        overflow: hidden;
+        -webkit-user-select: none;
+        user-select: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/src/renderer/avatar/index.ts
+++ b/src/renderer/avatar/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './App.css';
+
+const container = document.getElementById('root');
+if (!container) {
+  throw new Error('Avatar root element not found');
+}
+const root = createRoot(container);
+root.render(React.createElement(App));

--- a/src/renderer/avatar/types.d.ts
+++ b/src/renderer/avatar/types.d.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AvatarBridgeMessage } from '@/common/avatarBridge';
+
+declare global {
+  interface Window {
+    avatarApi: {
+      onBridge: (callback: (msg: AvatarBridgeMessage) => void) => () => void;
+    };
+  }
+}
+
+export {};

--- a/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
@@ -144,6 +144,23 @@ const SystemModalContent: React.FC = () => {
     });
   }, []);
 
+  // 桌面 avatar 浮窗开关 / Floating desktop avatar toggle
+  const [avatarEnabled, setAvatarEnabled] = useState(false);
+
+  useEffect(() => {
+    ipcBridge.systemSettings.getAvatarEnabled
+      .invoke()
+      .then((enabled) => setAvatarEnabled(enabled))
+      .catch(() => {});
+  }, []);
+
+  const handleAvatarEnabledChange = useCallback((checked: boolean) => {
+    setAvatarEnabled(checked);
+    ipcBridge.systemSettings.setAvatarEnabled.invoke({ enabled: checked }).catch(() => {
+      setAvatarEnabled(!checked);
+    });
+  }, []);
+
   // 超时设置状态 / Timeout settings state
   const [promptTimeout, setPromptTimeout] = useState(DEFAULT_PROMPT_TIMEOUT);
   const [idleTimeout, setIdleTimeout] = useState(DEFAULT_IDLE_TIMEOUT);
@@ -201,6 +218,12 @@ const SystemModalContent: React.FC = () => {
     { key: 'language', label: t('settings.language'), component: <LanguageSwitcher /> },
     { key: 'theme', label: t('settings.theme'), component: <ThemeSwitcher /> },
     { key: 'closeToTray', label: t('settings.closeToTray'), component: <Switch checked={closeToTray} onChange={handleCloseToTrayChange} /> },
+    {
+      key: 'avatarEnabled',
+      label: t('settings.avatarEnabled'),
+      hint: t('settings.avatarEnabledDesc'),
+      component: <Switch checked={avatarEnabled} onChange={handleAvatarEnabledChange} />,
+    },
     {
       key: 'promptTimeout',
       label: t('settings.promptTimeout'),

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -107,6 +107,8 @@
   "cacheClearFailed": "Failed to clear cache",
   "language": "Language",
   "closeToTray": "Close to Tray",
+  "avatarEnabled": "Floating avatar",
+  "avatarEnabledDesc": "Show a floating desktop companion that reflects your active conversation",
   "gemini": "Gemini",
   "model": "Model",
   "runtime": "Runtime",

--- a/src/renderer/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/i18n/locales/ja-JP/settings.json
@@ -107,6 +107,8 @@
   "cacheClearFailed": "Failed to clear cache",
   "language": "言語",
   "closeToTray": "トレイに最小化",
+  "avatarEnabled": "フローティング アバター",
+  "avatarEnabledDesc": "現在の会話状態を反映するフローティング デスクトップ コンパニオンを表示",
   "gemini": "Gemini",
   "model": "モデル",
   "runtime": "ランタイム",

--- a/src/renderer/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/i18n/locales/ko-KR/settings.json
@@ -107,6 +107,8 @@
   "cacheClearFailed": "캐시 정리 실패",
   "language": "언어",
   "closeToTray": "트레이로 닫기",
+  "avatarEnabled": "플로팅 아바타",
+  "avatarEnabledDesc": "현재 대화 상태를 반영하는 플로팅 데스크톱 컴패니언 표시",
   "gemini": "Gemini",
   "model": "모델",
   "runtime": "런타임",

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -105,6 +105,8 @@
   "cacheClearFailed": "Önbellek temizlenemedi",
   "language": "Dil",
   "closeToTray": "Tepsiye Kapat",
+  "avatarEnabled": "Yüzen Avatar",
+  "avatarEnabledDesc": "Aktif konuşmanızı yansıtan yüzen masaüstü yardımcısını göster",
   "gemini": "Gemini",
   "model": "Model",
   "runtime": "Çalışma Zamanı",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -107,6 +107,8 @@
   "cacheClearFailed": "缓存清理失败",
   "language": "语言",
   "closeToTray": "关闭到托盘",
+  "avatarEnabled": "桌面 Avatar 浮窗",
+  "avatarEnabledDesc": "在桌面显示一个跟随当前对话状态的浮动伙伴",
   "gemini": "Gemini",
   "model": "模型",
   "runtime": "运行环境",

--- a/src/renderer/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/i18n/locales/zh-TW/settings.json
@@ -107,6 +107,8 @@
   "cacheClearFailed": "Failed to clear cache",
   "language": "語言",
   "closeToTray": "關閉到托盤",
+  "avatarEnabled": "桌面 Avatar 浮動視窗",
+  "avatarEnabledDesc": "在桌面顯示一個跟隨目前對話狀態的浮動夥伴",
   "gemini": "Gemini",
   "model": "模型",
   "runtime": "執行環境",


### PR DESCRIPTION
## Summary

MVP-0 of the sudowork-avatar floating desktop companion. Adds an independent transparent always-on-top BrowserWindow with a placeholder breathing orb, capability-isolated bridge (sandbox + contextIsolation + dedicated IPC channel + main-side allowlist), and a 3-state visual FSM driven by the existing ACP response stream. Default OFF — users opt in via System Settings.

This PR is delivered as 9 focused commits — each compiles, lints, types, and tests cleanly on its own. **Reviewers should review commit-by-commit; `gh pr merge --rebase` preserves the full history per repo convention.**

Full product / architecture spec: [sudowork-avatar README](https://github.com/elfenlieds7/sudowork-avatar/blob/main/README.md) (§2.9 security, §3.2 MVP-0 scope).

## Commit-by-commit walkthrough

| Commit | Scope |
|---|---|
| `chore(avatar): scaffold capability-isolated avatar window infrastructure` | New files (preload-avatar / avatarBroadcast / avatarWindow / renderer entry) + electron-vite multi-entry registration + 1-line dispatch hook in `src/adapter/main.ts` (no-op until allowlist populated) |
| `feat(avatar): create floating window in dev mode behind env flag` | `SUDOWORK_AVATAR_DEV=1` opens the window during `createWindow()`. Closes alongside the main window. |
| `feat(avatar): drive 3-state FSM from chat.response.stream` | Allowlists `chat.response.stream`. App.tsx subscribes via `window.avatarApi.onBridge` and switches between idle / thinking / error states with CSS animations. |
| `feat(avatar): user-facing Settings toggle drives avatar window lifecycle` | Adds `getAvatarEnabled` / `setAvatarEnabled` system-settings bridge methods, `avatar.enabled` ProcessConfig key, `onAvatarEnabledChanged` listener, and a Switch row in System Settings (with i18n in 6 locales). Default OFF. Env flag still works as dev override. |
| `feat(avatar): persist window position across sessions` | Saves `avatar.bounds` on close, restores on open. Validates the saved rect against currently connected displays via `screen.getDisplayMatching`; falls back to bottom-right default when invalid. |
| `feat(avatar): global hotkey toggle (CommandOrControl+Shift+A)` | _(later reverted; see below)_ |
| `ci: re-trigger build` | Empty commit to retrigger CI after rapid back-to-back pushes had it dedup'd. |
| `fix(avatar): correct dev/prod renderer URL relative to vite root` | Smoke-test fix: dev URL was `${rendererUrl}/src/renderer/avatar/index.html`, but electron-vite serves the renderer with vite root at `src/renderer/`, so the correct path is `${rendererUrl}/avatar/index.html`. The wrong path silently fell back to the main window HTML. |
| `revert(avatar): drop global hotkey from MVP-0, defer to MVP-1` | Removes the global hotkey path. Both candidate chords (Ctrl+Shift+A, Ctrl+Alt+A) had real-world conflicts on test machines. MVP-1 plans a user-configurable hotkey input — fixed defaults can't be made universally conflict-free. Settings toggle is the sole MVP-0 entry point. |

## Why a dedicated IPC channel instead of reusing `adapterWindowList`

The avatar window is sandboxed + contextIsolated, intended to host LLM-driven content susceptible to prompt injection. Reusing the generic main bridge mega-channel (`ADAPTER_BRIDGE_EVENT_KEY`) would expose **every** bridge event to the avatar process, requiring per-event filter trust at the preload layer.

Instead the allowlist lives at the main process boundary. The avatar renderer literally never receives events the main process chose not to forward. Adding a new permitted event requires an explicit edit to `AVATAR_ALLOWED_BROADCAST_NAMES`, eliminating ambient drift.

| | preload-side filter (rejected) | main-side allowlist (this PR) |
|---|---|---|
| Allowlist location | preload (runtime trust) | main process Set (hardcoded) |
| Avatar process IPC reach | All bridge events arrive | Only allowlisted events arrive |
| Preload bug consequence | Mega channel leaks if filter wrong | Capped by main-side gate |
| Audit surface | Scattered if-chains | Single Set literal |

## Acceptance Criteria — verified end-to-end

Local smoke test against a running dev build (CDP attach via ai-dev-browser; pyautogui for OS-level mouse where needed):

- [x] **Avatar window creates correctly** — bounds `{x:3604, y:1316, w:220, h:220}` (bottom-right of multi-monitor setup), transparent, frameless, alwaysOnTop, skipTaskbar.
- [x] **Renderer loads avatar entry** — `http://localhost:5600/avatar/index.html` after path fix; React mounts; `.orb` element with `data-state="idle"` rendered.
- [x] **Placeholder orb renders** — blue radial gradient with breathing animation (idle); cyan with brighter glow (thinking) — see `docs/avatar-visual/mvp0-orb-{idle,thinking}.png` in the [spec repo](https://github.com/elfenlieds7/sudowork-avatar/tree/main/docs/avatar-visual).
- [x] **FSM transitions correctly end-to-end** — drove a real Sudoclaw conversation via CDP keyboard (skip init → 新会话 → type → Enter):

  ```
  t=0       idle
  t=7.81s   thinking      ← chat.response.stream type=content
  t=8.81s   idle          ← chat.response.stream type=finish + 1s debounce
  ```

  Bridge logger captured: `[{name:'chat.response.stream', type:'content'}, {name:'chat.response.stream', type:'finish'}]` — confirming the main-side allowlist forwards correctly and avatar's preload onBridge delivers to renderer.

- [x] **Sandbox / capability isolation verified** — `typeof require === 'undefined'`; `window.avatarApi` exposes only `onBridge` (no generic emit); avatar process never receives events outside the allowlist.
- [x] **Settings toggle wired** — `getAvatarEnabled` / `setAvatarEnabled` providers persist `avatar.enabled` and notify the main-process listener which opens / closes the avatar window. Default OFF. Verified end-to-end (toggle OFF closes window, toggle ON reopens it).
- [x] **Position memory** — moved avatar via `window.moveTo(800, 400)`, toggled OFF (saves bounds), toggled ON (`createAvatarWindow` reads + restores). Result: window reopens at exactly `(800, 400)` — delta 0px.
- [x] _(reverted)_ Global hotkey — removed from MVP-0 after both candidate chords showed real-world conflicts. MVP-1 will expose user-configurable hotkey input.

What's **explicitly out of scope** for MVP-0 (deferred to MVP-1+):

- Text bubble / dedicated avatar conversation / pet persona / 7-state FSM
- STT / screen capture / content filter
- Live2D / 3D / overlay drawing
- User-configurable global hotkey (to replace the reverted hardcoded chord)

## Notes for reviewers

- Pre-existing tsc error at `src/renderer/pages/conversation/workspace/index.tsx:1210` (Arco Tree `onRightClick` prop, introduced in `078eba3c2` on 2026-04-23) is unrelated to this PR.
- Pre-existing 32 vitest failures on origin/dev tip are unaffected by this PR (verified via stash + rerun).
- Sandbox claim accuracy: only `require()` and Node module APIs are blocked by `sandbox: true`. `process` (Electron's sandboxed view), `fetch`, and `XMLHttpRequest` remain accessible by design — security comes from the multi-layer allowlist + Electron's webSecurity / CORS, not from disabling browser APIs. Spec [§2.9 in sudowork-avatar README](https://github.com/elfenlieds7/sudowork-avatar/blob/main/README.md) was corrected accordingly after the smoke test.

## Test plan

Each commit ran through the local quality gates before being pushed:
- [x] `node_modules/.bin/eslint --fix` clean on touched files
- [x] `node_modules/.bin/prettier --check` clean on touched files
- [x] `node_modules/.bin/tsc --noEmit` shows no new errors (pre-existing `workspace/index.tsx:1210` tracked separately)
- [x] `node_modules/.bin/vitest run` shows no new failures vs origin/dev baseline (32 fail pre-existing, 32 fail with PR — 0 regression)
- [x] **Real UI smoke test** — drove sudowork main window via CDP, sent a chat, observed avatar FSM transitions matching spec; verified Settings toggle and position memory end-to-end

CI required:
- [ ] macOS arm64 / macOS x64 / Windows x64 / Windows arm64 builds + Release Script Test
