### PR TITLE
fix(i18n): replace hardcoded Chinese strings with t() calls in sidebar and Guide page

### DIFF
--- a/src/renderer/i18n/locales/en-US/common.json
+++ b/src/renderer/i18n/locales/en-US/common.json
@@ -63,6 +63,13 @@
   "refresh": "Refresh",
   "tray.showWindow": "Show Sudowork",
   "tray.quit": "Quit",
+  "siderMenu": {
+    "agent": "Digital Assistants",
+    "skillStore": "Skill Store",
+    "security": "Security",
+    "webui": "Remote Access",
+    "cron": "Scheduled Tasks"
+  },
   "ariaLabel": {
     "close": "Close",
     "edit": "Edit",

--- a/src/renderer/i18n/locales/en-US/guid.json
+++ b/src/renderer/i18n/locales/en-US/guid.json
@@ -52,6 +52,10 @@
       "compareContent": "Please compare... and..., analyzing their principles, pros/cons, and use cases"
     }
   },
+  "skillSelectorTitle": "Skills",
+  "noSkills": "No skills available",
+  "skillAdded": "Skill added: {{name}}",
+  "skillNotInstalled": "Skill not installed: {{name}}",
   "trySuggestionPrompts": "Try these clickable example prompts:",
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "No Main Agent is available. Please login to Google or install Claude/Codex CLI. Go to settings?",

--- a/src/renderer/i18n/locales/en-US/login.json
+++ b/src/renderer/i18n/locales/en-US/login.json
@@ -15,6 +15,8 @@
   "languageToggle": "Change language",
   "footerPrimary": "Transform your command-line AI",
   "footerSecondary": "Modern & Efficient",
+  "logout": "Sign Out",
+  "logoutSuccess": "Signed out successfully",
   "errors": {
     "empty": "Please enter username and password",
     "invalidCredentials": "Invalid username or password",

--- a/src/renderer/i18n/locales/ja-JP/common.json
+++ b/src/renderer/i18n/locales/ja-JP/common.json
@@ -60,6 +60,13 @@
   "refresh": "更新",
   "tray.showWindow": "Sudowork を表示",
   "tray.quit": "終了",
+  "siderMenu": {
+    "agent": "デジタルアシスタント",
+    "skillStore": "スキルストア",
+    "security": "セキュリティ",
+    "webui": "リモート接続",
+    "cron": "スケジュールタスク"
+  },
   "ariaLabel": {
     "close": "閉じる",
     "edit": "編集",

--- a/src/renderer/i18n/locales/ja-JP/guid.json
+++ b/src/renderer/i18n/locales/ja-JP/guid.json
@@ -52,6 +52,10 @@
       "compareContent": "...と...の違いを、原理、メリット・デメリット、適用場面などの観点から分析してください"
     }
   },
+  "skillSelectorTitle": "スキル",
+  "noSkills": "スキルがありません",
+  "skillAdded": "スキルを追加しました：{{name}}",
+  "skillNotInstalled": "スキルがインストールされていません：{{name}}",
   "trySuggestionPrompts": "クリックして試せるサンプルプロンプト：",
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "メインエージェントが利用できません。Google にログインするか、Claude/Codex CLI をインストールしてください。設定へ移動しますか？",

--- a/src/renderer/i18n/locales/ja-JP/login.json
+++ b/src/renderer/i18n/locales/ja-JP/login.json
@@ -15,6 +15,8 @@
   "languageToggle": "言語を切り替える",
   "footerPrimary": "コマンドラインAIをモダンに変革",
   "footerSecondary": "効率的でエレガント",
+  "logout": "ログアウト",
+  "logoutSuccess": "ログアウトしました",
   "errors": {
     "empty": "ユーザー名とパスワードを入力してください",
     "invalidCredentials": "ユーザー名またはパスワードが正しくありません",

--- a/src/renderer/i18n/locales/ko-KR/common.json
+++ b/src/renderer/i18n/locales/ko-KR/common.json
@@ -60,6 +60,13 @@
   "refresh": "새로고침",
   "tray.showWindow": "Sudowork 표시",
   "tray.quit": "종료",
+  "siderMenu": {
+    "agent": "디지털 어시스턴트",
+    "skillStore": "스킬 스토어",
+    "security": "보안",
+    "webui": "원격 접속",
+    "cron": "예약 작업"
+  },
   "ariaLabel": {
     "close": "닫기",
     "edit": "편집",

--- a/src/renderer/i18n/locales/ko-KR/guid.json
+++ b/src/renderer/i18n/locales/ko-KR/guid.json
@@ -52,6 +52,10 @@
       "compareContent": "...와 ...의 차이점을 원리, 장단점, 적용 사례 등의 관점에서 분석해 주세요"
     }
   },
+  "skillSelectorTitle": "스킬",
+  "noSkills": "사용 가능한 스킬이 없습니다",
+  "skillAdded": "스킬이 추가되었습니다: {{name}}",
+  "skillNotInstalled": "스킬이 설치되지 않았습니다: {{name}}",
   "trySuggestionPrompts": "클릭하여 사용해 볼 수 있는 예시 프롬프트:",
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "사용 가능한 메인 에이전트가 없습니다. Google에 로그인하거나 Claude/Codex CLI를 설치해 주세요. 설정으로 이동하시겠습니까?",

--- a/src/renderer/i18n/locales/ko-KR/login.json
+++ b/src/renderer/i18n/locales/ko-KR/login.json
@@ -15,6 +15,8 @@
   "languageToggle": "언어 변경",
   "footerPrimary": "명령줄 AI의 혁신",
   "footerSecondary": "현대적이고 효율적인",
+  "logout": "로그아웃",
+  "logoutSuccess": "로그아웃되었습니다",
   "errors": {
     "empty": "사용자 이름과 비밀번호를 입력하세요",
     "invalidCredentials": "잘못된 사용자 이름 또는 비밀번호",

--- a/src/renderer/i18n/locales/tr-TR/common.json
+++ b/src/renderer/i18n/locales/tr-TR/common.json
@@ -58,5 +58,12 @@
   "setupContinuesInBackground": "Uygulamaya şimdi girin. Çalışma zamanı kurulumu arka planda devam edecek.",
   "refresh": "Yenile",
   "tray.showWindow": "Sudowork'ü Göster",
-  "tray.quit": "Çıkış"
+  "tray.quit": "Çıkış",
+  "siderMenu": {
+    "agent": "Dijital Asistanlar",
+    "skillStore": "Beceri Mağazası",
+    "security": "Güvenlik",
+    "webui": "Uzak Erişim",
+    "cron": "Zamanlanmış Görevler"
+  }
 }

--- a/src/renderer/i18n/locales/tr-TR/guid.json
+++ b/src/renderer/i18n/locales/tr-TR/guid.json
@@ -52,6 +52,10 @@
       "compareContent": "Lütfen ... ve ... arasındaki farkları ilkeler, artılar/eksiler ve kullanım alanları açısından analiz edin"
     }
   },
+  "skillSelectorTitle": "Beceriler",
+  "noSkills": "Mevcut beceri yok",
+  "skillAdded": "Beceri eklendi: {{name}}",
+  "skillNotInstalled": "Beceri yüklü değil: {{name}}",
   "trySuggestionPrompts": "Tıklanabilir örnek bilgi istemleri:",
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "Kullanılabilir bir Ana Ajan yok. Lütfen Google'a giriş yapın veya Claude/Codex CLI kurun. Ayarlara gitmek ister misiniz?",

--- a/src/renderer/i18n/locales/tr-TR/login.json
+++ b/src/renderer/i18n/locales/tr-TR/login.json
@@ -15,6 +15,8 @@
   "languageToggle": "Dili değiştir",
   "footerPrimary": "Komut satırı AI'nızı dönüştürün",
   "footerSecondary": "Modern ve Verimli",
+  "logout": "Çıkış Yap",
+  "logoutSuccess": "Başarıyla çıkış yapıldı",
   "errors": {
     "empty": "Lütfen kullanıcı adı ve şifre girin",
     "invalidCredentials": "Geçersiz kullanıcı adı veya şifre",

--- a/src/renderer/i18n/locales/zh-CN/common.json
+++ b/src/renderer/i18n/locales/zh-CN/common.json
@@ -63,6 +63,13 @@
   "refresh": "刷新",
   "tray.showWindow": "显示 Sudowork",
   "tray.quit": "退出",
+  "siderMenu": {
+    "agent": "数字助手",
+    "skillStore": "技能商店",
+    "security": "安全防护",
+    "webui": "远程连接",
+    "cron": "定时任务"
+  },
   "ariaLabel": {
     "close": "关闭",
     "edit": "编辑",

--- a/src/renderer/i18n/locales/zh-CN/guid.json
+++ b/src/renderer/i18n/locales/zh-CN/guid.json
@@ -52,6 +52,10 @@
       "compareContent": "请对比...和...的区别，从原理、优缺点、适用场景等方面分析"
     }
   },
+  "skillSelectorTitle": "技能",
+  "noSkills": "暂无技能",
+  "skillAdded": "已添加技能：{{name}}",
+  "skillNotInstalled": "技能未安装：{{name}}",
   "trySuggestionPrompts": "试试这些可点击的案例提示词：",
   "agentFallbackNotice": "{{original}} 不可用，已自动切换到 {{fallback}}。",
   "noAgentAvailable": "没有可用的 Main Agent。请登录 Google 或安装 Claude/Codex CLI。是否前往设置？",

--- a/src/renderer/i18n/locales/zh-CN/login.json
+++ b/src/renderer/i18n/locales/zh-CN/login.json
@@ -19,6 +19,8 @@
   "languageToggle": "切换语言",
   "footerPrimary": "命令行 AI 的现代化体验",
   "footerSecondary": "高效且优雅",
+  "logout": "退出登录",
+  "logoutSuccess": "已退出登录",
   "errors": {
     "empty": "请输入用户名和密码",
     "invalidCredentials": "用户名或密码错误",

--- a/src/renderer/i18n/locales/zh-TW/common.json
+++ b/src/renderer/i18n/locales/zh-TW/common.json
@@ -58,5 +58,12 @@
   "setupContinuesInBackground": "先進入應用程式，執行環境會繼續在背景安裝。",
   "refresh": "重新整理",
   "tray.showWindow": "顯示 Sudowork",
-  "tray.quit": "結束"
+  "tray.quit": "結束",
+  "siderMenu": {
+    "agent": "數位助手",
+    "skillStore": "技能商店",
+    "security": "安全防護",
+    "webui": "遠端連線",
+    "cron": "排程任務"
+  }
 }

--- a/src/renderer/i18n/locales/zh-TW/guid.json
+++ b/src/renderer/i18n/locales/zh-TW/guid.json
@@ -52,6 +52,10 @@
       "compareContent": "請對比...和...的區別，從原理、優缺點、適用場景等方面分析"
     }
   },
+  "skillSelectorTitle": "技能",
+  "noSkills": "暫無技能",
+  "skillAdded": "已新增技能：{{name}}",
+  "skillNotInstalled": "技能未安裝：{{name}}",
   "trySuggestionPrompts": "試試這些可點擊的案例提示詞：",
   "agentFallbackNotice": "{{original}} is unavailable, using {{fallback}} instead.",
   "noAgentAvailable": "目前沒有可用的主代理。請登入 Google 或安裝 Claude/Codex CLI。要前往設定嗎？",

--- a/src/renderer/i18n/locales/zh-TW/login.json
+++ b/src/renderer/i18n/locales/zh-TW/login.json
@@ -15,6 +15,8 @@
   "languageToggle": "切換語言",
   "footerPrimary": "命令列 AI 的現代化體驗",
   "footerSecondary": "高效且優雅",
+  "logout": "登出",
+  "logoutSuccess": "已登出",
   "errors": {
     "empty": "請輸入使用者名稱與密碼",
     "invalidCredentials": "使用者名稱或密碼錯誤",

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -115,9 +115,9 @@ const GuidPage: React.FC = () => {
       const skillExists = installedSkills.some((s) => s.name === skillParam);
       if (skillExists && !selectedSkills.includes(skillParam)) {
         setSelectedSkills([...selectedSkills, skillParam]);
-        Message.success(`已添加技能：${skillParam}`);
+        Message.success(t('guid.skillAdded', { name: skillParam }));
       } else if (!skillExists) {
-        Message.warning(`技能未安装：${skillParam}`);
+        Message.warning(t('guid.skillNotInstalled', { name: skillParam }));
       }
       void navigate('/guid', { replace: true, state: location.state });
     }
@@ -663,7 +663,7 @@ const GuidPage: React.FC = () => {
               mentionSelectorBadge={<MentionSelectorBadge visible={mention.mentionSelectorVisible} open={mention.mentionSelectorOpen} onOpenChange={mention.setMentionSelectorOpen} agentLabel={mention.selectedAgentLabel} mentionMenu={mentionDropdownNode} onResetQuery={() => mention.setMentionQuery(null)} />}
               mentionDropdown={mentionDropdownNode}
               skillSelectorOpen={skillSelectorController.isOpen}
-              skillSelectorMenu={skillSelectorController.isOpen ? <SkillSelectorMenu title='技能' items={skillMenuItems} selectedKeys={selectedSkills} activeIndex={skillSelectorController.activeIndex} onHoverItem={(index) => skillSelectorController.setActiveIndex(index)} onSelectItem={(_item) => skillSelectorController.onSelectByIndex(skillSelectorController.activeIndex)} emptyText='暂无技能' searchQuery={skillSelectorController.searchQuery} onSearchChange={skillSelectorController.setSearchQuery} onDismiss={() => skillSelectorController.setDismissed(true)} /> : null}
+              skillSelectorMenu={skillSelectorController.isOpen ? <SkillSelectorMenu title={t('guid.skillSelectorTitle')} items={skillMenuItems} selectedKeys={selectedSkills} activeIndex={skillSelectorController.activeIndex} onHoverItem={(index) => skillSelectorController.setActiveIndex(index)} onSelectItem={(_item) => skillSelectorController.onSelectByIndex(skillSelectorController.activeIndex)} emptyText={t('guid.noSkills')} searchQuery={skillSelectorController.searchQuery} onSearchChange={skillSelectorController.setSearchQuery} onDismiss={() => skillSelectorController.setDismissed(true)} /> : null}
               selectedSkills={selectedSkills}
               onRemoveSkill={(skillName) => setSelectedSkills(selectedSkills.filter((s) => s !== skillName))}
               getSkillDisplayName={(skillName) => {

--- a/src/renderer/sider.tsx
+++ b/src/renderer/sider.tsx
@@ -44,11 +44,11 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
 
   // 功能菜单项定义 / Function menu items definition
   const functionMenus = [
-    { id: 'agent', label: '数字助手', icon: Robot, path: '/settings/agent' },
-    { id: 'skill-store', label: '技能商店', icon: Lightning, path: '/settings/skill' },
-    { id: 'security', label: '安全防护', icon: Shield, path: '/settings/security' },
-    { id: 'webui', label: '远程连接', icon: Earth, path: '/settings/webui' },
-    { id: 'cron', label: '定时任务', icon: AlarmClock, path: '/settings/cron' },
+    { id: 'agent', label: t('common.siderMenu.agent'), icon: Robot, path: '/settings/agent' },
+    { id: 'skill-store', label: t('common.siderMenu.skillStore'), icon: Lightning, path: '/settings/skill' },
+    { id: 'security', label: t('common.siderMenu.security'), icon: Shield, path: '/settings/security' },
+    { id: 'webui', label: t('common.siderMenu.webui'), icon: Earth, path: '/settings/webui' },
+    { id: 'cron', label: t('common.siderMenu.cron'), icon: AlarmClock, path: '/settings/cron' },
   ];
 
   // 处理功能菜单点击 — 在 GuidPage 内联显示，通过 query param 传递 menuId
@@ -231,7 +231,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                     className='flex items-center gap-8px text-[rgb(var(--danger-6))]'
                     onClick={async () => {
                       await logout();
-                      Message.success('已退出登录');
+                      Message.success(t('login.logoutSuccess'));
                       void navigate('/login', { replace: true });
                     }}
                   >


### PR DESCRIPTION
Replace hardcoded Chinese strings in the sidebar menu labels and Guide page with proper i18n `t()` calls so they respond to language switching.

Closes #508