### PR TITLE
fix: 将托盘图标双击改为单击触发窗口显示

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -471,7 +471,7 @@ const createOrUpdateTray = (): void => {
     const icon = getTrayIcon();
     if (!tray) {
       tray = new Tray(icon);
-      tray.on('double-click', () => {
+      tray.on('click', () => {
         if (mainWindow) {
           mainWindow.show();
           mainWindow.focus();


### PR DESCRIPTION
Closes #510

将系统托盘图标的事件监听从 `double-click` 改为 `click`，使用户单击托盘图标即可恢复应用窗口。

Generated with [Claude Code](https://claude.ai/code)