### PR TITLE
feat(openclaw): symlink shared identity/soul/memory into per-session workspaces

### DIFF
--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -14,6 +14,7 @@ import { DRAFTS_DIR_NAME } from '@/common/constants';
 import { getSystemDir } from './initStorage';
 import { SUDOCLAW_DIR } from './services/sudoclaw/SudoclawInstallService';
 import { computeOpenClawIdentityHash } from './utils/openclawUtils';
+import { mainLog, mainWarn } from './utils/mainLogger';
 
 /**
  * 创建工作空间目录（不复制文件）
@@ -95,18 +96,81 @@ export function getSudoclawWorkspaceRoot(): string {
   return getSystemDir().workDir;
 }
 
+/**
+ * Shared identity/soul/memory file names that should be symlinked from the
+ * parent (persistent) workspace into each per-session temporary workspace.
+ *
+ * This ensures every new conversation inherits the user's long-term persona,
+ * soul memory and accumulated memory data without duplicating it.  Because we
+ * use symlinks the agent can also *write* to these files and the changes
+ * persist across sessions automatically.
+ *
+ * 共享人设/灵魂/记忆文件名列表 — 在每个临时会话工作空间中创建指向父级持久
+ * 工作空间的符号链接。确保每个新会话继承用户的长期人格、灵魂记忆和积累的
+ * 记忆数据，而不是每个会话独立人格。
+ */
+const SHARED_IDENTITY_ENTRIES = ['IDENTITY.md', 'SOUL.md', 'memory'];
+
+/**
+ * Create symlinks in `sessionWorkspace` pointing to entries that exist in
+ * `parentWorkspace`.  Existing entries (symlink or real file) in the session
+ * workspace are left untouched — we never overwrite user-provided files.
+ *
+ * On Windows, directories are linked via junctions (no admin rights needed)
+ * while regular files use a normal symlink.
+ *
+ * 在会话工作空间中创建指向父级工作空间中共享文件的符号链接。
+ * 已存在的条目不会被覆盖，确保用户自定义工作空间的文件不受影响。
+ */
+async function symlinkSharedIdentityFiles(sessionWorkspace: string, parentWorkspace: string): Promise<void> {
+  for (const name of SHARED_IDENTITY_ENTRIES) {
+    const source = path.join(parentWorkspace, name);
+    const target = path.join(sessionWorkspace, name);
+
+    try {
+      // Skip if source does not exist in parent workspace
+      const sourceStat = await fs.stat(source).catch(() => null);
+      if (!sourceStat) continue;
+
+      // Skip if target already exists in session workspace (don't overwrite)
+      const targetExists = await fs.lstat(target).catch(() => null);
+      if (targetExists) continue;
+
+      if (sourceStat.isDirectory()) {
+        // Use 'junction' on Windows (no admin privilege needed), 'dir' on others
+        await fs.symlink(source, target, process.platform === 'win32' ? 'junction' : 'dir');
+      } else {
+        await fs.symlink(source, target, 'file');
+      }
+      mainLog('initAgent', `Symlinked shared ${name}: ${target} → ${source}`);
+    } catch (err) {
+      mainWarn('initAgent', `Failed to symlink shared ${name} into session workspace: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
 export const createOpenClawAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
   // Use workspace root from sudoclaw.json so the agent's working dir matches the UI workspace panel.
   // Falls back to getSystemDir().workDir if sudoclaw.json is missing or has no workspace configured.
   const tempName = `sudoclaw-temp-${Date.now()}`;
   let resolvedWorkspace = extra.workspace;
+  const isAutoWorkspace = !resolvedWorkspace;
   if (!resolvedWorkspace) {
     const root = getSudoclawWorkspaceRoot();
     resolvedWorkspace = path.join(root, tempName);
     await fs.mkdir(resolvedWorkspace, { recursive: true });
   }
   const { workspace, customWorkspace } = await buildWorkspaceWidthFiles(tempName, resolvedWorkspace, extra.defaultFiles, extra.customWorkspace);
+
+  // Symlink shared identity/soul/memory files from the parent workspace into
+  // the per-session workspace so the agent inherits long-term persona data.
+  // Only for auto-generated workspaces — custom workspaces manage their own files.
+  if (isAutoWorkspace) {
+    const parentWorkspace = path.dirname(workspace);
+    await symlinkSharedIdentityFiles(workspace, parentWorkspace);
+  }
+
   const expectedIdentityHash = await computeOpenClawIdentityHash(workspace);
 
   const stateDir = SUDOCLAW_DIR;

--- a/tests/unit/initAgentSharedIdentity.test.ts
+++ b/tests/unit/initAgentSharedIdentity.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Tests for shared identity/soul/memory symlink logic in initAgent.
+ *
+ * These tests validate the core symlink behavior that enables persona
+ * memory sharing across OpenClaw sessions (issue #520).
+ */
+
+// Mirror the constant from initAgent.ts
+const SHARED_IDENTITY_ENTRIES = ['IDENTITY.md', 'SOUL.md', 'memory'];
+
+/**
+ * Re-implement the symlink logic here for isolated unit testing.
+ * This avoids importing the real initAgent module which has heavy
+ * Electron/process dependencies that don't work in a test environment.
+ */
+async function symlinkSharedIdentityFiles(sessionWorkspace: string, parentWorkspace: string): Promise<void> {
+  for (const name of SHARED_IDENTITY_ENTRIES) {
+    const source = path.join(parentWorkspace, name);
+    const target = path.join(sessionWorkspace, name);
+
+    try {
+      const sourceStat = await fs.stat(source).catch(() => null);
+      if (!sourceStat) continue;
+
+      const targetExists = await fs.lstat(target).catch(() => null);
+      if (targetExists) continue;
+
+      if (sourceStat.isDirectory()) {
+        await fs.symlink(source, target, process.platform === 'win32' ? 'junction' : 'dir');
+      } else {
+        await fs.symlink(source, target, 'file');
+      }
+    } catch {
+      // Silently skip failures in test
+    }
+  }
+}
+
+describe('Shared Identity Symlink', () => {
+  let tmpDir: string;
+  let parentWorkspace: string;
+  let sessionWorkspace: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sudowork-test-'));
+    parentWorkspace = path.join(tmpDir, 'workspace');
+    sessionWorkspace = path.join(parentWorkspace, 'sudoclaw-temp-12345');
+    await fs.mkdir(parentWorkspace, { recursive: true });
+    await fs.mkdir(sessionWorkspace, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('symlinks IDENTITY.md from parent to session workspace', async () => {
+    const identityContent = '# IDENTITY.md\n\n- **Name:**\n  TestBot\n';
+    await fs.writeFile(path.join(parentWorkspace, 'IDENTITY.md'), identityContent);
+
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    const target = path.join(sessionWorkspace, 'IDENTITY.md');
+    const stat = await fs.lstat(target);
+    expect(stat.isSymbolicLink()).toBe(true);
+
+    const content = await fs.readFile(target, 'utf-8');
+    expect(content).toBe(identityContent);
+  });
+
+  test('symlinks SOUL.md from parent to session workspace', async () => {
+    const soulContent = '# Soul Memory\n\nI am a helpful assistant.\n';
+    await fs.writeFile(path.join(parentWorkspace, 'SOUL.md'), soulContent);
+
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    const target = path.join(sessionWorkspace, 'SOUL.md');
+    const stat = await fs.lstat(target);
+    expect(stat.isSymbolicLink()).toBe(true);
+
+    const content = await fs.readFile(target, 'utf-8');
+    expect(content).toBe(soulContent);
+  });
+
+  test('symlinks memory directory from parent to session workspace', async () => {
+    const memoryDir = path.join(parentWorkspace, 'memory');
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, 'note.md'), 'user prefers dark mode');
+
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    const target = path.join(sessionWorkspace, 'memory');
+    const stat = await fs.lstat(target);
+    expect(stat.isSymbolicLink()).toBe(true);
+
+    const content = await fs.readFile(path.join(target, 'note.md'), 'utf-8');
+    expect(content).toBe('user prefers dark mode');
+  });
+
+  test('skips entries that do not exist in parent workspace', async () => {
+    // Parent workspace has no identity files
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    for (const name of SHARED_IDENTITY_ENTRIES) {
+      const target = path.join(sessionWorkspace, name);
+      expect(fsSync.existsSync(target)).toBe(false);
+    }
+  });
+
+  test('does not overwrite existing files in session workspace', async () => {
+    const parentContent = 'parent identity';
+    const sessionContent = 'session identity';
+
+    await fs.writeFile(path.join(parentWorkspace, 'IDENTITY.md'), parentContent);
+    await fs.writeFile(path.join(sessionWorkspace, 'IDENTITY.md'), sessionContent);
+
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    // Session file should remain unchanged (not replaced by symlink)
+    const target = path.join(sessionWorkspace, 'IDENTITY.md');
+    const stat = await fs.lstat(target);
+    expect(stat.isSymbolicLink()).toBe(false);
+
+    const content = await fs.readFile(target, 'utf-8');
+    expect(content).toBe(sessionContent);
+  });
+
+  test('changes to symlinked file persist to parent workspace', async () => {
+    const originalContent = '# Soul Memory\n\nOriginal.\n';
+    await fs.writeFile(path.join(parentWorkspace, 'SOUL.md'), originalContent);
+
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    // Agent writes through the symlink
+    const updatedContent = '# Soul Memory\n\nUpdated by agent.\n';
+    await fs.writeFile(path.join(sessionWorkspace, 'SOUL.md'), updatedContent);
+
+    // Parent workspace should reflect the change
+    const parentContent = await fs.readFile(path.join(parentWorkspace, 'SOUL.md'), 'utf-8');
+    expect(parentContent).toBe(updatedContent);
+  });
+
+  test('symlinks all available entries simultaneously', async () => {
+    await fs.writeFile(path.join(parentWorkspace, 'IDENTITY.md'), 'identity');
+    await fs.writeFile(path.join(parentWorkspace, 'SOUL.md'), 'soul');
+    await fs.mkdir(path.join(parentWorkspace, 'memory'), { recursive: true });
+
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    for (const name of SHARED_IDENTITY_ENTRIES) {
+      const target = path.join(sessionWorkspace, name);
+      const stat = await fs.lstat(target);
+      expect(stat.isSymbolicLink()).toBe(true);
+    }
+  });
+
+  test('partially available entries are symlinked (only existing ones)', async () => {
+    // Only SOUL.md exists in parent
+    await fs.writeFile(path.join(parentWorkspace, 'SOUL.md'), 'soul');
+
+    await symlinkSharedIdentityFiles(sessionWorkspace, parentWorkspace);
+
+    expect(fsSync.existsSync(path.join(sessionWorkspace, 'IDENTITY.md'))).toBe(false);
+    expect((await fs.lstat(path.join(sessionWorkspace, 'SOUL.md'))).isSymbolicLink()).toBe(true);
+    expect(fsSync.existsSync(path.join(sessionWorkspace, 'memory'))).toBe(false);
+  });
+});


### PR DESCRIPTION
IDENTITY.md、SOUL.md 和 memory/ 目录现在会从父级共享工作空间符号链接到每个会话临时目录，实现人设记忆跨会话共享。

Closes #520