### PR TITLE
fix(enterprise): remove hardcoded Moss Server URL default value

### DIFF
--- a/src/process/WorkerManage.ts
+++ b/src/process/WorkerManage.ts
@@ -58,7 +58,16 @@ const buildConversation = (conversation: TChatConversation, options?: BuildConve
         dangerouslySkipPermissions?: boolean;
         runtimeType?: 'host' | 'docker';
       };
-      const mossServerUrl = extra?.mossServerUrl || 'http://127.0.0.1:43127';
+
+      // Moss Server URL must be configured in enterprise settings
+      // Moss Server URL 必须在企业设置中配置
+      // Do NOT use hardcoded default value - read from enterprise config instead
+      // 不使用硬编码默认值 - 从企业配置读取
+      const mossServerUrl = extra?.mossServerUrl;
+      if (!mossServerUrl) {
+        mainError('WorkerManage', 'Moss Server URL not configured for remote-agent conversation');
+        return null;
+      }
       const authToken = extra?.authToken || '';
       const wsUrl = extra?.acpWsUrl;
       const mossSessionPending = extra?.mossSessionPending;

--- a/src/process/providers/RemoteConversationProvider.ts
+++ b/src/process/providers/RemoteConversationProvider.ts
@@ -76,7 +76,15 @@ export class RemoteConversationProvider implements IConversationProvider {
     // Start initialization
     // 开始初始化
     this.mossApiPromise = (async () => {
-      const api = initMossApi(this.config.mossServerUrl || 'http://127.0.0.1:43127');
+      // Moss Server URL must be configured in enterprise settings
+      // Moss Server URL 必须在企业设置中配置
+      // Do NOT use hardcoded default value - read from enterprise config instead
+      // 不使用硬编码默认值 - 从企业配置读取
+      if (!this.config.mossServerUrl) {
+        throw new Error('Moss Server URL not configured. Please configure server URL in enterprise settings.');
+      }
+
+      const api = initMossApi(this.config.mossServerUrl);
 
       // Use JWT token directly (from eeclaw auth storage)
       // 直接使用 JWT token（来自 eeclaw auth storage）


### PR DESCRIPTION
## Summary
- Remove hardcoded Moss Server URL default value (`http://127.0.0.1:43127`)
- Moss Server URL should be read from enterprise settings (`eeclaw.serverUrl`)
- Add proper error handling when Moss Server URL is not configured

## Changes
- `WorkerManage.ts`: Check `mossServerUrl` exists before creating RemoteAgent, return null if not configured
- `RemoteConversationProvider.ts`: Throw error if `mossServerUrl` not configured

## Test plan
- [ ] Enterprise mode login with configured server URL works correctly
- [ ] Enterprise mode without server URL shows proper error message
- [ ] Local mode (non-enterprise) is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)