### PR TITLE
test(e2e): add 5 critical scode test cases + coverage doc

### DIFF
--- a/docs/scode-e2e-coverage.md
+++ b/docs/scode-e2e-coverage.md
@@ -1,0 +1,182 @@
+# Sudo Code (scode) E2E Test Coverage Plan
+
+## Overview
+
+This document tracks the end-to-end test coverage for the Sudo Code agent
+running through the sudowork UI via ACP (Agent Control Protocol). Tests
+live in `tests/e2e/cases/scode-*.yaml`.
+
+## Feature Inventory
+
+Features are grouped by category. Coverage status:
+- **Covered** — has an e2e test case that exercises it
+- **Gap** — not yet tested, should be
+- **N/A** — not applicable in ACP/UI mode (feature gap or design constraint)
+
+---
+
+### 1. Core Conversation
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| Single-turn prompt | Covered | scode-basic-conversation | |
+| Multi-turn context | Covered | scode-basic-conversation | Follow-up references prior turn |
+| Streaming response | Covered | all cases | Implicit in every interaction |
+| Graceful cancel mid-execution | Covered | scode-graceful-cancel | Stop during sleep, verify context preserved |
+| Agent switching (Sudoclaw ↔ scode) | Covered | scode-agent-switch | 3 sessions across 2 agents |
+
+### 2. Tool Usage — File Operations
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| read_file | Covered | scode-file-read-and-analysis | Reads package.json |
+| write_file | Covered | scode-code-and-run | Writes Python script |
+| edit_file | Covered | scode-edit-file | Write → edit text → read back verified |
+| glob_search | Covered | scode-file-read-and-analysis | Finds .yaml files |
+| grep_search | Covered | scode-file-read-and-analysis | Searches for AcpConnection |
+
+### 3. Tool Usage — Execution
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| bash | Covered | scode-code-and-run, scode-graceful-cancel | Run script, echo, sleep |
+| REPL (Python/JS subprocess) | Gap | — | Different from bash — persistent REPL session |
+| PowerShell | N/A | — | Windows only |
+| NotebookEdit (Jupyter) | Gap | — | Requires .ipynb file setup |
+
+### 4. Tool Usage — Search & Web
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| WebSearch | Covered | scode-web-search | Searches current info, verifies results |
+| WebFetch (URL → extract) | Covered | scode-web-fetch | Fetches httpbin.org/json, extracts keys |
+
+### 5. Tool Usage — Code Intelligence
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| LSP goToDefinition | Gap | — | Requires language server setup |
+| LSP findReferences | Gap | — | |
+| LSP hover | Gap | — | |
+| LSP documentSymbol | Gap | — | |
+| ToolSearch | Gap | — | Search for tools by keyword |
+
+### 6. Tool Usage — Planning & Structured
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| EnterPlanMode / ExitPlanMode | Covered | scode-planning-mode | Plan calculator → implement → test |
+| TodoWrite | Gap | — | Task list management |
+| AskUserQuestion | Gap | — | Scode prompts user for clarification |
+| StructuredOutput | Gap | — | Return structured data |
+| Sleep | Gap | — | Low priority |
+
+### 7. Tool Usage — Background & Parallel
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| Agent (sub-agents) | Gap | — | Launch parallel sub-agents |
+| TaskCreate / TaskGet / TaskList | Gap | — | Background task management |
+| Workers (boot, trust, prompt) | Gap | — | Worker lifecycle |
+| Teams (parallel sub-agents) | Gap | — | Team coordination |
+| CronCreate / CronDelete | Gap | — | Scheduled recurring tasks |
+
+### 8. Git Workflow
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| /commit (generate + create) | Covered | scode-git-workflow | Init repo → write file → commit → verify log |
+| /pr (draft/create PR) | Gap | — | High priority — core workflow |
+| /diff (show changes) | Gap | — | |
+| /issue (create GitHub issue) | Gap | — | |
+| /review (code review) | Gap | — | |
+
+### 9. Session Management
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| Session auto-save | Gap | — | Verify .scode/sessions/ created |
+| /resume (load saved session) | Gap | — | |
+| /session list / switch / fork | Gap | — | |
+| /export (session to markdown) | Gap | — | |
+| /compact (compress history) | Gap | — | |
+
+### 10. Configuration & Discovery
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| /model (switch model) | N/A | — | Not available in ACP mode — feature gap |
+| /permissions (switch mode) | Gap | — | read-only vs workspace-write vs danger |
+| /auth (switch auth mode) | N/A | — | Managed by sudowork credential injection |
+| /skills (list/invoke) | Gap | — | |
+| /agents (list) | Gap | — | |
+| /mcp (list/show servers) | Gap | — | |
+| /plugins (manage) | Gap | — | |
+| /config (inspect) | Gap | — | |
+
+### 11. Diagnostics
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| /doctor | Gap | — | Auth, config, workspace health |
+| /status | Gap | — | Model, permissions, git state |
+| /sandbox | Gap | — | Isolation status |
+| /cost (token usage) | Gap | — | |
+
+### 12. Auth
+
+| Feature | Status | Test Case | Notes |
+|---------|--------|-----------|-------|
+| Subscription auth (CC OAuth) | Covered | all cases | Implicit — uses injected CLAUDE_CODE_OAUTH_TOKEN |
+| Proxy auth (sudorouter) | Gap | — | Via ANTHROPIC_API_KEY injection |
+| API key auth | Gap | — | |
+| scode login (CLI) | Covered | manual e2e | Tested outside UI |
+| scode logout (CLI) | Covered | manual e2e | Tested outside UI |
+
+---
+
+## Coverage Summary
+
+| Category | Covered | Gap | N/A | Total |
+|----------|---------|-----|-----|-------|
+| Core Conversation | 5 | 0 | 0 | 5 |
+| File Operations | 5 | 0 | 0 | 5 |
+| Execution | 1 | 2 | 1 | 4 |
+| Search & Web | 2 | 0 | 0 | 2 |
+| Code Intelligence | 0 | 5 | 0 | 5 |
+| Planning & Structured | 1 | 4 | 0 | 5 |
+| Background & Parallel | 0 | 5 | 0 | 5 |
+| Git Workflow | 1 | 4 | 0 | 5 |
+| Session Management | 0 | 5 | 0 | 5 |
+| Config & Discovery | 0 | 6 | 2 | 8 |
+| Diagnostics | 0 | 4 | 0 | 4 |
+| Auth | 2 | 2 | 0 | 4 |
+| **Total** | **17** | **37** | **3** | **57** |
+
+**Current coverage: 17/54 testable features = ~31%**
+
+Additionally, `scode-multi-tool-chain` covers the read → analyze → write → verify
+cross-tool integration pattern that exercises multiple features in a single flow.
+
+## Priority for Next Round
+
+### P0 — Core Differentiators
+1. Git workflow: `/commit` + `/pr` (scode's primary value proposition)
+2. Planning mode: `/plan` then execute
+3. edit_file: explicit text replacement verification
+
+### P1 — High-Value Tools
+4. WebFetch: fetch URL and extract info
+5. Sub-agents: launch Agent tool for parallel work
+6. Background tasks: TaskCreate + TaskGet lifecycle
+
+### P2 — Session & Config
+7. Session resume: send prompt → close → resume → verify context
+8. Permission modes: read-only restrictions
+9. /doctor diagnostics through UI
+
+### P3 — Advanced
+10. LSP code navigation
+11. REPL persistent sessions
+12. Cron scheduling
+13. MCP/Skills/Plugins integration

--- a/tests/e2e/cases/scode-edit-file.yaml
+++ b/tests/e2e/cases/scode-edit-file.yaml
@@ -1,0 +1,56 @@
+name: "scode edit file"
+description: >
+  Test the edit_file tool explicitly: ask scode to write a file, then
+  make a targeted text replacement, then read it back to confirm.
+  Verifies write_file → edit_file → read_file chain.
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: New conversation with Sudo Code ──
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Phase 2: Write a file with known content ──
+  - op: type_text
+    text: "Write a file at /tmp/scode-edit-test.txt with this exact content:\nHello World\nThis is line two\nGoodbye World"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-edit-01-written.png"
+  - op: judge
+    expect: "write file"
+
+  # ── Phase 3: Edit — replace "Goodbye" with "See you" ──
+  - op: type_text
+    text: "Now use the edit tool to replace \"Goodbye World\" with \"See you later\" in that file. Then read it back and show me the full content."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-edit-02-edited.png"
+  - op: judge
+    expect: "See you later"
+
+  # ── Phase 4: Cleanup ──
+  - op: type_text
+    text: "Delete /tmp/scode-edit-test.txt"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 30

--- a/tests/e2e/cases/scode-git-workflow.yaml
+++ b/tests/e2e/cases/scode-git-workflow.yaml
@@ -1,0 +1,77 @@
+name: "scode git workflow"
+description: >
+  Test git workflow: init a repo, write a file, ask scode to commit it.
+  Verifies bash (git init/add), write_file, and /commit-style workflow.
+
+steps:
+  - op: wait_for_app_ready
+    timeout: 300
+
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Phase 1: Set up a git repo with a file ──
+  - op: type_text
+    text: "Run these commands: mkdir -p /tmp/scode-git-test && cd /tmp/scode-git-test && git init && git config user.email \"test@test.com\" && git config user.name \"Test\""
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 30
+  - op: screenshot
+    path: "screenshots/scode-git-01-init.png"
+
+  # ── Phase 2: Write a file ──
+  - op: type_text
+    text: "Write a file at /tmp/scode-git-test/hello.py with a simple hello world script."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-git-02-written.png"
+  - op: judge
+    expect: "hello"
+
+  # ── Phase 3: Ask to commit ──
+  - op: type_text
+    text: "Now git add and commit that file with a meaningful commit message. Show me the git log after."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-git-03-committed.png"
+  - op: judge
+    expect: "commit"
+
+  # ── Phase 4: Verify git log ──
+  - op: type_text
+    text: "Run git log --oneline in /tmp/scode-git-test/ and show the output."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 30
+  - op: screenshot
+    path: "screenshots/scode-git-04-log.png"
+  - op: judge
+    expect: "hello"
+
+  # ── Cleanup ──
+  - op: type_text
+    text: "Delete /tmp/scode-git-test/ directory"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 30

--- a/tests/e2e/cases/scode-multi-tool-chain.yaml
+++ b/tests/e2e/cases/scode-multi-tool-chain.yaml
@@ -1,0 +1,67 @@
+name: "scode multi-tool chain"
+description: >
+  Long-chain workflow: read a real source file → analyze its structure →
+  write a summary doc → verify the summary references the original.
+  Tests read_file → reasoning → write_file → read_file in one flow.
+
+steps:
+  - op: wait_for_app_ready
+    timeout: 300
+
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Phase 1: Read and analyze a source file ──
+  - op: type_text
+    text: "Read /Users/songym/cursor-projects/sudowork/src/types/acpTypes.ts and list all the ACP backend IDs defined in ACP_BACKENDS_ALL. Just the IDs, one per line."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-chain-01-analyzed.png"
+  - op: judge
+    expect: "claude scode"
+
+  # ── Phase 2: Write a summary based on analysis ──
+  - op: type_text
+    text: "Now write a file at /tmp/scode-acp-summary.md summarizing what you found: list each backend ID with a one-line description of what it is. Use markdown format."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-chain-02-summary.png"
+  - op: judge
+    expect: "markdown summary"
+
+  # ── Phase 3: Read back and verify ──
+  - op: type_text
+    text: "Read /tmp/scode-acp-summary.md back and confirm it mentions both 'claude' and 'scode' backends."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-chain-03-verified.png"
+  - op: judge
+    expect: "claude scode"
+
+  # ── Cleanup ──
+  - op: type_text
+    text: "Delete /tmp/scode-acp-summary.md"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 30

--- a/tests/e2e/cases/scode-planning-mode.yaml
+++ b/tests/e2e/cases/scode-planning-mode.yaml
@@ -1,0 +1,66 @@
+name: "scode planning mode"
+description: >
+  Test planning mode: ask scode to plan a multi-step task before executing.
+  Verifies EnterPlanMode/ExitPlanMode tools and plan-then-execute workflow.
+
+steps:
+  - op: wait_for_app_ready
+    timeout: 300
+
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Ask for a task that should trigger planning ──
+  - op: type_text
+    text: "I want you to create a simple calculator module in Python at /tmp/scode-calc/. It should have add, subtract, multiply, divide functions, plus a test file. Plan the implementation first before writing any code."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 120
+  - op: screenshot
+    path: "screenshots/scode-plan-01-planned.png"
+  - op: judge
+    expect: "plan"
+
+  # ── Approve the plan ──
+  - op: type_text
+    text: "Looks good, go ahead and implement it."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 120
+  - op: screenshot
+    path: "screenshots/scode-plan-02-implemented.png"
+  - op: judge
+    expect: "calculator"
+
+  # ── Verify by running ──
+  - op: type_text
+    text: "Run the test file to verify it works. Show me the output."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-plan-03-tested.png"
+  - op: judge
+    expect: "pass"
+
+  # ── Cleanup ──
+  - op: type_text
+    text: "Delete /tmp/scode-calc/ directory"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 30

--- a/tests/e2e/cases/scode-web-fetch.yaml
+++ b/tests/e2e/cases/scode-web-fetch.yaml
@@ -1,0 +1,44 @@
+name: "scode web fetch"
+description: >
+  Test WebFetch tool: ask scode to fetch a known URL and extract specific
+  information. Different from WebSearch — this fetches a single page.
+
+steps:
+  - op: wait_for_app_ready
+    timeout: 300
+
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # ── Fetch a known URL ──
+  - op: type_text
+    text: "Fetch the URL https://httpbin.org/json and tell me what keys are in the JSON response."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 90
+  - op: screenshot
+    path: "screenshots/scode-webfetch-01-result.png"
+  - op: judge
+    expect: "slideshow"
+
+  # ── Follow-up using fetched context ──
+  - op: type_text
+    text: "What is the title field in that JSON?"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/scode-webfetch-02-followup.png"
+  - op: judge
+    expect: "title"


### PR DESCRIPTION
## Summary
- Add 5 critical scode e2e test cases covering P0/P1 features
- Add `docs/scode-e2e-coverage.md` tracking 57 features across 12 categories
- Current coverage: 17/54 testable features (~31%), up from ~24%

## New test cases
| Case | Turns | Coverage |
|------|-------|----------|
| scode-edit-file | 3 | edit_file tool (write → edit → read back) |
| scode-web-fetch | 2 | WebFetch tool (fetch URL → extract info) |
| scode-planning-mode | 4 | EnterPlanMode → approve → implement → test |
| scode-git-workflow | 5 | git init → write → commit → verify log |
| scode-multi-tool-chain | 4 | read_file → analyze → write_file → verify |

## Test plan
- [x] All 5 cases pass with `python tests/e2e/runner.py --port 9230 --case <name>`
- [x] 13/13 judge assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)