### PR TITLE
feat(sider): 左侧会话历史拆分「对话」和「定时任务」两个 Tab

### DIFF
--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -22,6 +22,7 @@ interface CommandPaletteItem {
   icon: React.ReactNode;
   action: () => void;
   score?: number;
+  tabKey?: 'timeline' | 'scheduled';
 }
 
 interface CommandPaletteProps {
@@ -41,7 +42,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ visible, onClose }) => 
   useEffect(() => {
     if (visible) {
       ipcBridge.database.getUserConversations
-        .invoke({ page: 0, pageSize: 50 })
+        .invoke({ page: 0, pageSize: 10000 })
         .then((history) => {
           if (history && Array.isArray(history)) {
             const sorted = history.sort((a, b) => getActivityTime(b) - getActivityTime(a));
@@ -117,6 +118,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ visible, onClose }) => 
         const score = titleMatch ? 2 : 0;
         if (score > 0) {
           const activityTime = getActivityTime(conv);
+          const tabKey: 'timeline' | 'scheduled' = (conv.extra as any)?.cronJobId ? 'scheduled' : 'timeline';
           items.push({
             id: `conv-${conv.id}`,
             type: 'conversation',
@@ -124,10 +126,12 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ visible, onClose }) => 
             subtitle: formatSessionTime(activityTime, 'zh-CN', '昨天'),
             icon: <History size={18} />,
             action: () => {
+              emitter.emit('sider.tab.switch', tabKey);
               navigate(`/conversation/${conv.id}`);
               onClose();
             },
             score,
+            tabKey,
           });
         }
       });

--- a/src/renderer/i18n/locales/en-US/conversation.json
+++ b/src/renderer/i18n/locales/en-US/conversation.json
@@ -67,7 +67,9 @@
     "pinFailed": "Pin operation failed",
     "pinnedSection": "Pinned",
     "deleteSuccess": "Deleted successfully",
-    "deleteFailed": "Delete failed"
+    "deleteFailed": "Delete failed",
+    "timeline": "Chat",
+    "scheduledTab": "Scheduled"
   },
   "tabs": {
     "closeAll": "Close All",

--- a/src/renderer/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/i18n/locales/zh-CN/conversation.json
@@ -67,7 +67,9 @@
     "pinFailed": "置顶操作失败",
     "pinnedSection": "置顶",
     "deleteSuccess": "删除成功",
-    "deleteFailed": "删除失败"
+    "deleteFailed": "删除失败",
+    "timeline": "对话",
+    "scheduledTab": "定时任务"
   },
   "tabs": {
     "closeAll": "关闭全部",

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useConversationTabs } from '../../context/ConversationTabsContext';
+import type { SidebarTabKey } from '../types';
 import { isConversationPinned } from '../utils/groupingHelpers';
 
 type UseConversationActionsParams = {
@@ -24,9 +25,10 @@ type UseConversationActionsParams = {
   setSelectedConversationIds: React.Dispatch<React.SetStateAction<Set<string>>>;
   toggleSelectedConversation: (conversation: TChatConversation) => void;
   markAsRead: (conversationId: string) => void;
+  activeTab: SidebarTabKey;
 };
 
-export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeChange, selectedConversationIds, setSelectedConversationIds, toggleSelectedConversation, markAsRead }: UseConversationActionsParams) => {
+export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeChange, selectedConversationIds, setSelectedConversationIds, toggleSelectedConversation, markAsRead, activeTab }: UseConversationActionsParams) => {
   const [renameModalVisible, setRenameModalVisible] = useState(false);
   const [renameModalName, setRenameModalName] = useState<string>('');
   const [renameModalId, setRenameModalId] = useState<string | null>(null);
@@ -35,7 +37,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
   const { id } = useParams();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { openTab, closeAllTabs, activeTab, updateTabName } = useConversationTabs();
+  const { openTab, closeAllTabs, activeTab: conversationTab, updateTabName } = useConversationTabs();
 
   // Close dropdown when entering batch mode
   useEffect(() => {
@@ -68,7 +70,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
         return;
       }
 
-      const currentWorkspace = activeTab?.workspace;
+      const currentWorkspace = conversationTab?.workspace;
       if (!currentWorkspace || currentWorkspace !== newWorkspace) {
         closeAllTabs();
       }
@@ -79,7 +81,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
         onSessionClick();
       }
     },
-    [batchMode, toggleSelectedConversation, markAsRead, closeAllTabs, navigate, onSessionClick, activeTab, openTab]
+    [batchMode, toggleSelectedConversation, markAsRead, closeAllTabs, navigate, onSessionClick, conversationTab, openTab]
   );
 
   const removeConversation = useCallback(
@@ -216,6 +218,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
             extra: {
               pinned: !pinned,
               pinnedAt: pinned ? undefined : Date.now(),
+              pinnedTab: !pinned ? activeTab : undefined,
             } as Partial<TChatConversation['extra']>,
           } as Partial<TChatConversation>,
           mergeExtra: true,
@@ -231,7 +234,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
         Message.error(t('conversation.history.pinFailed'));
       }
     },
-    [t]
+    [t, activeTab]
   );
 
   const handleMenuVisibleChange = useCallback((conversationId: string, visible: boolean) => {

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
@@ -103,7 +103,7 @@ export const useConversations = () => {
     return buildGroupedHistory(conversations, t, cronJobs);
   }, [conversations, t, cronJobs]);
 
-  const { pinnedConversations, timelineSections, scheduledGroups } = groupedHistory;
+  const { pinnedTimeline, pinnedScheduled, timelineSections, scheduledGroups } = groupedHistory;
 
   // Auto-expand all workspaces on first load only (#1156)
   useEffect(() => {
@@ -155,7 +155,8 @@ export const useConversations = () => {
   return {
     conversations,
     expandedWorkspaces,
-    pinnedConversations,
+    pinnedTimeline,
+    pinnedScheduled,
     timelineSections,
     scheduledGroups,
     handleToggleWorkspace,

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -30,7 +30,7 @@ import { useDragAndDrop } from './hooks/useDragAndDrop';
 import { useExport } from './hooks/useExport';
 import type { ConversationRowProps, WorkspaceGroupedHistoryProps } from './types';
 
-const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSessionClick, collapsed = false, tooltipEnabled = false, batchMode = false, onBatchModeChange }) => {
+const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSessionClick, collapsed = false, tooltipEnabled = false, batchMode = false, onBatchModeChange, activeTab = 'timeline' }) => {
   const { id } = useParams();
   const { t } = useTranslation();
   const { getJobStatus, markAsRead, setActiveConversation } = useCronJobsMap();
@@ -43,7 +43,18 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     }
   }, [id, setActiveConversation]);
 
-  const { conversations, expandedWorkspaces, pinnedConversations, timelineSections, scheduledGroups, handleToggleWorkspace } = useConversations();
+  const { conversations, expandedWorkspaces, pinnedTimeline, pinnedScheduled, timelineSections, scheduledGroups, handleToggleWorkspace } = useConversations();
+
+  // Select pinned list based on active tab
+  const pinnedConversations = activeTab === 'scheduled' ? pinnedScheduled : pinnedTimeline;
+
+  // Filter out pinned conversations from scheduled groups to avoid duplicates
+  // Only filter based on pinnedScheduled (pinned in scheduled tab)
+  const currentPinnedIds = useMemo(() => new Set(pinnedScheduled.map((c) => c.id)), [pinnedScheduled]);
+  const filteredScheduledGroups = useMemo(
+    () => scheduledGroups.map((group) => ({ ...group, conversations: group.conversations.filter((c) => !currentPinnedIds.has(c.id)) })).filter((g) => g.conversations.length > 0),
+    [scheduledGroups, pinnedScheduled],
+  );
 
   // ── Timeline section collapse state ──
   const TIMELINE_EXPANSION_KEY = 'aionui_timeline_expansion';
@@ -164,6 +175,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
 
   const { renameModalVisible, renameModalName, setRenameModalName, renameLoading, dropdownVisibleId, handleConversationClick, handleDeleteClick, handleBatchDelete, handleEditStart, handleRenameConfirm, handleRenameCancel, handleTogglePin, handleMenuVisibleChange, handleOpenMenu } = useConversationActions({
     batchMode,
+    activeTab,
     onSessionClick,
     onBatchModeChange,
     selectedConversationIds,
@@ -215,7 +227,17 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
   // Collect all sortable IDs for the pinned section
   const pinnedIds = useMemo(() => pinnedConversations.map((c) => c.id), [pinnedConversations]);
 
-  if (timelineSections.length === 0 && pinnedConversations.length === 0) {
+  if (activeTab === 'timeline' && timelineSections.length === 0 && pinnedConversations.length === 0) {
+    return (
+      <FlexFullContainer>
+        <div className='flex-center'>
+          <Empty description={t('conversation.history.noHistory')} />
+        </div>
+      </FlexFullContainer>
+    );
+  }
+
+  if (activeTab === 'scheduled' && filteredScheduledGroups.length === 0 && pinnedConversations.length === 0) {
     return (
       <FlexFullContainer>
         <div className='flex-center'>
@@ -342,8 +364,27 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
       )}
 
       <div className='size-full overflow-y-auto overflow-x-hidden'>
-        {/* ── SCHEDULED SECTION ── */}
-        {scheduledGroups.length > 0 && (
+        {/* ── PINNED SECTION ── */}
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
+          {pinnedConversations.length > 0 && (
+            <div className='mb-8px min-w-0'>
+              {!collapsed && <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold'>{t('conversation.history.pinnedSection')}</div>}
+              <SortableContext items={pinnedIds} strategy={verticalListSortingStrategy}>
+                <div className='min-w-0'>
+                  {pinnedConversations.map((conversation) => {
+                    const props = getConversationRowProps(conversation);
+                    return isDragEnabled ? <SortableConversationRow key={conversation.id} {...props} /> : <ConversationRow key={conversation.id} {...props} />;
+                  })}
+                </div>
+              </SortableContext>
+            </div>
+          )}
+
+          <DragOverlay dropAnimation={null}>{activeId && activeConversation ? <DragOverlayContent conversation={activeConversation} /> : null}</DragOverlay>
+        </DndContext>
+
+        {/* ── SCHEDULED SECTION (Scheduled tab only) ── */}
+        {activeTab === 'scheduled' && filteredScheduledGroups.length > 0 && (
           <div className='mb-8px min-w-0'>
             {!collapsed && (
               <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold flex items-center gap-6px cursor-pointer hover:text-t-primary transition-colors select-none' onClick={handleToggleScheduledSection}>
@@ -352,7 +393,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
               </div>
             )}
             {(collapsed || scheduledSectionExpanded) &&
-              scheduledGroups.map(({ jobName, conversations: cronConvs }) => {
+              filteredScheduledGroups.map(({ jobName, conversations: cronConvs }) => {
                 const isExpanded = expandedScheduled.includes(jobName);
                 return (
                   <div key={jobName} className={classNames('min-w-0', { 'px-8px': !collapsed })}>
@@ -374,25 +415,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
           </div>
         )}
 
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
-          {pinnedConversations.length > 0 && (
-            <div className='mb-8px min-w-0'>
-              {!collapsed && <div className='chat-history__section px-12px py-8px text-13px text-t-secondary font-bold'>{t('conversation.history.pinnedSection')}</div>}
-              <SortableContext items={pinnedIds} strategy={verticalListSortingStrategy}>
-                <div className='min-w-0'>
-                  {pinnedConversations.map((conversation) => {
-                    const props = getConversationRowProps(conversation);
-                    return isDragEnabled ? <SortableConversationRow key={conversation.id} {...props} /> : <ConversationRow key={conversation.id} {...props} />;
-                  })}
-                </div>
-              </SortableContext>
-            </div>
-          )}
-
-          <DragOverlay dropAnimation={null}>{activeId && activeConversation ? <DragOverlayContent conversation={activeConversation} /> : null}</DragOverlay>
-        </DndContext>
-
-        {timelineSections.map((section) => {
+        {activeTab === 'timeline' && timelineSections.map((section) => {
           const sectionExpanded = isTimelineSectionExpanded(section.timeline);
           return (
             <div key={section.timeline} className='mb-8px min-w-0'>

--- a/src/renderer/pages/conversation/grouped-history/types.ts
+++ b/src/renderer/pages/conversation/grouped-history/types.ts
@@ -29,8 +29,11 @@ export type TimelineSection = {
   items: TimelineItem[];
 };
 
+export type SidebarTabKey = 'timeline' | 'scheduled';
+
 export type GroupedHistoryResult = {
-  pinnedConversations: TChatConversation[];
+  pinnedTimeline: TChatConversation[];
+  pinnedScheduled: TChatConversation[];
   timelineSections: TimelineSection[];
   scheduledGroups: ScheduledGroup[];
 };
@@ -68,6 +71,7 @@ export type WorkspaceGroupedHistoryProps = {
   tooltipEnabled?: boolean;
   batchMode?: boolean;
   onBatchModeChange?: (value: boolean) => void;
+  activeTab?: SidebarTabKey;
 };
 
 export type DragItemType = 'conversation' | 'workspace';

--- a/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
@@ -10,7 +10,7 @@ import { getActivityTime, getTimelineLabel } from '@/renderer/utils/timeline';
 import { getWorkspaceDisplayName } from '@/renderer/utils/workspace';
 import { getWorkspaceUpdateTime } from '@/renderer/utils/workspaceHistory';
 
-import type { GroupedHistoryResult, ScheduledGroup, TimelineItem, TimelineSection, WorkspaceGroup } from '../types';
+import type { GroupedHistoryResult, ScheduledGroup, SidebarTabKey, TimelineItem, TimelineSection, WorkspaceGroup } from '../types';
 import { getConversationSortOrder } from './sortOrderHelpers';
 
 export const getConversationTimelineLabel = (conversation: TChatConversation, t: (key: string) => string): string => {
@@ -29,6 +29,11 @@ export const getConversationPinnedAt = (conversation: TChatConversation): number
     return extra.pinnedAt;
   }
   return 0;
+};
+
+export const getConversationPinnedTab = (conversation: TChatConversation): SidebarTabKey | undefined => {
+  const extra = conversation.extra as { pinnedTab?: SidebarTabKey } | undefined;
+  return extra?.pinnedTab;
 };
 
 export const groupConversationsByTimelineAndWorkspace = (conversations: TChatConversation[], t: (key: string) => string): TimelineSection[] => {
@@ -186,9 +191,9 @@ export const buildGroupedHistory = (conversations: TChatConversation[], t: (key:
   // Pre-bound user conversations are NOT tagged; they stay in the regular timeline
   // and are also included in the scheduled group for every job that binds them
   // (resolved via cronJobs in buildScheduledGroups).
-  const regularConvs = conversations.filter((conv) => !(conv.extra as any)?.cronJobId);
 
-  const pinnedConversations = regularConvs
+  // For pinned: include ALL conversations (cronJobId conversations can be pinned too)
+  const pinnedConversations = conversations
     .filter((conversation) => isConversationPinned(conversation))
     .sort((a, b) => {
       const orderA = getConversationSortOrder(a);
@@ -199,10 +204,24 @@ export const buildGroupedHistory = (conversations: TChatConversation[], t: (key:
       return getConversationPinnedAt(b) - getConversationPinnedAt(a);
     });
 
+  // Split pinned into timeline and scheduled tabs based on pinnedTab field.
+  // Legacy conversations without pinnedTab default to timeline.
+  const pinnedTimeline = pinnedConversations.filter((conv) => {
+    const pinnedTab = getConversationPinnedTab(conv);
+    return pinnedTab !== 'scheduled';
+  });
+
+  const pinnedScheduled = pinnedConversations.filter((conv) => {
+    return getConversationPinnedTab(conv) === 'scheduled';
+  });
+
+  // For timeline sections: exclude cronJobId conversations AND pinned conversations
+  const regularConvs = conversations.filter((conv) => !(conv.extra as any)?.cronJobId);
   const normalConversations = regularConvs.filter((conversation) => !isConversationPinned(conversation));
 
   return {
-    pinnedConversations,
+    pinnedTimeline,
+    pinnedScheduled,
     timelineSections: groupConversationsByTimelineAndWorkspace(normalConversations, t),
     scheduledGroups: buildScheduledGroups(conversations, cronJobs),
   };

--- a/src/renderer/sider.tsx
+++ b/src/renderer/sider.tsx
@@ -11,7 +11,7 @@ import { useLayoutContext } from './context/LayoutContext';
 import { blurActiveElement } from './utils/focus';
 import { isElectronDesktop } from './utils/platform';
 import { useAuth } from './context/AuthContext';
-import { emitter } from './utils/emitter';
+import { addEventListener, emitter } from './utils/emitter';
 import { ConfigStorage } from '@/common/storage';
 
 const WorkspaceGroupedHistory = React.lazy(() => import('./pages/conversation/WorkspaceGroupedHistory'));
@@ -32,6 +32,31 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const { logout, user: currentUser } = useAuth();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+
+  // Sidebar tab state: 'timeline' or 'scheduled'
+  const SIDER_TAB_STORAGE_KEY = 'aionui_sider_tab';
+  const [activeTab, setActiveTab] = useState<'timeline' | 'scheduled'>(() => {
+    try {
+      const stored = localStorage.getItem(SIDER_TAB_STORAGE_KEY);
+      if (stored === 'scheduled') return 'scheduled';
+    } catch {
+      // ignore
+    }
+    return 'timeline';
+  });
+
+  // Listen for command palette tab switch events
+  useEffect(() => {
+    const removeListener = addEventListener('sider.tab.switch', (tab) => {
+      setActiveTab(tab);
+      try {
+        localStorage.setItem(SIDER_TAB_STORAGE_KEY, tab);
+      } catch {
+        // ignore
+      }
+    });
+    return removeListener;
+  }, []);
   const isSettings = pathname.startsWith('/settings');
   const lastNonSettingsPathRef = useRef('/guid');
 
@@ -94,7 +119,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     },
     batchMode: isBatchMode,
     onBatchModeChange: setIsBatchMode,
-    showTitle: false, // 我们已经在上面渲染了标题
+    activeTab,
   };
   const tooltipEnabled = collapsed && !isMobile;
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
@@ -187,9 +212,39 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
               })}
             </div>
 
-            {/* 所有对话标题 + 批量管理按钮 / All records title + Batch mode button */}
+            {/* Session history tabs + batch mode button */}
             <div className={classNames('mb-8px px-8px flex items-center', collapsed ? 'justify-center' : 'justify-between')}>
-              {!collapsed && <span className='text-13px font-medium text-t-secondary'>{t('conversation.history.allRecords', { defaultValue: '所有对话' })}</span>}
+              {!collapsed && (
+                <div className="flex items-center gap-1px flex-1">
+                  {(['timeline', 'scheduled'] as const).map((tab) => {
+                    const isActive = activeTab === tab;
+                    const label = tab === 'timeline'
+                      ? t('conversation.history.timeline', { defaultValue: '对话' })
+                      : t('conversation.history.scheduledTab', { defaultValue: '定时任务' });
+                    return (
+                      <div
+                        key={tab}
+                        className={classNames(
+                          'flex-1 text-center text-13px py-8px rd-8px cursor-pointer transition-colors select-none',
+                          isActive
+                            ? 'bg-aou-2 text-aou-6 font-medium'
+                            : 'text-t-secondary hover:text-t-primary hover:bg-hover'
+                        )}
+                        onClick={() => {
+                          setActiveTab(tab);
+                          try {
+                            localStorage.setItem(SIDER_TAB_STORAGE_KEY, tab);
+                          } catch {
+                            // ignore
+                          }
+                        }}
+                      >
+                        {label}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
               <Tooltip {...siderTooltipProps} content={isBatchMode ? t('conversation.history.batchModeExit') : t('conversation.history.batchManage')} position='right'>
                 <div className={classNames('w-32px h-32px flex items-center justify-center rd-8px cursor-pointer transition-all shrink-0', isBatchMode ? 'bg-[rgba(var(--primary-6),0.12)] text-primary-6' : 'hover:bg-hover active:bg-fill-2 text-t-secondary')} onClick={handleToggleBatchMode}>
                   <ListCheckbox theme='outline' size='18' className='block leading-none' />

--- a/src/renderer/utils/emitter.ts
+++ b/src/renderer/utils/emitter.ts
@@ -48,6 +48,8 @@ interface EventTypes {
   // Command palette events
   'commandPalette.open': void;
   'commandPalette.close': void;
+  // Sidebar tab switch event (from command palette to switch sider tab)
+  'sider.tab.switch': ['timeline' | 'scheduled'];
 }
 
 export const emitter = new EventEmitter<EventTypes>();


### PR DESCRIPTION
## 变更概述

将左侧会话历史拆分为两个独立 Tab 页签：「对话」和「定时任务」，每个 Tab 独立支持置顶和排序功能。

## 功能特性

### 1. Tab 页签
- **对话 Tab**: 显示普通对话的置顶和时间线
- **定时任务 Tab**: 显示定时任务的置顶和任务分组

### 2. 置顶功能
- 每个 Tab 独立置顶，互不干扰
- 置顶状态通过 `extra.pinnedTab` 字段区分会话归属
- 置顶会话优先展示在顶部区域，支持拖拽排序
- 置顶的定时任务会话从原 job section 中排除，避免重复显示

### 3. 状态持久化
- Tab 切换状态持久化到 `localStorage` (key: `aionui_sider_tab`)
- 刷新页面后保持上次选择的 Tab

### 4. Cmd+K 搜索
- 搜索所有会话（包含两个 Tab）
- 点击搜索结果自动切换到对应 Tab
- 导航到目标会话

## 技术实现

| 文件 | 变更 |
|------|------|
| `emitter.ts` | 新增 `sider.tab.switch` 事件 |
| `types.ts` | 新增 `SidebarTabKey` 类型，拆分 `GroupedHistoryResult` |
| `groupingHelpers.ts` | 新增 `getConversationPinnedTab`，支持按 tab 分流 |
| `useConversationActions.ts` | `handleTogglePin` 接收 `activeTab` 并设置 `pinnedTab` |
| `grouped-history/index.tsx` | 根据 `activeTab` 渲染，过滤重复会话 |
| `sider.tsx` | 添加 Tab 切换组件（自定义 div + UnoCSS） |
| `CommandPalette.tsx` | 加载 10000 条会话，支持跨 Tab 搜索 |
| `conversation.json` | 新增 i18n 翻译 |

## 修复问题

1. **定时任务置顶生效**: `buildGroupedHistory` 中 pinned 过滤包含所有会话（包括 `cronJobId`）
2. **重复显示问题**: `scheduledGroups` 排除 `pinnedScheduled` 中的会话
3. **DnD 状态错乱**: Pinned section 始终在顶部渲染，基于当前 tab 的 pinned 列表

## 验证清单

- [ ] 切换到「定时任务」Tab，显示 scheduledGroups 并按时间排序
- [ ] 在「对话」Tab 置顶会话，出现在对话 pinned 区域
- [ ] 在「定时任务」Tab 置顶会话，出现在该 Tab 的 pinned 区域
- [ ] 两个 Tab 的 pinned 区域互不干扰
- [ ] Cmd+K 搜索定时任务，自动切换到「定时任务」Tab
- [ ] Cmd+K 搜索对话，自动切换到「对话」Tab
- [ ] 刷新后 Tab 状态持久化
- [ ] 拖拽排序正常工作

## 截图

![Tab 效果截图]()