### PR TITLE
fix(acp): inject Claude Code OAuth token for scode subscription auth

### DIFF
--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -418,6 +418,22 @@ export async function spawnGenericBackend(backend: string, cliPath: string, work
     }
   }
 
+  // Inject Claude Code OAuth token for scode subscription auth if available
+  if (backend === 'scode' && !cleanEnv.CLAUDE_CODE_OAUTH_TOKEN) {
+    try {
+      const keychain = require('child_process').execFileSync('security', [
+        'find-generic-password', '-s', 'Claude Code-credentials', '-a', require('os').userInfo().username, '-w',
+      ], { encoding: 'utf-8', timeout: 3000 }).trim();
+      const payload = JSON.parse(keychain);
+      if (payload?.claudeAiOauth?.accessToken) {
+        cleanEnv.CLAUDE_CODE_OAUTH_TOKEN = payload.claudeAiOauth.accessToken;
+        mainLog('[ACP scode]', 'Injected Claude Code OAuth token from keychain');
+      }
+    } catch {
+      // Claude Code credentials not available — scode will use other auth methods
+    }
+  }
+
   ensureMinNodeVersion(cleanEnv, 18, 17, `${backend} ACP`);
 
   const spawnStart = Date.now();


### PR DESCRIPTION
## Summary
- Inject `CLAUDE_CODE_OAUTH_TOKEN` from Claude Code's macOS Keychain when spawning scode ACP backend, enabling subscription auth mode
- Existing injection only provided `ANTHROPIC_API_KEY` (proxy mode) — subscription auth had no token and failed with "no token available for subscription provider"
- Bump ai-dev-browser submodule to latest

## Test plan
- [x] `scode login` imports CC token successfully
- [x] Start sudowork, select Sudo Code agent, send "hello, what can you do?" — scode responds with full capability list
- [x] Dev server logs show `[ACP scode] Injected Claude Code OAuth token from keychain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)