### PR TITLE
fix: auto-set consumer mode for upgrading users

### DIFF
--- a/src/renderer/hooks/useAppMode.ts
+++ b/src/renderer/hooks/useAppMode.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getAppMode } from '@/common/eeclawMode';
+import { getAppMode, setAppMode } from '@/common/eeclawMode';
 import { useEffect, useState } from 'react';
 
 // Pre-initialize app mode on module load (avoids first-frame flash)
@@ -19,6 +19,12 @@ if (typeof window !== 'undefined') {
     initialModeResolved = true;
     cachedMode = mode ?? 'c';
     appModeWasNull = mode === null; // null = new user who never chose a mode
+    // Old user upgrade: has sudowork_auth_v2 but no appMode → auto-set 'c'
+    if (mode === null && localStorage.getItem('sudowork_auth_v2')) {
+      setAppMode('c').catch((e) => {
+        console.error('[useAppMode] Failed to auto-set consumer mode for upgrading user:', e);
+      });
+    }
     return cachedMode;
     // getAppMode() returns null for new users, fallback to 'c'
     // needsSetup is determined by appModeWasNull, not by the mode value itself


### PR DESCRIPTION
## Summary
- Auto-set consumer mode ('c') for existing users upgrading to version with appMode
- Prevents mode selection dialog from appearing on upgrade

## Fix
In `useAppMode.ts`, detect old users (has `sudowork_auth_v2` but no `appMode` in ConfigStorage) and automatically write `'c'` to ConfigStorage.

| Scenario | Behavior |
|----------|----------|
| Old user upgrade | Write 'c', no mode selection |
| New user | Show mode selection |
| User already set mode | No change |