### PR TITLE
refactor(skills): consolidate skill-loading SSOT/DRY in agentUtils + AcpSkillManager

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -22,7 +22,7 @@ import { SUDOCLAW_DIR } from '../services/sudoclaw/SudoclawInstallService';
 import { checkSudoclawHealth, SUDOCLAW_HEALTH_TIMEOUT_MS } from '../services/sudoclaw/sudoclawHealth';
 import type AcpAgent from '../task/AcpAgent';
 import type OpenClawAgent from '../task/OpenClawAgent';
-import { prepareFirstMessage, prepareOpenClawFirstMessage, injectSkillsDirectoryHint } from '../task/agentUtils';
+import { prepareFirstMessage, prepareOpenClawFirstMessage } from '../task/agentUtils';
 import { resolveOpenClawConnectionStatus } from '../utils/connectionStatus';
 import { listWorkspaceSkillTargets, resolveConversationEnabledSkillNames } from '../utils/workspaceSkillTargets';
 import { areSkillSelectionsEqual, resolveLatestConversationEnabledSkills } from '../utils/conversationAssistantSkills';
@@ -1036,18 +1036,16 @@ This identity statement takes priority over the default identity in USER.md.
         let agentContent = other.input;
 
         const skillsToInject = other.skills?.length ? other.skills : enabledSkills;
-        // Use prepareOpenClawFirstMessage — openclaw agents have a file read tool and must
-        // read SKILL.md directly. prepareFirstMessageWithSkillsIndex injects [LOAD_SKILL:]
-        // which is a Gemini-only protocol that openclaw doesn't support.
-        agentContent = await prepareOpenClawFirstMessage(agentContent, {
-          presetContext,
-          enabledSkills: skillsToInject,
-        });
+
+        // Resolve workspace skills hint (skillsDir + enumerated skill names) before
+        // building the first message so prepareOpenClawFirstMessage can fold the
+        // [Skills Directory] block into a single-pass [Assistant Rules] envelope.
         const skillsDir = resolveWorkspaceSkillsDir(conversation);
+        let workspaceSkillsHint: { skillsDir: string; enabledSkillNames?: string[] } | undefined;
         if (skillsDir) {
           // Read the actual symlinked skill names from disk — the directory is the
-          // source of truth for what the agent can use (may include more skills than
-          // the stored enabledSkills list when no filter is applied).
+          // source of truth for what the agent can use (may include more skills
+          // than the stored enabledSkills list when no filter is applied).
           const linkedSkillNames = await fs
             .readdir(skillsDir, { withFileTypes: true })
             .then((entries) =>
@@ -1057,8 +1055,17 @@ This identity statement takes priority over the default identity in USER.md.
                 .sort()
             )
             .catch(() => skillsToInject ?? []);
-          agentContent = await injectSkillsDirectoryHint(agentContent, skillsDir, linkedSkillNames);
+          workspaceSkillsHint = { skillsDir, enabledSkillNames: linkedSkillNames };
         }
+
+        // Use prepareOpenClawFirstMessage — openclaw agents have a file read tool and must
+        // read SKILL.md directly. prepareFirstMessageWithSkillsIndex injects [LOAD_SKILL:]
+        // which is a Gemini-only protocol that openclaw doesn't support.
+        agentContent = await prepareOpenClawFirstMessage(agentContent, {
+          presetContext,
+          enabledSkills: skillsToInject,
+          workspaceSkillsHint,
+        });
 
         if (workspaceFiles.length > 0 && (task as OpenClawAgent).workspace) {
           const hint = `[Context: 用户工作区为 ${(task as OpenClawAgent).workspace}。下方 @ 引用的文件来自该工作区。当用户询问「这个文件夹」「这里有什么文件」时，请基于这些附加文件回答，而非你的默认工作区。]\n\n`;

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -37,7 +37,7 @@ import { handlePreviewOpenEvent } from '../utils/previewUtils';
 import { cronBusyGuard } from '@process/services/cron/CronBusyGuard';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
 import { translateLLMError } from '@process/utils/llmErrorTranslation';
-import { injectSkillsDirectoryHint, prepareFirstMessageWithSkillsIndex } from './agentUtils';
+import { prepareFirstMessageWithSkillsIndex } from './agentUtils';
 import { cleanupIntermediateFiles } from './draftsCleanup';
 import BaseAgent from './BaseAgent';
 
@@ -704,13 +704,11 @@ This identity statement takes priority over the default identity in USER.md.
         }
 
         if (this.isFirstMessage) {
-          contentToSend = await prepareFirstMessageWithSkillsIndex(contentToSend, {
-            presetContext: this.options.presetContext,
-            enabledSkills: this.options.enabledSkills,
-            workspace: this.workspace,
-            presetAgentType: this.options.backend,
-          });
-
+          // For Claude ACP we additionally pass a workspace skills hint so the
+          // [Skills Directory] block is folded into the single-pass envelope
+          // (other ACP backends like Codex / sudo-code don't currently get
+          // the workspace hint — preserving prior behaviour).
+          let workspaceSkillsHint: { skillsDir: string } | undefined;
           if (this.options.backend === 'claude') {
             const skillsDir = resolveWorkspaceSkillsDir({
               type: 'acp',
@@ -719,10 +717,16 @@ This identity statement takes priority over the default identity in USER.md.
                 backend: this.options.backend,
               },
             });
-            if (skillsDir) {
-              contentToSend = await injectSkillsDirectoryHint(contentToSend, skillsDir);
-            }
+            if (skillsDir) workspaceSkillsHint = { skillsDir };
           }
+
+          contentToSend = await prepareFirstMessageWithSkillsIndex(contentToSend, {
+            presetContext: this.options.presetContext,
+            enabledSkills: this.options.enabledSkills,
+            workspace: this.workspace,
+            presetAgentType: this.options.backend,
+            workspaceSkillsHint,
+          });
         } else if (this.options.presetAssistantId && this.options.presetContext) {
           // For subsequent messages, inject identity override to ensure latest assistant name
           // 后续消息时，注入身份声明以确保使用最新的助手名称

--- a/src/process/task/AcpSkillManager.ts
+++ b/src/process/task/AcpSkillManager.ts
@@ -91,8 +91,17 @@ function extractBody(content: string): string {
  * - 可选 skills: 通过 enabledSkills 参数控制
  */
 export class AcpSkillManager {
-  private static instance: AcpSkillManager | null = null;
-  private static instanceKey: string | null = null;
+  /**
+   * Per-key instance cache.
+   *
+   * Previously a single mutable instance keyed by enabledSkills was kept; when
+   * two concurrent conversations had different enabledSkills lists the second
+   * caller's getInstance() would replace the first caller's manager mid-flight,
+   * dropping any in-progress discoverSkills() work.  A Map keyed by the same
+   * canonical cacheKey lets independent conversations coexist; resetInstance()
+   * still clears everything (the `skill change → reset` workflow is preserved).
+   */
+  private static cache: Map<string, AcpSkillManager> = new Map();
 
   private skills: Map<string, SkillDefinition> = new Map();
   private builtinSkills: Map<string, SkillDefinition> = new Map();
@@ -129,25 +138,20 @@ export class AcpSkillManager {
     // no skills → load none).  An empty array must NOT map to 'all'.
     const cacheKey = enabledSkills ? (enabledSkills.length > 0 ? [...enabledSkills].sort().join(',') : '__none__') : 'all';
 
-    // 如果缓存键变化，需要重新创建实例
-    // If cache key changed, need to recreate instance
-    if (AcpSkillManager.instance && AcpSkillManager.instanceKey === cacheKey) {
-      return AcpSkillManager.instance;
+    let instance = AcpSkillManager.cache.get(cacheKey);
+    if (!instance) {
+      instance = new AcpSkillManager();
+      AcpSkillManager.cache.set(cacheKey, instance);
     }
-
-    // 创建新实例
-    AcpSkillManager.instance = new AcpSkillManager();
-    AcpSkillManager.instanceKey = cacheKey;
-    return AcpSkillManager.instance;
+    return instance;
   }
 
   /**
-   * 重置单例实例（用于测试或配置变更）
-   * Reset singleton instance (for testing or config changes)
+   * 清空所有缓存的实例（用于测试或 skills 目录变更后强制重新发现）
+   * Clear all cached instances (for tests or to force rediscovery after skills directory changes)
    */
   static resetInstance(): void {
-    AcpSkillManager.instance = null;
-    AcpSkillManager.instanceKey = null;
+    AcpSkillManager.cache.clear();
   }
 
   /**

--- a/src/process/task/AcpSkillManager.ts
+++ b/src/process/task/AcpSkillManager.ts
@@ -5,11 +5,9 @@
  */
 
 /**
- * ACP Skill Manager - 为 ACP agents (Claude/OpenCode/Codex) 提供 skills 按需加载能力
- * 借鉴 aioncli-core 的 SkillManager 设计
- *
- * ACP Skill Manager - Provides on-demand skill loading for ACP agents (Claude/OpenCode/Codex)
- * Inspired by aioncli-core's SkillManager design
+ * ACP Skill Manager — provides on-demand skill loading for ACP agents
+ * (Claude / OpenCode / Codex / sudo-code).  Inspired by aioncli-core's
+ * SkillManager design.
  */
 
 import fs from 'fs/promises';
@@ -19,34 +17,25 @@ import { existsSync } from 'fs';
 import { getSkillsDir, getBuiltinSkillsDir, getHubSkillsDir, getCustomSkillsDir, isUserSkillEnabled } from '../initStorage';
 import { ExtensionRegistry } from '@/extensions';
 
-/**
- * Skill 定义（与 aioncli-core 兼容）
- * Skill definition (compatible with aioncli-core)
- */
+/** Skill definition (shape compatible with aioncli-core). */
 export interface SkillDefinition {
-  /** 技能唯一名称 / Unique skill name */
+  /** Unique skill name. */
   name: string;
-  /** 技能描述（用于索引）/ Skill description (for indexing) */
+  /** Description used for the index injected into the agent prompt. */
   description: string;
-  /** 文件路径 / File path */
+  /** Filesystem location of the SKILL.md file. */
   location: string;
-  /** 完整内容（延迟加载）/ Full content (lazy loaded) */
+  /** Full skill body (lazily loaded — undefined until first read). */
   body?: string;
 }
 
-/**
- * Skill 索引（轻量级，用于首条消息注入）
- * Skill index (lightweight, for first message injection)
- */
+/** Lightweight index entry used when injecting skills into the first message. */
 export interface SkillIndex {
   name: string;
   description: string;
 }
 
-/**
- * 解析 SKILL.md 的 frontmatter
- * Parse frontmatter from SKILL.md
- */
+/** Parse the YAML frontmatter from a SKILL.md (supports name + description). */
 function parseFrontmatter(content: string): { name?: string; description?: string } {
   const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
   if (!frontmatterMatch) {
@@ -56,13 +45,12 @@ function parseFrontmatter(content: string): { name?: string; description?: strin
   const frontmatter = frontmatterMatch[1];
   const result: { name?: string; description?: string } = {};
 
-  // 解析 name
   const nameMatch = frontmatter.match(/^name:\s*['"]?([^'"\n]+)['"]?\s*$/m);
   if (nameMatch) {
     result.name = nameMatch[1].trim();
   }
 
-  // 解析 description（支持单引号、双引号、无引号）
+  // Description supports single-quoted, double-quoted, or unquoted values.
   const descMatch = frontmatter.match(/^description:\s*['"]?(.+?)['"]?\s*$/m);
   if (descMatch) {
     result.description = descMatch[1].trim();
@@ -71,24 +59,24 @@ function parseFrontmatter(content: string): { name?: string; description?: strin
   return result;
 }
 
-/**
- * 移除 frontmatter，只保留 body 内容
- * Remove frontmatter, keep only body content
- */
+/** Strip the frontmatter and return only the SKILL.md body. */
 function extractBody(content: string): string {
   return content.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '').trim();
 }
 
 /**
- * ACP Skill Manager
- * 为 ACP agents 提供 skills 的索引加载和按需获取能力
+ * Loads and caches skill indexes/bodies for ACP agents.
  *
- * 使用单例模式避免重复文件系统扫描
- * Uses singleton pattern to avoid repeated filesystem scans
+ * Skill sources, in priority order:
+ *   - builtin   (_system/_builtin/): auto-injected for every conversation
+ *   - custom    (_custom/): user-uploaded; enabledSkills-gated
+ *   - hub       (_hub/): hub-installed; enabledSkills-gated
+ *   - extension (registered via aion-extension.json): enabledSkills-gated
+ *   - legacy    (flat top-level layout, deprecated): enabledSkills-gated
  *
- * 支持两类 skills:
- * - 内置 skills (_builtin/): 所有场景自动注入
- * - 可选 skills: 通过 enabledSkills 参数控制
+ * Filesystem scans are cached per enabledSkills key so that concurrent
+ * conversations with different skill lists don't trigger repeated scans
+ * (see the `cache` field doc for the concurrency rationale).
  */
 export class AcpSkillManager {
   /**
@@ -127,11 +115,13 @@ export class AcpSkillManager {
   }
 
   /**
-   * 获取单例实例（带 enabledSkills 缓存键）
-   * Get singleton instance (with enabledSkills cache key)
+   * Get the manager instance for a given enabledSkills list.
    *
-   * @param enabledSkills - 启用的 skills 列表，用作缓存键 / Enabled skills list, used as cache key
-   * @returns AcpSkillManager 实例 / AcpSkillManager instance
+   * The list (or undefined) is canonicalised to a cache key; concurrent
+   * conversations with different enabledSkills get independent managers
+   * (see the `cache` field doc for why).
+   *
+   * @param enabledSkills - the conversation's enabledSkills (cache key)
    */
   static getInstance(enabledSkills?: string[]): AcpSkillManager {
     // Distinguish between undefined (non-preset → load all) and [] (preset with
@@ -147,16 +137,16 @@ export class AcpSkillManager {
   }
 
   /**
-   * 清空所有缓存的实例（用于测试或 skills 目录变更后强制重新发现）
-   * Clear all cached instances (for tests or to force rediscovery after skills directory changes)
+   * Clear all cached instances. Used by tests and by skillHubBridge after
+   * skills directory mutations (install / uninstall) to force rediscovery.
    */
   static resetInstance(): void {
     AcpSkillManager.cache.clear();
   }
 
   /**
-   * 初始化：发现并加载内置 skills 的索引（所有场景自动注入）
-   * Initialize: discover and load index of builtin skills (auto-injected for all scenarios)
+   * Discover and load the index of builtin skills (auto-injected for every
+   * conversation, regardless of enabledSkills).
    */
   async discoverBuiltinSkills(): Promise<void> {
     if (this.builtinInitialized) return;
@@ -186,7 +176,7 @@ export class AcpSkillManager {
             name: name || skillName,
             description: description || `Builtin Skill: ${skillName}`,
             location: skillFile,
-            // body 不在这里加载，按需获取
+            // body is loaded on demand via getSkill() — see lazy-load below.
           };
 
           this.builtinSkills.set(skillName, skillDef);
@@ -204,12 +194,11 @@ export class AcpSkillManager {
   }
 
   /**
-   * 从 ExtensionRegistry 加载扩展贡献的 skills
-   * Load extension-contributed skills from ExtensionRegistry
+   * Load extension-contributed skills from ExtensionRegistry.
    *
-   * 扩展 skills 通过 aion-extension.json 的 contributes.skills 声明，
-   * 由 SkillResolver 解析后缓存在 ExtensionRegistry 中。
-   * 这里将它们合并到 AcpSkillManager 中，使 agent 能够按需加载。
+   * Extensions declare skills via aion-extension.json's `contributes.skills`;
+   * SkillResolver parses and caches them in ExtensionRegistry.  This pass
+   * merges them into the manager so agents can load them on demand.
    */
   private async discoverExtensionSkills(enabledSkills?: string[]): Promise<void> {
     if (this.extensionInitialized) return;
@@ -224,14 +213,14 @@ export class AcpSkillManager {
       }
 
       for (const extSkill of extSkills) {
-        // 如果指定了 enabledSkills，只加载被启用的扩展 skills
-        // If enabledSkills is specified, only load enabled extension skills.
-        // An empty array means "no skills" (preset assistant with none selected).
+        // If enabledSkills is provided, only load extension skills in that
+        // list.  An empty array means "no skills" (preset assistant with
+        // none selected) — distinct from undefined (no preset, load all).
         if (enabledSkills && !enabledSkills.includes(extSkill.name)) {
           continue;
         }
 
-        // 避免与内置/可选 skills 冲突 / Avoid conflicts with builtin/optional skills
+        // Avoid conflicts with builtin/optional skills.
         if (this.builtinSkills.has(extSkill.name) || this.skills.has(extSkill.name)) {
           mainWarn('AcpSkillManager', `Extension skill "${extSkill.name}" conflicts with existing skill, skipping`);
           continue;
@@ -257,13 +246,31 @@ export class AcpSkillManager {
   }
 
   /**
-   * 初始化：发现并加载所有 skills 的索引（不加载 body）
-   * Initialize: discover and load index of all skills (without body)
+   * Helper: scan a single skills directory and populate a target map.
+   *
+   * Filters (all opt-in):
+   *  - enabledSkills:    if provided, only include skill names in this list
+   *                      (an empty array means "no skills enabled")
+   *  - skipDisabledCheck: bypass isUserSkillEnabled() — used for sources where
+   *                      every directory entry is implicitly enabled (e.g.
+   *                      hub/custom managed by the skills UI)
+   *  - skipUnderscorePrefix: skip directory names starting with "_" — used by
+   *                      the legacy-flat scan to avoid descending into the
+   *                      structured _builtin/_hub/_custom subdirs
+   *  - skipIfPresentIn:  skip skill names already loaded into this map — used
+   *                      by the legacy-flat scan so it doesn't shadow newer
+   *                      structured locations
    */
-  /**
-   * Helper to discover skills from a specific directory
-   */
-  private async discoverSkillsFromDir(dir: string, targetMap: Map<string, SkillDefinition>, enabledSkills?: string[], skipDisabledCheck = false): Promise<void> {
+  private async discoverSkillsFromDir(
+    dir: string,
+    targetMap: Map<string, SkillDefinition>,
+    enabledSkills?: string[],
+    options: {
+      skipDisabledCheck?: boolean;
+      skipUnderscorePrefix?: boolean;
+      skipIfPresentIn?: Map<string, SkillDefinition>;
+    } = {}
+  ): Promise<void> {
     if (!existsSync(dir)) return;
 
     try {
@@ -273,14 +280,13 @@ export class AcpSkillManager {
         if (!entry.isDirectory()) continue;
         const skillName = entry.name;
 
-        // An empty array means "no skills" (preset assistant with none selected).
-        if (enabledSkills && !enabledSkills.includes(skillName)) {
-          continue;
-        }
+        if (options.skipUnderscorePrefix && skillName.startsWith('_')) continue;
+        if (options.skipIfPresentIn && options.skipIfPresentIn.has(skillName)) continue;
 
-        if (!skipDisabledCheck && !(await isUserSkillEnabled(skillName))) {
-          continue;
-        }
+        // An empty array means "no skills" (preset assistant with none selected).
+        if (enabledSkills && !enabledSkills.includes(skillName)) continue;
+
+        if (!options.skipDisabledCheck && !(await isUserSkillEnabled(skillName))) continue;
 
         const skillFile = path.join(dir, skillName, 'SKILL.md');
         if (!existsSync(skillFile)) continue;
@@ -289,13 +295,11 @@ export class AcpSkillManager {
           const content = await fs.readFile(skillFile, 'utf-8');
           const { name, description } = parseFrontmatter(content);
 
-          const skillDef: SkillDefinition = {
+          targetMap.set(skillName, {
             name: name || skillName,
             description: description || `Skill: ${skillName}`,
             location: skillFile,
-          };
-
-          targetMap.set(skillName, skillDef);
+          });
         } catch (error) {
           mainWarn('AcpSkillManager', `Failed to load skill ${skillName} from ${dir}:`, error);
         }
@@ -305,11 +309,22 @@ export class AcpSkillManager {
     }
   }
 
+  /**
+   * Discover and load the index of all optional skills (without body).
+   *
+   * Sources scanned, in priority order (first writer wins for `this.skills`):
+   *   1. custom  (skillsDir/_custom/)
+   *   2. hub     (skillsDir/_hub/)
+   *   3. legacy  (skillsDir/<name>/, flat layout kept for backward compat)
+   *
+   * Builtin skills (skillsDir/_system/_builtin/) and extension skills live in
+   * their own maps and are merged into the index by getSkillsIndex().
+   */
   async discoverSkills(enabledSkills?: string[]): Promise<void> {
-    // 始终先加载内置 skills / Always load builtin skills first
+    // Always load builtin skills first.
     await this.discoverBuiltinSkills();
 
-    // 加载扩展贡献的 skills / Load extension-contributed skills
+    // Load extension-contributed skills.
     await this.discoverExtensionSkills(enabledSkills);
 
     if (this.initialized) return;
@@ -318,7 +333,6 @@ export class AcpSkillManager {
     // user-enabled workspace skills so that standalone agents like Claude Code
     // can also use skills such as "browser".
     // When enabledSkills is an explicit list (preset agent), only load those.
-
     const skillsDir = this.skillsDir;
     if (!existsSync(skillsDir)) {
       mainWarn('AcpSkillManager', `Skills directory not found: ${skillsDir}`);
@@ -326,68 +340,23 @@ export class AcpSkillManager {
       return;
     }
 
-    // Discover skills from all three subdirectories
-    // Priority: custom > hub > builtin (builtin already loaded above)
+    // Priority order: custom > hub > legacy-flat.  Each scan populates its
+    // dedicated map AND mirrors into this.skills using first-writer-wins so
+    // the union map preserves priority for getSkillsIndex / hasSkill lookups.
     await this.discoverSkillsFromDir(this.customSkillsDir, this.customSkills, enabledSkills);
+    for (const [key, skill] of this.customSkills) if (!this.skills.has(key)) this.skills.set(key, skill);
+
     await this.discoverSkillsFromDir(this.hubSkillsDir, this.hubSkills, enabledSkills);
+    for (const [key, skill] of this.hubSkills) if (!this.skills.has(key)) this.skills.set(key, skill);
 
-    // Merge custom and hub skills into the main skills map (custom takes priority)
-    for (const [key, skill] of this.customSkills) {
-      if (!this.skills.has(key)) {
-        this.skills.set(key, skill);
-      }
-    }
-    for (const [key, skill] of this.hubSkills) {
-      if (!this.skills.has(key)) {
-        this.skills.set(key, skill);
-      }
-    }
-
-    // Legacy: also scan flat directories for backward compatibility
-    try {
-      const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-
-        const skillName = entry.name;
-
-        // Skip all `_` prefixed directories (new structure dirs)
-        if (skillName.startsWith('_')) continue;
-
-        // Skip if already found in subdirectories
-        if (this.skills.has(skillName)) continue;
-
-        // An empty array means "no skills" (preset assistant with none selected).
-        if (enabledSkills && !enabledSkills.includes(skillName)) {
-          continue;
-        }
-
-        if (!(await isUserSkillEnabled(skillName))) {
-          continue;
-        }
-
-        const skillFile = path.join(skillsDir, skillName, 'SKILL.md');
-        if (!existsSync(skillFile)) continue;
-
-        try {
-          const content = await fs.readFile(skillFile, 'utf-8');
-          const { name, description } = parseFrontmatter(content);
-
-          const skillDef: SkillDefinition = {
-            name: name || skillName,
-            description: description || `Skill: ${skillName}`,
-            location: skillFile,
-          };
-
-          this.skills.set(skillName, skillDef);
-        } catch (error) {
-          mainWarn('AcpSkillManager', `Failed to load skill ${skillName}:`, error);
-        }
-      }
-    } catch (error) {
-      mainError('AcpSkillManager', `Failed to discover legacy skills:`, error);
-    }
+    // Legacy flat layout (deprecated): scan skillsDir directly for any
+    // remaining top-level skill folders not in _custom/_hub/_builtin.  Pass
+    // skipUnderscorePrefix to avoid re-entering the structured dirs and
+    // skipIfPresentIn=this.skills so legacy entries don't shadow newer ones.
+    await this.discoverSkillsFromDir(skillsDir, this.skills, enabledSkills, {
+      skipUnderscorePrefix: true,
+      skipIfPresentIn: this.skills,
+    });
 
     mainLog('AcpSkillManager', `Discovered ${this.skills.size} optional skills (custom: ${this.customSkills.size}, hub: ${this.hubSkills.size})`);
 
@@ -395,47 +364,28 @@ export class AcpSkillManager {
   }
 
   /**
-   * 获取所有 skills 的索引（轻量级）
-   * 包含内置 skills + 可选 skills
-   * Get index of all skills (lightweight)
-   * Includes builtin skills + optional skills
+   * Get a lightweight index of every loaded skill (builtin + optional +
+   * extension).  Used to inject the [Available Skills] block into the first
+   * message.
    */
   getSkillsIndex(): SkillIndex[] {
-    // 合并内置 skills、可选 skills 和扩展 skills
-    // Merge builtin, optional, and extension skills
     const allSkills: SkillIndex[] = [];
 
-    // 内置 skills 优先 / Builtin skills first
+    // Builtin first, then optional (custom/hub/legacy union), then extension.
     for (const skill of this.builtinSkills.values()) {
-      allSkills.push({
-        name: skill.name,
-        description: skill.description,
-      });
+      allSkills.push({ name: skill.name, description: skill.description });
     }
-
-    // 然后是可选 skills / Then optional skills
     for (const skill of this.skills.values()) {
-      allSkills.push({
-        name: skill.name,
-        description: skill.description,
-      });
+      allSkills.push({ name: skill.name, description: skill.description });
     }
-
-    // 最后是扩展 skills / Then extension skills
     for (const skill of this.extensionSkills.values()) {
-      allSkills.push({
-        name: skill.name,
-        description: skill.description,
-      });
+      allSkills.push({ name: skill.name, description: skill.description });
     }
 
     return allSkills;
   }
 
-  /**
-   * 获取内置 skills 的索引
-   * Get index of builtin skills only
-   */
+  /** Get a lightweight index of builtin skills only. */
   getBuiltinSkillsIndex(): SkillIndex[] {
     return Array.from(this.builtinSkills.values()).map((skill) => ({
       name: skill.name,
@@ -443,39 +393,20 @@ export class AcpSkillManager {
     }));
   }
 
-  /**
-   * 检查是否有任何 skills（内置或可选）
-   * Check if there are any skills (builtin or optional)
-   */
+  /** Check whether any skill (builtin, optional, or extension) is loaded. */
   hasAnySkills(): boolean {
     return this.customSkills.size > 0 || this.hubSkills.size > 0 || this.builtinSkills.size > 0 || this.skills.size > 0 || this.extensionSkills.size > 0;
   }
 
   /**
-   * 按名称获取单个 skill 的完整内容（按需加载）
-   * 先查找内置 skills，再查找可选 skills
-   * Get full content of a skill by name (on-demand loading)
-   * Search builtin skills first, then optional skills
+   * Get a single skill by name with full body loaded.
+   * Search order (priority): custom > hub > merged skills > builtin > extension.
+   * Body is read from disk on first access and cached on the SkillDefinition.
    */
   async getSkill(name: string): Promise<SkillDefinition | null> {
-    // 按优先级查找：自定义 > Hub > 合并的 skills > 内置 > 扩展
-    // Search by priority: custom > hub > merged skills > builtin > extension
-    let skill = this.customSkills.get(name);
-    if (!skill) {
-      skill = this.hubSkills.get(name);
-    }
-    if (!skill) {
-      skill = this.skills.get(name);
-    }
-    if (!skill) {
-      skill = this.builtinSkills.get(name);
-    }
-    if (!skill) {
-      skill = this.extensionSkills.get(name);
-    }
+    const skill = this.customSkills.get(name) || this.hubSkills.get(name) || this.skills.get(name) || this.builtinSkills.get(name) || this.extensionSkills.get(name);
     if (!skill) return null;
 
-    // 如果 body 还没加载，现在加载
     if (skill.body === undefined) {
       try {
         const content = await fs.readFile(skill.location, 'utf-8');
@@ -489,10 +420,7 @@ export class AcpSkillManager {
     return skill;
   }
 
-  /**
-   * 获取多个 skills 的完整内容
-   * Get full content of multiple skills
-   */
+  /** Get multiple skills with bodies loaded; missing names are silently dropped. */
   async getSkills(names: string[]): Promise<SkillDefinition[]> {
     const results: SkillDefinition[] = [];
     for (const name of names) {
@@ -504,18 +432,12 @@ export class AcpSkillManager {
     return results;
   }
 
-  /**
-   * 检查 skill 是否存在（包括内置和可选）
-   * Check if a skill exists (including builtin and optional)
-   */
+  /** Check whether a skill exists across any source (builtin, optional, extension). */
   hasSkill(name: string): boolean {
     return this.customSkills.has(name) || this.hubSkills.has(name) || this.builtinSkills.has(name) || this.skills.has(name) || this.extensionSkills.has(name);
   }
 
-  /**
-   * 清除缓存的 body 内容（用于刷新）
-   * Clear cached body content (for refresh)
-   */
+  /** Drop cached body content across every source so the next getSkill() re-reads from disk. */
   clearCache(): void {
     for (const skill of this.builtinSkills.values()) {
       skill.body = undefined;
@@ -535,10 +457,7 @@ export class AcpSkillManager {
   }
 }
 
-/**
- * 构建 skills 索引文本（用于首条消息注入）
- * Build skills index text (for first message injection)
- */
+/** Build the [Available Skills] block injected into a first message. */
 export function buildSkillsIndexText(skills: SkillIndex[]): string {
   if (skills.length === 0) return '';
 
@@ -551,10 +470,7 @@ you can request it by outputting: [LOAD_SKILL: skill-name]
 ${lines.join('\n')}`;
 }
 
-/**
- * 检测消息中是否请求加载 skill
- * Detect if message requests loading a skill
- */
+/** Extract any [LOAD_SKILL: <name>] requests emitted by the agent. */
 export function detectSkillLoadRequest(content: string): string[] {
   const matches = content.matchAll(/\[LOAD_SKILL:\s*([^\]]+)\]/gi);
   const requested: string[] = [];
@@ -564,10 +480,7 @@ export function detectSkillLoadRequest(content: string): string[] {
   return requested;
 }
 
-/**
- * 构建 skill 内容文本（用于注入）
- * Build skill content text (for injection)
- */
+/** Build the [Skill: <name>] content blocks injected when a skill is loaded. */
 export function buildSkillContentText(skills: SkillDefinition[]): string {
   if (skills.length === 0) return '';
 

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -208,6 +208,92 @@ Ask yourself: "Is this file what the user ultimately wants?"
 [End of File Intent Marking System Rules]`;
 }
 
+// ---------------------------------------------------------------------------
+// Shared helpers
+//
+// All four "prepare first message" functions follow the same shape:
+//   1. collect instruction blocks (presetContext, drafts, skills, ...)
+//   2. if any → wrap with [Assistant Rules]/[User Request]
+//   3. else → return content untouched
+//
+// Variants differ only in which skill block they emit (full content / index
+// pointer / concrete list / workspace hint).  Extract the common pieces here
+// so each variant is a thin composition.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap collected instruction blocks with the [Assistant Rules]/[User Request]
+ * envelope.  All preset-driven agents (Gemini / ACP / OpenClaw) use the same
+ * prefix-based format to remain compatible with external CLIs (Claude Code,
+ * Codex CLI, etc.) that don't grok XML tags.
+ */
+function wrapWithUserRequest(content: string, instructions: string[]): string {
+  if (instructions.length === 0) return content;
+  return `[Assistant Rules - You MUST follow these instructions]\n${instructions.join('\n\n')}\n\n[User Request]\n${content}`;
+}
+
+/**
+ * Push presetContext and (optionally) drafts instruction onto the block list.
+ * Both are config-driven and shared by all preset agents.
+ */
+function pushPresetPreamble(instructions: string[], config: FirstMessageConfig, includeDrafts: boolean): void {
+  if (config.presetContext) {
+    instructions.push(config.presetContext);
+  }
+  if (includeDrafts && config.workspace) {
+    instructions.push(buildDraftsInstruction(config.workspace));
+  }
+}
+
+/**
+ * Discover and return the builtin skills index.  Builtin skills auto-inject
+ * for every preset agent; the only difference between agents is the *format*
+ * of the surrounding instruction block (see {@link buildBuiltinSkillsBlock}).
+ */
+async function loadBuiltinSkillsIndex(): Promise<SkillIndex[]> {
+  const skillManager = AcpSkillManager.getInstance();
+  await skillManager.discoverBuiltinSkills();
+  return skillManager.getBuiltinSkillsIndex();
+}
+
+/**
+ * Format the builtin-skills index into an instruction block.
+ *
+ * - 'load-tag' (Gemini-style ACP / Codex / Claude): emit [Available Skills]
+ *   list plus [Skills Location] directing the agent to read SKILL.md on demand.
+ *   Built-in skills only — non-builtin (hub/custom) skills are *not* injected.
+ *
+ * - 'concrete-list' (OpenClaw): emit [Builtin Skills] with each skill's full
+ *   path inline, since OpenClaw uses its file-read tool directly without the
+ *   [LOAD_SKILL:] protocol.
+ */
+function buildBuiltinSkillsBlock(skillsIndex: SkillIndex[], format: 'load-tag' | 'concrete-list'): string | null {
+  if (skillsIndex.length === 0) return null;
+
+  const systemSkillsDir = getBuiltinSkillsDir();
+
+  if (format === 'load-tag') {
+    return `${buildSkillsIndexText(skillsIndex)}
+
+[Skills Location]
+Builtin skills are stored at:
+- ${systemSkillsDir}/{skill-name}/SKILL.md
+
+Each skill has a SKILL.md file containing detailed instructions.
+To use a skill, read its SKILL.md file when needed.
+
+For example:
+- Builtin "cron" skill: ${systemSkillsDir}/cron/SKILL.md`;
+  }
+
+  // 'concrete-list'
+  const lines = skillsIndex.map((s) => `- ${s.name} (${s.description}): ${systemSkillsDir}/${s.name}/SKILL.md`);
+  return `[Builtin Skills]
+The following builtin skills are available. When a user request matches a skill's description, you MUST read that skill's SKILL.md and follow its instructions INSTEAD OF using any native tool for that capability.
+
+${lines.join('\n')}`;
+}
+
 /**
  * 构建系统指令内容（完整 skills 内容注入 - 用于 Gemini）
  * Build system instructions content (full skills content injection - for Gemini)
@@ -217,16 +303,7 @@ Ask yourself: "Is this file what the user ultimately wants?"
  */
 export async function buildSystemInstructions(config: FirstMessageConfig): Promise<string | undefined> {
   const instructions: string[] = [];
-
-  // 添加预设上下文 / Add preset context
-  if (config.presetContext) {
-    instructions.push(config.presetContext);
-  }
-
-  // 添加草稿箱使用指令 / Add drafts box instructions
-  if (config.workspace) {
-    instructions.push(buildDraftsInstruction(config.workspace));
-  }
+  pushPresetPreamble(instructions, config, true);
 
   // 加载并添加 skills 内容 / Load and add skills content
   if (config.enabledSkills && config.enabledSkills.length > 0) {
@@ -236,11 +313,7 @@ export async function buildSystemInstructions(config: FirstMessageConfig): Promi
     }
   }
 
-  if (instructions.length === 0) {
-    return undefined;
-  }
-
-  return instructions.join('\n\n');
+  return instructions.length === 0 ? undefined : instructions.join('\n\n');
 }
 
 /**
@@ -256,14 +329,7 @@ export async function buildSystemInstructions(config: FirstMessageConfig): Promi
  */
 export async function prepareFirstMessage(content: string, config: FirstMessageConfig): Promise<string> {
   const systemInstructions = await buildSystemInstructions(config);
-
-  if (!systemInstructions) {
-    return content;
-  }
-
-  // 使用与 Gemini Agent 类似的直接前缀格式，确保 Claude/Codex 等外部 agent 能正确识别
-  // Use direct prefix format similar to Gemini Agent to ensure Claude/Codex can recognize it
-  return `[Assistant Rules - You MUST follow these instructions]\n${systemInstructions}\n\n[User Request]\n${content}`;
+  return systemInstructions ? wrapWithUserRequest(content, [systemInstructions]) : content;
 }
 
 /**
@@ -277,57 +343,15 @@ export async function prepareFirstMessage(content: string, config: FirstMessageC
  * Hub/custom/system 下的非 builtin skills 不会通过首条消息注入给 agent。
  * Note: For ACP/OpenClaw assistants, only builtin skills under _system/_builtin are exposed here.
  * Non-builtin skills from hub/custom/system are not injected via the first message.
- *
- * @param content - 原始消息内容 / Original message content
- * @param config - 首次消息配置 / First message configuration
- * @returns 注入系统指令后的消息内容 / Message content with system instructions injected
  */
 export async function prepareFirstMessageWithSkillsIndex(content: string, config: FirstMessageConfig): Promise<string> {
   const instructions: string[] = [];
+  pushPresetPreamble(instructions, config, true);
 
-  // 1. 添加预设规则 / Add preset rules
-  if (config.presetContext) {
-    instructions.push(config.presetContext);
-  }
+  const skillsBlock = buildBuiltinSkillsBlock(await loadBuiltinSkillsIndex(), 'load-tag');
+  if (skillsBlock) instructions.push(skillsBlock);
 
-  // 1.5 添加草稿箱使用指令 / Add drafts box instructions
-  if (config.workspace) {
-    instructions.push(buildDraftsInstruction(config.workspace));
-  }
-
-  // 2. 仅加载内置 skills 索引
-  // Load builtin skills index only
-  const skillManager = AcpSkillManager.getInstance();
-  await skillManager.discoverBuiltinSkills();
-
-  const builtinSkillsIndex = skillManager.getBuiltinSkillsIndex();
-  if (builtinSkillsIndex.length > 0) {
-    const systemSkillsDir = getBuiltinSkillsDir();
-    const indexText = buildSkillsIndexText(builtinSkillsIndex);
-
-    // 告诉 Agent 只从 builtin skills 目录按需读取
-    // Tell Agent to read only from the builtin skills directory on demand
-    const skillsInstruction = `${indexText}
-
-[Skills Location]
-Builtin skills are stored at:
-- ${systemSkillsDir}/{skill-name}/SKILL.md
-
-Each skill has a SKILL.md file containing detailed instructions.
-To use a skill, read its SKILL.md file when needed.
-
-For example:
-- Builtin "cron" skill: ${systemSkillsDir}/cron/SKILL.md`;
-
-    instructions.push(skillsInstruction);
-  }
-
-  if (instructions.length === 0) {
-    return content;
-  }
-
-  const systemInstructions = instructions.join('\n\n');
-  return `[Assistant Rules - You MUST follow these instructions]\n${systemInstructions}\n\n[User Request]\n${content}`;
+  return wrapWithUserRequest(content, instructions);
 }
 
 /**
@@ -338,41 +362,15 @@ For example:
  * Do NOT inject [LOAD_SKILL:] instructions — those are for Gemini ACP agents only.
  * Only inject presetContext + builtin skills location hint (read-based, not tag-based).
  * Workspace skills are handled separately by injectSkillsDirectoryHint.
- *
- * @param content - 原始消息内容 / Original message content
- * @param config - 首次消息配置 / First message configuration
- * @returns 注入系统指令后的消息内容 / Message content with system instructions injected
  */
 export async function prepareOpenClawFirstMessage(content: string, config: FirstMessageConfig): Promise<string> {
   const instructions: string[] = [];
+  pushPresetPreamble(instructions, config, false);
 
-  // 1. 添加预设规则 / Add preset rules
-  if (config.presetContext) {
-    instructions.push(config.presetContext);
-  }
+  const skillsBlock = buildBuiltinSkillsBlock(await loadBuiltinSkillsIndex(), 'concrete-list');
+  if (skillsBlock) instructions.push(skillsBlock);
 
-  // 2. 加载内置 skills 索引 — 告诉 agent 直接读取 SKILL.md，不使用 [LOAD_SKILL:] 协议
-  // Load builtin skills index — tell agent to read SKILL.md directly, no [LOAD_SKILL:] protocol
-  const skillManager = AcpSkillManager.getInstance();
-  await skillManager.discoverBuiltinSkills();
-
-  const builtinSkillsIndex = skillManager.getBuiltinSkillsIndex();
-  if (builtinSkillsIndex.length > 0) {
-    const systemSkillsDir = getBuiltinSkillsDir();
-    const lines = builtinSkillsIndex.map((s) => `- ${s.name} (${s.description}): ${systemSkillsDir}/${s.name}/SKILL.md`);
-    const skillsInstruction = `[Builtin Skills]
-The following builtin skills are available. When a user request matches a skill's description, you MUST read that skill's SKILL.md and follow its instructions INSTEAD OF using any native tool for that capability.
-
-${lines.join('\n')}`;
-    instructions.push(skillsInstruction);
-  }
-
-  if (instructions.length === 0) {
-    return content;
-  }
-
-  const systemInstructions = instructions.join('\n\n');
-  return `[Assistant Rules - You MUST follow these instructions]\n${systemInstructions}\n\n[User Request]\n${content}`;
+  return wrapWithUserRequest(content, instructions);
 }
 
 /**

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -100,19 +100,30 @@ Example: If user asks about document operations, first run 'mcporter list' to se
 The mcporter config is at: ${MCPORTER_CONFIG_PATH}`;
 }
 
-/**
- * 首次消息处理配置
- * First message processing configuration
- */
+/** First-message processing configuration. */
 export interface FirstMessageConfig {
-  /** 预设上下文/规则 / Preset context/rules */
+  /** Preset rules/context to inject as [Assistant Rules]. */
   presetContext?: string;
-  /** 启用的 skills 列表 / Enabled skills list */
+  /** Enabled skills (skill names; UUIDs are resolved by loadSkillsContent). */
   enabledSkills?: string[];
-  /** 工作空间路径 / Workspace path (used for drafts instruction) */
+  /** Workspace path (used for drafts instruction). */
   workspace?: string;
-  /** 预设 Agent 类型 / Preset agent type - used to control skill injection behavior */
+  /** Preset agent type — controls which skill injection format is used. */
   presetAgentType?: PresetAgentType | string;
+  /**
+   * Optional workspace skills directory hint.  When set, an additional
+   * [Skills Directory] block is injected pointing at this directory so the
+   * agent knows where to read non-builtin skills' SKILL.md from.
+   *
+   * - skillsDir is required if the hint is set
+   * - enabledSkillNames, if provided, enumerates discoverable skills inline
+   *   (with descriptions resolved via AcpSkillManager); when omitted the hint
+   *   is just the directory path with a relative-path resolution note
+   */
+  workspaceSkillsHint?: {
+    skillsDir: string;
+    enabledSkillNames?: string[];
+  };
 }
 
 /**
@@ -295,6 +306,38 @@ ${lines.join('\n')}`;
 }
 
 /**
+ * Build the [Skills Directory] block used for non-builtin (workspace-installed)
+ * skills.  When enabledSkillNames is provided, enumerate them inline with
+ * descriptions resolved via AcpSkillManager.  Otherwise emit just the path +
+ * relative-path resolution hint.
+ */
+async function buildWorkspaceSkillsHintBlock(hint: NonNullable<FirstMessageConfig['workspaceSkillsHint']>): Promise<string> {
+  const { skillsDir, enabledSkillNames } = hint;
+
+  if (enabledSkillNames && enabledSkillNames.length > 0) {
+    const skillManager = AcpSkillManager.getInstance();
+    await skillManager.discoverSkills(enabledSkillNames);
+    const descriptionMap = new Map<string, string>(skillManager.getSkillsIndex().map((s: SkillIndex) => [s.name, s.description]));
+    const lines = enabledSkillNames.map((name) => {
+      const desc = descriptionMap.get(name);
+      return desc ? `- ${name} (${desc}): ${skillsDir}/${name}/SKILL.md` : `- ${name}: ${skillsDir}/${name}/SKILL.md`;
+    });
+    return `[Skills Directory]
+Skills are installed at: ${skillsDir}
+Each skill has a SKILL.md file containing detailed instructions. When a user request matches a skill's description, you MUST read that skill's SKILL.md and follow its instructions INSTEAD OF using any native tool for that capability.
+
+Available workspace skills:
+${lines.join('\n')}
+
+When skill instructions reference relative paths like "skills/{name}/scripts/...", resolve them as "${skillsDir}/{name}/scripts/...".`;
+  }
+
+  return `[Skills Directory]
+Skills are installed at: ${skillsDir}
+When skill instructions reference relative paths like "skills/{name}/scripts/...", resolve them as "${skillsDir}/{name}/scripts/...".`;
+}
+
+/**
  * 构建系统指令内容（完整 skills 内容注入 - 用于 Gemini）
  * Build system instructions content (full skills content injection - for Gemini)
  *
@@ -351,6 +394,10 @@ export async function prepareFirstMessageWithSkillsIndex(content: string, config
   const skillsBlock = buildBuiltinSkillsBlock(await loadBuiltinSkillsIndex(), 'load-tag');
   if (skillsBlock) instructions.push(skillsBlock);
 
+  if (config.workspaceSkillsHint) {
+    instructions.push(await buildWorkspaceSkillsHintBlock(config.workspaceSkillsHint));
+  }
+
   return wrapWithUserRequest(content, instructions);
 }
 
@@ -370,45 +417,25 @@ export async function prepareOpenClawFirstMessage(content: string, config: First
   const skillsBlock = buildBuiltinSkillsBlock(await loadBuiltinSkillsIndex(), 'concrete-list');
   if (skillsBlock) instructions.push(skillsBlock);
 
+  if (config.workspaceSkillsHint) {
+    instructions.push(await buildWorkspaceSkillsHintBlock(config.workspaceSkillsHint));
+  }
+
   return wrapWithUserRequest(content, instructions);
 }
 
 /**
- * 为首条消息补充 workspace skills 目录提示，供 OpenClaw 自行读取非 builtin skills。
- * Add workspace skills directory hint so OpenClaw can discover non-builtin skills by itself.
+ * @deprecated Pass `workspaceSkillsHint` to `prepareFirstMessageWithSkillsIndex`
+ * or `prepareOpenClawFirstMessage` instead so the hint is built in a single
+ * pass.  This wrapper exists only for callers we haven't migrated yet; new
+ * code must not call it.
  *
- * Enumerates enabled skill names so the agent knows exactly which skills exist
- * and where to find their SKILL.md files — mirroring the builtin skills instruction.
+ * Splices a [Skills Directory] block in front of [User Request] in already-
+ * wrapped content.  The two-pass shape (wrap, then post-hoc string-replace)
+ * is fragile: any change to the [User Request] sentinel breaks it silently.
  */
 export async function injectSkillsDirectoryHint(content: string, skillsDir: string, enabledSkillNames?: string[]): Promise<string> {
-  // Warm the skill manager so hub/custom skill descriptions are available.
-  // discoverSkills() is idempotent — returns immediately if already initialized.
-  const skillManager = AcpSkillManager.getInstance();
-  await skillManager.discoverSkills(enabledSkillNames);
-  const descriptionMap = new Map<string, string>(skillManager.getSkillsIndex().map((s: SkillIndex) => [s.name, s.description]));
-
-  const skillLines =
-    enabledSkillNames && enabledSkillNames.length > 0
-      ? enabledSkillNames
-          .map((name) => {
-            const desc = descriptionMap.get(name);
-            return desc ? `- ${name} (${desc}): ${skillsDir}/${name}/SKILL.md` : `- ${name}: ${skillsDir}/${name}/SKILL.md`;
-          })
-          .join('\n')
-      : null;
-
-  const hint = skillLines
-    ? `[Skills Directory]
-Skills are installed at: ${skillsDir}
-Each skill has a SKILL.md file containing detailed instructions. When a user request matches a skill's description, you MUST read that skill's SKILL.md and follow its instructions INSTEAD OF using any native tool for that capability.
-
-Available workspace skills:
-${skillLines}
-
-When skill instructions reference relative paths like "skills/{name}/scripts/...", resolve them as "${skillsDir}/{name}/scripts/...".`
-    : `[Skills Directory]
-Skills are installed at: ${skillsDir}
-When skill instructions reference relative paths like "skills/{name}/scripts/...", resolve them as "${skillsDir}/{name}/scripts/...".`;
+  const hint = await buildWorkspaceSkillsHintBlock({ skillsDir, enabledSkillNames });
 
   if (content.includes('[User Request]')) {
     return content.replace('[User Request]', `${hint}\n\n[User Request]`);

--- a/tests/unit/acpSkillManagerCache.test.ts
+++ b/tests/unit/acpSkillManagerCache.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/process/initStorage', () => ({
+  getSkillsDir: vi.fn(() => '/tmp/.nexus/skills'),
+  getBuiltinSkillsDir: vi.fn(() => '/tmp/.nexus/skills/_system/_builtin'),
+  getHubSkillsDir: vi.fn(() => '/tmp/.nexus/skills/_hub'),
+  getCustomSkillsDir: vi.fn(() => '/tmp/.nexus/skills/_custom'),
+  isUserSkillEnabled: vi.fn(async () => true),
+}));
+
+vi.mock('../../src/extensions', () => ({
+  ExtensionRegistry: {
+    getInstance: vi.fn(() => ({ getSkills: () => [] })),
+  },
+}));
+
+import { AcpSkillManager } from '../../src/process/task/AcpSkillManager';
+
+describe('AcpSkillManager.getInstance per-key cache', () => {
+  afterEach(() => {
+    AcpSkillManager.resetInstance();
+  });
+
+  it('returns the same instance for the same enabledSkills key', () => {
+    const a = AcpSkillManager.getInstance(['pptx', 'docx']);
+    const b = AcpSkillManager.getInstance(['docx', 'pptx']); // order-insensitive
+    expect(a).toBe(b);
+  });
+
+  it('returns distinct instances for different enabledSkills (concurrent conversations do not stomp)', () => {
+    const avatar = AcpSkillManager.getInstance(['desktop-screenshot']);
+    const main = AcpSkillManager.getInstance(['pptx', 'docx']);
+    const noPreset = AcpSkillManager.getInstance(undefined);
+    const emptyPreset = AcpSkillManager.getInstance([]);
+
+    expect(avatar).not.toBe(main);
+    expect(avatar).not.toBe(noPreset);
+    expect(noPreset).not.toBe(emptyPreset);
+
+    // Calling getInstance again for the original key must still return the
+    // original instance — i.e., the second caller did NOT evict the first.
+    expect(AcpSkillManager.getInstance(['desktop-screenshot'])).toBe(avatar);
+    expect(AcpSkillManager.getInstance(['pptx', 'docx'])).toBe(main);
+  });
+
+  it('resetInstance clears all cached instances', () => {
+    const before = AcpSkillManager.getInstance(['pptx']);
+    AcpSkillManager.resetInstance();
+    const after = AcpSkillManager.getInstance(['pptx']);
+    expect(after).not.toBe(before);
+  });
+});

--- a/tests/unit/agentUtils.test.ts
+++ b/tests/unit/agentUtils.test.ts
@@ -2,12 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const discoverBuiltinSkills = vi.fn(async () => {});
 const getBuiltinSkillsIndex = vi.fn(() => [{ name: 'cron', description: 'Builtin cron skill' }]);
+const discoverSkills = vi.fn(async () => {});
+const getSkillsIndex = vi.fn(() => [{ name: 'cron', description: 'Builtin cron skill' }]);
 
 vi.mock('../../src/process/task/AcpSkillManager', () => ({
   AcpSkillManager: {
     getInstance: vi.fn(() => ({
       discoverBuiltinSkills,
       getBuiltinSkillsIndex,
+      discoverSkills,
+      getSkillsIndex,
     })),
   },
   buildSkillsIndexText: vi.fn((skills: Array<{ name: string; description: string }>) => {
@@ -25,6 +29,8 @@ describe('prepareFirstMessageWithSkillsIndex', () => {
   beforeEach(() => {
     discoverBuiltinSkills.mockClear();
     getBuiltinSkillsIndex.mockClear();
+    discoverSkills.mockClear();
+    getSkillsIndex.mockClear();
   });
 
   it('injects only builtin skill paths for ACP/OpenClaw agents', async () => {
@@ -62,7 +68,7 @@ describe('prepareFirstMessageWithSkillsIndex', () => {
   it('injects workspace skills directory hint before user request', async () => {
     const { injectSkillsDirectoryHint } = await import('../../src/process/task/agentUtils');
 
-    const result = injectSkillsDirectoryHint('[Assistant Rules - You MUST follow these instructions]\n\n[User Request]\ndo something', '/tmp/workspace/skills');
+    const result = await injectSkillsDirectoryHint('[Assistant Rules - You MUST follow these instructions]\n\n[User Request]\ndo something', '/tmp/workspace/skills');
 
     expect(result).toContain('[Skills Directory]');
     expect(result).toContain('/tmp/workspace/skills');

--- a/tests/unit/agentUtils.test.ts
+++ b/tests/unit/agentUtils.test.ts
@@ -74,4 +74,23 @@ describe('prepareFirstMessageWithSkillsIndex', () => {
     expect(result).toContain('/tmp/workspace/skills');
     expect(result.indexOf('[Skills Directory]')).toBeLessThan(result.indexOf('[User Request]'));
   });
+
+  it('folds workspaceSkillsHint into a single-pass envelope (no post-hoc splice)', async () => {
+    const { prepareFirstMessageWithSkillsIndex } = await import('../../src/process/task/agentUtils');
+
+    const result = await prepareFirstMessageWithSkillsIndex('do something', {
+      presetContext: 'rules',
+      workspace: '/tmp/workspace',
+      presetAgentType: 'claude',
+      workspaceSkillsHint: { skillsDir: '/tmp/workspace/skills' },
+    });
+
+    expect(result).toContain('[Assistant Rules');
+    expect(result).toContain('[Skills Directory]');
+    expect(result).toContain('/tmp/workspace/skills');
+    expect(result).toContain('[User Request]');
+    // Order: Assistant Rules → Skills Directory → User Request, all from one wrap.
+    expect(result.indexOf('[Assistant Rules')).toBeLessThan(result.indexOf('[Skills Directory]'));
+    expect(result.indexOf('[Skills Directory]')).toBeLessThan(result.indexOf('[User Request]'));
+  });
 });


### PR DESCRIPTION
## Summary

Mechanical refactor of skill loading in `src/process/task/{agentUtils.ts,AcpSkillManager.ts}` and the two call sites in `conversationBridge.ts` + `AcpAgent.ts`.  No behaviour change for end users; net **-36 LOC** in production code (the +36 in the diff stat is new tests + denser docstrings).

Discovered while planning a new \`desktop-screenshot\` skill for the floating avatar — the surface area was hard to extend safely without first untangling the existing duplication.

### Concrete fixes

1. **\`AcpSkillManager\` singleton race** (commit \`14b9a0de\`).  The singleton kept a single mutable instance keyed by \`enabledSkills\`; two concurrent conversations with different skill lists would stomp each other's manager mid-discovery.  Replaced with \`Map<cacheKey, AcpSkillManager>\`.  \`resetInstance()\` semantics preserved (clears the whole map — \`skillHubBridge.ts:236\` workflow unchanged).

2. **5 \`prepare*\` near-duplicates → 4 thin compositions** (commit \`af60fa87\`).  Extracted \`wrapWithUserRequest\` / \`pushPresetPreamble\` / \`loadBuiltinSkillsIndex\` / \`buildBuiltinSkillsBlock\`.  Each \`prepareXxx\` is now ~5 lines.  Output strings preserved exactly — existing tests pass unchanged.

3. **Legacy-flat scan unified** (commit \`00901504\`).  The \"backward-compat\" 40-line block in \`discoverSkills()\` re-implemented \`discoverSkillsFromDir\`.  Folded both paths through one helper with two new opt-in flags (\`skipUnderscorePrefix\`, \`skipIfPresentIn\`).  Same commit normalises bilingual zh/en docstrings to English-only across the file.

4. **\`injectSkillsDirectoryHint\` two-pass splice → single-pass envelope** (commit \`4c291653\`).  \`[Skills Directory]\` block was being spliced into \`[User Request]\` via \`String.replace\` after \`prepare*\` had already wrapped the content — fragile (any change to the \`[User Request]\` sentinel breaks it silently).  Added \`workspaceSkillsHint\` to \`FirstMessageConfig\`; both prepare functions now build the block inline before the single wrap.  Old export kept as \`@deprecated\` thin wrapper for any out-of-tree consumers.

### Pre-existing test debt repaired (drive-by)

\`tests/unit/agentUtils.test.ts\` had been silently failing since \`a9ecdca9\` (\"fix(skills): improve skill discovery reliability\"):
- mock didn't stub \`discoverSkills\` / \`getSkillsIndex\` (added in that commit) → \`TypeError\` every run
- \`injectSkillsDirectoryHint\` flipped to \`async\` in the same commit; test wasn't updated to \`await\`

Both fixed; net test delta vs \`origin/dev\`:
| | Before | After |
|---|---|---|
| Tests passed | 1123 | 1126 |
| Tests failed | 33 | 31 |

Remaining 31 failures are pre-existing env/integration breakage on \`dev\` unrelated to this refactor (windowsImagePaths, mainInitGate, useConversations, etc.).  \`tsc\` is clean except for the same pre-existing \`workspace/index.tsx:1210\` \`onRightClick\` errors.

### Out of scope (deliberately deferred)

- Moving \`loadSkillsContent\` from \`initStorage.ts\` into \`AcpSkillManager\`.  Would carry \`skillsContentCache\` / \`getSkillIdToNameMap\` / \`SKILL_SUBDIRS\` across module boundaries — the SSOT win is real but small (the two caches are already invalidated together via \`clearSkillsCache()\` + \`AcpSkillManager.resetInstance()\` from \`skillHubBridge.ts:236\`).  Better as a separate focused PR.
- Tightening the frontmatter parser (multi-line description, embedded quotes).  Separate concern; no skills currently in-tree trip the existing edge cases.
- Replacing the string-based \`[Assistant Rules]\` / \`[User Request]\` envelope with a typed builder.  Out of scope, much more invasive.

## Test plan

- [x] \`tests/unit/agentUtils.test.ts\` (4 tests) — covers all 3 prepare* paths + new single-pass workspace hint + deprecated wrapper
- [x] \`tests/unit/acpSkillManagerCache.test.ts\` (3 tests, NEW) — race regression: order-insensitive key, concurrent independent instances don't stomp, \`resetInstance\` clears all
- [x] Full vitest run: 1126 passing (no regressions vs \`origin/dev\` baseline of 1123)
- [x] \`tsc --noEmit\`: clean except pre-existing \`workspace/index.tsx:1210\`
- [x] \`eslint\` on touched files: clean
- [ ] Smoke test in dev build that OpenClaw + Claude ACP first-message envelopes still look correct under both \`enabledSkills\`-with-hub-skills and \`enabledSkills\`-empty paths