### PR TITLE
fix: prevent upgrade dialog from being dismissed during download

### DIFF
--- a/src/renderer/components/UpdateModal/index.tsx
+++ b/src/renderer/components/UpdateModal/index.tsx
@@ -316,6 +316,10 @@ const UpdateModal: React.FC = () => {
     };
   }, [downloadId, t]);
 
+  // 下载过程中不允许关闭弹窗（只能通过关闭按钮关闭）
+  // Prevent accidental dismissal during active download
+  const isDownloading = status === 'downloading';
+
   const handleClose = () => {
     setVisible(false);
   };
@@ -508,6 +512,8 @@ const UpdateModal: React.FC = () => {
     <AionModal
       visible={visible}
       onCancel={handleClose}
+      maskClosable={!isDownloading}
+      escToExit={!isDownloading}
       size={status === 'available' ? 'medium' : 'small'}
       header={{
         title: t('update.modalTitle'),

--- a/src/renderer/components/base/AionModal.tsx
+++ b/src/renderer/components/base/AionModal.tsx
@@ -174,6 +174,7 @@ const AionModal: React.FC<AionModalProps> = ({
   onCancel,
   className = '',
   style,
+  escToExit: escToExitProp = true,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -371,7 +372,7 @@ const AionModal: React.FC<AionModalProps> = ({
       title={null}
       closable={false}
       footer={null}
-      escToExit
+      escToExit={escToExitProp}
       onCancel={onCancel}
       className={`aionui-modal ${className}`}
       style={finalStyle}


### PR DESCRIPTION
Fixes #523

During an active download, clicking outside the modal or pressing ESC would close the dialog, hiding progress and confusing the user. Now `maskClosable` and `escToExit` are disabled while the download is in progress, so only the explicit close button can dismiss the modal.

Generated with [Claude Code](https://claude.ai/code)