### PR TITLE
fix: append refresh_token to WebSocket URL for server-side refresh

### DIFF
--- a/src/agent/remote/MossWsConnection.ts
+++ b/src/agent/remote/MossWsConnection.ts
@@ -222,12 +222,22 @@ export class MossWsConnection {
       throw new Error('No ws_url available');
     }
 
+    // Append refresh_token to wsUrl for server-side token refresh on WS upgrade
+    let wsUrlWithRefresh = this.wsUrl!;
+    try {
+      const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
+      if (authStorage?.refresh_token) {
+        const separator = wsUrlWithRefresh.includes('?') ? '&' : '?';
+        wsUrlWithRefresh += `${separator}refresh_token=${encodeURIComponent(authStorage.refresh_token)}`;
+      }
+    } catch { /* ignore */ }
+
     return new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         reject(new Error('WebSocket connection timeout'));
       }, this.CONNECTION_TIMEOUT_MS);
 
-      this.ws = new WebSocket(this.wsUrl!, {
+      this.ws = new WebSocket(wsUrlWithRefresh, {
         headers: { 'Authorization': `Bearer ${this.accessToken}` },
       });
 

--- a/src/agent/remote/MossWsConnection.ts
+++ b/src/agent/remote/MossWsConnection.ts
@@ -9,6 +9,7 @@ import type { IResponseMessage } from '@/common/ipcBridge';
 import { uuid } from '@/common/utils';
 import { mainLog, mainError } from '@/process/utils/mainLogger';
 import { ProcessConfig } from '@/process/initStorage';
+import { getValidToken } from '@/process/bridge/eeclawBridge';
 
 /**
  * Moss Server WebSocket connection config
@@ -116,42 +117,16 @@ export class MossWsConnection {
       return this.config.authToken;
     }
 
-    // Try to get token from ProcessConfig if authToken is empty
+    // Try shared getValidToken which handles refresh with dedup
     if (!this.config.authToken) {
       try {
-        const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
-        if (authStorage?.access_token?.startsWith('eyJ')) {
-          this.config.authToken = authStorage.access_token;
-          return authStorage.access_token;
-        }
-        // Try refresh token if access token is missing/expired
-        if (authStorage?.refresh_token) {
-          const response = await fetch(`${this.config.serverUrl}/api/v1/auth/token`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              ...(authStorage.device_id ? { 'X-Device-Id': authStorage.device_id } : {}),
-            },
-            body: JSON.stringify({
-              grant_type: 'refresh_token',
-              refresh_token: authStorage.refresh_token,
-            }),
-            signal: AbortSignal.timeout(15000),
-          });
-          const data = await response.json();
-          if (response.ok && data.access_token) {
-            await ProcessConfig.set('eeclaw.authStorage', {
-              access_token: data.access_token,
-              refresh_token: data.refresh_token || authStorage.refresh_token,
-              expires_at: Date.now() + (data.expires_in || 3600) * 1000,
-              device_id: authStorage.device_id,
-            });
-            this.config.authToken = data.access_token;
-            return data.access_token;
-          }
+        const token = await getValidToken();
+        if (token) {
+          this.config.authToken = token;
+          return token;
         }
       } catch (e) {
-        mainError('MossWsConnection', 'Failed to get token from ProcessConfig:', e);
+        mainError('MossWsConnection', 'Failed to get valid token:', e);
       }
     }
 
@@ -199,14 +174,33 @@ export class MossWsConnection {
       body.runtime = { type: this.config.runtimeType };
     }
 
-    const response = await fetch(`${this.config.serverUrl}/api/v1/sessions`, {
+    let token = this.accessToken || await getValidToken();
+    let response = await fetch(`${this.config.serverUrl}/api/v1/sessions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.accessToken}`,
+        'Authorization': `Bearer ${token}`,
       },
       body: JSON.stringify(body),
     });
+
+    if (response.status === 401) {
+      mainLog('MossWsConnection', 'Create session returned 401, force refreshing token and retrying');
+      try {
+        token = await getValidToken(true);
+        this.accessToken = token;
+        response = await fetch(`${this.config.serverUrl}/api/v1/sessions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+          },
+          body: JSON.stringify(body),
+        });
+      } catch (refreshError) {
+        mainError('MossWsConnection', 'Token refresh on 401 failed:', refreshError);
+      }
+    }
 
     if (!response.ok) {
       const text = await response.text();

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -12,7 +12,7 @@ import { resetConversationProvider } from '../providers';
 
 let refreshPromise: Promise<string> | null = null;
 
-async function getValidToken(): Promise<string> {
+export async function getValidToken(forceRefresh = false): Promise<string> {
   const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
   const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
 
@@ -22,26 +22,28 @@ async function getValidToken(): Promise<string> {
 
   const { access_token, refresh_token, expires_at, device_id } = authStorage;
 
-  // If token is still valid (more than 5 minutes before expiration), return it
-  // 如果令牌仍然有效（距离过期超过 5 分钟），则返回它
-  if (expires_at > Date.now() + 5 * 60 * 1000) {
+  const now = Date.now();
+  const remainingMs = expires_at - now;
+
+  if (!forceRefresh && expires_at > now + 5 * 60 * 1000) {
+    mainLog('eeclawBridge', `[getValidToken] Token still valid (remaining=${Math.round(remainingMs / 1000)}s), returning cached access_token`);
     return access_token;
   }
 
-  // If already refreshing, wait for it
-  // 如果已经在刷新，则等待它
   if (refreshPromise) {
+    mainLog('eeclawBridge', '[getValidToken] Refresh already in progress, waiting...');
     return refreshPromise;
   }
 
-  // Start refresh
-  // 开始刷新
+  mainLog('eeclawBridge', `[getValidToken] ${forceRefresh ? 'Force refresh requested' : `Token expired (remaining=${Math.round(remainingMs / 1000)}s)`}, starting refresh (refresh_token=${refresh_token ? refresh_token.slice(0, 20) + '...' : 'NONE'})`);
+
   refreshPromise = (async () => {
     try {
       if (!refresh_token) {
         throw new Error('No refresh token available');
       }
 
+      mainLog('eeclawBridge', `[getValidToken] Sending refresh request to ${serverUrl}/api/v1/auth/token`);
       const response = await fetch(`${serverUrl}/api/v1/auth/token`, {
         method: 'POST',
         headers: {
@@ -58,15 +60,18 @@ async function getValidToken(): Promise<string> {
       const data = await response.json();
 
       if (!response.ok) {
+        mainWarn('eeclawBridge', `[getValidToken] Refresh failed: status=${response.status}, error=${data?.error || 'unknown'}`);
         throw new Error(data?.error || 'token_refresh_failed');
       }
 
       const newAuthStorage = {
         access_token: data.access_token,
-        refresh_token: data.refresh_token || refresh_token, // Keep old one if not provided
+        refresh_token: data.refresh_token || refresh_token,
         expires_at: Date.now() + (data.expires_in || 3600) * 1000,
         device_id,
       };
+
+      mainLog('eeclawBridge', `[getValidToken] Refresh successful! new_expires_at=${newAuthStorage.expires_at}, new_refresh_token=${newAuthStorage.refresh_token ? newAuthStorage.refresh_token.slice(0, 20) + '...' : 'NONE'}`);
 
       await ProcessConfig.set('eeclaw.authStorage', newAuthStorage);
       setCachedAuthToken(data.access_token);

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -5,96 +5,11 @@
  */
 
 import { mainLog, mainError } from '@process/utils/mainLogger';
+import { getValidToken } from '@process/bridge/eeclawBridge';
 import { ProcessConfig } from '@process/initStorage';
-import { setCachedAuthToken } from '@/common/enterpriseDebugConfig';
-import { ipcBridge } from '@/common';
 import WebSocket from 'ws';
 import { uuid } from '@/common/utils';
 import type { IResponseMessage } from '@/common/ipcBridge';
-
-let refreshPromise: Promise<string> | null = null;
-
-async function getValidToken(): Promise<string> {
-  const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
-  if (!authStorage) {
-    throw new Error('No auth storage found');
-  }
-
-  const { access_token, refresh_token, expires_at, device_id } = authStorage;
-
-  if (expires_at > Date.now() + 5 * 60 * 1000) {
-    return access_token;
-  }
-
-  if (refreshPromise) {
-    return refreshPromise;
-  }
-
-  refreshPromise = (async () => {
-    try {
-      const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
-      if (!serverUrl) {
-        throw new Error('No server URL found');
-      }
-
-      if (!refresh_token) {
-        throw new Error('No refresh token available');
-      }
-
-      const response = await fetch(`${serverUrl}/api/v1/auth/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(device_id ? { 'X-Device-Id': device_id } : {}),
-        },
-        body: JSON.stringify({
-          grant_type: 'refresh_token',
-          refresh_token,
-        }),
-        signal: AbortSignal.timeout(15000),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data?.error || 'token_refresh_failed');
-      }
-
-      const newAuthStorage = {
-        access_token: data.access_token,
-        refresh_token: data.refresh_token || refresh_token,
-        expires_at: Date.now() + (data.expires_in || 3600) * 1000,
-        device_id,
-      };
-
-      await ProcessConfig.set('eeclaw.authStorage', newAuthStorage);
-      setCachedAuthToken(data.access_token);
-
-      // We explicitly DO NOT update enterprise config globally from here
-      // ProcessConfig handles sync internally for 'eeclaw.authStorage'
-
-      // Notify renderer process about the refreshed token
-      try {
-        ipcBridge.eeclaw.tokenRefreshed.emit({
-          access_token: data.access_token,
-          refresh_token: data.refresh_token || refresh_token,
-          expires_at: newAuthStorage.expires_at,
-        });
-      } catch (e) {
-        mainLog('MossSessionApi', 'Failed to emit token refresh event to renderer:', e);
-      }
-
-      return data.access_token;
-    } catch (error) {
-      mainError('MossSessionApi', 'Token refresh failed:', error);
-      throw error;
-    } finally {
-      refreshPromise = null;
-    }
-  })();
-
-  return refreshPromise;
-}
 
 /**
  * Moss Server Session API client
@@ -141,6 +56,44 @@ export class MossSessionApi {
   }
 
   /**
+   * Force refresh the access token, ignoring cache.
+   * Used when a 401 response indicates the current token is invalid on the server.
+   */
+  async forceRefreshToken(): Promise<string> {
+    mainLog('MossSessionApi', 'Force refreshing token due to 401');
+    this.accessToken = null;
+    const token = await getValidToken(true);
+    this.accessToken = token;
+    return token;
+  }
+
+  /**
+   * Fetch with automatic 401 retry: if the first request returns 401,
+   * force-refresh the token and retry once.
+   */
+  private async fetchWithRetry(url: string, options: RequestInit): Promise<Response> {
+    const token = await this.ensureAuthenticated();
+    const headers = new Headers(options.headers);
+    headers.set('Authorization', `Bearer ${token}`);
+
+    let response = await fetch(url, { ...options, headers });
+
+    if (response.status === 401) {
+      mainLog('MossSessionApi', `Request to ${url} returned 401, attempting token refresh and retry`);
+      try {
+        const newToken = await this.forceRefreshToken();
+        const retryHeaders = new Headers(options.headers);
+        retryHeaders.set('Authorization', `Bearer ${newToken}`);
+        response = await fetch(url, { ...options, headers: retryHeaders });
+      } catch (refreshError) {
+        mainError('MossSessionApi', 'Token refresh on 401 failed:', refreshError);
+      }
+    }
+
+    return response;
+  }
+
+  /**
    * Get all sessions from Moss Server
    * GET /api/v1/sessions
    *
@@ -153,13 +106,8 @@ export class MossSessionApi {
    * 此方法仅保留用于未来的管理/调试目的。
    */
   async listSessions(): Promise<MossSession[]> {
-    const token = await this.ensureAuthenticated();
-
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions`, {
       method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (!response.ok) {
@@ -176,8 +124,6 @@ export class MossSessionApi {
    * POST /api/v1/sessions
    */
   async createSession(params: { cwd?: string; assistantName?: string; dangerouslySkipPermissions?: boolean; runtimeType?: 'host' | 'docker' }): Promise<MossSession> {
-    const token = await this.ensureAuthenticated();
-
     mainLog('MossSessionApi', `Creating session: cwd=${params.cwd}, assistant=${params.assistantName || 'default'}`);
 
     const body: Record<string, unknown> = {
@@ -186,19 +132,14 @@ export class MossSessionApi {
       assistant_name: params.assistantName,
     };
 
-    // Only include runtime if runtimeType is specified
-    // 只有当 runtimeType 指定时才包含 runtime 字段
-    // Moss Server will use its default if not provided
-    // 如果不提供，Moss Server 会使用默认值
     if (params.runtimeType) {
       body.runtime = { type: params.runtimeType };
     }
 
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(body),
     });
@@ -218,13 +159,8 @@ export class MossSessionApi {
    * GET /api/v1/sessions/{sessionId}
    */
   async getSession(sessionId: string): Promise<MossSession> {
-    const token = await this.ensureAuthenticated();
-
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions/${sessionId}`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions/${sessionId}`, {
       method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (!response.ok) {
@@ -243,15 +179,10 @@ export class MossSessionApi {
    * DELETE /api/v1/sessions/{sessionId}
    */
   async deleteSession(sessionId: string): Promise<void> {
-    const token = await this.ensureAuthenticated();
-
     mainLog('MossSessionApi', `Deleting session: ${sessionId}`);
 
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions/${sessionId}`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions/${sessionId}`, {
       method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (!response.ok) {
@@ -274,15 +205,12 @@ export class MossSessionApi {
    * PATCH /api/v1/sessions/{sessionId}
    */
   async updateSession(sessionId: string, updates: { title?: string }): Promise<MossSession> {
-    const token = await this.ensureAuthenticated();
-
     mainLog('MossSessionApi', `Updating session: ${sessionId}, updates: ${JSON.stringify(updates)}`);
 
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions/${sessionId}`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions/${sessionId}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(updates),
     });
@@ -317,15 +245,10 @@ export class MossSessionApi {
       messages: any[];
     };
   }> {
-    const token = await this.ensureAuthenticated();
-
     mainLog('MossSessionApi', `Getting session context: ${sessionId}`);
 
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions/${sessionId}/context`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions/${sessionId}/context`, {
       method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (!response.ok) {
@@ -343,15 +266,10 @@ export class MossSessionApi {
    * POST /api/v1/sessions/{sessionId}/terminate
    */
   async terminateSession(sessionId: string): Promise<void> {
-    const token = await this.ensureAuthenticated();
-
     mainLog('MossSessionApi', `Terminating session: ${sessionId}`);
 
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions/${sessionId}/terminate`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions/${sessionId}/terminate`, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (!response.ok) {
@@ -374,15 +292,10 @@ export class MossSessionApi {
    * POST /api/v1/sessions/{sessionId}/resume
    */
   async resumeSession(sessionId: string): Promise<{ wsUrl: string; session: MossSession }> {
-    const token = await this.ensureAuthenticated();
-
     mainLog('MossSessionApi', `Resuming session: ${sessionId}`);
 
-    const response = await fetch(`${this.serverUrl}/api/v1/sessions/${sessionId}/resume`, {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/sessions/${sessionId}/resume`, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (!response.ok) {

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -412,7 +412,17 @@ export class MossSessionApi {
     const token = await this.ensureAuthenticated();
     mainLog('MossSessionApi', `Connecting to WebSocket: ${wsUrl}`);
 
-    const ws = new WebSocket(wsUrl, {
+    // Append refresh_token to wsUrl for server-side token refresh on WS upgrade
+    let wsUrlWithRefresh = wsUrl;
+    try {
+      const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
+      if (authStorage?.refresh_token) {
+        const separator = wsUrlWithRefresh.includes('?') ? '&' : '?';
+        wsUrlWithRefresh += `${separator}refresh_token=${encodeURIComponent(authStorage.refresh_token)}`;
+      }
+    } catch { /* ignore */ }
+
+    const ws = new WebSocket(wsUrlWithRefresh, {
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -562,13 +562,33 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           setReady(true);
 
           // Sync token to ConfigStorage for eeclawBridge
+          // Prefer ProcessConfig's refresh_token if it's newer (main process may have rotated it)
           try {
+            const existingConfig = await ConfigStorage.get('eeclaw.authStorage');
+            const configRefreshToken = existingConfig?.refresh_token;
+            const configExpiresAt = existingConfig?.expires_at;
+
+            // Use the newer refresh_token: the one from ProcessConfig if it was refreshed by main process
+            const useConfigRefreshToken = configRefreshToken && configRefreshToken !== authStorage.refresh_token;
+            const finalRefreshToken = useConfigRefreshToken ? configRefreshToken : authStorage.refresh_token;
+            const finalExpiresAt = (configExpiresAt && configExpiresAt > authStorage.expires_at) ? configExpiresAt : authStorage.expires_at;
+            const finalAccessToken = (configExpiresAt && configExpiresAt > authStorage.expires_at && existingConfig?.access_token) ? existingConfig.access_token : authStorage.access_token;
+
             await ConfigStorage.set('eeclaw.authStorage', {
-              access_token: authStorage.access_token,
-              refresh_token: authStorage.refresh_token,
-              expires_at: authStorage.expires_at,
+              access_token: finalAccessToken,
+              refresh_token: finalRefreshToken,
+              expires_at: finalExpiresAt,
               device_id: authStorage.device_id,
             });
+
+            // If ProcessConfig had a newer token, also update localStorage
+            if (finalRefreshToken !== authStorage.refresh_token || finalExpiresAt !== authStorage.expires_at) {
+              authStorage.access_token = finalAccessToken;
+              authStorage.refresh_token = finalRefreshToken;
+              authStorage.expires_at = finalExpiresAt;
+              localStorage.setItem(EECLAW_AUTH_STORAGE_KEY, JSON.stringify(authStorage));
+              console.log('[Auth] Synced newer token from ProcessConfig to localStorage');
+            }
           } catch (e) {
             console.warn('[Auth] Failed to sync eeclaw auth to ConfigStorage:', e);
           }
@@ -690,6 +710,32 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       abortRef.current?.abort();
     };
   }, [refresh]);
+
+  // Sync token refresh events from main process to renderer localStorage
+  // Main process (MossSessionApi/eeclawBridge) may refresh tokens, revoking the old
+  // refresh_token on the server. Without this sync, renderer would try to use the
+  // old refresh_token and get "Invalid refresh token" errors.
+  useEffect(() => {
+    const unsubscribe = ipcBridge.eeclaw.tokenRefreshed.on((data) => {
+      const eeclawStored = localStorage.getItem(EECLAW_AUTH_STORAGE_KEY);
+      if (eeclawStored) {
+        try {
+          const authStorage: EeclawAuthStorage = JSON.parse(eeclawStored);
+          authStorage.access_token = data.access_token;
+          authStorage.refresh_token = data.refresh_token;
+          authStorage.expires_at = data.expires_at;
+          localStorage.setItem(EECLAW_AUTH_STORAGE_KEY, JSON.stringify(authStorage));
+          setUser({ ...authStorage.user, token: data.access_token });
+          console.log('[Auth] Token synced from main process refresh');
+        } catch (e) {
+          console.error('[Auth] Failed to sync token refresh from main process:', e);
+        }
+      }
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   const login = useCallback(async ({ phone, code, enterprise_code, invitation_code: _invitation_code, remember: _remember }: LoginParams): Promise<LoginResult> => {
     const deviceId = getDeviceId();


### PR DESCRIPTION
## Summary
- Append `refresh_token` as query parameter to WebSocket URL when connecting to Moss server
- Enables server-side token refresh during WS upgrade when access_token is expired

## Changes
- `src/agent/remote/MossWsConnection.ts`: Append refresh_token from ProcessConfig to wsUrl query params
- `src/process/remote/MossSessionApi.ts`: Append refresh_token from ProcessConfig to wsUrl query params

## Test plan
- [ ] Login to enterprise, wait for access_token to expire
- [ ] Create new session, verify WS connection succeeds with automatic token refresh
- [ ] Verify active WS session continues working after token refresh