### PR TITLE
test(e2e): add 6 scode integration test cases

### DIFF
--- a/tests/e2e/cases/scode-agent-switch.yaml
+++ b/tests/e2e/cases/scode-agent-switch.yaml
@@ -1,0 +1,75 @@
+name: "scode agent switch"
+description: >
+  Test switching between Sudoclaw and Sudo Code agents within the same
+  session. Verify each agent responds independently and correctly.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Start with Sudoclaw ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudoclaw"
+  - op: pause
+    duration: 3000
+  - op: type_text
+    text: "Reply with exactly: I am Sudoclaw."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-switch-01-sudoclaw.png"
+  - op: judge
+    expect: "Sudoclaw"
+
+  # ── Phase 2: Switch to Sudo Code in a new conversation ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+  - op: type_text
+    text: "Reply with exactly: I am Sudo Code."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-switch-02-sudocode.png"
+  - op: judge
+    expect: "Sudo Code"
+
+  # ── Phase 3: Switch back to Sudoclaw, verify independent ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudoclaw"
+  - op: pause
+    duration: 3000
+  - op: type_text
+    text: "What is 2+2? Reply with the word for the number, not the digit."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-switch-03-back.png"
+  - op: judge
+    expect: "four"

--- a/tests/e2e/cases/scode-basic-conversation.yaml
+++ b/tests/e2e/cases/scode-basic-conversation.yaml
@@ -1,0 +1,50 @@
+name: "scode basic conversation"
+description: >
+  Smoke test: select Sudo Code agent, send a greeting, verify it responds,
+  then send a follow-up question to verify multi-turn context is preserved.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Navigate to new conversation and select Sudo Code ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+  - op: screenshot
+    path: "screenshots/scode-basic-00-selected.png"
+  - op: judge
+    expect: "Sudo Code"
+
+  # ── Phase 2: Send greeting ──
+  - op: type_text
+    text: "Hello! Tell me your name and list 3 things you can help with. Keep it brief."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-basic-01-greeting.png"
+  - op: judge
+    expect: "code file search"
+
+  # ── Phase 3: Follow-up to verify multi-turn context ──
+  - op: type_text
+    text: "Expand on the first thing you listed. Give a concrete example."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-basic-02-followup.png"
+  - op: judge
+    expect: "example"

--- a/tests/e2e/cases/scode-code-and-run.yaml
+++ b/tests/e2e/cases/scode-code-and-run.yaml
@@ -1,0 +1,56 @@
+name: "scode code and run"
+description: >
+  Real workflow: ask Sudo Code to write a Python script, then run it via bash,
+  then ask to modify the code. Tests write_file, bash, and edit_file tools
+  in a natural code→run→iterate cycle.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Navigate to new conversation and select Sudo Code ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Phase 2: Ask to write and run a script ──
+  - op: type_text
+    text: "Write a Python script at /tmp/scode-e2e-test.py that prints the first 10 Fibonacci numbers, one per line. Then run it and show me the output."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 120
+  - op: screenshot
+    path: "screenshots/scode-coderun-01-written.png"
+  - op: judge
+    expect: "fibonacci python"
+
+  # ── Phase 3: Ask to modify the script ──
+  - op: type_text
+    text: "Now modify the script to also print the sum at the end, then run it again."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 120
+  - op: screenshot
+    path: "screenshots/scode-coderun-02-modified.png"
+  - op: judge
+    expect: "sum modify"
+
+  # ── Phase 4: Cleanup ──
+  - op: type_text
+    text: "Delete /tmp/scode-e2e-test.py"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 30

--- a/tests/e2e/cases/scode-file-read-and-analysis.yaml
+++ b/tests/e2e/cases/scode-file-read-and-analysis.yaml
@@ -1,0 +1,60 @@
+name: "scode file read and analysis"
+description: >
+  Real workflow: ask Sudo Code to find and read a specific file in the
+  sudowork project, explain what it does, then search for related code.
+  Tests read_file, glob_search, and grep_search tools.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Navigate to new conversation and select Sudo Code ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Phase 2: Ask to read and explain a file (use absolute path since scode uses temp workspace) ──
+  - op: type_text
+    text: "Read the file /Users/songym/cursor-projects/sudowork/package.json. Tell me the project name and list 3 key dependencies. Be concise."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-fileread-01-explain.png"
+  - op: judge
+    expect: "dependencies"
+
+  # ── Phase 3: Search for related code ──
+  - op: type_text
+    text: "Now use grep to search for 'AcpConnection' in /Users/songym/cursor-projects/sudowork/src/. List just the file paths."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-fileread-02-grep.png"
+  - op: judge
+    expect: "AcpConnection"
+
+  # ── Phase 4: Glob search ──
+  - op: type_text
+    text: "Use glob to find all .yaml files under /Users/songym/cursor-projects/sudowork/tests/e2e/cases/. List them."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-fileread-03-glob.png"
+  - op: judge
+    expect: "yaml"

--- a/tests/e2e/cases/scode-graceful-cancel.yaml
+++ b/tests/e2e/cases/scode-graceful-cancel.yaml
@@ -1,0 +1,52 @@
+name: "scode graceful cancel"
+description: >
+  Test ACP session cancel with Sudo Code: send a multi-step prompt where
+  one step is a long sleep, stop mid-execution, then ask what it completed.
+  Verifies session stays alive and context is preserved.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Navigate to new conversation and select Sudo Code ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 5000
+
+  # ── Phase 2: Send a 3-step prompt (step 2 = sleep = guaranteed busy) ──
+  - op: type_text
+    text: "Run these 3 bash commands one at a time: 1. echo \"step-one-done\", 2. sleep 30, 3. echo \"step-three-done\""
+  - op: press_key
+    key: "Enter"
+    wait: 3
+
+  # ── Phase 3: Wait for step 1, then stop during step 2 (sleep) ──
+  - op: pause
+    duration: 15000
+  - op: screenshot
+    path: "screenshots/scode-cancel-01-during-sleep.png"
+  - op: stop_conversation
+    timeout: 10
+    wait: 2
+  - op: screenshot
+    path: "screenshots/scode-cancel-02-after-stop.png"
+
+  # ── Phase 4: Ask what it did — should know about step 1 ──
+  - op: type_text
+    text: "What did you manage to complete before being stopped?"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-cancel-03-followup.png"
+  - op: judge
+    expect: "step-one-done"

--- a/tests/e2e/cases/scode-web-search.yaml
+++ b/tests/e2e/cases/scode-web-search.yaml
@@ -1,0 +1,47 @@
+name: "scode web search"
+description: >
+  Test Sudo Code's web search capability: ask a question that requires
+  current information, verify the response contains search results with
+  sources/citations.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Navigate to new conversation and select Sudo Code ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Phase 2: Ask a question requiring web search ──
+  - op: type_text
+    text: "Search the web: what is the latest stable version of Rust as of 2026? Include the source URL."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 90
+  - op: screenshot
+    path: "screenshots/scode-websearch-01-result.png"
+  - op: judge
+    expect: "Rust"
+
+  # ── Phase 3: Follow-up using search context ──
+  - op: type_text
+    text: "What are the main new features in that version? Summarize in 3 bullet points."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-websearch-02-followup.png"
+  - op: judge
+    expect: "feature"


### PR DESCRIPTION
## Summary
- Add 6 end-to-end test cases for Sudo Code agent through the sudowork UI
- Covers: basic conversation, code generation + execution, file read + search, web search, graceful cancel, agent switching
- All 14/14 judge assertions pass locally

## Test cases
| Case | Turns | Coverage |
|------|-------|----------|
| scode-basic-conversation | 2 | ACP connection, streaming response, multi-turn context |
| scode-code-and-run | 3 | write_file, bash, edit_file tools |
| scode-file-read-and-analysis | 3 | read_file, grep_search, glob_search tools |
| scode-web-search | 2 | WebSearch tool, citations |
| scode-graceful-cancel | 2 | cancel/stop, session recovery |
| scode-agent-switch | 3 | Sudoclaw ↔ Sudo Code switching |

## Test plan
- [x] All 6 cases pass with `python tests/e2e/runner.py --port 9230 --case <name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)