### PR TITLE
fix: prevent model selector from resetting to gemini-3-flash-preview on preview open

### DIFF
--- a/src/renderer/components/OpenClawModelSelector.tsx
+++ b/src/renderer/components/OpenClawModelSelector.tsx
@@ -48,12 +48,26 @@ const OpenClawModelSelector: React.FC<{
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
   const lastSyncedModelRef = useRef<string | null>(null);
 
+  // Track whether the model has been restored from DB to prevent the initial sync
+  // effect from prematurely overwriting the user-selected model with the primary model.
+  // Without this guard, when the component remounts (e.g., preview panel open/close
+  // causes layout tree restructuring), the sync effect fires before the async DB read
+  // completes, picking the isPrimary model (gemini-3-flash-preview) instead of the
+  // user's actual selection.
+  // 跟踪模型是否已从数据库恢复，防止初始同步 effect 在异步 DB 读取完成之前
+  // 用主模型 (gemini-3-flash-preview) 覆盖用户选择的模型。
+  const [isModelRestoredFromDb, setIsModelRestoredFromDb] = useState(false);
+
   // Load current model from conversation extra on mount
   useEffect(() => {
     // 只有当 models 加载完成后才会执行
     if (!models) {
       return;
     }
+
+    // Reset the flag when conversation or models change to prevent stale state
+    // 当会话或模型列表变化时重置标志，防止状态过期
+    setIsModelRestoredFromDb(false);
 
     ipcBridge.conversation.get
       .invoke({ id: conversationId })
@@ -68,6 +82,7 @@ const OpenClawModelSelector: React.FC<{
             setSelectedModelId(primaryModel.model_id);
           }
         }
+        setIsModelRestoredFromDb(true);
       })
       .catch((err) => {
         console.error('[OpenClawModelSelector] Failed to load conversation:', err);
@@ -76,6 +91,7 @@ const OpenClawModelSelector: React.FC<{
         if (primaryModel) {
           setSelectedModelId(primaryModel.model_id);
         }
+        setIsModelRestoredFromDb(true);
       });
   }, [conversationId, models]);
 
@@ -153,8 +169,11 @@ const OpenClawModelSelector: React.FC<{
   );
 
   // Ensure the current model is synced on first load as well.
+  // Wait for DB model to be restored before syncing to prevent overwriting
+  // the user's selection with the primary model on component remount.
+  // 等待数据库模型恢复后再同步，防止在组件重新挂载时用主模型覆盖用户的选择。
   useEffect(() => {
-    if (!models?.length) {
+    if (!models?.length || !isModelRestoredFromDb) {
       return;
     }
 
@@ -167,7 +186,7 @@ const OpenClawModelSelector: React.FC<{
       updateState: selectedModelId == null,
       reason: 'initial',
     });
-  }, [models, selectedModelId, syncSelectedModel]);
+  }, [models, selectedModelId, syncSelectedModel, isModelRestoredFromDb]);
 
   // Format model label with ratio and primary indicator
   const formatModelLabel = useCallback(
@@ -182,8 +201,9 @@ const OpenClawModelSelector: React.FC<{
   const selectedModel = models?.find((m) => m.model_id === selectedModelId) || models?.find((m) => m.isPrimary);
   const displayLabel = selectedModel ? formatModelLabel(selectedModel) : selectedModelId || t('conversation.welcome.selectModel');
 
-  // Show loading state when models are being fetched
-  if (isLoading) {
+  // Show loading state when models are being fetched or model is being restored from DB
+  // 模型列表加载中或正在从数据库恢复模型时显示加载状态
+  if (isLoading || (models && !isModelRestoredFromDb)) {
     return (
       <Button className={classNames('sendbox-model-btn header-model-btn', compact && '!max-w-[120px]', isMobileCompact && '!max-w-[160px]')} shape='round' size='small' disabled>
         <span className='flex items-center gap-6px min-w-0'>


### PR DESCRIPTION
Fixes #527

When opening the preview panel, ChatLayout restructures the JSX tree, causing React to unmount/remount the model selector. On remount, the initial sync effect would fire before the async DB read completed, picking the isPrimary model (gemini-3-flash-preview) instead of the user's actual selection.

Adds `isModelRestoredFromDb` state guard to ensure the sync effect waits for the DB value before syncing.

Generated with [Claude Code](https://claude.ai/code)