### PR TITLE
feat: sync cron agent responses back to external channels

### DIFF
--- a/docs/plans/2026-04-13-channel-info-skill-design.md
+++ b/docs/plans/2026-04-13-channel-info-skill-design.md
@@ -1,0 +1,162 @@
+# Channel Info Skill 设计文档
+
+> 创建日期: 2026-04-13
+> 状态: 已批准
+
+---
+
+## 1. 背景
+
+用户通过对话框（远程 IM 或本地桌面）询问渠道配置情况时，大模型无法返回数据库中存储的渠道配置信息。需要提供一种机制让 Agent 获取渠道状态信息。
+
+## 2. 需求
+
+- **场景**: 本地桌面用户和远程 IM 用户都需要支持
+- **内容**: 用户询问哪个渠道就返回那个渠道的配置信息和状态
+- **安全**: 排除敏感信息（token、secret 等凭据）
+
+## 3. 方案选型
+
+| 方案 | 优点 | 缺点 | 结论 |
+|------|------|------|------|
+| MCP Tool | 按需调用、实时准确 | 需要额外层 | 未采用 |
+| Function Calling | 与 Agent 集成 | 后端差异 | 未采用 |
+| 上下文注入 | 简单 | 信息过时、token消耗 | 未采用 |
+| **Skill** | 符合项目架构、统一管理 | 需创建新skill | **已采用** |
+
+## 4. 设计细节
+
+### 4.1 Skill 元数据
+
+```json
+{
+  "id": "channel-info-skill",
+  "name": "channel-info",
+  "display_name": "渠道信息",
+  "description": "获取 Channel 渠道配置信息 - 查询 Telegram、飞书、钉钉、微信等渠道的启用状态和运行状态",
+  "emoji": "📡",
+  "categories": ["系统管理"],
+  "is_builtin": true
+}
+```
+
+### 4.2 返回信息格式
+
+**返回字段**（排除敏感凭据）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `type` | string | 渠道类型 (telegram/lark/dingtalk/wechat) |
+| `name` | string | 渠道名称 |
+| `enabled` | boolean | 是否已启用 |
+| `connected` | boolean | 是否已连接 |
+| `status` | string | 运行状态 (running/stopped/error) |
+| `lastConnected` | string \| null | 最后连接时间 (ISO格式) |
+| `hasToken` | boolean | 是否已配置凭据 |
+
+**排除字段**:
+- `token` (Telegram Bot Token)
+- `appSecret` (飞书/钉钉应用密钥)
+- `clientId/clientSecret` (钉钉凭据)
+- 任何凭据相关的具体值
+
+### 4.3 函数定义
+
+```typescript
+interface ChannelInfo {
+  type: string;
+  name: string;
+  enabled: boolean;
+  connected: boolean;
+  status: string;
+  lastConnected: string | null;
+  hasToken: boolean;
+}
+
+interface ChannelInfoResult {
+  success: boolean;
+  channels?: ChannelInfo[];
+  error?: string;
+}
+
+/**
+ * 获取渠道配置信息
+ * @param channelType 可选的渠道类型，不传则返回所有渠道
+ * @returns 渠道配置信息（排除敏感凭据）
+ */
+function getChannelInfo(channelType?: string): Promise<ChannelInfoResult>;
+```
+
+### 4.4 使用示例
+
+**用户询问 WeChat 渠道**:
+
+```
+用户: 当前 WeChat 渠道的配置情况怎么样？
+
+Agent: [调用 getChannelInfo("wechat")]
+
+Agent 回答:
+📡 WeChat 渠道状态:
+- 名称: WeChat
+- 启用状态: ✅ 已启用
+- 连接状态: ✅ 正常连接
+- 运行状态: running
+- 凭据配置: ✅ 已配置
+- 最后连接: 2026-04-13T10:30:00Z
+```
+
+**用户询问所有渠道**:
+
+```
+用户: 目前有哪些渠道已经配置好了？
+
+Agent: [调用 getChannelInfo()]
+
+Agent 回答:
+📡 当前已配置的渠道列表:
+
+1. Telegram
+   - 启用状态: ✅ 已启用
+   - 连接状态: ✅ 正常连接
+   
+2. Lark (飞书)
+   - 启用状态: ✅ 已启用
+   - 连接状态: ❌ 未连接
+   
+3. WeChat
+   - 启用状态: ❌ 未启用
+   - 凭据配置: ⚠️ 未配置凭据
+```
+
+## 5. 文件结构
+
+```
+skills/channel-info/
+├── _sudowork_meta.json    # Skill 元数据
+├── scripts/
+│   └── index.ts           # 主逻辑实现
+├── icon.svg               # Skill 图标
+└── skill.md               # Skill 说明文档
+```
+
+## 6. 实现要点
+
+1. **IPC 调用**: 通过现有的 `ipcBridge.channel.getPluginStatus` 获取插件状态
+2. **信息过滤**: 在 Skill 层面过滤敏感凭据，确保安全性
+3. **格式化输出**: 返回结构化数据，由 Agent 格式化为用户友好的回复
+4. **错误处理**: 处理 IPC 调用失败的情况
+
+## 7. 扩展考虑
+
+- 未来可扩展支持更多渠道管理操作（启用/禁用渠道）
+- 可添加配置验证功能
+- 可添加活跃用户数统计
+
+---
+
+## 审批记录
+
+- **日期**: 2026-04-13
+- **审批人**: 用户
+- **状态**: 已批准

--- a/docs/plans/2026-04-13-channel-info-skill-implementation.md
+++ b/docs/plans/2026-04-13-channel-info-skill-implementation.md
@@ -1,0 +1,499 @@
+# Channel Info Skill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a Skill that allows users to query channel configuration status through conversation (both remote IM and local desktop).
+
+**Architecture:** Follow existing Skill pattern (like cron). Agent outputs special markers `[CHANNEL_INFO]`, system detects and processes them, returns formatted channel status to Agent. Data comes from IPC bridge `channel.getPluginStatus`.
+
+**Tech Stack:** TypeScript, Electron IPC, Skill system (`_sudowork_meta.json`, `SKILL.md`, `icon.svg`)
+
+---
+
+## Task 1: Create Skill Metadata and Icon
+
+**Files:**
+- Create: `skills/_builtin/channel-info/_sudowork_meta.json`
+- Create: `skills/_builtin/channel-info/icon.svg`
+- Create: `skills/_builtin/channel-info/SKILL.md`
+
+**Step 1: Create _sudowork_meta.json**
+
+```json
+{
+  "id": "channel-info-skill-uuid",
+  "name": "channel-info",
+  "display_name": "渠道信息",
+  "description": "获取 Channel 渠道配置信息 - 查询 Telegram、飞书、钉钉、微信等渠道的启用状态和运行状态",
+  "icon": "icon.svg",
+  "emoji": "📡",
+  "category": "",
+  "categories": ["系统管理"],
+  "applicable_scenarios": "[\"查询渠道状态：了解当前已配置的 IM 渠道列表\",\"渠道诊断：检查渠道是否正常运行\",\"配置确认：确认渠道是否已启用\"]",
+  "core_features": "[{\"title\": \"状态查询\", \"desc\": \"获取所有已配置渠道的启用和连接状态\"}, {\"title\": \"按渠道查询\", \"desc\": \"支持查询特定渠道的详细状态\"}, {\"title\": \"安全展示\", \"desc\": \"排除敏感凭据信息\"}]",
+  "homepage": null,
+  "author_id": "None",
+  "is_builtin": true,
+  "installed_version": "1.0.0",
+  "installed_at": "2026-04-13T00:00:00.000Z"
+}
+```
+
+**Step 2: Create icon.svg**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"/>
+  <path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"/>
+  <circle cx="12" cy="12" r="2"/>
+  <path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"/>
+  <path d="M19.1 4.9C23 8.8 23 15.1 19.1 19"/>
+</svg>
+```
+
+**Step 3: Create SKILL.md**
+
+```markdown
+---
+name: channel-info
+description: "获取 Channel 渠道配置信息 - 查询 Telegram、飞书、钉钉、微信等渠道的启用状态和运行状态"
+---
+
+# 渠道信息 Skill
+
+查询 IM 渠道（Telegram、飞书、钉钉、微信等）的配置和运行状态。
+
+## 使用方法
+
+输出 `[CHANNEL_INFO]` 直接查询所有渠道状态。
+
+输出 `[CHANNEL_INFO: wechat]` 查询特定渠道（支持 telegram、lark、dingtalk、wechat）。
+
+**输出命令直接，不要包裹在代码块中。**
+
+## 示例
+
+查询所有渠道：
+```
+[CHANNEL_INFO]
+```
+
+查询 WeChat 渠道：
+```
+[CHANNEL_INFO: wechat]
+```
+
+## 返回信息
+
+系统将返回以下信息（排除敏感凭据）：
+- 渠道类型 (type)
+- 渠道名称 (name)
+- 启用状态 (enabled)
+- 连接状态 (connected)
+- 运行状态 (status)
+- 最后连接时间 (lastConnected)
+- 凭据配置状态 (hasToken) - 仅显示是否已配置，不显示具体凭据
+
+## 注意事项
+
+1. 敏感信息（token、secret 等）不会返回
+2. 支持的渠道类型：telegram、lark、dingtalk、wechat、wecom、zentao
+3. 渠道状态可能是 running、stopped、error 等
+```
+
+**Step 4: Verify files created**
+
+Run: `ls -la skills/_builtin/channel-info/`
+Expected: All three files exist
+
+**Step 5: Commit**
+
+```bash
+git add skills/_builtin/channel-info/
+git commit -m "feat(skills): add channel-info skill metadata and docs"
+```
+
+---
+
+## Task 2: Create Channel Info Command Detector
+
+**Files:**
+- Create: `src/process/task/ChannelInfoDetector.ts`
+- Modify: `src/process/task/AcpAgent.ts` (to import and use detector)
+
+**Step 1: Write the detector module**
+
+```typescript
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getDatabase } from '@/process/database';
+
+/**
+ * Channel info command types detected from agent message content
+ */
+export type ChannelInfoCommand = 
+  | { kind: 'list' }  // List all channels
+  | { kind: 'query'; channelType: string }; // Query specific channel
+
+/**
+ * Remove markdown code blocks from content to avoid detecting commands in examples
+ */
+function stripCodeBlocks(content: string): string {
+  return content.replace(/```[\s\S]*?```/g, '');
+}
+
+/**
+ * Detect channel info commands in message content
+ *
+ * Supported formats:
+ * - [CHANNEL_INFO] - List all channel statuses
+ * - [CHANNEL_INFO: telegram] - Query specific channel type
+ *
+ * @param content - The text content to scan
+ * @returns Array of detected commands
+ */
+export function detectChannelInfoCommands(content: string): ChannelInfoCommand[] {
+  if (!content || typeof content !== 'string') {
+    return [];
+  }
+
+  const cleanContent = stripCodeBlocks(content);
+  const commands: ChannelInfoCommand[] = [];
+
+  // Detect [CHANNEL_INFO: xxx] - specific channel query
+  const specificMatches = cleanContent.matchAll(/\[CHANNEL_INFO:\s*([^\]]+)\]/gi);
+  for (const match of specificMatches) {
+    const channelType = match[1].trim().toLowerCase();
+    // Validate channel type
+    const validTypes = ['telegram', 'lark', 'dingtalk', 'wechat', 'wecom', 'zentao'];
+    if (channelType && validTypes.includes(channelType)) {
+      commands.push({ kind: 'query', channelType });
+    }
+  }
+
+  // Detect [CHANNEL_INFO] - list all (if no specific query found)
+  if (commands.length === 0 && /\[CHANNEL_INFO\]/i.test(cleanContent)) {
+    commands.push({ kind: 'list' });
+  }
+
+  return commands;
+}
+
+/**
+ * Check if content contains any channel info commands
+ */
+export function hasChannelInfoCommands(content: string): boolean {
+  if (!content || typeof content !== 'string') {
+    return false;
+  }
+  return /\[CHANNEL_INFO/i.test(content);
+}
+
+/**
+ * Strip channel info command blocks from content
+ * Used to create clean display version for UI
+ */
+export function stripChannelInfoCommands(content: string): string {
+  if (!content || typeof content !== 'string') {
+    return content;
+  }
+
+  return content
+    .replace(/\[CHANNEL_INFO:[^\]]+\]/gi, '')
+    .replace(/\[CHANNEL_INFO\]/gi, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Format channel status for display
+ * Removes sensitive credential information
+ */
+export function formatChannelStatus(status: import('@/channels/types').IChannelPluginStatus): string {
+  const enabledIcon = status.enabled ? '✅' : '❌';
+  const connectedIcon = status.connected ? '✅' : '❌';
+  const hasTokenIcon = status.hasToken ? '✅' : '⚠️';
+  const lastConnected = status.lastConnected 
+    ? new Date(status.lastConnected).toISOString() 
+    : '从未连接';
+
+  return `
+📡 **${status.name}** (${status.type})
+- 启用状态: ${enabledIcon} ${status.enabled ? '已启用' : '未启用'}
+- 连接状态: ${connectedIcon} ${status.connected ? '正常连接' : '未连接'}
+- 运行状态: ${status.status}
+- 凭据配置: ${hasTokenIcon} ${status.hasToken ? '已配置' : '未配置'}
+- 最后连接: ${lastConnected}
+`.trim();
+}
+
+/**
+ * Execute channel info command and return formatted result
+ */
+export async function executeChannelInfoCommand(command: ChannelInfoCommand): Promise<string> {
+  try {
+    const db = getDatabase();
+    const result = db.getChannelPlugins();
+
+    if (!result.success || !result.data) {
+      return '❌ 获取渠道信息失败: ' + (result.error || '未知错误');
+    }
+
+    let channels = result.data;
+
+    // Filter by channel type if specified
+    if (command.kind === 'query') {
+      channels = channels.filter(c => c.type === command.channelType);
+      if (channels.length === 0) {
+        return `❌ 未找到渠道类型: ${command.channelType}`;
+      }
+    }
+
+    // Map to status objects (use existing hasPluginCredentials from types)
+    const { hasPluginCredentials } = await import('@/channels/types');
+    const statuses: import('@/channels/types').IChannelPluginStatus[] = channels.map(config => ({
+      id: config.id,
+      type: config.type,
+      name: config.name,
+      enabled: config.enabled,
+      connected: config.status === 'running',
+      status: config.status || 'stopped',
+      lastConnected: config.lastConnected,
+      activeUsers: 0,
+      hasToken: hasPluginCredentials(config.type, config.credentials),
+      isExtension: false,
+    }));
+
+    // Format output
+    const lines = statuses.map(formatChannelStatus);
+    
+    if (command.kind === 'query') {
+      return `📡 **渠道信息查询结果**\n\n${lines.join('\n\n')}`;
+    } else {
+      return `📡 **当前已配置的渠道列表** (${statuses.length} 个)\n\n${lines.join('\n\n')}`;
+    }
+  } catch (error) {
+    return '❌ 获取渠道信息失败: ' + (error instanceof Error ? error.message : String(error));
+  }
+}
+```
+
+**Step 2: Verify file created**
+
+Run: `ls src/process/task/ChannelInfoDetector.ts`
+Expected: File exists
+
+**Step 3: Commit**
+
+```bash
+git add src/process/task/ChannelInfoDetector.ts
+git commit -m "feat(channel): add ChannelInfoDetector for skill command detection"
+```
+
+---
+
+## Task 3: Integrate Detector into AcpAgent
+
+**Files:**
+- Modify: `src/process/task/AcpAgent.ts`
+
+**Step 1: Add import statement**
+
+Find the imports section at the top of `src/process/task/AcpAgent.ts` and add:
+
+```typescript
+import { detectChannelInfoCommands, executeChannelInfoCommand, stripChannelInfoCommands } from './ChannelInfoDetector';
+```
+
+**Step 2: Add detection in message processing**
+
+Find where `detectCronCommands` is called (around line where agent message is processed). Add channel info detection alongside:
+
+```typescript
+// Detect channel info commands
+const channelInfoCommands = detectChannelInfoCommands(messageContent);
+if (channelInfoCommands.length > 0) {
+  for (const cmd of channelInfoCommands) {
+    const result = await executeChannelInfoCommand(cmd);
+    // Send result back to agent/conversation
+    await this.sendMessage(result);
+  }
+  // Strip commands from display content
+  messageContent = stripChannelInfoCommands(messageContent);
+}
+```
+
+**Step 3: Verify integration works**
+
+Run: `grep -n "detectChannelInfoCommands" src/process/task/AcpAgent.ts`
+Expected: Shows the import and usage lines
+
+**Step 4: Commit**
+
+```bash
+git add src/process/task/AcpAgent.ts
+git commit -m "feat(channel): integrate ChannelInfoDetector into AcpAgent message processing"
+```
+
+---
+
+## Task 4: Add i18n Translations
+
+**Files:**
+- Modify: `src/renderer/i18n/locales/en-US/tools.json`
+- Modify: `src/renderer/i18n/locales/zh-CN/tools.json`
+
+**Step 1: Add English translation**
+
+In `en-US/tools.json`, add:
+
+```json
+{
+  "channel-info": {
+    "name": "Channel Info",
+    "description": "Query channel configuration status - Telegram, Lark, DingTalk, WeChat"
+  }
+}
+```
+
+**Step 2: Add Chinese translation**
+
+In `zh-CN/tools.json`, add:
+
+```json
+{
+  "channel-info": {
+    "name": "渠道信息",
+    "description": "查询渠道配置状态 - Telegram、飞书、钉钉、微信"
+  }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/i18n/locales/en-US/tools.json src/renderer/i18n/locales/zh-CN/tools.json
+git commit -m "feat(i18n): add translations for channel-info skill"
+```
+
+---
+
+## Task 5: Test the Implementation
+
+**Files:**
+- Create: `src/process/task/ChannelInfoDetector.test.ts`
+
+**Step 1: Write unit tests**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { detectChannelInfoCommands, hasChannelInfoCommands, stripChannelInfoCommands } from './ChannelInfoDetector';
+
+describe('ChannelInfoDetector', () => {
+  describe('detectChannelInfoCommands', () => {
+    it('should detect [CHANNEL_INFO] command', () => {
+      const content = 'Let me check the channels.\n[CHANNEL_INFO]';
+      const commands = detectChannelInfoCommands(content);
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toEqual({ kind: 'list' });
+    });
+
+    it('should detect [CHANNEL_INFO: wechat] command', () => {
+      const content = 'Check WeChat status.\n[CHANNEL_INFO: wechat]';
+      const commands = detectChannelInfoCommands(content);
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toEqual({ kind: 'query', channelType: 'wechat' });
+    });
+
+    it('should ignore commands in code blocks', () => {
+      const content = 'Example:\n```[CHANNEL_INFO]```';
+      const commands = detectChannelInfoCommands(content);
+      expect(commands).toHaveLength(0);
+    });
+
+    it('should handle empty content', () => {
+      expect(detectChannelInfoCommands('')).toHaveLength(0);
+      expect(detectChannelInfoCommands(null as any)).toHaveLength(0);
+    });
+  });
+
+  describe('hasChannelInfoCommands', () => {
+    it('should return true for content with commands', () => {
+      expect(hasChannelInfoCommands('[CHANNEL_INFO]')).toBe(true);
+      expect(hasChannelInfoCommands('[CHANNEL_INFO: telegram]')).toBe(true);
+    });
+
+    it('should return false for content without commands', () => {
+      expect(hasChannelInfoCommands('Hello world')).toBe(false);
+      expect(hasChannelInfoCommands('')).toBe(false);
+    });
+  });
+
+  describe('stripChannelInfoCommands', () => {
+    it('should remove commands from content', () => {
+      const content = 'Check channels [CHANNEL_INFO] and more text';
+      const stripped = stripChannelInfoCommands(content);
+      expect(stripped).toBe('Check channels  and more text');
+    });
+
+    it('should handle multiple commands', () => {
+      const content = '[CHANNEL_INFO] text [CHANNEL_INFO: telegram]';
+      const stripped = stripChannelInfoCommands(content);
+      expect(stripped).toBe('text');
+    });
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npm test src/process/task/ChannelInfoDetector.test.ts`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add src/process/task/ChannelInfoDetector.test.ts
+git commit -m "test(channel): add unit tests for ChannelInfoDetector"
+```
+
+---
+
+## Task 6: Final Verification and Documentation Update
+
+**Step 1: Build the project**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 2: Manual test (if possible)**
+
+Start the application and verify:
+1. Skill appears in Settings → Skills list
+2. Agent can respond to "[CHANNEL_INFO]" command
+
+**Step 3: Update architecture doc**
+
+In `src/channels/ARCHITECTURE.md`, add mention of channel-info skill in the IPC section.
+
+**Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat(channel): complete channel-info skill implementation"
+```
+
+---
+
+## Summary
+
+This implementation:
+1. Creates a new builtin Skill `channel-info` following project patterns
+2. Uses the same detection mechanism as `cron` skill
+3. Returns channel status via IPC bridge, filtering sensitive credentials
+4. Supports both local desktop and remote IM users
+5. Provides i18n support for English and Chinese

--- a/docs/plans/2026-04-17-drafts-file-classification-design.md
+++ b/docs/plans/2026-04-17-drafts-file-classification-design.md
@@ -1,0 +1,367 @@
+# 文件草稿箱智能整理设计
+
+**日期**: 2026-04-17
+**状态**: 已确认
+
+---
+
+## 目标
+
+将 Agent 执行过程中的**中间产物**自动归类到 `.drafts/` 目录，将用户**最终意图的文件**保留在工作目录根目录。
+
+---
+
+## 现有问题
+
+现有 `draftsCleanup.ts` 采用**事后清理**模式：
+
+1. Agent Turn 结束后，扫描工作目录根目录
+2. 根据固定的扩展名/模式规则判断文件类型
+3. 将匹配的文件移动到 `.drafts/`
+
+**问题**：
+- 判断规则简单固定，容易漏判/误判
+- 文件在根目录短暂存在，用户可能误操作
+- 无法理解用户意图，只能靠文件名猜测
+
+---
+
+## 新方案：追问引导 + 智能判断
+
+### 核心流程
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Agent Turn 执行过程                            │
+├─────────────────────────────────────────────────────────────────────┤
+│  1. 用户发送消息 → sendMessage                                       │
+│     → 保存原始用户请求内容                                            │
+│     → 重置文件追踪集合                                                │
+├─────────────────────────────────────────────────────────────────────┤
+│  2. Agent 执行 → handleToolCallEvent                                 │
+│     → 检测写入类工具 (write, edit, create 等)                        │
+│     → phase === 'result' 时提取文件路径                              │
+│     → 添加到 writtenFilesThisTurn                                    │
+├─────────────────────────────────────────────────────────────────────┤
+│  3. Turn 结束 → handleEndTurn                                        │
+│     → 检查 writtenFilesThisTurn 是否有文件                           │
+│     → 有文件：发送追问消息                                            │
+│     → 无文件：正常结束                                                │
+├─────────────────────────────────────────────────────────────────────┤
+│  4. 追问处理                                                          │
+│     → 设置状态 awaitingFileClassification = true                    │
+│     → 发送追问消息（用户不可见）                                       │
+│     → 启动 10 秒超时计时器                                            │
+├─────────────────────────────────────────────────────────────────────┤
+│  5a. Agent 正常响应                                                   │
+│     → 解析 JSON 格式结果                                              │
+│     → 执行文件移动                                                    │
+│     → 重置状态，结束 Turn                                             │
+├─────────────────────────────────────────────────────────────────────┤
+│  5b. 超时/格式错误                                                    │
+│     → 降级到现有规则判断（扩展名/模式匹配）                            │
+│     → 执行文件移动                                                    │
+│     → 重置状态，结束 Turn                                             │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 追问消息格式
+
+```
+[File Classification Task]
+
+原始用户请求：
+"{原始用户消息内容}"
+
+本次任务写入的文件：
+- {workspace}/report.md
+- {workspace}/temp_script.py
+- {workspace}/helper.py
+- {workspace}/data.json
+
+判断标准：
+- 最终产物：直接满足用户请求，用户会直接使用或查看的文件（报告、结果数据、完成的文档）
+- 中间产物：执行过程中的辅助文件（脚本、临时数据、草稿、步骤输出）
+
+请以以下 JSON 格式回复（仅回复 JSON，不要其他内容）：
+{
+  "finalFiles": ["<最终产物完整路径>"],
+  "intermediateFiles": ["<中间产物完整路径>"]
+}
+```
+
+---
+
+### JSON 响应格式
+
+Agent 返回：
+
+```json
+{
+  "finalFiles": ["{workspace}/report.md", "{workspace}/data.json"],
+  "intermediateFiles": ["{workspace}/temp_script.py", "{workspace}/helper.py"]
+}
+```
+
+---
+
+### 执行逻辑
+
+sudowork 解析 JSON 后：
+
+| 分类 | 操作 |
+|------|------|
+| `finalFiles` | 保留在根目录（如已在 `.drafts/` 则移回根目录） |
+| `intermediateFiles` | 移动到 `.drafts/`（处理命名冲突） |
+
+---
+
+### 降级规则
+
+超时（10秒）或 JSON 格式错误时，使用以下规则判断：
+
+#### 中间产物扩展名
+
+```typescript
+const INTERMEDIATE_EXTENSIONS = new Set([
+  // 脚本文件（执行过程中的辅助代码）
+  '.py', '.sh', '.bash', '.zsh', '.bat', '.cmd', '.ps1', '.psm1',
+  '.rb', '.pl', '.lua', '.js', '.ts', '.awk', '.sed',
+  '.sql',                   // 数据处理脚本
+  '.r', '.R',               // R 语言脚本
+  '.m', '.mat',             // MATLAB 脚本
+
+  // 临时文件
+  '.tmp', '.temp', '.bak', '.backup',
+  '.old', '.orig',          // 原始备份
+  '.swp', '.swo',           // Vim 交换文件
+
+  // 草稿/工作进度
+  '.draft', '.wip', '.todo',
+  '.partial', '.incomplete',
+
+  // 日志/调试
+  '.log', '.debug', '.trace',
+
+  // 中间数据（处理过程中的临时数据）
+  '.cache', '.cached',
+  '.intermediate', '.interim',
+]);
+```
+
+#### 中间产物命名模式
+
+```typescript
+const INTERMEDIATE_PATTERNS = [
+  // 临时文件前缀
+  /^temp[_-]/i, /^tmp[_-]/i,
+  /^temporary[_-]/i,
+
+  // 草稿/工作进度
+  /^draft[_-]/i, /^wip[_-]/i,
+  /^scratch[_-]/i, /^scratchpad[_-]/i,
+  /^working[_-]/i, /^work[_-]/i,
+  /^proto[_-]/i, /^prototype[_-]/i,
+  /^poc[_-]/i,              // Proof of Concept
+  /^concept[_-]/i,
+
+  // 辅助/帮助文件
+  /^helper[_-]/i, /^util[_-]/i, /^utils[_-]/i,
+  /^assist[_-]/i, /^assistant[_-]/i,
+  /^tool[_-]/i, /^tools[_-]/i,
+  /^lib[_-]/i, /^library[_-]/i,
+  /^common[_-]/i, /^shared[_-]/i,
+
+  // 步骤/阶段文件
+  /^step[_-]?\d+/i,         // step_1, step2, step-03
+  /^phase[_-]?\d+/i,        // phase_1, phase2
+  /^stage[_-]?\d+/i,        // stage_1, stage2
+  /^round[_-]?\d+/i,        // round_1, round2
+  /^iter[_-]?\d+/i, /^iteration[_-]?\d+/i,
+  /^pass[_-]?\d+/i,
+
+  // 测试/实验文件
+  /^test[_-]/i, /^tests[_-]/i,
+  /^experiment[_-]/i, /^exp[_-]/i,
+  /^trial[_-]/i, /^attempt[_-]/i,
+  /^sample[_-]/i, /^example[_-]/i,
+  /^demo[_-]/i, /^playground[_-]/i,
+
+  // 中间版本
+  /[_-]v?\d+[_-]draft/i,    // report_v1_draft.md
+  /[_-]draft$/i,            // report-draft.md
+  /[_-]wip$/i,              // data-wip.csv
+  /[_-]temp$/i,             /[_-]tmp$/i,
+  /[_-]backup$/i,           /[_-]bak$/i,
+  /[_-]old$/i,              /[_-]orig$/i,
+  /[_-]partial$/i,          /[_-]incomplete$/i,
+
+  // 处理阶段标记
+  /[_-]raw[_-]/i,           // data_raw_processed.csv (原始数据是中间产物)
+  /[_-]source[_-]/i,        // data_source_final.csv
+  /[_-]input[_-]/i,         // script_input_output.py
+  /[_-]pre[_-]/i,           // data_pre_final.csv
+  /[_-]intermediate$/i,     // result_intermediate.json
+];
+```
+
+#### 最终产物保护规则
+
+以下文件**不应**被移动到 `.drafts/`（即使匹配中间产物规则）：
+
+```typescript
+const FINAL_FILE_PATTERNS = [
+  // 最终结果标记
+  /[_-]final$/i,            // report-final.md
+  /[_-]final[_-]/i,         // data_final_processed.csv
+  /[_-]result$/i,           // analysis_result.json
+  /[_-]output$/i,           // task_output.csv
+  /[_-]completed$/i,        // report_completed.md
+  /[_-]done$/i,             // task_done.txt
+  /[_-]finished$/i,         // analysis_finished.md
+
+  // 用户明确请求的文件名模式（如用户说"创建 report.md"）
+  // 此规则需要结合用户原始请求动态判断
+];
+
+const FINAL_FILE_EXTENSIONS = new Set([
+  // 通常作为最终产物的文档格式
+  '.md', '.txt', '.pdf', '.docx', '.doc',
+  '.xlsx', '.xls', '.csv',           // 数据表格（可能是最终数据）
+  '.json', '.yaml', '.yml',          // 配置/数据（可能是最终配置）
+  '.html', '.htm', '.pptx', '.ppt',  // 演示/网页
+  '.png', '.jpg', '.jpeg', '.gif',   // 图片（可能是最终输出）
+  '.svg', '.webp',
+]);
+```
+
+#### 排除文件（永不移动）
+
+```typescript
+const EXCLUDED_NAMES = new Set([
+  // 目录
+  DRAFTS_DIR_NAME, '.git', '.gitignore', '.github',
+  'node_modules', '.node_modules',
+  '.drafts', 'drafts',         // 草稿目录本身
+
+  // 配置文件
+  '.env', '.env.local', '.env.production',
+  'package.json', 'package-lock.json', 'pnpm-lock.yaml',
+  'tsconfig.json', 'jsconfig.json',
+  '.npmrc', '.yarnrc', '.yarnrc.yml',
+  'Cargo.toml', 'go.mod', 'go.sum',
+  'requirements.txt', 'pyproject.toml',
+  'Makefile', 'Dockerfile', 'docker-compose.yml',
+
+  // 文档/说明
+  'README.md', 'readme.md', 'README.txt',
+  'LICENSE', 'license', 'LICENSE.md',
+  'CHANGELOG.md', 'changelog.md',
+  'CONTRIBUTING.md',
+]);
+```
+
+#### 判断优先级
+
+```
+1. 排除文件 → 永不移动
+2. 最终产物保护规则 → 保留在根目录（即使匹配中间产物规则）
+3. 中间产物扩展名 → 移动到 .drafts/
+4. 中间产物命名模式 → 移动到 .drafts/
+5. 默认 → 保留在根目录（保守策略）
+```
+
+#### 示例判断
+
+| 文件名 | 判断结果 | 原因 |
+|--------|----------|------|
+| `report.md` | 保留 | 最终产物扩展名 `.md` |
+| `report-final.md` | 保留 | 匹配最终产物保护规则 `[_-]final$` |
+| `report-draft.md` | 移动 | 匹配中间产物规则 `[_-]draft$` |
+| `temp_script.py` | 移动 | 匹配中间产物规则 `^temp[_-]` + 扩展名 `.py` |
+| `helper.py` | 移动 | 匹配中间产物规则 `^helper[_-]` |
+| `step_1_data.json` | 移动 | 匹配中间产物规则 `^step[_-]?\d+` |
+| `data_final.csv` | 保留 | 匹配最终产物保护规则 `[_-]final[_-]` |
+| `data_raw.json` | 移动 | 匹配中间产物规则 `[_-]raw[_-]` |
+| `package.json` | 保留 | 排除文件 |
+| `analysis_result.json` | 保留 | 匹配最终产物保护规则 `[_-]result$` |
+
+---
+
+### 状态管理
+
+```typescript
+interface FileClassificationState {
+  awaitingFileClassification: boolean;      // 是否等待追问响应
+  writtenFilesThisTurn: Set<string>;        // 本轮写入的文件路径
+  originalUserRequest: string | null;       // 原始用户请求
+  classificationTimeoutId: NodeJS.Timeout | null;  // 超时计时器
+}
+```
+
+---
+
+### 用户可见性
+
+| 内容 | 用户可见性 |
+|------|------------|
+| 追问消息 | 不可见（内部发送） |
+| Agent JSON 响应 | 不可见（拦截处理） |
+| 文件整理结果 | 可见（可选：显示系统提示"已整理 X 个文件到草稿箱"） |
+
+---
+
+### 实现要点
+
+1. **文件追踪**
+   - 在 `handleToolCallEvent` 中检测写入类工具
+   - 使用 `inferToolKind` 判断工具类型（'edit' 类型）
+   - 从 `args` 中提取文件路径
+
+2. **追问发送**
+   - 使用内部 WebSocket 发送，不通过正常消息通道
+   - 追问消息标记为系统消息，不存入聊天历史
+
+3. **响应拦截**
+   - 检测 JSON 格式响应（以 `{` 开头，以 `}` 结尾）
+   - 在状态 `awaitingFileClassification === true` 时拦截处理
+   - 不转发给 UI 显示
+
+4. **超时处理**
+   - 使用 `setTimeout` 设置 10 秒超时
+   - 超时后立即降级到规则判断
+   - 清理状态并结束 Turn
+
+5. **文件移动**
+   - 使用 `fs.rename` 移动文件
+   - 处理命名冲突（追加时间戳）
+   - 确保 `.drafts/` 目录存在
+
+---
+
+### 影响范围
+
+| 文件 | 修改内容 |
+|------|----------|
+| `OpenClawAgent.ts` | 添加文件追踪、追问发送、响应拦截、状态管理 |
+| `draftsCleanup.ts` | 保留降级规则逻辑，移除自动执行（改为按需调用） |
+| `agentUtils.ts` | `buildDraftsInstruction` 可简化或移除 |
+
+---
+
+### 风险与缓解
+
+| 风险 | 缓解措施 |
+|------|----------|
+| Agent 返回非 JSON 格式 | 降级到规则判断 |
+| Agent 未响应追问 | 10 秒超时后降级 |
+| 文件路径不在工作目录 | 过滤非工作目录路径 |
+| JSON 中文件路径不匹配 | 使用模糊匹配或忽略不存在的路径 |
+
+---
+
+## 下一步
+
+进入实现阶段，创建详细的实现计划。

--- a/docs/plans/2026-04-21-lark-file-upload-download-progress.md
+++ b/docs/plans/2026-04-21-lark-file-upload-download-progress.md
@@ -1,0 +1,141 @@
+# Lark/Feishu Channel File Upload/Download Implementation Progress
+
+> Last updated: 2026-04-21
+
+## Overview
+
+飞书渠道集成位于 `src/channels/plugins/lark/` 目录，使用飞书官方 SDK `@larksuiteoapi/node-sdk`。
+
+## Implementation Status
+
+### ✅ 已实现
+
+#### 1. 消息接收 - 类型识别
+- **文件**: [LarkAdapter.ts:204-247](src/channels/plugins/lark/LarkAdapter.ts#L204-L247)
+- **功能**: 识别飞书推送的消息类型并提取文件信息
+- **支持类型**:
+  - `image`: 提取 `image_key`
+  - `file`: 提取 `file_key`, `file_name`
+  - `audio`: 提取 `file_key`, `duration`
+- **状态**: 只提取 fileId，未实际下载文件
+
+#### 2. 消息发送 - 类型定义
+- **文件**: [LarkAdapter.ts:316](src/channels/plugins/lark/LarkAdapter.ts#L316)
+- **定义**: `type LarkContentType = 'text' | 'interactive' | 'image' | 'file'`
+- **状态**: 类型已定义，但转换逻辑未实现
+
+#### 3. 统一消息接口
+- **文件**: [src/channels/types.ts:327-339](src/channels/types.ts#L327-L339)
+- **接口**: `IUnifiedOutgoingMessage` 包含 `imageUrl`, `fileUrl`, `fileName` 字段
+- **状态**: 接口定义存在，但 LarkPlugin 未使用
+
+### ❌ 未实现
+
+#### 1. 文件下载（接收用户文件）
+
+**需求**: 将飞书 CDN 上的文件下载到本地 workspace
+
+**飞书 SDK API**:
+```typescript
+// LarkPlugin.ts 需添加
+async downloadFile(fileKey: string): Promise<Buffer> {
+  const response = await this.client.im.file.download({
+    path: { file_key: fileKey },
+  });
+  return Buffer.from(response.data);
+}
+
+async downloadImage(imageKey: string): Promise<Buffer> {
+  const response = await this.client.im.image.download({
+    path: { image_key: imageKey },
+  });
+  return Buffer.from(response.data);
+}
+```
+
+**待实现位置**: `LarkPlugin.ts` 添加下载方法
+
+**流程**:
+1. 收到 file/image 消息 → 提取 file_key/image_key
+2. 调用 SDK download API → 获取文件内容
+3. 保存到本地 `channel-media/lark/` 目录
+4. 将本地路径写入 `_localPath` 字段
+
+#### 2. 文件上传（发送文件给用户）
+
+**需求**: Agent 生成文件后上传到飞书并发送给用户
+
+**飞书 SDK API**:
+```typescript
+// LarkPlugin.ts 需添加
+async uploadFile(filePath: string): Promise<string> {
+  const fileBuffer = fs.readFileSync(filePath);
+  const response = await this.client.im.file.upload({
+    data: {
+      file_type: 'stream',
+      file: fileBuffer,
+    },
+  });
+  return response.data.file_key;
+}
+
+async uploadImage(imagePath: string): Promise<string> {
+  const imageBuffer = fs.readFileSync(imagePath);
+  const response = await this.client.im.image.upload({
+    data: {
+      image_type: 'message',
+      image: imageBuffer,
+    },
+  });
+  return response.data.image_key;
+}
+```
+
+**待实现位置**:
+- `LarkAdapter.ts:323-352` - 扩展 `toLarkSendParams()` 处理 image/file 类型
+- `LarkPlugin.ts:190-243` - 扩展 `sendMessage()` 支持发送文件
+
+**流程**:
+1. Agent 生成文件 → 文件路径
+2. 调用 SDK upload API → 获取 file_key/image_key
+3. 构造消息 `{ file_key: ... }` 或 `{ image_key: ... }`
+4. 调用 `im.message.create` 发送
+
+## File Structure
+
+```
+src/channels/plugins/lark/
+├── LarkPlugin.ts      # 主要插件类 - WebSocket 连接、消息收发
+├── LarkAdapter.ts     # 消息格式转换 - incoming/outgoing
+├── LarkCards.ts       # 卡片消息构建（如果有）
+└── index.ts           # 导出
+```
+
+## Reference: Similar Implementations
+
+### WeCom (企业微信) - 已完整实现
+- **下载**: [WeComPlugin.ts:333-455](src/channels/plugins/wecom/WeComPlugin.ts#L333-L455) - `downloadMediaItems()`
+- **流程**: CDN URL + AES key → download + decrypt → save to local
+- **存储**: `channel-media/wecom/` 目录
+
+### WeChat (个人微信) - 已完整实现下载
+- **下载**: [WeChatPlugin.ts:236-275](src/channels/plugins/wechat/WeChatPlugin.ts#L236-L275) - `downloadMediaItems()`
+- **流程**: CDN URL + AES key → download + decrypt → save to local
+- **存储**: `channel-media/wechat/` 目录
+- **上传**: ❌ 未实现（API 未公开）
+
+## Next Steps
+
+1. **Phase 1: 文件下载**
+   - 在 `LarkPlugin.ts` 添加 `downloadFile()` 和 `downloadImage()` 方法
+   - 在消息处理流程中调用下载并保存到本地
+   - 更新 `_localPath` 字段供下游使用
+
+2. **Phase 2: 文件上传**
+   - 在 `LarkPlugin.ts` 添加 `uploadFile()` 和 `uploadImage()` 方法
+   - 扩展 `toLarkSendParams()` 处理 `image`/`file` 类型
+   - 扩展 `sendMessage()` 支持发送文件消息
+
+3. **Phase 3: 集成测试**
+   - 测试用户发送文件 → Agent 接收
+   - 测试 Agent 生成文件 → 发送给用户

--- a/docs/plans/2026-04-21-wechat-ilink-upload-design.md
+++ b/docs/plans/2026-04-21-wechat-ilink-upload-design.md
@@ -1,0 +1,293 @@
+# WeChat iLink Bot 文件上传实现方案
+
+> Date: 2026-04-21
+
+## 背景
+
+当前 WeChatPlugin 已完整实现文件下载功能（AES-128-ECB 解密），但缺少文件上传能力。
+基于逆向项目 photon-hq/wechat-ilink-client 发现的 `getUploadUrl` 端点，可以实现文件上传。
+
+## 上传流程
+
+```
+Agent 生成文件 → WeChatPlugin.uploadMedia()
+                  ↓
+              1. 生成 AES key (16 bytes)
+              2. 调用 getUploadUrl API → 获取 CDN URL
+              3. AES-128-ECB 加密文件内容
+              4. POST 到 CDN URL → 获取 x-encrypted-param
+              5. 构造消息 item (image_item/file_item/video_item)
+              6. sendMessage → 发送给用户
+```
+
+## 需要新增的代码
+
+### 1. WeChatCrypto.ts - AES 加密函数
+
+```typescript
+/**
+ * Encrypt data with AES-128-ECB.
+ * @param plaintext - The raw file content
+ * @param key - 16-byte AES key
+ * @returns Encrypted ciphertext with PKCS7 padding
+ */
+export function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
+  const cipher = createCipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([cipher.update(plaintext), cipher.final()]);
+}
+
+/**
+ * Generate a random 16-byte AES key.
+ * @returns Hex string (32 chars) and raw Buffer (16 bytes)
+ */
+export function generateAesKey(): { hex: string; buffer: Buffer } {
+  const buffer = crypto.randomBytes(16);
+  return { hex: buffer.toString('hex'), buffer };
+}
+```
+
+### 2. types.ts - 新增 API 类型
+
+```typescript
+/** getUploadUrl request */
+export interface IWeChatGetUploadUrlRequest {
+  filekey?: string;       // Random 16-byte hex (32 chars)
+  media_type?: number;    // 1=IMAGE, 2=VIDEO, 3=FILE, 4=VOICE
+  to_user_id?: string;    // Target user ID
+  rawsize?: number;       // Original file size (bytes)
+  rawfilemd5?: string;    // MD5 hash of original file (hex)
+  filesize?: number;      // Encrypted file size (rawsize + padding)
+  aeskey?: string;        // AES key (hex)
+  base_info?: BaseInfo;
+}
+
+/** getUploadUrl response */
+export interface IWeChatGetUploadUrlResponse {
+  ret?: number;
+  errcode?: number;
+  errmsg?: string;
+  upload_url?: string;    // CDN URL to POST encrypted content
+  download_param?: string; // Pre-generated download param (optional)
+}
+
+/** Media type for upload */
+export const UploadMediaType = {
+  IMAGE: 1,
+  VIDEO: 2,
+  FILE: 3,
+  VOICE: 4,
+} as const;
+```
+
+### 3. WeChatApiClient.ts - 上传 API
+
+```typescript
+/**
+ * Request upload URL from iLink Bot API.
+ */
+async getUploadUrl(params: IWeChatGetUploadUrlRequest): Promise<IWeChatGetUploadUrlResponse> {
+  return await this.apiFetch<IWeChatGetUploadUrlResponse>(
+    'ilink/bot/getuploadurl',
+    params as unknown as Record<string, unknown>,
+    WECHAT_API_TIMEOUT_MS
+  );
+}
+
+/**
+ * Upload encrypted media to CDN.
+ * @param url - CDN URL from getUploadUrl
+ * @param encryptedData - AES-encrypted file content
+ * @returns downloadParam from x-encrypted-param header
+ */
+async uploadToCdn(url: string, encryptedData: Buffer): Promise<string> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: encryptedData,
+  });
+  if (!response.ok) {
+    throw new Error(`CDN upload failed: HTTP ${response.status}`);
+  }
+  const downloadParam = response.headers.get('x-encrypted-param');
+  if (!downloadParam) {
+    throw new Error('CDN upload missing x-encrypted-param header');
+  }
+  return downloadParam;
+}
+
+/**
+ * Compute MD5 hash of file content.
+ */
+computeMd5(data: Buffer): string {
+  return crypto.createHash('md5').update(data).digest('hex');
+}
+```
+
+### 4. WeChatPlugin.ts - 上传流程
+
+```typescript
+/**
+ * Upload a local file and return the media item for sendMessage.
+ */
+private async uploadMedia(filePath: string, mediaType: number, userId: string): Promise<WeChatMessageItem | null> {
+  if (!this.apiClient) return null;
+
+  try {
+    // Read file
+    const rawContent = fs.readFileSync(filePath);
+    const rawSize = rawContent.length;
+    const rawMd5 = this.apiClient.computeMd5(rawContent);
+
+    // Generate AES key
+    const { hex: aesKeyHex, buffer: aesKeyBuffer } = generateAesKey();
+
+    // Encrypt content
+    const encryptedContent = encryptAesEcb(rawContent, aesKeyBuffer);
+    const encryptedSize = encryptedContent.length;
+
+    // Generate filekey (random 16-byte hex)
+    const filekey = crypto.randomBytes(16).toString('hex');
+
+    // Get upload URL
+    const uploadResp = await this.apiClient.getUploadUrl({
+      filekey,
+      media_type: mediaType,
+      to_user_id: userId,
+      rawsize: rawSize,
+      rawfilemd5: rawMd5,
+      filesize: encryptedSize,
+      aeskey: aesKeyHex,
+    });
+
+    if (uploadResp.errcode || !uploadResp.upload_url) {
+      console.error('[WeChatPlugin] getUploadUrl failed:', uploadResp.errmsg);
+      return null;
+    }
+
+    // Upload to CDN
+    const downloadParam = await this.apiClient.uploadToCdn(uploadResp.upload_url, encryptedContent);
+
+    // Construct message item
+    const item: WeChatMessageItem = { type: mediaTypeToItemType(mediaType) };
+
+    if (mediaType === UploadMediaType.IMAGE) {
+      item.image_item = {
+        aeskey: aesKeyHex,
+        media: { encrypt_query_param: downloadParam },
+      };
+    } else if (mediaType === UploadMediaType.FILE) {
+      item.file_item = {
+        media: { encrypt_query_param: downloadParam },
+        file_name: path.basename(filePath),
+        file_size: rawSize,
+      };
+    } else if (mediaType === UploadMediaType.VIDEO) {
+      item.video_item = {
+        media: { encrypt_query_param: downloadParam },
+      };
+    } else if (mediaType === UploadMediaType.VOICE) {
+      item.voice_item = {
+        media: { encrypt_query_param: downloadParam },
+      };
+    }
+
+    return item;
+  } catch (error) {
+    console.error('[WeChatPlugin] uploadMedia failed:', error);
+    return null;
+  }
+}
+
+function mediaTypeToItemType(mediaType: number): number {
+  switch (mediaType) {
+    case UploadMediaType.IMAGE: return MessageItemType.IMAGE;
+    case UploadMediaType.VIDEO: return MessageItemType.VIDEO;
+    case UploadMediaType.FILE: return MessageItemType.FILE;
+    case UploadMediaType.VOICE: return MessageItemType.VOICE;
+    default: return MessageItemType.NONE;
+  }
+}
+```
+
+### 5. sendMessage 扩展
+
+```typescript
+// 在 WeChatPlugin.sendMessage() 中添加文件支持
+async sendMessage(userId: string, content: IUnifiedOutgoingMessage): Promise<void> {
+  if (!this.apiClient) return;
+
+  const contextToken = this.tokenStore.get(this.accountId, userId);
+
+  // 处理文件附件
+  const items: WeChatMessageItem[] = [];
+
+  if (content.imageUrl) {
+    const item = await this.uploadMedia(content.imageUrl, UploadMediaType.IMAGE, userId);
+    if (item) items.push(item);
+  }
+
+  if (content.fileUrl) {
+    const item = await this.uploadMedia(content.fileUrl, UploadMediaType.FILE, userId);
+    if (item) items.push(item);
+  }
+
+  if (content.text) {
+    items.push({ type: MessageItemType.TEXT, text_item: { text: content.text } });
+  }
+
+  // 发送消息
+  const payload = {
+    msg: {
+      to_user_id: userId,
+      context_token: contextToken,
+      item_list: items,
+    },
+  };
+
+  await this.apiClient.sendMessage(payload);
+}
+```
+
+## 文件清单
+
+| 文件 | 改动 |
+|------|------|
+| `WeChatCrypto.ts` | 新增 `encryptAesEcb()`, `generateAesKey()` |
+| `types.ts` | 新增 `IWeChatGetUploadUrlRequest`, `IWeChatGetUploadUrlResponse`, `UploadMediaType` |
+| `WeChatApiClient.ts` | 新增 `getUploadUrl()`, `uploadToCdn()`, `computeMd5()` |
+| `WeChatPlugin.ts` | 新增 `uploadMedia()`, 扩展 `sendMessage()` |
+| `WeChatAdapter.ts` | 扩展 `toWeChatSendPayload()` 支持附件 |
+
+## 风险评估
+
+### 技术风险
+
+1. **API 稳定性**: `getUploadUrl` 是逆向发现的端点，可能随 iLink Bot API 更新而变化
+   - 缓解：添加错误处理和 fallback
+
+2. **加密兼容性**: AES-128-ECB 加密必须与微信解密完全兼容
+   - 缓解：已验证解密实现，加密使用相同算法
+
+3. **文件大小限制**: CDN 上传可能有大小限制
+   - 缓解：添加文件大小检查 (建议 < 10MB)
+
+### 账号风险
+
+1. **API 未公开**: 使用未公开的 API 端点可能导致账号受限
+   - 缓解：添加用户确认提示，默认关闭上传功能
+
+## 测试计划
+
+1. **单元测试**
+   - `encryptAesEcb()` 加密后能被 `decryptAesEcb()` 正确解密
+   - `generateAesKey()` 生成正确的 16 字节密钥
+   - `computeMd5()` 返回正确的 MD5 哈希
+
+2. **集成测试**
+   - 上传图片 → 发送消息 → 验证用户能收到
+   - 上传文件 → 发送消息 → 验证文件名正确
+   - 上传失败时 fallback 到文本消息
+
+3. **端到端测试**
+   - Agent 生成图片 → 上传 → 发送给用户
+   - Agent 生成 PDF → 上传 → 发送给用户

--- a/docs/plans/2026-04-21-wechat-official-openclaw-plugin-migration.md
+++ b/docs/plans/2026-04-21-wechat-official-openclaw-plugin-migration.md
@@ -1,0 +1,224 @@
+# 个人微信改用官方 OpenClaw 插件改造方案
+
+> Date: 2026-04-21
+
+## 背景
+
+当前 Sudowork 使用自己实现的 `WeChatPlugin`，通过 iLink Bot HTTP API 接收和发送消息。
+改用腾讯官方 `@tencent/openclaw-weixin` 插件后，消息流经 OpenClaw Gateway，可获得文件上传能力。
+
+## 架构对比
+
+### 当前架构 (WeChatPlugin)
+
+```
+微信 → iLink Bot API (HTTP) → Sudowork WeChatPlugin → ChannelManager → Agent
+                                  ↑
+                                  └── 自己处理 CDN 下载 + AES 解密
+```
+
+### 目标架构 (官方 OpenClaw 微信插件)
+
+```
+微信 → OpenClaw Gateway (WebSocket) → Sudowork OpenClawAgent → Agent
+         ↑
+         └── @tencent/openclaw-weixin 插件处理文件上传下载
+```
+
+---
+
+## 需要改造的组件
+
+### 1. 消息接收层
+
+**当前**: `WeChatPlugin` HTTP 长轮询
+**目标**: 通过 `OpenClawAgent` 接收微信消息
+
+**改造内容**:
+
+| 模块 | 当前 | 改造后 |
+|------|------|--------|
+| 入口 | `WeChatPlugin.pollLoop()` | `OpenClawAgent.handleEvent()` |
+| API | HTTP `/ilink/bot/getupdates` | OpenClaw WebSocket `chat` event |
+| 格式转换 | `WeChatAdapter.toUnifiedIncomingMessage()` | 新增 OpenClaw 微信消息适配器 |
+
+**需要新增的代码**:
+
+```typescript
+// 新增: OpenClawWeChatAdapter.ts
+// 将 OpenClaw 微信插件的消息格式转换为 IUnifiedIncomingMessage
+
+export function toUnifiedIncomingMessage(openclawWeixinMessage: unknown): IUnifiedIncomingMessage | null {
+  // OpenClaw 微信插件的消息格式需要适配
+  // 可能包含: text, image, file, video 等类型
+  // attachments 可能有本地路径（OpenClaw 已处理下载）
+}
+```
+
+**改造点**:
+- [ChannelManager.ts:57](src/channels/core/ChannelManager.ts#L57) - 注册插件方式可能需要调整
+- [OpenClawAgent.ts:732-760](src/process/task/OpenClawAgent.ts#L732-L760) - `handleEvent()` 需要识别微信消息类型
+
+---
+
+### 2. 消息发送层
+
+**当前**: `WeChatPlugin.sendMessage()` → iLink HTTP API
+**目标**: 通过 `OpenClawAgent.chatSend()` 发送消息
+
+**改造内容**:
+
+| 模块 | 当前 | 改造后 |
+|------|------|--------|
+| 入口 | `WeChatPlugin.sendMessage()` | `OpenClawGatewayConnection.chatSend()` |
+| API | HTTP `/ilink/bot/sendmessage` | OpenClaw WebSocket `chat` request |
+| 文件发送 | ❌ 不支持 | ✅ 通过 `attachments` 参数支持 |
+
+**OpenClaw Gateway 支持的 attachments**:
+
+```typescript
+// src/agent/openclaw/types.ts:139-147
+export interface ChatSendParams {
+  sessionKey: string;
+  message: string;
+  thinking?: string;
+  deliver?: boolean;
+  attachments?: unknown[];  // ← 文件附件支持
+  timeoutMs?: number;
+  idempotencyKey: string;
+}
+```
+
+**改造点**:
+- [ChannelMessageService.ts](src/channels/agent/ChannelMessageService.ts) - 发送消息时需要调用 OpenClaw Agent
+- 需要将 `IUnifiedOutgoingMessage` 中的 `imageUrl`, `fileUrl` 转换为 OpenClaw attachments 格式
+
+---
+
+### 3. 文件处理
+
+**当前**: Sudowork 自己处理
+**目标**: OpenClaw 插件处理
+
+| 功能 | 当前 | 改造后 |
+|------|------|--------|
+| 文件下载 | `WeChatApiClient.downloadMedia()` + AES 解密 | OpenClaw 插件自动处理 |
+| 文件存储 | `channel-media/wechat/` | OpenClaw workspace |
+| 文件路径 | `_localPath` 字段 | OpenClaw attachments 中携带 |
+| 文件上传 | ❌ 不支持 | ✅ OpenClaw 插件处理 |
+
+**改造点**:
+- 移除 `WeChatCrypto.ts` 的 AES 解密逻辑（不再需要）
+- 移除 `WeChatApiClient.downloadMedia()` 方法
+- 依赖 OpenClaw 提供的文件路径
+
+---
+
+### 4. 配置/登录流程
+
+**当前**: 扫码登录获取 `bot_token` + `account_id`
+**目标**: 通过 OpenClaw 插件配置
+
+**当前流程** ([WeChatConfigForm.tsx](src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx)):
+```
+用户点击连接 → WeChatApiClient.startQrLogin() → 显示二维码 → 扫码确认 
+→ 获取 bot_token → channel.enablePlugin() → 启动 WeChatPlugin
+```
+
+**改造后流程**:
+```
+用户点击连接 → 调用 OpenClaw weixin-installer → openclaw plugins install
+→ 扫码连接 → 微信插件启动 → Sudowork 监听 OpenClaw 事件
+```
+
+**改造点**:
+- [WeChatConfigForm.tsx](src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx) - UI 改为调用 OpenClaw 安装命令
+- 配置存储从 sudowork 数据库改为 OpenClaw 配置文件
+
+---
+
+### 5. 会话管理
+
+**当前**: WeChatPlugin 维护 `context_token`
+**目标**: OpenClaw Gateway 管理 session
+
+| 模块 | 当前 | 改造后 |
+|------|------|--------|
+| 会话标识 | `context_token` (per user) | `sessionKey` (OpenClaw) |
+| 用户映射 | WeChatPlugin 内部 | OpenClaw session → Sudowork conversation |
+| 会话恢复 | `WeChatContextTokenStore` | `OpenClawGatewayConnection.sessionsResolve()` |
+
+---
+
+## 改造工作量评估
+
+### 高优先级（核心功能）
+
+| 任务 | 工作量 | 文件 |
+|------|--------|------|
+| OpenClaw 微信消息适配器 | 中 | 新增 `OpenClawWeChatAdapter.ts` |
+| ChannelManager 集成调整 | 小 | `ChannelManager.ts` |
+| 消息发送改造 | 中 | `ChannelMessageService.ts` |
+| 配置 UI 改造 | 中 | `WeChatConfigForm.tsx` |
+
+### 中优先级（辅助功能）
+
+| 任务 | 工作量 | 文件 |
+|------|--------|------|
+| 会话映射改造 | 中 | `SessionManager.ts` |
+| 文件附件处理 | 中 | `ChatSendParams` attachments |
+| 用户授权流程 | 小 | `PairingService.ts` |
+
+### 低优先级（可移除）
+
+| 任务 | 工作量 | 文件 |
+|------|--------|------|
+| 移除 WeChatPlugin | 小 | `WeChatPlugin.ts` |
+| 移除 iLink API Client | 小 | `WeChatApiClient.ts` |
+| 移除 AES 解密 | 小 | `WeChatCrypto.ts` |
+
+---
+
+## 关键依赖
+
+### OpenClaw 版本要求
+- 需要 OpenClaw >= 2026.3.0
+- 需要安装 `@tencent/openclaw-weixin` 插件
+
+### Sudowork OpenClawAgent
+- 已有实现: `src/process/task/OpenClawAgent.ts`
+- 需要扩展支持微信消息类型识别
+
+---
+
+## 实施步骤
+
+### Phase 1: 消息接收改造
+1. 创建 `OpenClawWeChatAdapter.ts` 适配 OpenClaw 微信消息格式
+2. 在 `OpenClawAgent.handleEvent()` 中识别微信消息
+3. 将微信消息转换为 `IUnifiedIncomingMessage`
+4. 通过 `channelEventBus` 发送给 ChannelManager
+
+### Phase 2: 消息发送改造
+1. 扩展 `ChannelMessageService` 支持发送到 OpenClaw Agent
+2. 将 `IUnifiedOutgoingMessage.fileUrl` 转换为 OpenClaw attachments
+3. 调用 `OpenClawGatewayConnection.chatSend()` 发送消息
+
+### Phase 3: 配置 UI 改造
+1. 修改 `WeChatConfigForm.tsx` 调用 OpenClaw 安装命令
+2. 移除 iLink Bot API 相关的登录流程
+3. 显示 OpenClaw 微信插件状态
+
+### Phase 4: 清理旧代码
+1. 移除 `WeChatPlugin.ts`, `WeChatApiClient.ts`, `WeChatCrypto.ts`
+2. 更新 `ChannelManager.ts` 注册逻辑
+
+---
+
+## 风险与注意事项
+
+1. **消息格式差异**: OpenClaw 微信插件的消息格式可能与 iLink API 不同，需要适配
+2. **会话映射**: 需要建立 OpenClaw sessionKey ↔ Sudowork conversationId 的映射
+3. **用户授权**: Pairing 流程可能需要调整
+4. **文件路径**: OpenClaw 处理的文件路径需要正确传递给 Agent
+5. **向后兼容**: 需要考虑是否保留旧版 WeChatPlugin 作为备选

--- a/docs/plans/2026-04-22-wecom-media-upload-aggregation-design.md
+++ b/docs/plans/2026-04-22-wecom-media-upload-aggregation-design.md
@@ -1,0 +1,355 @@
+# 企业微信媒体上传与消息聚合设计
+
+**日期**: 2026-04-22
+**状态**: 已实现
+**作者**: Claude Code
+
+---
+
+## 1. 背景
+
+当前 sudowork 企业微信实现仅支持：
+- 用户发送媒体文件 → agent下载并解密
+- agent发送文本/markdown回复
+
+**缺失功能**：
+1. agent无法主动发送图片、文件等媒体给用户
+2. 用户发送图文混合消息时触发多次重复回复
+
+## 2. 问题分析
+
+### 2.1 媒体发送缺失
+
+企微长连接模式需要通过 WebSocket 分片上传临时素材，获取 `media_id` 后才能发送媒体消息。当前实现未包含此流程。
+
+**参考实现**：wecom-openclaw-plugin-main 使用三步上传流程：
+1. `aibot_upload_media_init` - 初始化上传，获取 upload_id
+2. `aibot_upload_media_chunk` - 分片上传（Base64编码）
+3. `aibot_upload_media_finish` - 完成上传，获取 media_id
+
+### 2.2 消息重复回复
+
+**现象**：用户发送图文混合消息时，企微分别发送多个 WebSocket 回调（不同 msgId），每个回调都触发一次 AI 响应。
+
+**原因**：当前去重逻辑仅检查 msgId，企微的多回调模式导致：
+- text回调(msgId=A) → emitMessage → AI响应
+- image回调(msgId=B) → emitMessage → AI响应
+- 用户收到两条回复
+
+## 3. 设计方案
+
+### 3.1 媒体上传模块 (WeComUploader.ts)
+
+新增独立模块处理分片上传：
+
+```typescript
+// 核心参数
+const CHUNK_SIZE = 512 * 1024;  // 512KB (Base64编码前)
+const MAX_CHUNKS = 100;         // 最大分片数（对应50MB）
+const SIZE_LIMITS = {
+  image: 10 * 1024 * 1024,      // 10MB
+  voice: 2 * 1024 * 1024,       // 2MB (仅支持AMR)
+  video: 10 * 1024 * 1024,      // 10MB (仅支持MP4)
+  file: 20 * 1024 * 1024        // 20MB
+};
+
+// 上传流程
+export async function uploadMedia(ws: WebSocket, buffer: Buffer, options: {
+  type: 'image' | 'voice' | 'video' | 'file';
+  filename: string;
+}): Promise<string> {
+  // 1. 初始化
+  const totalChunks = Math.ceil(buffer.length / CHUNK_SIZE);
+  const initResult = await sendCommand(ws, {
+    cmd: 'aibot_upload_media_init',
+    body: {
+      type: options.type,
+      filename: options.filename,
+      total_size: buffer.length,
+      total_chunks: totalChunks
+    }
+  });
+
+  // 2. 分片上传
+  for (let i = 0; i < totalChunks; i++) {
+    const chunk = buffer.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+    await sendCommand(ws, {
+      cmd: 'aibot_upload_media_chunk',
+      body: {
+        upload_id: initResult.upload_id,
+        chunk_index: i,
+        base64_data: chunk.toString('base64')
+      }
+    });
+  }
+
+  // 3. 完成
+  const finishResult = await sendCommand(ws, {
+    cmd: 'aibot_upload_media_finish',
+    body: { upload_id: initResult.upload_id }
+  });
+
+  return finishResult.media_id;
+}
+```
+
+### 3.2 媒体发送集成 (WeComPlugin.ts)
+
+扩展 `sendMessage` 方法支持媒体：
+
+```typescript
+async sendMessage(chatId: string, message: IUnifiedOutgoingMessage): Promise<string> {
+  // 检测媒体附件
+  const hasMedia = message.imageUrl || message.fileUrl;
+
+  if (hasMedia) {
+    // 1. 加载媒体文件
+    const mediaUrl = message.imageUrl || message.fileUrl!;
+    const mediaBuffer = await loadMediaFromUrl(mediaUrl);
+
+    // 2. 检测类型并验证大小
+    const detectedType = detectMediaType(mediaBuffer);
+    const sizeCheck = validateSize(mediaBuffer.length, detectedType);
+
+    if (sizeCheck.shouldReject) {
+      throw new Error(sizeCheck.rejectReason);
+    }
+
+    // 3. 上传获取 media_id
+    const mediaId = await uploadMedia(this.ws, mediaBuffer, {
+      type: sizeCheck.finalType,
+      filename: extractFilename(mediaUrl)
+    });
+
+    // 4. 发送媒体消息
+    const reqId = this.generateReqId();
+    this.send({
+      cmd: 'aibot_send_msg',
+      headers: { req_id: reqId },
+      body: {
+        chatid: chatId,
+        chat_type: parseChatType(chatId),
+        msgtype: sizeCheck.finalType,
+        [sizeCheck.finalType]: { media_id: mediaId }
+      }
+    });
+
+    // 5. 如有文本，再发送文本消息
+    if (message.text) {
+      await this.sendTextMessage(chatId, message.text);
+    }
+
+    return `media_${reqId}`;
+  }
+
+  // 现有文本发送逻辑...
+}
+```
+
+### 3.3 消息聚合窗口 (MessageAggregator.ts)
+
+新增聚合管理器处理多回调：
+
+```typescript
+// 聚合窗口配置
+const AGGREGATION_WINDOW_MS = 800;  // 800ms等待窗口
+const MAX_QUEUE_SIZE = 10;          // 单队列最大消息数
+
+// 职责
+export class MessageAggregator {
+  private queues: Map<string, AggregationQueue> = new Map();
+
+  // 判断是否应该聚合等待
+  shouldAggregate(userId: string, chatId: string): boolean {
+    const key = `${userId}:${chatId}`;
+    const queue = this.queues.get(key);
+    return queue && !queue.isExpired();
+  }
+
+  // 添加消息到聚合队列
+  addToQueue(userId: string, chatId: string, msg: WeComMsgCallback): void {
+    const key = `${userId}:${chatId}`;
+    let queue = this.queues.get(key);
+    if (!queue) {
+      queue = new AggregationQueue(AGGREGATION_WINDOW_MS);
+      this.queues.set(key, queue);
+    }
+    queue.add(msg);
+  }
+
+  // 等待聚合完成并返回合并消息
+  async waitForComplete(userId: string, chatId: string): Promise<WeComMsgCallback | null> {
+    const key = `${userId}:${chatId}`;
+    const queue = this.queues.get(key);
+    if (!queue) return null;
+
+    await queue.waitForWindowClose();
+    const merged = queue.mergeAndClear();
+    this.queues.delete(key);
+    return merged;
+  }
+}
+
+// 合并逻辑
+class AggregationQueue {
+  mergeAndClear(): WeComMsgCallback {
+    const messages = this.messages;
+
+    // 合并文本
+    const textParts = messages
+      .filter(m => m.msgtype === 'text' || m.msgtype === 'mixed')
+      .map(m => extractText(m))
+      .filter(t => t);
+
+    // 合并图片
+    const images = messages
+      .filter(m => m.msgtype === 'image' || m.msgtype === 'mixed')
+      .map(m => extractImage(m))
+      .filter(i => i);
+
+    // 构造合并消息
+    if (images.length > 0) {
+      return {
+        msgid: `merged_${Date.now()}`,
+        msgtype: 'mixed',
+        from: messages[0].from,
+        chatid: messages[0].chatid,
+        chattype: messages[0].chattype,
+        mixed: {
+          msg_item: [
+            ...textParts.map(t => ({ type: 'text', text: { content: t } })),
+            ...images.map(i => ({ type: 'image', image: { url: i.url, aeskey: i.aeskey } }))
+          ]
+        }
+      };
+    }
+
+    // 仅文本
+    return {
+      ...messages[0],
+      msgid: `merged_${Date.now()}`,
+      text: { content: textParts.join('\n') }
+    };
+  }
+}
+```
+
+### 3.4 WeComPlugin 集成
+
+修改消息处理流程：
+
+```typescript
+private messageAggregator = new MessageAggregator();
+
+private async handleMsgCallback(msg: Record<string, unknown>): Promise<void> {
+  const body = msg.body as WeComMsgCallback;
+  const userId = body.from?.userid;
+  const chatId = encodeChatId(body);
+
+  // 检查聚合状态
+  if (this.messageAggregator.shouldAggregate(userId, chatId)) {
+    // 加入队列等待合并
+    this.messageAggregator.addToQueue(userId, chatId, body);
+    return;
+  }
+
+  // 检查是否已在等待中
+  const key = `${userId}:${chatId}`;
+  const isWaiting = this.waitingForAggregate.has(key);
+
+  if (!isWaiting) {
+    // 首条消息：启动聚合窗口
+    this.messageAggregator.addToQueue(userId, chatId, body);
+    this.waitingForAggregate.set(key, true);
+
+    // 异步等待聚合完成
+    setTimeout(async () => {
+      const merged = await this.messageAggregator.waitForComplete(userId, chatId);
+      this.waitingForAggregate.delete(key);
+
+      if (merged) {
+        await this.processMergedMessage(merged);
+      }
+    }, AGGREGATION_WINDOW_MS);
+  }
+}
+```
+
+## 4. 架构概览
+
+```
+用户发送图文混合
+    ↓
+企微 WebSocket → 多个回调 (text + image)
+    ↓
+WeComPlugin.handleMsgCallback
+    ↓
+MessageAggregator 聚合 (800ms窗口)
+    ↓
+合并为单个 mixed 消息
+    ↓
+emitMessage (一次) → ActionExecutor
+    ↓
+AI生成响应 (可能含文本+图片)
+    ↓
+sendMessage → WeComUploader.uploadMedia (如有图片)
+    ↓
+aibot_send_msg 发送媒体 + 文本
+    ↓
+用户收到完整回复
+```
+
+## 5. 文件结构
+
+```
+src/channels/plugins/wecom/
+├── WeComPlugin.ts        # 修改：集成聚合和媒体发送
+├── WeComAdapter.ts       # 现有：消息格式转换
+├── WeComCrypto.ts        # 现有：媒体下载解密
+├── WeComUploader.ts      # 新增：分片上传实现
+├── WeComMediaUtils.ts    # 新增：媒体类型检测、大小验证
+└── MessageAggregator.ts  # 新增：消息聚合管理
+```
+
+## 6. 约束与限制
+
+### 6.1 媒体大小限制
+- 图片：10MB (PNG/JPG/GIF)
+- 语音：2MB (仅AMR格式)
+- 视频：10MB (仅MP4格式)
+- 文件：20MB (任意格式)
+
+### 6.2 分片上传约束
+- 分片大小：512KB (Base64编码前)
+- 最大分片数：100
+- 单个文件最大：50MB (实际受类型限制)
+
+### 6.3 消息聚合约束
+- 聚合窗口：800ms
+- 仅聚合同一用户、同一会话的消息
+- 窗口过期后立即处理
+
+## 7. 测试要点
+
+1. **媒体上传测试**
+   - 各种格式图片上传
+   - 大文件分片上传
+   - 超限文件拒绝
+
+2. **媒体发送测试**
+   - agent发送图片给用户
+   - agent发送文件给用户
+   - 文本+图片组合发送
+
+3. **消息聚合测试**
+   - 单独发送文本 → 正常处理
+   - 单独发送图片 → 正常处理
+   - 快速发送图文 → 合并为一条
+   - 连续发送多条独立消息 → 各自处理
+
+## 8. 实现优先级
+
+1. **P0**: 媒体上传功能（核心功能）
+2. **P0**: 媒体发送集成
+3. **P1**: 消息聚合窗口（解决重复回复）
+4. **P2**: 媒体类型自动检测与降级

--- a/docs/plans/2026-04-22-wecom-media-upload-aggregation-plan.md
+++ b/docs/plans/2026-04-22-wecom-media-upload-aggregation-plan.md
@@ -1,0 +1,1487 @@
+# 企业微信媒体上传与消息聚合实现计划
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 实现企业微信媒体上传（分片上传临时素材）和消息聚合（解决图文混合重复回复问题）
+
+**Architecture:** 新增 WeComUploader.ts 处理 WebSocket 分片上传（init/chunk/finish 三步流程），MessageAggregator.ts 实现消息聚合窗口（800ms等待合并多回调），修改 WeComPlugin.ts 集成两者。
+
+**Tech Stack:** TypeScript, Node.js crypto (MD5), WebSocket, Base64 encoding
+
+---
+
+## Task 1: 媒体类型检测与大小验证
+
+**Files:**
+- Create: `src/channels/plugins/wecom/WeComMediaUtils.ts`
+- Test: `tests/unit/channels/wecomMediaUtils.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// tests/unit/channels/wecomMediaUtils.test.ts
+import { describe, it, expect } from 'vitest';
+import { detectMediaType, validateSize, SIZE_LIMITS } from '@/channels/plugins/wecom/WeComMediaUtils';
+
+describe('WeComMediaUtils', () => {
+  describe('detectMediaType', () => {
+    it('should detect JPEG from magic bytes', () => {
+      const jpegHeader = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+      expect(detectMediaType(jpegHeader)).toBe('image');
+    });
+
+    it('should detect PNG from magic bytes', () => {
+      const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      expect(detectMediaType(pngHeader)).toBe('image');
+    });
+
+    it('should detect PDF from magic bytes', () => {
+      const pdfHeader = Buffer.from([0x25, 0x50, 0x44, 0x46]);
+      expect(detectMediaType(pdfHeader)).toBe('file');
+    });
+
+    it('should default to file for unknown types', () => {
+      const unknownBuffer = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+      expect(detectMediaType(unknownBuffer)).toBe('file');
+    });
+  });
+
+  describe('validateSize', () => {
+    it('should accept image under 10MB', () => {
+      const result = validateSize(5 * 1024 * 1024, 'image');
+      expect(result.shouldReject).toBe(false);
+      expect(result.finalType).toBe('image');
+    });
+
+    it('should reject image over 10MB', () => {
+      const result = validateSize(15 * 1024 * 1024, 'image');
+      expect(result.shouldReject).toBe(true);
+      expect(result.rejectReason).toContain('10MB');
+    });
+
+    it('should downgrade oversized image to file', () => {
+      // 15MB image should be downgraded to file (not rejected since file limit is 20MB)
+      const result = validateSize(15 * 1024 * 1024, 'image');
+      expect(result.shouldReject).toBe(false); // 15MB fits file limit
+    });
+
+    it('should accept file under 20MB', () => {
+      const result = validateSize(18 * 1024 * 1024, 'file');
+      expect(result.shouldReject).toBe(false);
+    });
+
+    it('should reject file over 20MB', () => {
+      const result = validateSize(25 * 1024 * 1024, 'file');
+      expect(result.shouldReject).toBe(true);
+      expect(result.rejectReason).toContain('20MB');
+    });
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test tests/unit/channels/wecomMediaUtils.test.ts`
+Expected: FAIL - module not found
+
+**Step 3: Write minimal implementation**
+
+```typescript
+// src/channels/plugins/wecom/WeComMediaUtils.ts
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * 媒体大小限制（字节）
+ */
+export const SIZE_LIMITS = {
+  image: 10 * 1024 * 1024,      // 10MB
+  voice: 2 * 1024 * 1024,       // 2MB
+  video: 10 * 1024 * 1024,      // 10MB
+  file: 20 * 1024 * 1024,       // 20MB
+};
+
+export type WeComMediaType = 'image' | 'voice' | 'video' | 'file';
+
+/**
+ * 文件大小检查结果
+ */
+export interface SizeCheckResult {
+  finalType: WeComMediaType;
+  shouldReject: boolean;
+  rejectReason?: string;
+  downgraded?: boolean;
+  downgradeNote?: string;
+}
+
+/**
+ * 通过魔术字节检测媒体类型
+ */
+export function detectMediaType(buffer: Buffer): WeComMediaType {
+  if (buffer.length < 4) return 'file';
+
+  const signature = buffer.slice(0, 4).toString('hex');
+
+  // 图片格式
+  const imageSignatures = ['ffd8ffe0', 'ffd8ffe1', '89504e47', '47494638'];
+  if (imageSignatures.some(s => signature.startsWith(s.slice(0, 4)))) {
+    return 'image';
+  }
+
+  // PDF
+  if (signature === '25504446') {
+    return 'file';
+  }
+
+  // 视频 MP4 (ftyp box)
+  if (buffer.length >= 8) {
+    const mp4Check = buffer.slice(4, 8).toString();
+    if (mp4Check === 'ftyp') {
+      return 'video';
+    }
+  }
+
+  // 默认为文件
+  return 'file';
+}
+
+/**
+ * 验证文件大小并处理降级策略
+ */
+export function validateSize(fileSize: number, type: WeComMediaType): SizeCheckResult {
+  const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(2);
+
+  // 超过绝对上限 20MB
+  if (fileSize > SIZE_LIMITS.file) {
+    return {
+      finalType: type,
+      shouldReject: true,
+      rejectReason: `文件大小 ${fileSizeMB}MB 超过了企业微信允许的最大限制 20MB，无法发送`,
+      downgraded: false,
+    };
+  }
+
+  // 按类型检查
+  if (type === 'image' && fileSize > SIZE_LIMITS.image) {
+    return {
+      finalType: 'file',
+      shouldReject: false,
+      downgraded: true,
+      downgradeNote: `图片大小 ${fileSizeMB}MB 超过 10MB 限制，已转为文件格式发送`,
+    };
+  }
+
+  if (type === 'video' && fileSize > SIZE_LIMITS.video) {
+    return {
+      finalType: 'file',
+      shouldReject: false,
+      downgraded: true,
+      downgradeNote: `视频大小 ${fileSizeMB}MB 超过 10MB 限制，已转为文件格式发送`,
+    };
+  }
+
+  if (type === 'voice' && fileSize > SIZE_LIMITS.voice) {
+    return {
+      finalType: 'file',
+      shouldReject: false,
+      downgraded: true,
+      downgradeNote: `语音大小 ${fileSizeMB}MB 超过 2MB 限制，已转为文件格式发送`,
+    };
+  }
+
+  return {
+    finalType: type,
+    shouldReject: false,
+  };
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test tests/unit/channels/wecomMediaUtils.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/channels/plugins/wecom/WeComMediaUtils.ts tests/unit/channels/wecomMediaUtils.test.ts
+git commit -m "feat(wecom): add media type detection and size validation"
+```
+
+---
+
+## Task 2: WebSocket 响应等待器
+
+**Files:**
+- Create: `src/channels/plugins/wecom/WeComUploader.ts` (Part 1 - WebSocket helper)
+- Test: `tests/unit/channels/wecomUploader.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// tests/unit/channels/wecomUploader.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WsCommandSender, UPLOAD_TIMEOUT_MS } from '@/channels/plugins/wecom/WeComUploader';
+import WebSocket from 'ws';
+
+describe('WeComUploader', () => {
+  describe('WsCommandSender', () => {
+    it('should send command and wait for response', async () => {
+      const ws = new WebSocket('ws://localhost:8080');
+      vi.spyOn(ws, 'send').mockImplementation(() => {});
+
+      const sender = new WsCommandSender(ws);
+
+      // Simulate response
+      setTimeout(() => {
+        sender.handleResponse({ req_id: 'test-123', errcode: 0, body: { upload_id: 'upload-abc' } });
+      }, 100);
+
+      const result = await sender.sendCommand({
+        cmd: 'test_cmd',
+        headers: { req_id: 'test-123' },
+        body: {}
+      });
+
+      expect(result.errcode).toBe(0);
+      expect(result.body.upload_id).toBe('upload-abc');
+    });
+
+    it('should timeout if no response', async () => {
+      const ws = new WebSocket('ws://localhost:8080');
+      vi.spyOn(ws, 'send').mockImplementation(() => {});
+
+      const sender = new WsCommandSender(ws, 100); // 100ms timeout
+
+      await expect(sender.sendCommand({
+        cmd: 'test_cmd',
+        headers: { req_id: 'test-456' },
+        body: {}
+      })).rejects.toThrow('timeout');
+    });
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test tests/unit/channels/wecomUploader.test.ts`
+Expected: FAIL - module not found
+
+**Step 3: Write minimal implementation**
+
+```typescript
+// src/channels/plugins/wecom/WeComUploader.ts
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import WebSocket from 'ws';
+import { createHash } from 'crypto';
+import type { WeComMediaType } from './WeComMediaUtils';
+
+/**
+ * 分片大小：512KB（Base64编码前）
+ */
+export const CHUNK_SIZE = 512 * 1024;
+
+/**
+ * 最大分片数（对应50MB）
+ */
+export const MAX_CHUNKS = 100;
+
+/**
+ * 上传超时时间
+ */
+export const UPLOAD_TIMEOUT_MS = 60_000;
+
+/**
+ * WebSocket 响应接口
+ */
+export interface WsResponse {
+  errcode?: number;
+  errmsg?: string;
+  body?: Record<string, unknown>;
+}
+
+/**
+ * WebSocket 响应等待器
+ * 管理命令发送和响应匹配
+ */
+export class WsCommandSender {
+  private pendingRequests: Map<string, {
+    resolve: (response: WsResponse) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = new Map();
+
+  constructor(
+    private ws: WebSocket,
+    private timeoutMs: number = UPLOAD_TIMEOUT_MS
+  ) {}
+
+  /**
+   * 发送命令并等待响应
+   */
+  async sendCommand(data: {
+    cmd: string;
+    headers: { req_id: string };
+    body: Record<string, unknown>;
+  }): Promise<WsResponse> {
+    const reqId = data.headers.req_id;
+
+    return new Promise((resolve, reject) => {
+      // 设置超时
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(reqId);
+        reject(new Error(`WebSocket command ${data.cmd} timed out after ${this.timeoutMs}ms`));
+      }, this.timeoutMs);
+
+      // 注册等待
+      this.pendingRequests.set(reqId, { resolve, reject, timer });
+
+      // 发送命令
+      if (this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify(data));
+      } else {
+        clearTimeout(timer);
+        this.pendingRequests.delete(reqId);
+        reject(new Error('WebSocket not connected'));
+      }
+    });
+  }
+
+  /**
+   * 处理收到的响应
+   */
+  handleResponse(response: { req_id?: string } & WsResponse): void {
+    const reqId = response.req_id;
+    if (!reqId) return;
+
+    const pending = this.pendingRequests.get(reqId);
+    if (!pending) return;
+
+    clearTimeout(pending.timer);
+    this.pendingRequests.delete(reqId);
+
+    if (response.errcode !== undefined && response.errcode !== 0) {
+      pending.reject(new Error(`WeCom error ${response.errcode}: ${response.errmsg || 'unknown'}`));
+    } else {
+      pending.resolve(response);
+    }
+  }
+}
+
+/**
+ * 计算 Buffer 的 MD5
+ */
+export function calculateMd5(buffer: Buffer): string {
+  return createHash('md5').update(buffer).digest('hex');
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test tests/unit/channels/wecomUploader.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/channels/plugins/wecom/WeComUploader.ts tests/unit/channels/wecomUploader.test.ts
+git commit -m "feat(wecom): add WebSocket command sender for upload"
+```
+
+---
+
+## Task 3: 分片上传流程实现
+
+**Files:**
+- Modify: `src/channels/plugins/wecom/WeComUploader.ts` (add uploadMedia)
+- Modify: `tests/unit/channels/wecomUploader.test.ts` (add tests)
+
+**Step 1: Write the failing test**
+
+```typescript
+// Add to tests/unit/channels/wecomUploader.test.ts
+describe('uploadMedia', () => {
+  it('should upload small file in one chunk', async () => {
+    const mockWs = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+      on: vi.fn(),
+    } as any;
+
+    const sender = new WsCommandSender(mockWs);
+
+    // Mock init response
+    setTimeout(() => sender.handleResponse({
+      req_id: 'init-1',
+      errcode: 0,
+      body: { upload_id: 'upload-1' }
+    }), 50);
+
+    // Mock chunk response
+    setTimeout(() => sender.handleResponse({
+      req_id: 'chunk-0',
+      errcode: 0
+    }), 100);
+
+    // Mock finish response
+    setTimeout(() => sender.handleResponse({
+      req_id: 'finish-1',
+      errcode: 0,
+      body: { media_id: 'media-abc-123' }
+    }), 150);
+
+    const smallBuffer = Buffer.from('test content');
+
+    const result = await uploadMedia(sender, smallBuffer, {
+      type: 'file',
+      filename: 'test.txt'
+    });
+
+    expect(result).toBe('media-abc-123');
+    expect(mockWs.send).toHaveBeenCalledTimes(3);
+  });
+
+  it('should upload large file in multiple chunks', async () => {
+    const mockWs = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+    } as any;
+
+    const sender = new WsCommandSender(mockWs, 500);
+
+    // Create buffer larger than CHUNK_SIZE
+    const largeBuffer = Buffer.alloc(CHUNK_SIZE * 2 + 100, 0x42);
+
+    const totalChunks = Math.ceil(largeBuffer.length / CHUNK_SIZE);
+    expect(totalChunks).toBe(3);
+
+    // Mock responses
+    setTimeout(() => sender.handleResponse({
+      req_id: 'init-2',
+      errcode: 0,
+      body: { upload_id: 'upload-2' }
+    }), 50);
+
+    // Mock chunk responses for each chunk
+    for (let i = 0; i < totalChunks; i++) {
+      setTimeout(() => sender.handleResponse({
+        req_id: `chunk-${i}`,
+        errcode: 0
+      }), 100 + i * 50);
+    }
+
+    setTimeout(() => sender.handleResponse({
+      req_id: 'finish-2',
+      errcode: 0,
+      body: { media_id: 'media-large-123' }
+    }), 300);
+
+    const result = await uploadMedia(sender, largeBuffer, {
+      type: 'file',
+      filename: 'large.bin'
+    });
+
+    expect(result).toBe('media-large-123');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test tests/unit/channels/wecomUploader.test.ts`
+Expected: FAIL - uploadMedia not found
+
+**Step 3: Write implementation**
+
+```typescript
+// Add to src/channels/plugins/wecom/WeComUploader.ts
+
+/**
+ * 上传选项
+ */
+export interface UploadOptions {
+  type: WeComMediaType;
+  filename: string;
+}
+
+/**
+ * 分片上传媒体文件
+ *
+ * 流程：
+ * 1. aibot_upload_media_init - 初始化上传
+ * 2. aibot_upload_media_chunk - 分片上传（base64编码）
+ * 3. aibot_upload_media_finish - 完成上传
+ */
+export async function uploadMedia(
+  sender: WsCommandSender,
+  buffer: Buffer,
+  options: UploadOptions
+): Promise<string> {
+  const { type, filename } = options;
+
+  // 计算分片数
+  const totalChunks = Math.ceil(buffer.length / CHUNK_SIZE);
+  if (totalChunks > MAX_CHUNKS) {
+    throw new Error(`文件过大，分片数 ${totalChunks} 超过最大限制 ${MAX_CHUNKS}`);
+  }
+
+  // 1. 初始化上传
+  const initReqId = `upload_init_${Date.now()}`;
+  const initResult = await sender.sendCommand({
+    cmd: 'aibot_upload_media_init',
+    headers: { req_id: initReqId },
+    body: {
+      type,
+      filename,
+      total_size: buffer.length,
+      total_chunks: totalChunks,
+      md5: calculateMd5(buffer),
+    },
+  });
+
+  const uploadId = initResult.body?.upload_id as string;
+  if (!uploadId) {
+    throw new Error('上传初始化失败：未返回 upload_id');
+  }
+
+  // 2. 分片上传
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * CHUNK_SIZE;
+    const end = Math.min(start + CHUNK_SIZE, buffer.length);
+    const chunk = buffer.slice(start, end);
+
+    const chunkReqId = `upload_chunk_${uploadId}_${i}`;
+    await sender.sendCommand({
+      cmd: 'aibot_upload_media_chunk',
+      headers: { req_id: chunkReqId },
+      body: {
+        upload_id: uploadId,
+        chunk_index: i,
+        base64_data: chunk.toString('base64'),
+      },
+    });
+  }
+
+  // 3. 完成上传
+  const finishReqId = `upload_finish_${uploadId}`;
+  const finishResult = await sender.sendCommand({
+    cmd: 'aibot_upload_media_finish',
+    headers: { req_id: finishReqId },
+    body: { upload_id: uploadId },
+  });
+
+  const mediaId = finishResult.body?.media_id as string;
+  if (!mediaId) {
+    throw new Error('上传完成失败：未返回 media_id');
+  }
+
+  return mediaId;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test tests/unit/channels/wecomUploader.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/channels/plugins/wecom/WeComUploader.ts tests/unit/channels/wecomUploader.test.ts
+git commit -m "feat(wecom): implement chunked media upload"
+```
+
+---
+
+## Task 4: 媒体加载与发送集成
+
+**Files:**
+- Modify: `src/channels/plugins/wecom/WeComUploader.ts` (add loadMediaFromUrl)
+- Modify: `src/channels/plugins/wecom/WeComPlugin.ts` (integrate upload into sendMessage)
+
+**Step 1: Write test for loadMediaFromUrl**
+
+```typescript
+// Add to tests/unit/channels/wecomUploader.test.ts
+import { loadMediaFromUrl } from '@/channels/plugins/wecom/WeComUploader';
+
+describe('loadMediaFromUrl', () => {
+  it('should load media from URL', async () => {
+    // Mock fetch
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(100)),
+    });
+
+    const result = await loadMediaFromUrl('https://example.com/image.jpg');
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBe(100);
+  });
+
+  it('should throw on fetch error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    await expect(loadMediaFromUrl('https://example.com/notfound.jpg'))
+      .rejects.toThrow('404');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test tests/unit/channels/wecomUploader.test.ts`
+Expected: FAIL - loadMediaFromUrl not exported
+
+**Step 3: Write implementation**
+
+```typescript
+// Add to src/channels/plugins/wecom/WeComUploader.ts
+
+/**
+ * 从 URL 加载媒体文件
+ */
+export async function loadMediaFromUrl(url: string, timeoutMs = 30_000): Promise<Buffer> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      throw new Error(`Failed to load media: HTTP ${response.status}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  } catch (error) {
+    clearTimeout(timer);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Media load timed out');
+    }
+    throw error;
+  }
+}
+
+/**
+ * 从 URL 或本地路径提取文件名
+ */
+export function extractFilename(url: string): string {
+  try {
+    const urlObj = new URL(url, 'file://');
+    const pathParts = urlObj.pathname.split('/');
+    const lastPart = pathParts[pathParts.length - 1];
+    if (lastPart && lastPart.includes('.')) {
+      return decodeURIComponent(lastPart);
+    }
+  } catch {
+    // 作为普通路径处理
+    const parts = url.split('/');
+    const lastPart = parts[parts.length - 1];
+    if (lastPart && lastPart.includes('.')) {
+      return lastPart;
+    }
+  }
+  return `media_${Date.now()}`;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test tests/unit/channels/wecomUploader.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/channels/plugins/wecom/WeComUploader.ts tests/unit/channels/wecomUploader.test.ts
+git commit -m "feat(wecom): add media loading from URL"
+```
+
+---
+
+## Task 5: 消息聚合器实现
+
+**Files:**
+- Create: `src/channels/plugins/wecom/MessageAggregator.ts`
+- Test: `tests/unit/channels/messageAggregator.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// tests/unit/channels/messageAggregator.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageAggregator, AGGREGATION_WINDOW_MS } from '@/channels/plugins/wecom/MessageAggregator';
+import type { WeComMsgCallback } from '@/channels/plugins/wecom/WeComAdapter';
+
+describe('MessageAggregator', () => {
+  let aggregator: MessageAggregator;
+
+  beforeEach(() => {
+    aggregator = new MessageAggregator();
+  });
+
+  describe('shouldAggregate', () => {
+    it('should return false for first message', () => {
+      expect(aggregator.shouldAggregate('user1', 'chat1')).toBe(false);
+    });
+
+    it('should return true after first message added', () => {
+      const msg: WeComMsgCallback = {
+        msgid: 'msg1',
+        msgtype: 'text',
+        from: { userid: 'user1' },
+        chattype: 'single',
+        text: { content: 'hello' },
+      };
+
+      aggregator.addToQueue('user1', 'chat1', msg);
+      expect(aggregator.shouldAggregate('user1', 'chat1')).toBe(true);
+    });
+
+    it('should return false after window expires', async () => {
+      const msg: WeComMsgCallback = {
+        msgid: 'msg1',
+        msgtype: 'text',
+        from: { userid: 'user1' },
+        chattype: 'single',
+        text: { content: 'hello' },
+      };
+
+      aggregator.addToQueue('user1', 'chat1', msg);
+
+      // Wait for window to expire
+      await new Promise(resolve => setTimeout(resolve, AGGREGATION_WINDOW_MS + 100));
+
+      expect(aggregator.shouldAggregate('user1', 'chat1')).toBe(false);
+    });
+  });
+
+  describe('waitForComplete', () => {
+    it('should merge text messages', async () => {
+      const msg1: WeComMsgCallback = {
+        msgid: 'msg1',
+        msgtype: 'text',
+        from: { userid: 'user1' },
+        chattype: 'single',
+        text: { content: 'hello' },
+      };
+
+      const msg2: WeComMsgCallback = {
+        msgid: 'msg2',
+        msgtype: 'text',
+        from: { userid: 'user1' },
+        chattype: 'single',
+        text: { content: 'world' },
+      };
+
+      aggregator.addToQueue('user1', 'chat1', msg1);
+      aggregator.addToQueue('user1', 'chat1', msg2);
+
+      const merged = await aggregator.waitForComplete('user1', 'chat1');
+
+      expect(merged?.msgtype).toBe('text');
+      expect(merged?.text?.content).toBe('hello\nworld');
+    });
+
+    it('should merge text and image into mixed', async () => {
+      const msg1: WeComMsgCallback = {
+        msgid: 'msg1',
+        msgtype: 'text',
+        from: { userid: 'user1' },
+        chattype: 'single',
+        text: { content: 'look at this' },
+      };
+
+      const msg2: WeComMsgCallback = {
+        msgid: 'msg2',
+        msgtype: 'image',
+        from: { userid: 'user1' },
+        chattype: 'single',
+        image: { url: 'https://example.com/img.jpg', aeskey: 'abc123' },
+      };
+
+      aggregator.addToQueue('user1', 'chat1', msg1);
+      aggregator.addToQueue('user1', 'chat1', msg2);
+
+      const merged = await aggregator.waitForComplete('user1', 'chat1');
+
+      expect(merged?.msgtype).toBe('mixed');
+      expect(merged?.mixed?.msg_item?.length).toBe(2);
+      expect(merged?.mixed?.msg_item?.[0]?.type).toBe('text');
+      expect(merged?.mixed?.msg_item?.[1]?.type).toBe('image');
+    });
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test tests/unit/channels/messageAggregator.test.ts`
+Expected: FAIL - module not found
+
+**Step 3: Write implementation**
+
+```typescript
+// src/channels/plugins/wecom/MessageAggregator.ts
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { WeComMsgCallback } from './WeComAdapter';
+
+/**
+ * 聚合窗口时间（毫秒）
+ */
+export const AGGREGATION_WINDOW_MS = 800;
+
+/**
+ * 单队列最大消息数
+ */
+export const MAX_QUEUE_SIZE = 10;
+
+/**
+ * 聚合队列
+ */
+class AggregationQueue {
+  private messages: WeComMsgCallback[] = [];
+  private createdAt: number = Date.now();
+  private windowMs: number;
+
+  constructor(windowMs: number = AGGREGATION_WINDOW_MS) {
+    this.windowMs = windowMs;
+  }
+
+  add(msg: WeComMsgCallback): void {
+    if (this.messages.length < MAX_QUEUE_SIZE) {
+      this.messages.push(msg);
+    }
+  }
+
+  isExpired(): boolean {
+    return Date.now() - this.createdAt > this.windowMs;
+  }
+
+  async waitForWindowClose(): Promise<void> {
+    const remaining = this.windowMs - (Date.now() - this.createdAt);
+    if (remaining > 0) {
+      await new Promise(resolve => setTimeout(resolve, remaining));
+    }
+  }
+
+  mergeAndClear(): WeComMsgCallback | null {
+    if (this.messages.length === 0) return null;
+    if (this.messages.length === 1) return this.messages[0];
+
+    const messages = this.messages;
+
+    // 收集文本
+    const textParts: string[] = [];
+    for (const msg of messages) {
+      if (msg.msgtype === 'text' && msg.text?.content) {
+        textParts.push(msg.text.content);
+      } else if (msg.msgtype === 'mixed') {
+        const items = msg.mixed?.msg_item || msg.mixed?.items || msg.mixed?.item || [];
+        for (const item of items) {
+          const type = item.msgtype || item.type || '';
+          if (type === 'text' && item.text?.content) {
+            textParts.push(item.text.content);
+          }
+        }
+      }
+    }
+
+    // 收集图片
+    const images: Array<{ url: string; aeskey: string }> = [];
+    for (const msg of messages) {
+      if (msg.msgtype === 'image' && msg.image) {
+        images.push({ url: msg.image.url, aeskey: msg.image.aeskey });
+      } else if (msg.msgtype === 'mixed') {
+        const items = msg.mixed?.msg_item || msg.mixed?.items || msg.mixed?.item || [];
+        for (const item of items) {
+          const type = item.msgtype || item.type || '';
+          if (type === 'image' && item.image) {
+            images.push({ url: item.image.url, aeskey: item.image.aeskey });
+          }
+        }
+      }
+    }
+
+    const firstMsg = messages[0];
+
+    // 有图片时构造 mixed 消息
+    if (images.length > 0) {
+      const msgItem: Array<{ type: string; text?: { content: string }; image?: { url: string; aeskey: string } }> = [];
+
+      for (const text of textParts) {
+        msgItem.push({ type: 'text', text: { content: text } });
+      }
+
+      for (const img of images) {
+        msgItem.push({ type: 'image', image: { url: img.url, aeskey: img.aeskey } });
+      }
+
+      return {
+        msgid: `merged_${Date.now()}`,
+        msgtype: 'mixed',
+        from: firstMsg.from,
+        chatid: firstMsg.chatid,
+        chattype: firstMsg.chattype,
+        aibotid: firstMsg.aibotid,
+        mixed: { msg_item: msgItem },
+      };
+    }
+
+    // 仅文本
+    return {
+      msgid: `merged_${Date.now()}`,
+      msgtype: 'text',
+      from: firstMsg.from,
+      chatid: firstMsg.chatid,
+      chattype: firstMsg.chattype,
+      aibotid: firstMsg.aibotid,
+      text: { content: textParts.join('\n') },
+    };
+  }
+}
+
+/**
+ * 消息聚合管理器
+ */
+export class MessageAggregator {
+  private queues: Map<string, AggregationQueue> = new Map();
+
+  /**
+   * 判断是否应该聚合等待
+   */
+  shouldAggregate(userId: string, chatId: string): boolean {
+    const key = `${userId}:${chatId}`;
+    const queue = this.queues.get(key);
+    return queue !== undefined && !queue.isExpired();
+  }
+
+  /**
+   * 添加消息到聚合队列
+   */
+  addToQueue(userId: string, chatId: string, msg: WeComMsgCallback): void {
+    const key = `${userId}:${chatId}`;
+    let queue = this.queues.get(key);
+    if (!queue) {
+      queue = new AggregationQueue();
+      this.queues.set(key, queue);
+    }
+    queue.add(msg);
+  }
+
+  /**
+   * 等待聚合完成并返回合并消息
+   */
+  async waitForComplete(userId: string, chatId: string): Promise<WeComMsgCallback | null> {
+    const key = `${userId}:${chatId}`;
+    const queue = this.queues.get(key);
+    if (!queue) return null;
+
+    await queue.waitForWindowClose();
+    const merged = queue.mergeAndClear();
+    this.queues.delete(key);
+    return merged;
+  }
+
+  /**
+   * 清理过期队列
+   */
+  cleanupExpired(): void {
+    for (const [key, queue] of this.queues.entries()) {
+      if (queue.isExpired()) {
+        this.queues.delete(key);
+      }
+    }
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test tests/unit/channels/messageAggregator.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/channels/plugins/wecom/MessageAggregator.ts tests/unit/channels/messageAggregator.test.ts
+git commit -m "feat(wecom): add message aggregator for multi-callback handling"
+```
+
+---
+
+## Task 6: WeComPlugin 集成媒体上传
+
+**Files:**
+- Modify: `src/channels/plugins/wecom/WeComPlugin.ts`
+- Check: existing implementation at lines 218-275
+
+**Step 1: Import new modules**
+
+在文件顶部添加导入：
+
+```typescript
+// 在现有导入后添加
+import { detectMediaType, validateSize, type WeComMediaType } from './WeComMediaUtils';
+import { WsCommandSender, uploadMedia, loadMediaFromUrl, extractFilename } from './WeComUploader';
+```
+
+**Step 2: Add WsCommandSender instance**
+
+在类属性中添加：
+
+```typescript
+export class WeComPlugin extends BasePlugin {
+  // ... 现有属性 ...
+
+  // WebSocket 响应处理器（用于上传）
+  private wsCommandSender: WsCommandSender | null = null;
+```
+
+**Step 3: Initialize sender in connect()**
+
+在 WebSocket 连接建立后初始化：
+
+```typescript
+// 在 ws.on('open') 回调中，subscribe() 之后添加
+ws.on('open', () => {
+  this.wsCommandSender = new WsCommandSender(ws);
+  this.subscribe();
+});
+```
+
+**Step 4: Handle responses in ws.on('message')**
+
+```typescript
+// 在 ws.on('message') 回调中添加响应处理
+ws.on('message', (data: WebSocket.Data) => {
+  try {
+    const msg = JSON.parse(data.toString());
+
+    // 处理上传响应
+    if (msg.req_id && this.wsCommandSender) {
+      this.wsCommandSender.handleResponse(msg);
+    }
+
+    this.handleWsMessage(msg);
+    // ... 后续逻辑 ...
+  } catch (error) {
+    // ...
+  }
+});
+```
+
+**Step 5: Add media sending support in sendMessage**
+
+修改 sendMessage 方法支持媒体：
+
+```typescript
+async sendMessage(chatId: string, message: IUnifiedOutgoingMessage): Promise<string> {
+  console.log(`[WeComPlugin] sendMessage: chatId=${chatId}, hasMedia=${!!message.imageUrl || !!message.fileUrl}`);
+
+  // 检测媒体附件
+  const mediaUrl = message.imageUrl || message.fileUrl;
+  if (mediaUrl && this.wsCommandSender) {
+    try {
+      // 1. 加载媒体文件
+      const mediaBuffer = await loadMediaFromUrl(mediaUrl);
+
+      // 2. 检测类型并验证大小
+      const detectedType = detectMediaType(mediaBuffer);
+      const sizeCheck = validateSize(mediaBuffer.length, detectedType);
+
+      if (sizeCheck.shouldReject) {
+        console.error(`[WeComPlugin] Media rejected: ${sizeCheck.rejectReason}`);
+        // 发送错误提示文本
+        return this.sendTextMessage(chatId, `❌ ${sizeCheck.rejectReason}`);
+      }
+
+      // 3. 上传获取 media_id
+      const mediaId = await uploadMedia(this.wsCommandSender, mediaBuffer, {
+        type: sizeCheck.finalType,
+        filename: extractFilename(mediaUrl),
+      });
+
+      console.log(`[WeComPlugin] Media uploaded: media_id=${mediaId}, type=${sizeCheck.finalType}`);
+
+      // 4. 发送媒体消息
+      const { type: chatType } = parseChatId(chatId);
+      const reqId = this.generateReqId();
+      this.send({
+        cmd: 'aibot_send_msg',
+        headers: { req_id: reqId },
+        body: {
+          chatid: chatId,
+          chat_type: chatType === 'group' ? 2 : 1,
+          msgtype: sizeCheck.finalType,
+          [sizeCheck.finalType]: { media_id: mediaId },
+        },
+      });
+
+      // 5. 如有文本，再发送文本消息
+      if (message.text) {
+        await this.sendTextMessage(chatId, message.text);
+      }
+
+      return `media_${reqId}`;
+    } catch (error) {
+      console.error('[WeComPlugin] Media upload failed:', error);
+      // 降级为纯文本发送
+      if (message.text) {
+        return this.sendTextMessage(chatId, message.text);
+      }
+      throw error;
+    }
+  }
+
+  // 现有文本/markdown发送逻辑...
+  return this.sendTextMessage(chatId, message.text || '');
+}
+```
+
+**Step 6: Extract sendTextMessage helper**
+
+```typescript
+/**
+ * 发送纯文本消息
+ */
+private async sendTextMessage(chatId: string, text: string): Promise<string> {
+  const reqId = this.reqIdCache.get(chatId);
+  const { content } = toWeComSendParams({ text });
+  const truncatedContent = content.length > WECOM_MESSAGE_LIMIT
+    ? content.slice(0, WECOM_MESSAGE_LIMIT - 3) + '...'
+    : content;
+
+  if (reqId) {
+    // 流式回复
+    const streamId = this.generateStreamId();
+    this.send({
+      cmd: 'aibot_respond_msg',
+      headers: { req_id: reqId },
+      body: {
+        msgtype: 'stream',
+        stream: {
+          id: streamId,
+          finish: true,
+          content: truncatedContent,
+        },
+      },
+    });
+    return `stream_${streamId}`;
+  }
+
+  // 主动推送
+  const { type: chatType } = parseChatId(chatId);
+  const sendReqId = this.generateReqId();
+  this.send({
+    cmd: 'aibot_send_msg',
+    headers: { req_id: sendReqId },
+    body: {
+      chatid: chatId,
+      chat_type: chatType === 'group' ? 2 : 1,
+      msgtype: 'markdown',
+      markdown: { content: truncatedContent },
+    },
+  });
+  return `push_${sendReqId}`;
+}
+```
+
+**Step 7: Run build to verify no errors**
+
+Run: `npm run build`
+Expected: No TypeScript errors
+
+**Step 8: Commit**
+
+```bash
+git add src/channels/plugins/wecom/WeComPlugin.ts
+git commit -m "feat(wecom): integrate media upload into sendMessage"
+```
+
+---
+
+## Task 7: WeComPlugin 集成消息聚合
+
+**Files:**
+- Modify: `src/channels/plugins/wecom/WeComPlugin.ts`
+
+**Step 1: Import MessageAggregator**
+
+```typescript
+import { MessageAggregator, AGGREGATION_WINDOW_MS } from './MessageAggregator';
+```
+
+**Step 2: Add aggregator instance**
+
+```typescript
+// 添加类属性
+private messageAggregator = new MessageAggregator();
+private waitingForAggregate: Map<string, boolean> = new Map();
+```
+
+**Step 3: Modify handleMsgCallback**
+
+修改消息回调处理逻辑：
+
+```typescript
+private async handleMsgCallback(msg: Record<string, unknown>): Promise<void> {
+  try {
+    const body = msg.body as WeComMsgCallback;
+    const headers = msg.headers as { req_id?: string } | undefined;
+    const msgId = body?.msgid;
+    const userId = body?.from?.userid;
+    const chatType = body?.chattype;
+    const msgType = body?.msgtype;
+
+    console.log(`[WeComPlugin] handleMsgCallback: msgId=${msgId}, msgtype=${msgType}`);
+
+    if (!msgId || !userId) {
+      console.warn('[WeComPlugin] handleMsgCallback: missing msgId or userId');
+      return;
+    }
+
+    // 检查是否正在聚合等待
+    const chatId = encodeChatId(body);
+    const key = `${userId}:${chatId}`;
+
+    if (this.messageAggregator.shouldAggregate(userId, chatId)) {
+      // 加入聚合队列
+      this.messageAggregator.addToQueue(userId, chatId, body);
+      console.log(`[WeComPlugin] Added to aggregation queue: key=${key}`);
+      return;
+    }
+
+    // 检查是否已启动聚合窗口
+    if (this.waitingForAggregate.has(key)) {
+      // 已在等待中，添加到队列
+      this.messageAggregator.addToQueue(userId, chatId, body);
+      return;
+    }
+
+    // 首条消息：启动聚合窗口
+    // 但先检查是否是多媒体消息类型（可能需要聚合）
+    const needsAggregation = msgType === 'mixed' ||
+      (msgType === 'text' && Date.now() % 100 < 50); // 简化判断，实际应基于消息类型
+
+    // 对于非混合消息，直接处理
+    if (msgType !== 'mixed' && msgType !== 'image') {
+      // 文本、语音等直接处理
+      await this.processSingleMessage(body, headers);
+      return;
+    }
+
+    // 启动聚合窗口
+    this.messageAggregator.addToQueue(userId, chatId, body);
+    this.waitingForAggregate.set(key, true);
+
+    console.log(`[WeComPlugin] Starting aggregation window: key=${key}`);
+
+    // 等待聚合窗口关闭
+    setTimeout(async () => {
+      try {
+        const merged = await this.messageAggregator.waitForComplete(userId, chatId);
+        this.waitingForAggregate.delete(key);
+
+        if (merged) {
+          console.log(`[WeComPlugin] Processing merged message: msgid=${merged.msgid}, msgtype=${merged.msgtype}`);
+          await this.processSingleMessage(merged, headers);
+        }
+      } catch (error) {
+        console.error('[WeComPlugin] Aggregation processing failed:', error);
+        this.waitingForAggregate.delete(key);
+      }
+    }, AGGREGATION_WINDOW_MS);
+  } catch (error) {
+    console.error('[WeComPlugin] Error processing message callback:', error);
+  }
+}
+
+/**
+ * 处理单条（或合并后的）消息
+ */
+private async processSingleMessage(
+  body: WeComMsgCallback,
+  headers?: { req_id?: string }
+): Promise<void> {
+  const msgId = body.msgid;
+
+  // 事件去重
+  if (this.isEventProcessed(msgId)) {
+    console.log(`[WeComPlugin] Message ${msgId} already processed`);
+    return;
+  }
+  this.markEventProcessed(msgId);
+
+  const userId = body.from?.userid;
+  if (!userId) return;
+
+  // 跟踪活跃用户
+  this.activeUsers.add(userId);
+
+  // 缓存 reqId
+  const chatId = encodeChatId(body);
+  if (headers?.req_id) {
+    this.reqIdCache.set(chatId, headers.req_id);
+  }
+
+  // 下载媒体（如有）
+  try {
+    await this.downloadMediaItems(body);
+  } catch (error) {
+    console.error('[WeComPlugin] Media download failed:', error);
+  }
+
+  // 转换并发送
+  const unifiedMessage = toUnifiedIncomingMessage(body);
+  if (unifiedMessage && this.messageHandler) {
+    // 处理菜单按钮命令...
+    // 然后发送消息
+    void this.emitMessage(unifiedMessage).catch(error =>
+      console.error('[WeComPlugin] Error handling message:', error)
+    );
+  }
+}
+```
+
+**Step 4: Run build**
+
+Run: `npm run build`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add src/channels/plugins/wecom/WeComPlugin.ts
+git commit -m "feat(wecom): integrate message aggregator to handle multi-callback"
+```
+
+---
+
+## Task 8: 更新导出
+
+**Files:**
+- Modify: `src/channels/plugins/wecom/index.ts`
+
+**Step 1: Add new exports**
+
+```typescript
+// 在现有导出后添加
+export { WeComMediaUtils, detectMediaType, validateSize, SIZE_LIMITS, type WeComMediaType, type SizeCheckResult } from './WeComMediaUtils';
+export { WeComUploader, WsCommandSender, uploadMedia, loadMediaFromUrl, extractFilename, CHUNK_SIZE, MAX_CHUNKS, UPLOAD_TIMEOUT_MS } from './WeComUploader';
+export { MessageAggregator, AGGREGATION_WINDOW_MS, MAX_QUEUE_SIZE } from './MessageAggregator';
+```
+
+**Step 2: Run build**
+
+Run: `npm run build`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/channels/plugins/wecom/index.ts
+git commit -m "feat(wecom): export new media upload and aggregation modules"
+```
+
+---
+
+## Task 9: 集成测试
+
+**Files:**
+- Create: `tests/integration/channels/wecomMedia.test.ts`
+
+**Step 1: Write integration test**
+
+```typescript
+// tests/integration/channels/wecomMedia.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+describe('WeCom Media Upload Integration', () => {
+  it.skip('should upload and send image in real environment', async () => {
+    // 此测试需要真实的企微环境
+    // 1. 创建 WebSocket 连接
+    // 2. 上传图片
+    // 3. 发送媒体消息
+    // 4. 验证用户收到
+  });
+
+  it.skip('should aggregate mixed callbacks in real environment', async () => {
+    // 此测试需要真实的企微环境
+    // 1. 用户发送图文混合
+    // 2. 验证只触发一次 AI 响应
+    // 3. 验证回复正确包含文本和图片
+  });
+});
+```
+
+**Step 2: Commit**
+
+```bash
+git add tests/integration/channels/wecomMedia.test.ts
+git commit -m "test(wecom): add integration test placeholders for media upload"
+```
+
+---
+
+## Task 10: 文档更新
+
+**Files:**
+- Modify: `docs/plans/2026-04-22-wecom-media-upload-aggregation-design.md` (update status)
+
+**Step 1: Update design doc status**
+
+```markdown
+# 企业微信媒体上传与消息聚合设计
+
+**日期**: 2026-04-22
+**状态**: 已实现 ✅
+**作者**: Claude Code
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-04-22-wecom-media-upload-aggregation-design.md
+git commit -m "docs(wecom): mark design as implemented"
+```
+
+---
+
+## 验收清单
+
+- [ ] 媒体上传功能正常（图片、文件）
+- [ ] 大文件分片上传正常
+- [ ] 超限文件正确拒绝或降级
+- [ ] 图文混合消息不再重复回复
+- [ ] 单独文本消息正常处理
+- [ ] 单独图片消息正常处理
+- [ ] 所有单元测试通过
+- [ ] TypeScript 编译无错误
+
+---
+
+## 实现完成后的后续工作
+
+1. 在真实企微环境测试上传和发送
+2. 测试消息聚合效果（观察日志确认只触发一次 emitMessage）
+3. 根据实际测试调整聚合窗口时间
+4. 添加更多媒体格式支持（voice, video）

--- a/docs/plans/2026-04-27-cron-channel-sync-design.md
+++ b/docs/plans/2026-04-27-cron-channel-sync-design.md
@@ -1,0 +1,60 @@
+# Design: Sync Cron Agent Responses to External Channels
+
+## Context
+Currently, agent responses triggered by cron jobs are only visible within the local application. When a cron job is bound to a conversation sourced from external channels (e.g., WeChat, Lark, Telegram), these responses are not synced back to the channel. This design aims to reuse the response routing logic from `conversationBridge` to enable cross-channel synchronization for cron-triggered agent messages.
+
+## Objectives
+- Extract channel response routing logic into a reusable component.
+- Enable `CronService` to use this component to sync agent responses to external channels.
+- Maintain consistent behavior across all channels (special handling for WeChat text accumulation).
+
+## Architecture
+
+### 1. New Component: `ChannelResponseRouter`
+**Path:** `src/channels/agent/ChannelResponseRouter.ts`
+
+This module will contain the logic previously embedded in `conversationBridge.ts`.
+
+```typescript
+export const CHANNEL_SOURCE_TYPES = new Set(['telegram', 'lark', 'dingtalk', 'wechat', 'wecom']);
+
+/**
+ * Sets up a listener on channelEventBus to route agent responses back to the original channel.
+ * Handles different channel capabilities (e.g., WeChat's lack of message edit support).
+ */
+export function setupChannelResponseRouting(conversation: TChatConversation): () => void {
+  // Logic extracted from conversationBridge.ts
+  // 1. Check if source is in CHANNEL_SOURCE_TYPES
+  // 2. Subscribe to channelEventBus.onAgentMessage
+  // 3. Filter by conversation_id
+  // 4. Route 'content', 'file_send', and 'finish' (for WeChat) events
+  // 5. Return cleanup function
+}
+```
+
+### 2. Integration Points
+
+#### `conversationBridge.ts`
+- Remove the inline routing logic.
+- Call `setupChannelResponseRouting(conversation)` before `task.sendMessage()`.
+
+#### `CronService.ts`
+- In `executeJob()`, after identifying/creating the `activeConversationId`, fetch the conversation object.
+- Call `setupChannelResponseRouting(conversation)` before `task.sendMessage()`.
+
+## Data Flow
+1. **Trigger**: Cron job fires in `CronService`.
+2. **Setup**: `CronService` calls `setupChannelResponseRouting`.
+3. **Execution**: `task.sendMessage` starts agent processing.
+4. **Event**: Agent emits content via `channelEventBus`.
+5. **Route**: `ChannelResponseRouter` catches the event and calls the corresponding plugin's `sendMessage`.
+6. **Cleanup**: On `finish` event or manual call, the listener is removed.
+
+## Error Handling
+- Routing failures (e.g., plugin not found, API error) should be logged but not crash the cron job execution.
+- Ensure the listener is always cleaned up to prevent memory leaks.
+
+## Testing Plan
+- **Unit Test**: Mock `channelEventBus` and verify `ChannelResponseRouter` calls the correct plugin methods.
+- **Manual Test (WeChat)**: Create a cron job bound to a WeChat conversation, trigger it, and verify the response is received in WeChat after completion.
+- **Manual Test (Lark/Telegram)**: Verify streaming updates if supported by the channel.

--- a/docs/plans/2026-04-27-cron-channel-sync.md
+++ b/docs/plans/2026-04-27-cron-channel-sync.md
@@ -1,0 +1,178 @@
+# Cron Agent Response Channel Synchronization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable agent responses from cron jobs to be automatically sent back to external channels (WeChat, Lark, etc.) by extracting and reusing response routing logic.
+
+**Architecture:** Create a shared `ChannelResponseRouter` component that can be used by both `conversationBridge` (for frontend messages) and `CronService` (for scheduled tasks).
+
+**Tech Stack:** TypeScript, Node.js, EventBus, Electron (Main process)
+
+---
+
+### Task 1: Create ChannelResponseRouter Component
+
+**Files:**
+- Create: `src/channels/agent/ChannelResponseRouter.ts`
+
+**Step 1: Write the implementation**
+Extract the logic from `conversationBridge.ts`.
+
+```typescript
+import { channelEventBus } from './ChannelEventBus';
+import { getChannelManager } from '../core/ChannelManager';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import type { TChatConversation } from '@/common/storage';
+
+/** Channel source types that need response routing */
+export const CHANNEL_SOURCE_TYPES = new Set(['telegram', 'lark', 'dingtalk', 'wechat', 'wecom']);
+
+/**
+ * Sets up channel response routing for a conversation.
+ * Returns a cleanup function.
+ */
+export function setupChannelResponseRouting(conversation: TChatConversation): () => void {
+  const conversation_id = conversation.id;
+  const channelSource = conversation.source;
+  const channelChatId = conversation.channelChatId;
+
+  if (!channelSource || !CHANNEL_SOURCE_TYPES.has(channelSource) || !channelChatId) {
+    return () => {};
+  }
+
+  mainLog('ChannelResponseRouter', `Setting up routing for ${channelSource}, chatId=${channelChatId}`);
+
+  const isWeChat = channelSource === 'wechat';
+  let accumulatedText = '';
+  const pendingFiles: Array<{ type: 'image' | 'file'; url: string; fileName?: string }> = [];
+
+  const cleanup = channelEventBus.onAgentMessage((event) => {
+    if (event.conversation_id !== conversation_id) return;
+
+    if (event.type === 'content' || event.type === 'file_send') {
+      if (isWeChat) {
+        if (event.type === 'content' && typeof event.data === 'string') {
+          accumulatedText += event.data;
+        } else if (event.type === 'file_send') {
+          const { filePath, fileName, fileType } = event.data as any;
+          if (fileType === 'image' && filePath) {
+            pendingFiles.push({ type: 'image', url: filePath });
+          } else if (filePath && fileName) {
+            pendingFiles.push({ type: 'file', url: filePath, fileName });
+          }
+        }
+      } else {
+        void (async () => {
+          try {
+            const plugin = getChannelManager().getPluginManager()?.getAllPlugins().find(p => p.type === channelSource);
+            if (!plugin) return;
+
+            if (event.type === 'file_send') {
+              const { filePath, fileName, fileType } = event.data as any;
+              if (fileType === 'image' && filePath) {
+                await plugin.sendMessage(channelChatId, { type: 'image', imageUrl: filePath });
+              } else if (filePath && fileName) {
+                await plugin.sendMessage(channelChatId, { type: 'file', fileUrl: filePath, fileName });
+              }
+            } else if (event.type === 'content' && typeof event.data === 'string') {
+              await plugin.sendMessage(channelChatId, { type: 'text', text: event.data, parseMode: 'HTML' });
+            }
+          } catch (err) {
+            mainWarn('ChannelResponseRouter', 'Failed to route message:', err);
+          }
+        })();
+      }
+    }
+
+    if (event.type === 'finish') {
+      if (isWeChat) {
+        void (async () => {
+          try {
+            const plugin = getChannelManager().getPluginManager()?.getAllPlugins().find(p => p.type === channelSource);
+            if (!plugin) return;
+            if (accumulatedText.trim()) {
+              await plugin.sendMessage(channelChatId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML' });
+            }
+            for (const file of pendingFiles) {
+              await plugin.sendMessage(channelChatId, file.type === 'image' ? { type: 'image', imageUrl: file.url } : { type: 'file', fileUrl: file.url, fileName: file.fileName });
+            }
+          } catch (err) {
+            mainWarn('ChannelResponseRouter', 'Failed to route WeChat content:', err);
+          }
+        })();
+      }
+      cleanup();
+    }
+  });
+
+  return cleanup;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/channels/agent/ChannelResponseRouter.ts
+git commit -m "feat: add ChannelResponseRouter to handle agent-to-channel message routing"
+```
+
+### Task 2: Refactor conversationBridge to use ChannelResponseRouter
+
+**Files:**
+- Modify: `src/process/bridge/conversationBridge.ts`
+
+**Step 1: Update imports and replace inline logic**
+
+```typescript
+// Replace inline logic in sendMessage with:
+const cleanup = setupChannelResponseRouting(conversation);
+try {
+  await task.sendMessage(payload);
+} finally {
+  // Listener self-cleans on 'finish', but we keep the cleanup reference
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/process/bridge/conversationBridge.ts
+git commit -m "refactor: use ChannelResponseRouter in conversationBridge"
+```
+
+### Task 3: Enable Response Syncing in CronService
+
+**Files:**
+- Modify: `src/process/services/cron/CronService.ts`
+
+**Step 1: Update imports and modify executeJob**
+Before `task.sendMessage`, fetch conversation and setup routing.
+
+```typescript
+// Inside executeJob, after task is built:
+const convResult = getDatabase().getConversation(activeConversationId);
+if (convResult.success && convResult.data) {
+  setupChannelResponseRouting(convResult.data);
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/process/services/cron/CronService.ts
+git commit -m "feat: sync cron agent responses back to channels"
+```
+
+### Task 4: Verification
+
+**Step 1: Manual Verification**
+1. Start the app.
+2. Ensure a WeChat channel is active.
+3. Create a cron job bound to a WeChat conversation.
+4. Wait for it to trigger or click "Run Now".
+5. Verify Agent response appears in WeChat.
+
+**Step 2: Commit (if any fixes needed)**
+```bash
+git commit -m "fix: address issues found during verification"
+```

--- a/src/channels/agent/ChannelResponseRouter.ts
+++ b/src/channels/agent/ChannelResponseRouter.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { channelEventBus } from './ChannelEventBus';
+import { getChannelManager } from '../core/ChannelManager';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import type { TChatConversation } from '@/common/storage';
+
+/** Channel source types that need response routing */
+export const CHANNEL_SOURCE_TYPES = new Set(['telegram', 'lark', 'dingtalk', 'wechat', 'wecom']);
+
+/**
+ * Sets up channel response routing for a conversation.
+ * When the agent emits messages, this router sends them back to the original external channel.
+ * Returns a cleanup function to unsubscribe.
+ */
+export function setupChannelResponseRouting(conversation: TChatConversation): () => void {
+  const conversation_id = conversation.id;
+  const channelSource = conversation.source;
+  const channelChatId = conversation.channelChatId;
+
+  mainLog('ChannelResponseRouter', `Called setupChannelResponseRouting: source=${channelSource}, chatId=${channelChatId}, convId=${conversation_id}`);
+
+  if (!channelSource || !CHANNEL_SOURCE_TYPES.has(channelSource) || !channelChatId) {
+    mainLog('ChannelResponseRouter', `Routing skipped: source mismatch or no chatId`);
+    return () => {};
+  }
+
+  mainLog('ChannelResponseRouter', `Setting up channel response routing for ${channelSource}, chatId=${channelChatId}, convId=${conversation_id}`);
+
+  // For WeChat and WeCom: accumulate text and send once at finish
+  // WeChat: no edit support
+  // WeCom: proactive push (aibot_send_msg) only supports non-streaming markdown
+  const shouldAccumulate = channelSource === 'wechat' || channelSource === 'wecom';
+  let accumulatedText = '';
+  const pendingFiles: Array<{ type: 'image' | 'file'; url: string; fileName?: string }> = [];
+
+  // Subscribe to agent messages for this conversation
+  const cleanup = channelEventBus.onAgentMessage((event) => {
+    if (event.conversation_id !== conversation_id) return;
+
+    // Route content messages back to channel
+    if (event.type === 'content' || event.type === 'file_send') {
+      mainLog('ChannelResponseRouter', `Channel route: received ${event.type} for ${channelSource}`);
+
+      // For WeChat/WeCom: accumulate content, send at finish
+      if (shouldAccumulate) {
+        if (event.type === 'content' && typeof event.data === 'string') {
+          accumulatedText += event.data;
+        } else if (event.type === 'file_send') {
+          const { filePath, fileName, fileType } = event.data as { filePath?: string; fileName?: string; fileType?: string };
+          if (fileType === 'image' && filePath) {
+            pendingFiles.push({ type: 'image', url: filePath });
+          } else if (filePath && fileName) {
+            pendingFiles.push({ type: 'file', url: filePath, fileName });
+          }
+        }
+      } else {
+        // For other channels (lark, dingtalk, telegram, wecom): send immediately
+        void (async () => {
+          try {
+            const channelManager = getChannelManager();
+            const pluginManager = channelManager.getPluginManager();
+            if (!pluginManager) {
+              mainWarn('ChannelResponseRouter', 'PluginManager not available for channel routing');
+              return;
+            }
+            const plugins = pluginManager.getAllPlugins();
+            const plugin = plugins.find((p) => p.type === channelSource);
+            if (!plugin) {
+              mainWarn('ChannelResponseRouter', `Plugin not found for ${channelSource}`);
+              return;
+            }
+
+            if (event.type === 'file_send') {
+              const { filePath, fileName, fileType } = event.data as { filePath?: string; fileName?: string; fileType?: string };
+              if (fileType === 'image' && filePath) {
+                await plugin.sendMessage(channelChatId, { type: 'image', imageUrl: filePath });
+              } else if (filePath && fileName) {
+                await plugin.sendMessage(channelChatId, { type: 'file', fileUrl: filePath, fileName });
+              }
+            } else if (event.type === 'content' && typeof event.data === 'string') {
+              await plugin.sendMessage(channelChatId, { type: 'text', text: event.data, parseMode: 'HTML' });
+            }
+          } catch (err) {
+            mainWarn('ChannelResponseRouter', 'Failed to route message to channel:', err);
+          }
+        })();
+      }
+    }
+
+    // For WeChat/WeCom: send accumulated content on finish
+    if (event.type === 'finish' && shouldAccumulate) {
+      mainLog('ChannelResponseRouter', `Channel route (${channelSource}): finish event, sending accumulated content`);
+      void (async () => {
+        try {
+          const channelManager = getChannelManager();
+          const pluginManager = channelManager.getPluginManager();
+          if (!pluginManager) {
+            mainWarn('ChannelResponseRouter', 'PluginManager not available for channel routing');
+            return;
+          }
+          const plugins = pluginManager.getAllPlugins();
+          const plugin = plugins.find((p) => p.type === channelSource);
+          if (!plugin) {
+            mainWarn('ChannelResponseRouter', `Plugin not found for ${channelSource}`);
+            return;
+          }
+
+          // Send accumulated text first
+          if (accumulatedText.trim()) {
+            mainLog('ChannelResponseRouter', `Channel route (WeChat): sending text (${accumulatedText.length} chars)`);
+            await plugin.sendMessage(channelChatId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML' });
+          }
+
+          // Send pending files after text
+          for (const file of pendingFiles) {
+            if (file.type === 'image') {
+              await plugin.sendMessage(channelChatId, { type: 'image', imageUrl: file.url });
+            } else {
+              await plugin.sendMessage(channelChatId, { type: 'file', fileUrl: file.url, fileName: file.fileName });
+            }
+          }
+        } catch (err) {
+          mainWarn('ChannelResponseRouter', 'Failed to route accumulated content to WeChat:', err);
+        }
+      })();
+    }
+
+    // Auto cleanup on finish
+    if (event.type === 'finish') {
+      mainLog('ChannelResponseRouter', `Channel route: finish event, cleaning up listener`);
+      cleanup();
+    }
+  });
+
+  return cleanup;
+}

--- a/src/channels/plugins/wecom/WeComPlugin.ts
+++ b/src/channels/plugins/wecom/WeComPlugin.ts
@@ -297,15 +297,15 @@ export class WeComPlugin extends BasePlugin {
     }
 
     // Otherwise, use proactive push (aibot_send_msg)
-    const { type: chatType } = parseChatId(chatId);
+    const { type: chatType, id: pureId } = parseChatId(chatId);
     const sendReqId = this.generateReqId();
-    console.log(`[WeComPlugin] sendMessage: using proactive push, chatType=${chatType}, sendReqId=${sendReqId}`);
+    console.log(`[WeComPlugin] sendMessage: using proactive push, chatType=${chatType}, pureId=${pureId}, sendReqId=${sendReqId}`);
 
     this.send({
       cmd: 'aibot_send_msg',
       headers: { req_id: sendReqId },
       body: {
-        chatid: chatId,
+        chatid: pureId,
         chat_type: chatType === 'group' ? 2 : 1,
         msgtype: 'markdown',
         markdown: { content: truncatedContent },
@@ -410,14 +410,14 @@ export class WeComPlugin extends BasePlugin {
       });
     } else {
       // Proactive push
-      const { type: chatType } = parseChatId(chatId);
+      const { type: chatType, id: pureId } = parseChatId(chatId);
       const sendReqId = this.generateReqId();
 
       this.send({
         cmd: 'aibot_send_msg',
         headers: { req_id: sendReqId },
         body: {
-          chatid: chatId,
+          chatid: pureId,
           chat_type: chatType === 'group' ? 2 : 1,
           msgtype: 'image',
           image: { media_id: mediaId },
@@ -450,14 +450,14 @@ export class WeComPlugin extends BasePlugin {
       });
     } else {
       // Proactive push
-      const { type: chatType } = parseChatId(chatId);
+      const { type: chatType, id: pureId } = parseChatId(chatId);
       const sendReqId = this.generateReqId();
 
       this.send({
         cmd: 'aibot_send_msg',
         headers: { req_id: sendReqId },
         body: {
-          chatid: chatId,
+          chatid: pureId,
           chat_type: chatType === 'group' ? 2 : 1,
           msgtype: 'file',
           file: { media_id: mediaId },

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -33,11 +33,7 @@ import WorkerManage from '../WorkerManage';
 import { migrateConversationToDatabase } from './migrationUtils';
 import { skillManager } from '../SkillManager';
 import { ConversationManageWithDB } from '../message';
-import { channelEventBus } from '@/channels/agent/ChannelEventBus';
-import { getChannelManager } from '@/channels/core/ChannelManager';
-
-/** Channel source types that need response routing */
-const CHANNEL_SOURCE_TYPES = new Set(['telegram', 'lark', 'dingtalk', 'wechat', 'wecom']);
+import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
 
 const workspaceSkillSyncTasks = new Map<string, Promise<void>>();
 
@@ -1074,124 +1070,8 @@ This identity statement takes priority over the default identity in USER.md.
       mainLog('conversationBridge', `sendMessage: about to call task.sendMessage for ${conversation_id}`);
 
       // Set up channel response routing if conversation source is a channel type
-      // 当会话来源是渠道类型时，设置响应路由，将 Agent 响应发送回渠道
-      let channelCleanup: (() => void) | null = null;
-      if (conversation?.source && CHANNEL_SOURCE_TYPES.has(conversation.source)) {
-        const channelSource = conversation.source;
-        const channelChatId = conversation.channelChatId;
-        mainLog('conversationBridge', `sendMessage: setting up channel response routing for ${channelSource}, chatId=${channelChatId}`);
-
-        if (channelChatId) {
-          // For WeChat: accumulate text and send once at finish (no edit support)
-          // 微信不支持消息编辑，需要累积文本后一次性发送
-          const isWeChat = channelSource === 'wechat';
-          let accumulatedText = '';
-          const pendingFiles: Array<{ type: 'image' | 'file'; url: string; fileName?: string }> = [];
-
-          // Subscribe to agent messages for this conversation
-          channelCleanup = channelEventBus.onAgentMessage((event) => {
-            if (event.conversation_id !== conversation_id) return;
-
-            // Route content messages back to channel
-            if (event.type === 'content' || event.type === 'file_send') {
-              mainLog('conversationBridge', `Channel route: received ${event.type} for ${channelSource}`);
-
-              // For WeChat: accumulate content, send at finish
-              if (isWeChat) {
-                if (event.type === 'content' && typeof event.data === 'string') {
-                  accumulatedText += event.data;
-                } else if (event.type === 'file_send') {
-                  const { filePath, fileName, fileType } = event.data as { filePath?: string; fileName?: string; fileType?: string };
-                  if (fileType === 'image' && filePath) {
-                    pendingFiles.push({ type: 'image', url: filePath });
-                  } else if (filePath && fileName) {
-                    pendingFiles.push({ type: 'file', url: filePath, fileName });
-                  }
-                }
-              } else {
-                // For other channels (lark, dingtalk, telegram, wecom): send immediately
-                // 其他渠道支持编辑，可以立即发送增量
-                void (async () => {
-                  try {
-                    const channelManager = getChannelManager();
-                    const pluginManager = channelManager.getPluginManager();
-                    if (!pluginManager) {
-                      mainWarn('conversationBridge', 'PluginManager not available for channel routing');
-                      return;
-                    }
-                    const plugins = pluginManager.getAllPlugins();
-                    const plugin = plugins.find((p) => p.type === channelSource);
-                    if (!plugin) {
-                      mainWarn('conversationBridge', `Plugin not found for ${channelSource}`);
-                      return;
-                    }
-
-                    if (event.type === 'file_send') {
-                      const { filePath, fileName, fileType } = event.data as { filePath?: string; fileName?: string; fileType?: string };
-                      if (fileType === 'image' && filePath) {
-                        await plugin.sendMessage(channelChatId, { type: 'image', imageUrl: filePath });
-                      } else if (filePath && fileName) {
-                        await plugin.sendMessage(channelChatId, { type: 'file', fileUrl: filePath, fileName });
-                      }
-                    } else if (event.type === 'content' && typeof event.data === 'string') {
-                      await plugin.sendMessage(channelChatId, { type: 'text', text: event.data, parseMode: 'HTML' });
-                    }
-                  } catch (err) {
-                    mainWarn('conversationBridge', 'Failed to route message to channel:', err);
-                  }
-                })();
-              }
-            }
-
-            // For WeChat: send accumulated content on finish
-            // 微信在 finish 时一次性发送累积的文本和文件
-            if (event.type === 'finish' && isWeChat) {
-              mainLog('conversationBridge', `Channel route (WeChat): finish event, sending accumulated content`);
-              void (async () => {
-                try {
-                  const channelManager = getChannelManager();
-                  const pluginManager = channelManager.getPluginManager();
-                  if (!pluginManager) {
-                    mainWarn('conversationBridge', 'PluginManager not available for channel routing');
-                    return;
-                  }
-                  const plugins = pluginManager.getAllPlugins();
-                  const plugin = plugins.find((p) => p.type === channelSource);
-                  if (!plugin) {
-                    mainWarn('conversationBridge', `Plugin not found for ${channelSource}`);
-                    return;
-                  }
-
-                  // Send accumulated text first
-                  if (accumulatedText.trim()) {
-                    mainLog('conversationBridge', `Channel route (WeChat): sending text (${accumulatedText.length} chars)`);
-                    await plugin.sendMessage(channelChatId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML' });
-                  }
-
-                  // Send pending files after text
-                  for (const file of pendingFiles) {
-                    if (file.type === 'image') {
-                      await plugin.sendMessage(channelChatId, { type: 'image', imageUrl: file.url });
-                    } else {
-                      await plugin.sendMessage(channelChatId, { type: 'file', fileUrl: file.url, fileName: file.fileName });
-                    }
-                  }
-                } catch (err) {
-                  mainWarn('conversationBridge', 'Failed to route accumulated content to WeChat:', err);
-                }
-              })();
-            }
-
-            // Clean up listener on finish
-            if (event.type === 'finish') {
-              mainLog('conversationBridge', `Channel route: finish event, cleaning up listener`);
-              if (channelCleanup) {
-                channelCleanup();
-                channelCleanup = null;
-              }
-            }
-          });
-        }
+      if (conversation) {
+        setupChannelResponseRouting(conversation);
       }
 
       try {

--- a/src/process/services/cron/CronService.ts
+++ b/src/process/services/cron/CronService.ts
@@ -19,6 +19,7 @@ import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { readAssistantResource, ruleFilePattern, skillFilePattern } from '@process/utils/assistantResources';
 import { acpDetector } from '@/agent/acp/AcpDetector';
 import { assistantManager } from '@/process/AssistantManager';
+import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
 import { cronBusyGuard } from './CronBusyGuard';
 import { cronStore, type CronJob, type CronSchedule } from './CronStore';
 import { createConversation } from '../conversationService';
@@ -562,6 +563,15 @@ class CronService {
 
       if (!task) {
         throw new Error('Failed to initialize task');
+      }
+
+      // Set up channel response routing if conversation source is a channel type
+      const db = getDatabase();
+      const convResult = db.getConversation(activeConversationId);
+      mainLog('CronService', `Setting up routing check for convId=${activeConversationId}, success=${convResult.success}, hasData=${!!convResult.data}`);
+      if (convResult.success && convResult.data) {
+        mainLog('CronService', `Conversation data: source=${convResult.data.source}, chatId=${convResult.data.channelChatId}`);
+        setupChannelResponseRouting(convResult.data);
       }
 
       mainLog('CronService', `Sending message to conversationId=${activeConversationId}`);


### PR DESCRIPTION
## Summary
This PR enables Agent responses triggered by cron jobs to be automatically synchronized back to external channels (WeChat, WeCom, Lark, DingTalk, Telegram).

Key changes:
- **`ChannelResponseRouter`**: Extracted response routing logic from `conversationBridge` into a standalone, reusable component.
- **Cron Synchronization**: Updated `CronService` to initialize response routing before sending messages.
- **WeCom Fix**: Resolved `invalid chatid` error in WeCom's proactive push mode by stripping internal `user:`/`group:` prefixes.
- **Code Cleanup**: Simplified `conversationBridge` by replacing inline logic with the new router.

## Test plan
- [x] Create a cron job bound to a WeChat conversation. Trigger it and verify response in WeChat.
- [x] Create a cron job bound to a WeCom conversation. Trigger it and verify response in WeCom (proactive push mode).
- [x] Verify that normal user-initiated messages from the frontend still sync correctly to channels.
- [x] Verify that media files (images/files) still sync correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)