### PR TITLE
refactor(openclaw): 临时工作区仅用于任务文件，人设记忆通过提示词声明共享

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -28,6 +28,7 @@ import { listWorkspaceSkillTargets, resolveConversationEnabledSkillNames } from 
 import { areSkillSelectionsEqual, resolveLatestConversationEnabledSkills } from '../utils/conversationAssistantSkills';
 import { copyFilesToDirectory, readDirectoryRecursive } from '../utils';
 import { computeOpenClawIdentityHash } from '../utils/openclawUtils';
+import { getSudoclawWorkspaceRoot } from '../initAgent';
 import { resolveWorkspaceSkillsDir } from '../utils/workspaceSkillsDir';
 import WorkerManage from '../WorkerManage';
 import { migrateConversationToDatabase } from './migrationUtils';
@@ -216,7 +217,9 @@ export function initConversationBridge(): void {
       await task.bootstrap.catch(() => {});
 
       const diagnostics = task.getDiagnostics();
-      const identityHash = await computeOpenClawIdentityHash(diagnostics.workspace || conversation.extra?.workspace);
+      // Compute identity hash from the shared workspace root (where IDENTITY.md/SOUL.md live),
+      // not from the per-session temp directory.
+      const identityHash = await computeOpenClawIdentityHash(getSudoclawWorkspaceRoot());
       const conversationModel = (conversation as { model?: { useModel?: string } }).model;
       const resolvedModel = diagnostics.model || conversation.extra?.openclawModelId || conversation.extra?.runtimeValidation?.expectedModel || conversationModel?.useModel;
 

--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -107,7 +107,11 @@ export const createOpenClawAgent = async (options: ICreateConversationParams): P
     await fs.mkdir(resolvedWorkspace, { recursive: true });
   }
   const { workspace, customWorkspace } = await buildWorkspaceWidthFiles(tempName, resolvedWorkspace, extra.defaultFiles, extra.customWorkspace);
-  const expectedIdentityHash = await computeOpenClawIdentityHash(workspace);
+  // Compute identity hash from the shared workspace root (where IDENTITY.md/SOUL.md live),
+  // not from the per-session temp directory. The temp workspace is only for task-specific files;
+  // identity and memory persist in the parent workspace across all sessions.
+  const sharedWorkspaceRoot = getSudoclawWorkspaceRoot();
+  const expectedIdentityHash = await computeOpenClawIdentityHash(sharedWorkspaceRoot);
 
   const stateDir = SUDOCLAW_DIR;
 

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -523,21 +523,29 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
       if (this.workspace) {
         const configuredWorkspace = getSudoclawWorkspaceRoot();
         const draftsInstruction = buildDraftsInstruction(this.workspace);
-        const workspaceDirective = `[CRITICAL: Workspace Path - MUST VERIFY ON EVERY FILE OPERATION]
+        const workspaceDirective = `[CRITICAL: Workspace & Identity - MUST VERIFY ON EVERY FILE OPERATION]
 
 ⚠️ PATH VERIFICATION CHECKLIST (apply to EVERY write/exec/bash operation):
 
-1. Your ONLY valid workspace is: ${this.workspace}
-2. FORBIDDEN path (DO NOT use): ${configuredWorkspace}
-3. Before any file write, VERIFY the path starts with '${this.workspace}'
-4. NOTE: Files mistakenly written to ${configuredWorkspace} are considered misplaced.
-   The system will automatically move them to ${this.workspace} after your turn completes.
-   Focus on using correct paths - no manual file movement is needed.
+1. Your task workspace (for task-specific output files) is: ${this.workspace}
+2. Before any file write, VERIFY the path starts with '${this.workspace}'
+3. All NEW files you create (scripts, documents, deliverables) MUST go into: ${this.workspace}
 
-[System: This directive applies even after errors/retries. The session workspace does NOT change.]
+[System: This directive applies even after errors/retries. The session task workspace does NOT change.]
 
-Your working directory for this session ONLY is '${this.workspace}'.
-All file operations, bash commands, and output (when calling write() tool) MUST use this path.
+## Task Workspace vs Shared Identity/Memory
+
+Your task workspace '${this.workspace}' is a **project directory** created for THIS specific task/session.
+It is used ONLY for storing files generated during this task (scripts, documents, reports, etc.).
+
+Your **identity, soul, and memory** persist across all sessions in the shared workspace:
+- Identity: ${configuredWorkspace}/IDENTITY.md
+- Soul: ${configuredWorkspace}/SOUL.md
+- Memory: ${configuredWorkspace}/memory/
+
+You are NOT a separate clone — you are the same OpenClaw entity across sessions.
+When you need to read or update your identity/soul/memory, access them from '${configuredWorkspace}'.
+When you create task output files, write them to '${this.workspace}'.
 
 ${draftsInstruction}`;
         processedContent = `${workspaceDirective}\n\n${processedContent}`;


### PR DESCRIPTION
临时工作区不再创造 OpenClaw 分身，而是作为任务工程目录。人设、灵魂、记忆通过提示词声明从共享 workspace 根目录读写。

Closes #520

Generated with [Claude Code](https://claude.ai/code)