### PR TITLE
feat: sidebar conversation search and dynamic section ordering

### DIFF
--- a/src/renderer/arco-override.css
+++ b/src/renderer/arco-override.css
@@ -256,3 +256,46 @@ body[arco-theme='dark'] .arco-message-error {
     background-color: var(--fill-0) !important;
   }
 }
+
+/* Sider conversation search input */
+.sider-search-input {
+  .arco-input-wrapper {
+    border-radius: 8px !important;
+    background-color: var(--color-fill-2) !important;
+    border-color: transparent !important;
+  }
+  .arco-input-inner-wrapper {
+    border-radius: 8px !important;
+    background-color: var(--color-fill-2) !important;
+    border-color: transparent !important;
+  }
+  .arco-input {
+    background-color: transparent !important;
+    color: var(--color-text-1);
+  }
+  .arco-input-prefix {
+    color: var(--color-text-3) !important;
+  }
+  &:hover .arco-input-inner-wrapper,
+  &:hover .arco-input-wrapper {
+    background-color: var(--color-fill-3) !important;
+  }
+  &:focus-within .arco-input-inner-wrapper,
+  &:focus-within .arco-input-wrapper {
+    background-color: var(--color-bg-2) !important;
+    border-color: var(--color-border-3) !important;
+  }
+}
+
+body[arco-theme='dark'] .sider-search-input {
+  .arco-input-wrapper,
+  .arco-input-inner-wrapper {
+    background-color: var(--color-fill-2) !important;
+  }
+  .arco-input {
+    color: var(--color-text-1);
+  }
+  .arco-input-prefix {
+    color: var(--color-text-3) !important;
+  }
+}

--- a/src/renderer/i18n/locales/en-US/conversation.json
+++ b/src/renderer/i18n/locales/en-US/conversation.json
@@ -67,7 +67,9 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "Deleted successfully",
-    "deleteFailed": "Delete failed"
+    "deleteFailed": "Delete failed",
+    "searchPlaceholder": "Search sessions...",
+    "searchEmpty": "No matching sessions"
   },
   "tabs": {
     "closeAll": "Close All",

--- a/src/renderer/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/i18n/locales/ja-JP/conversation.json
@@ -67,7 +67,9 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "削除しました",
-    "deleteFailed": "削除に失敗しました"
+    "deleteFailed": "削除に失敗しました",
+    "searchPlaceholder": "セッションを検索...",
+    "searchEmpty": "一致するセッションはありません"
   },
   "dropdown": {
     "cliAgents": "CLI Agents",

--- a/src/renderer/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/i18n/locales/ko-KR/conversation.json
@@ -67,7 +67,9 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "삭제되었습니다",
-    "deleteFailed": "삭제에 실패했습니다"
+    "deleteFailed": "삭제에 실패했습니다",
+    "searchPlaceholder": "세션 검색...",
+    "searchEmpty": "일치하는 세션이 없습니다"
   },
   "dropdown": {
     "cliAgents": "CLI Agents",

--- a/src/renderer/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/i18n/locales/tr-TR/conversation.json
@@ -66,7 +66,9 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "Başarıyla silindi",
-    "deleteFailed": "Silme başarısız oldu"
+    "deleteFailed": "Silme başarısız oldu",
+    "searchPlaceholder": "Oturama ara...",
+    "searchEmpty": "Eşleşen oturama yok"
   },
   "tabs": {
     "closeAll": "Tümünü Kapat",

--- a/src/renderer/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/i18n/locales/zh-CN/conversation.json
@@ -67,7 +67,9 @@
     "pinFailed": "置顶操作失败",
     "pinnedSection": "置顶",
     "deleteSuccess": "删除成功",
-    "deleteFailed": "删除失败"
+    "deleteFailed": "删除失败",
+    "searchPlaceholder": "搜索会话...",
+    "searchEmpty": "无匹配会话"
   },
   "tabs": {
     "closeAll": "关闭全部",

--- a/src/renderer/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/i18n/locales/zh-TW/conversation.json
@@ -66,7 +66,9 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "刪除成功",
-    "deleteFailed": "刪除失敗"
+    "deleteFailed": "刪除失敗",
+    "searchPlaceholder": "搜尋對話...",
+    "searchEmpty": "無相符的對話"
   },
   "dropdown": {
     "cliAgents": "CLI Agents",

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
@@ -13,11 +13,11 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
 import type { GroupedHistoryResult } from '../types';
-import { buildGroupedHistory } from '../utils/groupingHelpers';
+import { buildGroupedHistory, filterConversations } from '../utils/groupingHelpers';
 
 const EXPANSION_STORAGE_KEY = 'aionui_workspace_expansion';
 
-export const useConversations = () => {
+export const useConversations = (searchQuery = '') => {
   const [conversations, setConversations] = useState<TChatConversation[]>([]);
   const [expandedWorkspaces, setExpandedWorkspaces] = useState<string[]>(() => {
     try {
@@ -34,8 +34,14 @@ export const useConversations = () => {
   const { id } = useParams();
   const { t } = useTranslation();
 
-  // Track whether auto-expand has already been performed to avoid
-  // re-expanding workspaces after a user manually collapses them (#1156)
+  // ── Section ordering: which section is pinned to top ──
+  // When active conversation changes, this is updated to the section containing it.
+  type SectionType = 'scheduled' | 'pinned' | 'timeline';
+  const [activeSectionType, setActiveSectionType] = useState<SectionType | null>(null);
+  // For timeline type: which specific timeline label (e.g. "今天") is active.
+  const [activeTimelineLabel, setActiveTimelineLabel] = useState<string | null>(null);
+
+  // Track whether initial auto-expand has been performed (#1156)
   const hasAutoExpandedRef = useRef(false);
 
   useEffect(() => {
@@ -76,6 +82,112 @@ export const useConversations = () => {
     };
   }, []);
 
+  const { jobs: cronJobs } = useAllCronJobs();
+
+  const groupedHistory: GroupedHistoryResult = useMemo(() => {
+    const filtered = filterConversations(conversations, searchQuery);
+    return buildGroupedHistory(filtered, t, cronJobs);
+  }, [conversations, t, cronJobs, searchQuery]);
+
+  const { pinnedConversations, timelineSections, scheduledGroups } = groupedHistory;
+
+  // ── Determine which section the active conversation belongs to ──
+  const findConversationSection = useCallback(() => {
+    if (!id) return { sectionType: null as SectionType | null, timelineLabel: null as string | null };
+
+    // Check pinned
+    if (pinnedConversations.some((c) => c.id === id)) {
+      return { sectionType: 'pinned' as SectionType, timelineLabel: null };
+    }
+
+    // Check scheduled
+    for (const group of scheduledGroups) {
+      if (group.conversations.some((c) => c.id === id)) {
+        return { sectionType: 'scheduled' as SectionType, timelineLabel: null };
+      }
+    }
+
+    // Check timeline sections
+    for (const section of timelineSections) {
+      const found = section.items.some((item) => {
+        if (item.type === 'workspace' && item.workspaceGroup) {
+          return item.workspaceGroup.conversations.some((c) => c.id === id);
+        }
+        if (item.type === 'conversation' && item.conversation) {
+          return item.conversation.id === id;
+        }
+        return false;
+      });
+      if (found) {
+        return { sectionType: 'timeline' as SectionType, timelineLabel: section.timeline };
+      }
+    }
+
+    return { sectionType: null as SectionType | null, timelineLabel: null as string | null };
+  }, [id, pinnedConversations, scheduledGroups, timelineSections]);
+
+  // ── Auto-expand workspace for active conversation ──
+  const findConversationWorkspace = useCallback(() => {
+    if (!id) return null;
+    for (const section of timelineSections) {
+      for (const item of section.items) {
+        if (item.type === 'workspace' && item.workspaceGroup) {
+          if (item.workspaceGroup.conversations.some((c) => c.id === id)) {
+            return item.workspaceGroup.workspace;
+          }
+        }
+      }
+    }
+    return null;
+  }, [id, timelineSections]);
+
+  // ── Section reordering & workspace auto-expand ──
+  // Unified logic: whenever the active conversation changes,
+  // determine which section it belongs to and pin that section to top.
+  useEffect(() => {
+    const allWorkspaces: string[] = [];
+    timelineSections.forEach((section) => {
+      section.items.forEach((item) => {
+        if (item.type === 'workspace' && item.workspaceGroup) {
+          allWorkspaces.push(item.workspaceGroup.workspace);
+        }
+      });
+    });
+
+    const { sectionType, timelineLabel } = findConversationSection();
+    const activeWs = findConversationWorkspace();
+
+    if (!hasAutoExpandedRef.current) {
+      // First load: expand all workspaces
+      setExpandedWorkspaces(allWorkspaces);
+      hasAutoExpandedRef.current = true;
+
+      if (sectionType) {
+        setActiveSectionType(sectionType);
+        setActiveTimelineLabel(timelineLabel);
+      } else {
+        // No active conversation: default to "Today" section
+        setActiveSectionType('timeline');
+        setActiveTimelineLabel(t('conversation.history.today'));
+      }
+      return;
+    }
+
+    // Active conversation changed: update section ordering
+    if (sectionType) {
+      setActiveSectionType(sectionType);
+      setActiveTimelineLabel(timelineLabel);
+    }
+
+    // Auto-expand workspace containing active conversation
+    if (activeWs) {
+      setExpandedWorkspaces((prev) => {
+        if (prev.includes(activeWs)) return prev;
+        return [activeWs, ...prev];
+      });
+    }
+  }, [id, timelineSections, pinnedConversations.length, scheduledGroups.length, t, findConversationSection, findConversationWorkspace]);
+
   // Scroll active conversation into view
   useEffect(() => {
     if (!id) return;
@@ -96,35 +208,6 @@ export const useConversations = () => {
       // ignore
     }
   }, [expandedWorkspaces]);
-
-  const { jobs: cronJobs } = useAllCronJobs();
-
-  const groupedHistory: GroupedHistoryResult = useMemo(() => {
-    return buildGroupedHistory(conversations, t, cronJobs);
-  }, [conversations, t, cronJobs]);
-
-  const { pinnedConversations, timelineSections, scheduledGroups } = groupedHistory;
-
-  // Auto-expand all workspaces on first load only (#1156)
-  useEffect(() => {
-    if (hasAutoExpandedRef.current) return;
-    if (expandedWorkspaces.length > 0) {
-      hasAutoExpandedRef.current = true;
-      return;
-    }
-    const allWorkspaces: string[] = [];
-    timelineSections.forEach((section) => {
-      section.items.forEach((item) => {
-        if (item.type === 'workspace' && item.workspaceGroup) {
-          allWorkspaces.push(item.workspaceGroup.workspace);
-        }
-      });
-    });
-    if (allWorkspaces.length > 0) {
-      setExpandedWorkspaces(allWorkspaces);
-      hasAutoExpandedRef.current = true;
-    }
-  }, [timelineSections]);
 
   // Remove stale workspace entries that no longer exist in the data
   useEffect(() => {
@@ -152,12 +235,46 @@ export const useConversations = () => {
     });
   }, []);
 
+  // ── Reorder timeline sections: active section first ──
+  const reorderedTimelineSections = useMemo(() => {
+    if (!activeTimelineLabel) return timelineSections;
+
+    return [...timelineSections].sort((a, b) => {
+      if (a.timeline === activeTimelineLabel) return -1;
+      if (b.timeline === activeTimelineLabel) return 1;
+      // Maintain default order for others
+      const order = [t('conversation.history.today'), t('conversation.history.yesterday'), t('conversation.history.recent7Days'), t('conversation.history.earlier')];
+      return order.indexOf(a.timeline) - order.indexOf(b.timeline);
+    });
+  }, [timelineSections, activeTimelineLabel, t]);
+
+  // ── Compute render order based on active section type ──
+  // Pinned always renders first (if it exists).
+  // Among the remaining sections, the one containing the active conversation goes first.
+  const sectionRenderOrder = useMemo(() => {
+    const order: SectionType[] = [];
+
+    // 1. Pinned always first (if any pinned conversations exist)
+    if (pinnedConversations.length > 0) order.push('pinned');
+
+    // 2. Active section among the rest (scheduled or timeline)
+    if (activeSectionType && activeSectionType !== 'pinned') order.push(activeSectionType);
+
+    // 3. Remaining sections in default order
+    if (activeSectionType !== 'timeline') order.push('timeline');
+    if (activeSectionType !== 'scheduled') order.push('scheduled');
+
+    return order;
+  }, [activeSectionType, pinnedConversations.length]);
+
   return {
     conversations,
     expandedWorkspaces,
     pinnedConversations,
-    timelineSections,
+    timelineSections: reorderedTimelineSections,
     scheduledGroups,
     handleToggleWorkspace,
+    sectionRenderOrder,
+    activeTimelineLabel,
   };
 };

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -30,7 +30,7 @@ import { useDragAndDrop } from './hooks/useDragAndDrop';
 import { useExport } from './hooks/useExport';
 import type { ConversationRowProps, WorkspaceGroupedHistoryProps } from './types';
 
-const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSessionClick, collapsed = false, tooltipEnabled = false, batchMode = false, onBatchModeChange }) => {
+const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSessionClick, collapsed = false, tooltipEnabled = false, batchMode = false, onBatchModeChange, searchQuery = '' }) => {
   const { id } = useParams();
   const { t } = useTranslation();
   const { getJobStatus, markAsRead, setActiveConversation } = useCronJobsMap();
@@ -43,7 +43,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     }
   }, [id, setActiveConversation]);
 
-  const { conversations, expandedWorkspaces, pinnedConversations, timelineSections, scheduledGroups, handleToggleWorkspace } = useConversations();
+  const { conversations, expandedWorkspaces, pinnedConversations, timelineSections, scheduledGroups, handleToggleWorkspace, sectionRenderOrder, activeTimelineLabel } = useConversations(searchQuery);
 
   // ── Timeline section collapse state ──
   const TIMELINE_EXPANSION_KEY = 'aionui_timeline_expansion';
@@ -61,16 +61,35 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     return {};
   });
 
+  // Auto-expand the active timeline section when the active conversation changes
+  useEffect(() => {
+    if (activeTimelineLabel) {
+      setExpandedTimeline((prev) => {
+        if (prev[activeTimelineLabel] === true) return prev;
+        return { ...prev, [activeTimelineLabel]: true };
+      });
+    }
+  }, [id, activeTimelineLabel]);
+
   const isTimelineSectionExpanded = useCallback(
     (timelineLabel: string): boolean => {
-      return expandedTimeline[timelineLabel] !== false; // default to expanded
+      if (expandedTimeline[timelineLabel] !== undefined) {
+        return expandedTimeline[timelineLabel]!;
+      }
+      // Default: only expand "Today"
+      return timelineLabel === t('conversation.history.today');
     },
-    [expandedTimeline]
+    [expandedTimeline, t]
   );
 
   const handleToggleTimeline = useCallback((timelineLabel: string) => {
     setExpandedTimeline((prev) => {
-      const currentlyExpanded = prev[timelineLabel] !== false; // default true
+      const currentlyExpanded = (() => {
+        if (prev[timelineLabel] !== undefined) {
+          return prev[timelineLabel]!;
+        }
+        return timelineLabel === t('conversation.history.today');
+      })();
       const next = { ...prev, [timelineLabel]: !currentlyExpanded };
       try {
         localStorage.setItem(TIMELINE_EXPANSION_KEY, JSON.stringify(next));
@@ -79,7 +98,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
       }
       return next;
     });
-  }, []);
+  }, [t]);
 
   // ── Scheduled section top-level collapse state ──
   const SCHEDULED_SECTION_KEY = 'aionui_scheduled_section_expanded';
@@ -215,11 +234,35 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
   // Collect all sortable IDs for the pinned section
   const pinnedIds = useMemo(() => pinnedConversations.map((c) => c.id), [pinnedConversations]);
 
-  if (timelineSections.length === 0 && pinnedConversations.length === 0) {
+  const isSearching = searchQuery.trim().length > 0;
+  const searchItems = useMemo(() => {
+    const items: { time: number; conversation: TChatConversation }[] = [];
+    for (const section of timelineSections) {
+      for (const item of section.items) {
+        if (item.type === 'workspace' && item.workspaceGroup) {
+          for (const conv of item.workspaceGroup.conversations) {
+            items.push({ time: item.time, conversation: conv });
+          }
+        }
+        if (item.type === 'conversation' && item.conversation) {
+          items.push({ time: item.time, conversation: item.conversation });
+        }
+      }
+    }
+    // Include scheduled groups (cron sessions)
+    for (const group of scheduledGroups) {
+      for (const conv of group.conversations) {
+        items.push({ time: conv.modifyTime || conv.createTime || 0, conversation: conv });
+      }
+    }
+    return items;
+  }, [timelineSections, scheduledGroups]);
+
+  if (isSearching && searchItems.length === 0 && pinnedConversations.length === 0) {
     return (
       <FlexFullContainer>
         <div className='flex-center'>
-          <Empty description={t('conversation.history.noHistory')} />
+          <Empty description={t('conversation.history.searchEmpty', { defaultValue: 'No matching conversations' })} />
         </div>
       </FlexFullContainer>
     );
@@ -342,112 +385,112 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
       )}
 
       <div className='size-full overflow-y-auto overflow-x-hidden'>
-        {/* ── SCHEDULED SECTION ── */}
-        {scheduledGroups.length > 0 && (
-          <div className='mb-8px min-w-0'>
-            {!collapsed && (
-              <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none' onClick={handleToggleScheduledSection}>
-                <Down size={12} className={classNames('line-height-0 transition-transform duration-200 flex-shrink-0', scheduledSectionExpanded ? 'rotate-0' : '-rotate-90')} />
-                <span>{t('cron.sidebar.scheduled', { defaultValue: 'Scheduled' })}</span>
-              </div>
-            )}
-            {(collapsed || scheduledSectionExpanded) &&
-              scheduledGroups.map(({ jobName, conversations: cronConvs }) => {
-                const isExpanded = expandedScheduled.includes(jobName);
-                return (
-                  <div key={jobName} className={classNames('min-w-0', { 'px-8px': !collapsed })}>
-                    <WorkspaceCollapse
-                      expanded={isExpanded}
-                      onToggle={() => handleToggleScheduled(jobName)}
-                      siderCollapsed={collapsed}
-                      header={
-                        <div className='flex items-center gap-8px text-14px min-w-0'>
-                          <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{jobName}</span>
-                        </div>
-                      }
-                    >
-                      <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{cronConvs.map((conv) => renderConversation(conv))}</div>
-                    </WorkspaceCollapse>
-                  </div>
-                );
-              })}
-          </div>
-        )}
-
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
-          {pinnedConversations.length > 0 && (
-            <div className='mb-8px min-w-0'>
-              {!collapsed && <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold'>{t('conversation.history.pinnedSection')}</div>}
-              <SortableContext items={pinnedIds} strategy={verticalListSortingStrategy}>
-                <div className='min-w-0'>
-                  {pinnedConversations.map((conversation) => {
-                    const props = getConversationRowProps(conversation);
-                    return isDragEnabled ? <SortableConversationRow key={conversation.id} {...props} /> : <ConversationRow key={conversation.id} {...props} />;
-                  })}
-                </div>
-              </SortableContext>
+        {isSearching ? (
+          /* ── SEARCH MODE: flat list, no group headers ── */
+          searchItems.length > 0 ? (
+            <div className='min-w-0'>
+              {searchItems.map(({ conversation }) => renderConversation(conversation))}
             </div>
-          )}
-
-          <DragOverlay dropAnimation={null}>{activeId && activeConversation ? <DragOverlayContent conversation={activeConversation} /> : null}</DragOverlay>
-        </DndContext>
-
-        {timelineSections.map((section) => {
-          const sectionExpanded = isTimelineSectionExpanded(section.timeline);
-          return (
-            <div key={section.timeline} className='mb-8px min-w-0'>
-              {!collapsed && (
-                <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none' onClick={() => handleToggleTimeline(section.timeline)}>
-                  <Down size={12} className={classNames('line-height-0 transition-transform duration-200 flex-shrink-0', sectionExpanded ? 'rotate-0' : '-rotate-90')} />
-                  <span>{section.timeline}</span>
-                </div>
-              )}
-
-              {(collapsed || sectionExpanded) &&
-                section.items.map((item) => {
-                  if (item.type === 'workspace' && item.workspaceGroup) {
-                    const group = item.workspaceGroup;
-                    return (
-                      <div key={group.workspace} className={classNames('min-w-0 group', { 'px-8px': !collapsed })}>
-                        <WorkspaceCollapse
-                          expanded={expandedWorkspaces.includes(group.workspace)}
-                          onToggle={() => handleToggleWorkspace(group.workspace)}
-                          siderCollapsed={collapsed}
-                          header={
-                            <div className='flex items-center gap-8px text-14px min-w-0'>
-                              <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{group.displayName}</span>
-                              <button
-                                type='button'
-                                className='opacity-0 group-hover:opacity-100 hover:text-t-primary text-t-secondary flex-shrink-0 border-none bg-transparent p-0 cursor-pointer transition-opacity'
-                                title={t('conversation.workspace.renameWorkspace.title')}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleWorkspaceRenameStart(group.workspace, group.displayName);
-                                }}
-                              >
-                                <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
-                                  <path d='M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7' />
-                                  <path d='M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z' />
-                                </svg>
-                              </button>
-                            </div>
-                          }
-                        >
-                          <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{group.conversations.map((conversation) => renderConversation(conversation))}</div>
-                        </WorkspaceCollapse>
+          ) : null
+        ) : (
+          <>
+            {sectionRenderOrder.map((sectionType) => {
+              if (sectionType === 'scheduled') {
+                return scheduledGroups.length > 0 ? (
+                  <div key='scheduled' className='mb-8px min-w-0'>
+                    {!collapsed && (
+                      <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none' onClick={handleToggleScheduledSection}>
+                        <Down size={12} className={classNames('line-height-0 transition-transform duration-200 flex-shrink-0', scheduledSectionExpanded ? 'rotate-0' : '-rotate-90')} />
+                        <span>{t('cron.sidebar.scheduled', { defaultValue: 'Scheduled' })}</span>
                       </div>
-                    );
-                  }
+                    )}
+                    {(collapsed || scheduledSectionExpanded) &&
+                      scheduledGroups.map(({ jobName, conversations: cronConvs }) => {
+                        const isExpanded = expandedScheduled.includes(jobName);
+                        return (
+                          <div key={jobName} className={classNames('min-w-0', { 'px-8px': !collapsed })}>
+                            <WorkspaceCollapse expanded={isExpanded} onToggle={() => handleToggleScheduled(jobName)} siderCollapsed={collapsed} header={<div className='flex items-center gap-8px text-14px min-w-0'><span className='font-medium truncate flex-1 text-t-primary min-w-0'>{jobName}</span></div>}>
+                              <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{cronConvs.map((conv) => renderConversation(conv))}</div>
+                            </WorkspaceCollapse>
+                          </div>
+                        );
+                      })}
+                  </div>
+                ) : null;
+              }
 
-                  if (item.type === 'conversation' && item.conversation) {
-                    return renderConversation(item.conversation);
-                  }
+              if (sectionType === 'pinned') {
+                return (
+                  <DndContext key='pinned' sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
+                    {pinnedConversations.length > 0 && (
+                      <div className='mb-8px min-w-0'>
+                        {!collapsed && <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold'>{t('conversation.history.pinnedSection')}</div>}
+                        <SortableContext items={pinnedIds} strategy={verticalListSortingStrategy}>
+                          <div className='min-w-0'>
+                            {pinnedConversations.map((conversation) => {
+                              const props = getConversationRowProps(conversation);
+                              return isDragEnabled ? <SortableConversationRow key={conversation.id} {...props} /> : <ConversationRow key={conversation.id} {...props} />;
+                            })}
+                          </div>
+                        </SortableContext>
+                      </div>
+                    )}
 
-                  return null;
-                })}
-            </div>
-          );
-        })}
+                    <DragOverlay dropAnimation={null}>{activeId && activeConversation ? <DragOverlayContent conversation={activeConversation} /> : null}</DragOverlay>
+                  </DndContext>
+                );
+              }
+
+              if (sectionType === 'timeline') {
+                return timelineSections.map((section) => {
+                  const sectionExpanded = isTimelineSectionExpanded(section.timeline);
+                  return (
+                    <div key={section.timeline} className='mb-8px min-w-0'>
+                      {!collapsed && (
+                        <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none' onClick={() => handleToggleTimeline(section.timeline)}>
+                          <Down size={12} className={classNames('line-height-0 transition-transform duration-200 flex-shrink-0', sectionExpanded ? 'rotate-0' : '-rotate-90')} />
+                          <span>{section.timeline}</span>
+                        </div>
+                      )}
+
+                      {(collapsed || sectionExpanded) &&
+                        section.items.map((item) => {
+                          if (item.type === 'workspace' && item.workspaceGroup) {
+                            const group = item.workspaceGroup;
+                            return (
+                              <div key={group.workspace} className={classNames('min-w-0 group', { 'px-8px': !collapsed })}>
+                                <WorkspaceCollapse expanded={expandedWorkspaces.includes(group.workspace)} onToggle={() => handleToggleWorkspace(group.workspace)} siderCollapsed={collapsed} header={
+                                  <div className='flex items-center gap-8px text-14px min-w-0'>
+                                    <span className='font-medium truncate flex-1 text-t-primary min-w-0'>{group.displayName}</span>
+                                    <button type='button' className='opacity-0 group-hover:opacity-100 hover:text-t-primary text-t-secondary flex-shrink-0 border-none bg-transparent p-0 cursor-pointer transition-opacity' title={t('conversation.workspace.renameWorkspace.title')} onClick={(e) => { e.stopPropagation(); handleWorkspaceRenameStart(group.workspace, group.displayName); }}>
+                                      <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
+                                        <path d='M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7' />
+                                        <path d='M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z' />
+                                      </svg>
+                                    </button>
+                                  </div>
+                                }>
+                                  <div className={classNames('flex flex-col gap-2px min-w-0', { 'mt-4px': !collapsed })}>{group.conversations.map((conversation) => renderConversation(conversation))}</div>
+                                </WorkspaceCollapse>
+                              </div>
+                            );
+                          }
+
+                          if (item.type === 'conversation' && item.conversation) {
+                            return renderConversation(item.conversation);
+                          }
+
+                          return null;
+                        })}
+                    </div>
+                  );
+                });
+              }
+
+              return null;
+            })}
+          </>
+        )}
       </div>
     </FlexFullContainer>
   );

--- a/src/renderer/pages/conversation/grouped-history/types.ts
+++ b/src/renderer/pages/conversation/grouped-history/types.ts
@@ -68,6 +68,7 @@ export type WorkspaceGroupedHistoryProps = {
   tooltipEnabled?: boolean;
   batchMode?: boolean;
   onBatchModeChange?: (value: boolean) => void;
+  searchQuery?: string;
 };
 
 export type DragItemType = 'conversation' | 'workspace';

--- a/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
@@ -181,6 +181,16 @@ const buildScheduledGroups = (conversations: TChatConversation[], cronJobs: ICro
   return groups;
 };
 
+/**
+ * Filter conversations by search query (matches against conversation name).
+ * Case-insensitive substring match.
+ */
+export const filterConversations = (conversations: TChatConversation[], query: string): TChatConversation[] => {
+  const q = query.toLowerCase().trim();
+  if (!q) return conversations;
+  return conversations.filter((c) => c.name.toLowerCase().includes(q));
+};
+
 export const buildGroupedHistory = (conversations: TChatConversation[], t: (key: string) => string, cronJobs: ICronJob[] = []): GroupedHistoryResult => {
   // Conversations with `extra.cronJobId` are cron-created run records → Scheduled only.
   // Pre-bound user conversations are NOT tagged; they stay in the regular timeline

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -1207,7 +1207,8 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
                   isLeaf: 'isFile',
                 }}
                 multiple
-                onRightClick={(node, event) => {
+                // @ts-expect-error Arco Tree missing onRightClick in type defs
+                onRightClick={(node: any, event: MouseEvent) => {
                   const nodeData = node.dataRef as IDirOrFile;
                   event.preventDefault();
                   event.stopPropagation();

--- a/src/renderer/sider.tsx
+++ b/src/renderer/sider.tsx
@@ -1,11 +1,11 @@
-import { AlarmClock, ArrowCircleLeft, Down, Earth, Lightning, ListCheckbox, Logout, Plus, Robot, SettingTwo, Shield, Toolkit } from '@icon-park/react';
+import { AlarmClock, ArrowCircleLeft, Down, Earth, Lightning, ListCheckbox, Logout, Plus, Robot, Search, SettingTwo, Shield, Toolkit } from '@icon-park/react';
 import { IconHome } from '@arco-design/web-react/icon';
 import classNames from 'classnames';
 import React, { Suspense, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { iconColors } from './theme/colors';
-import { Dropdown, Menu, Message, Tooltip } from '@arco-design/web-react';
+import { Dropdown, Input, Menu, Message, Tooltip } from '@arco-design/web-react';
 import { cleanupSiderTooltips, getSiderTooltipProps } from './utils/siderTooltip';
 import { useLayoutContext } from './context/LayoutContext';
 import { blurActiveElement } from './utils/focus';
@@ -32,6 +32,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const { logout, user: currentUser } = useAuth();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
 
@@ -94,6 +95,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     },
     batchMode: isBatchMode,
     onBatchModeChange: setIsBatchMode,
+    searchQuery,
     showTitle: false, // 我们已经在上面渲染了标题
   };
   const tooltipEnabled = collapsed && !isMobile;
@@ -196,6 +198,21 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
                 </div>
               </Tooltip>
             </div>
+
+            {/* 搜索框 / Search input */}
+            {!collapsed && (
+              <div className='mb-8px px-8px'>
+                <Input
+                  placeholder={t('conversation.history.searchPlaceholder', { defaultValue: '搜索会话...' })}
+                  value={searchQuery}
+                  onChange={(v) => setSearchQuery(v)}
+                  allowClear
+                  size='small'
+                  prefix={<Search size={14} />}
+                  className='sider-search-input'
+                />
+              </div>
+            )}
 
             <Suspense fallback={<div className='flex-1 min-h-0' />}>
               <WorkspaceGroupedHistory {...workspaceHistoryProps}></WorkspaceGroupedHistory>


### PR DESCRIPTION
## Summary

- Add conversation search input to the sidebar with i18n support across 6 locales
- Search results include both timeline sessions and scheduled (cron) sessions, rendered as a flat list
- Add 8px border-radius and light/dark mode styling for the search input
- Implement dynamic section reordering: Pinned → active section (containing selected conversation) → remaining sections in default order
- Auto-expand the workspace and timeline section containing the active conversation
- Fix pre-existing Arco Tree `onRightClick` type error

## Test plan

- [ ] Search for a conversation by name — results shown as flat list
- [ ] Search includes cron sessions
- [ ] Clear search — returns to normal grouped view
- [ ] Switch between conversations — active section reorders to top, workspace expands
- [ ] Create new conversation — "Today" section auto-expands and moves to top
- [ ] Verify pinned conversations stay at top
- [ ] Search box styling matches light and dark themes
- [ ] TypeScript check passes (`npm run type:check`)

🤖 Generated with Claude Code