### PR TITLE
fix(enterprise): reset provider after enterprise login

### DIFF
--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -8,6 +8,7 @@ import { ipcBridge } from '@/common';
 import { ProcessConfig } from '@process/initStorage';
 import { mainWarn, mainLog } from '@process/utils/mainLogger';
 import { setCachedAuthToken, setCachedServerUrl, setCachedAppMode } from '@/common/enterpriseDebugConfig';
+import { resetConversationProvider } from '../providers';
 
 export function initEeclawBridge(): void {
   // Set app mode and update main process cache
@@ -72,7 +73,11 @@ export function initEeclawBridge(): void {
       setCachedAuthToken(data.access_token);
       setCachedAppMode('e');
 
-      mainLog('eeclawBridge', 'Login successful, cache updated');
+      // Reset provider singleton so next call creates RemoteConversationProvider
+      // 重置 Provider 单例，下次调用时会创建 RemoteConversationProvider
+      resetConversationProvider();
+
+      mainLog('eeclawBridge', 'Login successful, cache updated, provider reset');
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
- Fix timing issue where `ConversationProvider` was created before enterprise login completed
- Add `resetConversationProvider()` call after successful enterprise login to ensure the correct `RemoteConversationProvider` is created

## Problem
When an enterprise user logs in, the logs showed:
```
[INFO] App mode set to: e
[INFO] Using REMOTE provider (Enterprise Mode) - Server: not set, Token: not set
[INFO] Enterprise config incomplete, falling back to LOCAL provider
```

This happened because:
1. User selects enterprise mode → `setAppMode('e')` is called
2. Some service calls `getConversationProvider()` before login completes
3. Provider is created as `LocalConversationProvider` (singleton) because config is incomplete
4. User completes login → cache is updated but Provider singleton is NOT reset
5. All subsequent requests use the wrong `LocalConversationProvider`

## Solution
Call `resetConversationProvider()` in `eeclawBridge.ts` after successful login, so the next call to `getConversationProvider()` creates the correct `RemoteConversationProvider`.

## Test plan
- [ ] Enterprise user can login and use remote provider correctly
- [ ] Check logs show "Login successful, cache updated, provider reset"
- [ ] Verify conversations are stored on Moss Server after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)