### PR TITLE
fix: change sidebar session hover menu icon from vertical to horizontal dots

### DIFF
--- a/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
+++ b/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
@@ -174,7 +174,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
                   onOpenMenu(conversation);
                 }}
               >
-                <div className='flex flex-col gap-2px items-center justify-center' style={{ width: '16px', height: '16px' }}>
+                <div className='flex flex-row gap-1 items-center justify-center' style={{ width: '20px', height: '16px' }}>
                   <div className='w-2px h-2px rounded-full bg-current'></div>
                   <div className='w-2px h-2px rounded-full bg-current'></div>
                   <div className='w-2px h-2px rounded-full bg-current'></div>


### PR DESCRIPTION
## Summary
- Change the sidebar session history row hover menu icon from vertical `⋮` to horizontal `⋯` layout
- Expand container width from 16px to 20px for better spacing

## Test plan
- [ ] Verify the menu icon renders horizontally on hover
- [ ] Verify the icon remains accessible and clickable
- [ ] Check mobile view behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)