### PR TITLE
fix(enterprise): local conversation storage with on-click sync

### DIFF
--- a/docs/plans/2026-05-07-enterprise-local-conversation-storage-design.md
+++ b/docs/plans/2026-05-07-enterprise-local-conversation-storage-design.md
@@ -1,0 +1,220 @@
+# Design: Enterprise Mode Local Conversation Storage + On-Click Sync
+
+## Context
+
+企业模式下，会话历史存储采用"完全云端"模型：
+- 会话元数据存储在本地 SQLite（用于侧边栏展示）
+- 消息仅存储在 Moss Server，不持久化到本地
+- 每次查看历史消息时，都需调用 `getSessionContext()` 从 Moss Server 拉取
+- 离线状态下无法查看任何历史消息
+- 如果 Moss Server 不可用，已查看过的会话也无法加载
+
+## Objectives
+
+1. 企业用户会话消息同时存储在本地 DB（Moss Server 已有留存，无需修改）
+2. 企业用户新建会话保证生成的会话名称正确存储在本地会话表，确保历史列表展示正确
+3. 企业用户点击具体历史会话时触发一次从 Moss Server 同步历史会话记录的操作（同步完成后校准本地会话记录）
+4. 企业会话历史存储逻辑从完全云端，修改为本地存储 + 点击具体 session 时触发同步的模式
+
+## Architecture
+
+### 核心变更：从"完全云端"到"本地存储 + 点击同步"
+
+**之前：**
+```
+点击历史会话 → 每次从 Moss Server API 拉取消息 → 显示
+```
+
+**之后：**
+```
+点击历史会话 → 先从本地 DB 读取（即时显示）→ 后台从 Moss Server 同步 → 更新本地 DB + 名称
+```
+
+### 1. 提取消息转换逻辑为可复用方法
+
+**File:** `src/process/providers/RemoteConversationProvider.ts`
+
+原 `getMessages()` 方法内联了约 270 行 Moss→TMessage 转换逻辑，提取为：
+
+```typescript
+private convertMossMessagesToTMessages(
+  mossMessages: any[],
+  conversationId: string,
+  mossSessionId: string,
+): { messages: TMessage[]; foundModel: string }
+```
+
+供 `getMessages()` 和新增的 `syncFromMossServer()` 复用。
+
+### 2. 新增 `syncFromMossServer()` 方法
+
+**File:** `src/process/providers/RemoteConversationProvider.ts`
+
+```typescript
+async syncFromMossServer(conversationId: string): Promise<{ syncedCount: number; nameUpdated: boolean }>
+```
+
+执行流程：
+1. 从 DB 获取会话记录，提取 `mossSessionId`
+2. 调用 `api.getSessionContext(mossSessionId)` 从 Moss Server 获取消息
+3. 使用 `convertMossMessagesToTMessages()` 转换消息格式
+4. 调用 `db.deleteConversationMessages()` 清除本地旧消息（避免重复）
+5. 逐条 `db.insertMessage()` 写入转换后的消息
+6. 若 `contextData.context.customTitle` 存在且与本地名称不同，更新 `conversation.name`
+7. 更新 `extra.mossSessionUpdatedAt = Date.now()` 时间戳
+8. 返回 `{ syncedCount, nameUpdated }`
+
+### 3. 修改 `getMessages()` 为本地优先策略
+
+**File:** `src/process/providers/RemoteConversationProvider.ts`
+
+```typescript
+async getMessages(conversationId: string, _page = 0, _pageSize = 10000): Promise<TMessage[]>
+```
+
+变更：
+1. 先查询本地 DB：`db.getConversationMessages(conversationId, 0, 10000)`
+2. 若本地有消息 → 直接返回（快速、支持离线）
+3. 若本地无消息且 `mossSessionId` 存在 → 从 Moss Server 拉取并保存到本地，返回消息
+4. 若 `mossSessionPending` 或无 `mossSessionId` → 返回空数组
+
+### 4. 新增 IPC Bridge 端点
+
+**File:** `src/common/ipcBridge.ts`
+
+```typescript
+syncMessages: bridge.buildProvider<
+  IBridgeResponse<{ syncedCount: number; nameUpdated: boolean }>,
+  { conversation_id: string }
+>('conversation.sync-messages')
+```
+
+### 5. 注册同步处理器
+
+**File:** `src/process/bridge/conversationBridge.ts`
+
+```typescript
+ipcBridge.conversation.syncMessages.provider(async ({ conversation_id }) => {
+  const provider = getConversationProvider();
+  if (provider.type !== 'remote' || !provider.syncFromMossServer) {
+    return { success: true, data: { syncedCount: 0, nameUpdated: false } };
+  }
+  const result = await provider.syncFromMossServer(conversation_id);
+  if (result.nameUpdated) {
+    ipcBridge.database.conversationChanged.emit({ ... });
+  }
+  return { success: true, data: result };
+});
+```
+
+### 6. 页面加载时触发同步（渲染进程）
+
+**File:** `src/renderer/pages/conversation/index.tsx`
+
+在会话数据通过 SWR 加载后，若为 `remote-agent` 类型且有 `mossSessionId`：
+
+```typescript
+useEffect(() => {
+  if (!data || data.type !== 'remote-agent') return;
+  const extra = data.extra as { mossSessionId?: string; mossSessionPending?: boolean };
+  if (!extra?.mossSessionId || extra?.mossSessionPending) return;
+
+  ipcBridge.conversation.syncMessages
+    .invoke({ conversation_id: id! })
+    .then((result) => {
+      if (result.data?.nameUpdated) {
+        emitter.emit('chat.history.refresh');
+        void mutate();
+      }
+    })
+    .catch(...);
+}, [data?.id, data?.type]);
+```
+
+### 7. Provider 接口扩展
+
+**File:** `src/process/providers/types.ts`
+
+```typescript
+export interface IConversationProvider {
+  // ... existing methods
+
+  /**
+   * Sync messages from remote server to local DB (enterprise mode only)
+   */
+  syncFromMossServer?(conversationId: string): Promise<{ syncedCount: number; nameUpdated: boolean }>;
+}
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/process/providers/RemoteConversationProvider.ts` | 提取 `convertMossMessagesToTMessages()`，新增 `syncFromMossServer()`，修改 `getMessages()` 为本地优先 + Moss 不可用时仅日志，修改 `getConversation()` 直接返回本地记录不阻塞 |
+| `src/process/providers/types.ts` | 新增 `syncFromMossServer?()` 到 `IConversationProvider` 接口 |
+| `src/common/ipcBridge.ts` | 新增 `syncMessages` bridge 端点 |
+| `src/process/bridge/conversationBridge.ts` | 注册 `syncMessages` 处理器 |
+| `src/renderer/pages/conversation/index.tsx` | 页面加载时触发远程会话同步，同步完成后刷新消息列表 |
+| `src/process/bridge/databaseBridge.ts` | 更新注释，反映本地优先策略 |
+| `src/process/task/RemoteAgent.ts` | `handleStreamMessage()` 新增 `addOrUpdateMessage()` 持久化流式消息到本地 DB |
+
+## Real-time Message Persistence
+
+实时消息持久化通过主进程 + 渲染进程双路径完成：
+
+**主进程路径（新增）：**
+- `RemoteAgent.handleStreamMessage()` 在 IPC 转发后，调用 `addOrUpdateMessage()` 将消息写入本地 DB
+- 覆盖消息类型：`content`/`user_content`/`acp_tool_call`/`error`
+- 新增 `streamMsgToTMessage()` 方法将 `IResponseMessage` 转换为 `TMessage` 格式
+
+**渲染进程路径（已有）：**
+- `RemoteAgent` 通过 IPC `responseStream` 发送流式消息
+- `AcpSendBox`（remote-agent 复用 AcpChat）接收消息并调用 `addOrUpdateMessageList`
+- `useAddOrUpdateMessage` hook 批量通过 `ipcBridge.conversation.addMessage` 保存到本地 DB
+- 与 AcpAgent/OpenClawAgent 的持久化管线一致
+
+## Bugs Fixed During Implementation
+
+### Bug 1: 点击历史会话白屏
+
+**现象：** 点击企业历史会话后页面白屏，无内容展示。
+
+**根因：** `RemoteConversationProvider.getConversation()` 在返回本地 DB 记录前，同步调用 Moss Server 的 `getSession()` + `resumeSession()` API 获取 `wsUrl`。这些网络请求阻塞了 SWR 数据加载，Moss Server 不可用或响应慢时，页面一直处于 `isLoading` 状态，导致白屏。
+
+**修复：** `getConversation()` 改为直接返回本地 DB 记录，不再阻塞等待 Moss Server API。Moss Server 连接（resume/attach）延迟到用户实际发送消息时由 `RemoteAgent.initAgent()` 处理。
+
+**File:** `src/process/providers/RemoteConversationProvider.ts` — `getConversation()` 方法
+
+### Bug 2: 同步完成后历史消息不显示
+
+**现象：** 点击历史会话后不再白屏，但会话历史消息列表为空。
+
+**根因：** 两个问题叠加导致：
+1. `RemoteAgent.handleStreamMessage()` 仅通过 IPC `responseStream` 转发消息到渲染进程，**未调用 `addOrUpdateMessage()` 将消息持久化到本地 DB**（对比 AcpAgent/OpenClawAgent 均有持久化调用）。因此实时消息只会存在于渲染进程内存中，刷新或切回后丢失。
+2. `syncFromMossServer()` 完成后未触发消息列表刷新，本地 DB 已更新但 UI 未重新读取。
+
+**修复：**
+1. 在 `RemoteAgent.handleStreamMessage()` 中新增 `addOrUpdateMessage()` 调用，将 `content`/`user_content`/`acp_tool_call`/`error` 类型的流式消息实时写入本地 DB
+2. 在 `conversation/index.tsx` 的 sync 回调中，当 `syncedCount > 0` 或 `nameUpdated` 时触发 `emitter.emit('chat.history.refresh')` + `mutate()` 刷新侧边栏和消息列表
+
+**Files:**
+- `src/process/task/RemoteAgent.ts` — `handleStreamMessage()` + 新增 `streamMsgToTMessage()` 转换方法
+- `src/renderer/pages/conversation/index.tsx` — sync 回调中触发刷新
+
+### Bug 3: Moss Server 不可用时 getMessages() 日志过于激进
+
+**现象：** Moss Server 不可用时，`getMessages()` 的 `mainError` 日志大量输出，干扰排查。
+
+**修复：** `getMessages()` 中 Moss Server API 调用用独立 try-catch 包裹，失败时仅用 `mainLog` 记录（而非 `mainError`），返回空数组不抛出异常。
+
+**File:** `src/process/providers/RemoteConversationProvider.ts` — `getMessages()` 方法
+
+## Verification
+
+1. 新建企业会话 → 验证侧边栏历史显示正确名称
+2. 发送消息 → 验证消息持久化到本地 DB
+3. 关闭并重开应用 → 验证历史列表显示正确会话名称
+4. 点击历史会话 → 验证先从本地 DB 加载消息，然后后台从 Moss Server 同步
+5. 同步完成后验证本地消息与 Moss Server 消息一致，名称如有变更则更新
+6. 离线测试：断开 Moss Server → 验证已查看过的会话仍可从本地 DB 加载消息
+7. 验证非企业模式（ACP/OpenClaw）会话不受影响

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -62,6 +62,8 @@ export const conversation = {
   flushPendingMessages: bridge.buildProvider<void, { conversation_id: string }>('conversation.flush-pending-messages'),
   // Add a single message to the database (used for saving pending messages before unmount)
   addMessage: bridge.buildProvider<void, { conversation_id: string; message: import('@/common/chatLib').TMessage }>('conversation.add-message'),
+  // Sync messages from Moss Server to local DB (enterprise mode, triggered on conversation click)
+  syncMessages: bridge.buildProvider<IBridgeResponse<{ syncedCount: number; nameUpdated: boolean }>, { conversation_id: string }>('conversation.sync-messages'),
   confirmation: {
     add: bridge.buildEmitter<IConfirmation<any> & { conversation_id: string }>('confirmation.add'),
     update: bridge.buildEmitter<IConfirmation<any> & { conversation_id: string }>('confirmation.update'),

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -1147,4 +1147,29 @@ This identity statement takes priority over the default identity in USER.md.
       return Promise.resolve();
     }
   });
+
+  // Sync messages from Moss Server to local DB (enterprise mode, triggered on conversation click)
+  ipcBridge.conversation.syncMessages.provider(async ({ conversation_id }) => {
+    try {
+      const provider = getConversationProvider();
+      if (provider.type !== 'remote' || !provider.syncFromMossServer) {
+        return { success: true, data: { syncedCount: 0, nameUpdated: false } };
+      }
+
+      const result = await provider.syncFromMossServer(conversation_id);
+
+      if (result.nameUpdated) {
+        ipcBridge.database.conversationChanged.emit({
+          conversationId: conversation_id,
+          source: 'aionui',
+          action: 'updated',
+        });
+      }
+
+      return { success: true, data: result };
+    } catch (error) {
+      mainError('conversationBridge', 'Error syncing messages from Moss Server:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error), data: { syncedCount: 0, nameUpdated: false } };
+    }
+  });
 }

--- a/src/process/bridge/databaseBridge.ts
+++ b/src/process/bridge/databaseBridge.ts
@@ -14,9 +14,10 @@ export function initDatabaseBridge(): void {
   ipcBridge.database.getConversationMessages.provider(({ conversation_id, page = 0, pageSize = 10000 }) => {
     try {
       const provider = getConversationProvider();
-      // Note: For remote provider, messages are stored on Moss Server, not locally
-      // 注意：对于远程 Provider，消息存储在 Moss Server 上，不在本地
-      // The provider.getMessages() returns empty array for remote-agent
+      // For remote provider, messages are now stored locally after sync
+      // Local-first approach: reads from local DB first, falls back to Moss Server API
+      // 对于远程 Provider，消息在同步后存储在本地
+      // 本地优先策略：先从本地数据库读取，回退到 Moss Server API
       return provider.getMessages(conversation_id, page, pageSize);
     } catch (error) {
       mainError('DatabaseBridge', 'Error getting conversation messages:', error);

--- a/src/process/providers/RemoteConversationProvider.ts
+++ b/src/process/providers/RemoteConversationProvider.ts
@@ -174,15 +174,21 @@ export class RemoteConversationProvider implements IConversationProvider {
   }
 
   /**
-   * Get conversation - handles both pending and existing Moss sessions
-   * 获取会话 - 处理待创建和已存在的 Moss session
+   * Get conversation - LOCAL-FIRST approach
+   * 获取会话 - 本地优先策略
+   *
+   * Returns local DB record immediately without blocking on Moss Server API calls.
+   * Moss Server connection (resume/attach) is deferred to when the user actually
+   * sends a message, avoiding white screen when Moss Server is unavailable.
+   *
+   * 立即返回本地数据库记录，不阻塞等待 Moss Server API 调用。
+   * Moss Server 连接（resume/attach）延迟到用户实际发送消息时，
+   * 避免 Moss Server 不可用时白屏。
    */
   async getConversation(id: string): Promise<TChatConversation | undefined> {
     try {
       const db = getDatabase();
 
-      // Check local cache first
-      // 先检查本地缓存
       const existing = db.getConversation(id);
       if (!existing.success || !existing.data) {
         mainLog('RemoteProvider', `Conversation ${id} not found in local DB`);
@@ -190,94 +196,7 @@ export class RemoteConversationProvider implements IConversationProvider {
       }
 
       const conversation = existing.data;
-
-      // Extract extra fields
-      // 提取 extra 字段
-      const extra = existing.data.extra as {
-        mossSessionPending?: boolean;
-        acpWsUrl?: string;
-        mossSessionId?: string;
-      };
-
-      // If Moss session is pending OR no Moss session ID exists, return local record
-      // 如果 Moss session 待创建 或者 没有 Moss session ID，返回本地记录
-      // This handles:
-      // 1. New conversations with mossSessionPending: true
-      // 2. Existing conversations where Moss session was never created (mossSessionId undefined)
-      if (extra?.mossSessionPending || !extra?.mossSessionId) {
-        mainLog('RemoteProvider', `Conversation ${id} is pending Moss session creation (pending=${extra?.mossSessionPending}, mossSessionId=${extra?.mossSessionId})`);
-        return conversation;
-      }
-
-      // Existing Moss session - get wsUrl via resume API
-      // 已存在的 Moss session - 通过 resume API 获取 wsUrl
-      // Use the actual Moss session ID, not the local conversation ID
-      // 使用实际的 Moss session ID，不是本地会话 ID
-      const mossSessionId = extra.mossSessionId;
-      const api = await this.ensureMossApi();
-
-      // First check session status via GET /api/v1/sessions/:id
-      // 先通过 GET /api/v1/sessions/:id 检查 session 状态
-      const sessionInfo = await api.getSession(mossSessionId);
-      mainLog('RemoteProvider', `Session API response: ${JSON.stringify(sessionInfo)}`);
-      const status = sessionInfo.status || sessionInfo.desiredState;
-
-      mainLog('RemoteProvider', `Session ${mossSessionId} status: ${status}`);
-
-      // If session ended/terminated, call resume API to restart
-      // 如果 session 已结束，调用 resume API 重启
-      if (status === 'ended' || status === 'terminated' || status === 'detached') {
-        mainLog('RemoteProvider', `Session ${mossSessionId} ended, resuming...`);
-        const resumeResult = await api.resumeSession(mossSessionId);
-
-        // Update conversation with new wsUrl
-        // 更新会话的 wsUrl
-        const updatedConversation = {
-          ...conversation,
-          extra: {
-            ...conversation.extra,
-            acpWsUrl: resumeResult.wsUrl,
-            mossSessionPending: false,
-          },
-          status: 'finished',
-        } as TChatConversation;
-
-        db.updateConversation(id, updatedConversation);
-        return updatedConversation;
-      }
-
-      // Session is active - get wsUrl via GET /api/v1/sessions/:id (attach mode)
-      // Session 活跃 - 通过 GET API 获取 wsUrl（attach 模式）
-      const wsUrl = sessionInfo.wsUrl || sessionInfo.ws_url;
-      if (!wsUrl) {
-        // No wsUrl in response, call resume to get one
-        // 响应中没有 wsUrl，调用 resume 获取
-        const resumeResult = await api.resumeSession(mossSessionId);
-        const updatedConversation = {
-          ...conversation,
-          extra: {
-            ...conversation.extra,
-            acpWsUrl: resumeResult.wsUrl,
-            mossSessionPending: false,
-          },
-          status: 'finished',
-        } as TChatConversation;
-
-        db.updateConversation(id, updatedConversation);
-        return updatedConversation;
-      }
-
-      // Return conversation with wsUrl
-      // 返回带有 wsUrl 的会话
-      return {
-        ...conversation,
-        extra: {
-          ...conversation.extra,
-          acpWsUrl: wsUrl,
-          mossSessionPending: false,
-        },
-        status: 'finished',
-      } as TChatConversation;
+      return conversation;
     } catch (error) {
       mainError('RemoteProvider', `Failed to get conversation: ${error instanceof Error ? error.message : String(error)}`);
       return undefined;
@@ -374,237 +293,107 @@ export class RemoteConversationProvider implements IConversationProvider {
     // 按 modifyTime 排序
     conversations.sort((a, b) => (b.modifyTime || 0) - (a.modifyTime || 0));
 
-    mainLog('RemoteProvider', `Listed ${conversations.length} remote conversations from local DB`);
     return conversations;
   }
 
   // ========== Messages / 消息 ==========
 
   /**
-   * Get messages from Moss Server
-   * 从 Moss Server 获取消息
+   * Convert Moss Server messages to TMessage format (reusable)
+   * 将 Moss Server 消息转换为 TMessage 格式（可复用）
    */
-  async getMessages(conversationId: string, _page = 0, _pageSize = 10000): Promise<TMessage[]> {
-    try {
-      const db = getDatabase();
-      const existing = db.getConversation(conversationId);
+  private convertMossMessagesToTMessages(
+    allMessages: any[],
+    conversationId: string,
+    mossSessionId: string,
+  ): { messages: TMessage[]; foundModel: string } {
+    const messages: TMessage[] = [];
+    let messageIndex = 0;
+    let foundModel = '';
 
-      // If session is pending or no Moss session ID, no messages yet
-      // 如果 session 待创建 或者 没有 Moss session ID，还没有消息
-      const extra = existing.data?.extra as { mossSessionPending?: boolean; mossSessionId?: string } | undefined;
-      if (!existing.success || !existing.data || extra?.mossSessionPending || !extra?.mossSessionId) {
-        mainLog('RemoteProvider', `Session ${conversationId} is pending or no Moss session ID, no messages`);
-        return [];
+    for (const msg of allMessages) {
+      const msgType = msg.type;
+      const innerRole = msg.message?.role;
+      const msgModel = msg.message?.model;
+
+      if (msgType === 'assistant' && msgModel) {
+        foundModel = msgModel;
       }
 
-      // Use the actual Moss session ID for API calls
-      // 使用实际的 Moss session ID 进行 API 调用
-      const mossSessionId = extra.mossSessionId;
-      const api = await this.ensureMossApi();
-      const contextData = await api.getSessionContext(mossSessionId);
-
-      mainLog('RemoteProvider', `Session context raw data: ${JSON.stringify(contextData?.context)}`);
-
-      if (!contextData?.context?.messages?.length) {
-        mainLog('RemoteProvider', `No messages found for Moss session ${mossSessionId}`);
-        return [];
+      if (msgType !== 'user' && msgType !== 'assistant' && innerRole !== 'user' && innerRole !== 'assistant') {
+        continue;
       }
 
-      // Convert Moss messages to TMessage format
-      // 将 Moss 消息转换为 TMessage 格式
-      // Moss message structure: { type: "user"|"assistant", message: { role, content } }
-      // Moss 消息结构：{ type: "user"|"assistant", message: { role, content } }
-      const allMessages = contextData.context.messages;
-      mainLog('RemoteProvider', `Total messages: ${allMessages.length}, types: ${allMessages.map((m: any) => m.type).join(',')}`);
+      const contentArray = msg.message?.content || msg.content || [];
+      const timestamp = new Date(msg.timestamp || Date.now()).getTime();
+      const isError = msg.error || msg.isApiErrorMessage;
+      const msgRole = msgType || innerRole || 'unknown';
 
-      const messages: TMessage[] = [];
-      let messageIndex = 0;
-      let foundModel = '';
+      if (isError && msgRole === 'assistant') {
+        const errorText = Array.isArray(contentArray)
+          ? contentArray
+              .filter((c: any) => c?.type === 'text')
+              .map((c: any) => c.text || '')
+              .join('\n')
+          : typeof contentArray === 'string' ? contentArray : '';
+        messages.push({
+          id: `${conversationId}-${messageIndex++}`,
+          conversation_id: conversationId,
+          type: 'tips',
+          position: 'left',
+          content: { content: errorText || msg.error || 'Unknown error', type: 'error' },
+          create_time: timestamp,
+          status: 'finished',
+        } as unknown as TMessage);
+        continue;
+      }
 
-      for (const msg of allMessages) {
-        const msgType = msg.type;
-        const innerRole = msg.message?.role;
-        const msgModel = msg.message?.model;
-
-        // Extract model info from the LAST (most recent) assistant message
-        // 从最后一条（最近一条）assistant 消息中提取模型信息
-        // Update model info from every assistant message (last one wins)
-        // 从每条 assistant 消息更新模型信息（最后一条生效）
-        if (msgType === 'assistant' && msgModel) {
-          foundModel = msgModel;
-        }
-
-        // Skip non-user/assistant messages
-        // 跳过非 user/assistant 消息
-        if (msgType !== 'user' && msgType !== 'assistant' && innerRole !== 'user' && innerRole !== 'assistant') {
-          continue;
-        }
-
-        const contentArray = msg.message?.content || msg.content || [];
-        const timestamp = new Date(msg.timestamp || Date.now()).getTime();
-        const isError = msg.error || msg.isApiErrorMessage;
-        const msgRole = msgType || innerRole || 'unknown';
-
-        // Handle error messages
-        // 处理错误消息
-        if (isError && msgRole === 'assistant') {
-          const errorText = Array.isArray(contentArray)
-            ? contentArray
-                .filter((c: any) => c?.type === 'text')
-                .map((c: any) => c.text || '')
-                .join('\n')
-            : typeof contentArray === 'string' ? contentArray : '';
-          messages.push({
-            id: `${conversationId}-${messageIndex++}`,
-            conversation_id: conversationId,
-            type: 'tips',
-            position: 'left',
-            content: { content: errorText || msg.error || 'Unknown error', type: 'error' },
-            create_time: timestamp,
-            status: 'finished',
-          } as unknown as TMessage);
-          continue;
-        }
-
-        // User messages: process each content block
-        // 用户消息：处理每个 content block
-        if (msgRole === 'user' && Array.isArray(contentArray)) {
-          for (const block of contentArray) {
-            if (block?.type === 'text') {
-              // text block → text message
-              // text block → text 消息
-              const textContent = block.text || '';
-              if (textContent && textContent.trim()) {
-                messages.push({
-                  id: `${conversationId}-${messageIndex++}`,
-                  conversation_id: conversationId,
-                  type: 'text',
-                  role: 'user',
-                  position: 'right',
-                  content: { content: textContent },
-                  create_time: timestamp,
-                  status: 'finished',
-                } as unknown as TMessage);
-              }
-            } else if (block?.type === 'tool_result') {
-              // tool_result block → update tool call status or error tips
-              // tool_result block → 更新工具调用状态或错误提示
-              const toolUseId = block.tool_use_id || block.toolCallId;
-              const isError = block.is_error;
-              const resultContent = block.content || '';
-
-              if (isError) {
-                // Tool execution failed → tips message with error
-                // 工具执行失败 → 错误提示消息
-                messages.push({
-                  id: `${conversationId}-${messageIndex++}`,
-                  msg_id: toolUseId,
-                  conversation_id: conversationId,
-                  type: 'tips',
-                  position: 'left',
-                  content: { content: resultContent || 'Tool execution failed', type: 'error' },
-                  create_time: timestamp,
-                  status: 'finished',
-                } as unknown as TMessage);
-              } else {
-                // Tool execution success → update tool call status to completed
-                // 工具执行成功 → 更新工具调用状态为 completed
-                // Note: This creates a separate message; frontend will merge by toolCallId
-                // 注意：这会创建独立消息；前端会根据 toolCallId 合并
-                messages.push({
-                  id: `${conversationId}-${messageIndex++}`,
-                  msg_id: toolUseId,
-                  conversation_id: conversationId,
-                  type: 'acp_tool_call',
-                  position: 'left',
-                  content: {
-                    sessionId: mossSessionId,
-                    update: {
-                      sessionUpdate: 'tool_call_update',
-                      toolCallId: toolUseId,
-                      status: 'completed',
-                      content: [{ type: 'content', content: { type: 'text', text: resultContent } }],
-                    },
-                  },
-                  create_time: timestamp,
-                  status: 'finished',
-                } as unknown as TMessage);
-              }
-            }
-          }
-          continue;
-        }
-
-        // Fallback: User messages with simple text content
-        // 后备处理：用户消息的简单文本内容
-        if (msgRole === 'user') {
-          const textContent = Array.isArray(contentArray)
-            ? contentArray
-                .filter((c: any) => c?.type === 'text')
-                .map((c: any) => c.text || '')
-                .join('\n')
-            : typeof contentArray === 'string' ? contentArray : '';
-          if (textContent && textContent.trim()) {
-            messages.push({
-              id: `${conversationId}-${messageIndex++}`,
-              conversation_id: conversationId,
-              type: 'text',
-              role: 'user',
-              position: 'right',
-              content: { content: textContent },
-              create_time: timestamp,
-              status: 'finished',
-            } as unknown as TMessage);
-          }
-          continue;
-        }
-
-        // Assistant messages: process each content block separately
-        // Assistant 消息：分别处理每个 content block
-        if (msgRole === 'assistant' && Array.isArray(contentArray)) {
-          for (const block of contentArray) {
-            if (block?.type === 'thinking') {
-              // thinking block → skip, same as realtime transformMessage
-              // thinking block → 跳过，与实时消息 transformMessage 处理一致
-              // thinking 内容不显示在 UI 中
-              // thinking content is not displayed in UI
-              // Do nothing, skip this block
-            } else if (block?.type === 'text') {
-              // text block → text message
-              // text block → text 消息
-              const textContent = block.text || '';
-              if (textContent && textContent.trim()) {
-                messages.push({
-                  id: `${conversationId}-${messageIndex++}`,
-                  conversation_id: conversationId,
-                  type: 'text',
-                  role: 'assistant',
-                  position: 'left',
-                  content: { content: textContent },
-                  create_time: timestamp,
-                  status: 'finished',
-                } as unknown as TMessage);
-              }
-            } else if (block?.type === 'tool_use') {
-              // tool_use block → acp_tool_call message
-              // Must use ToolCallUpdate format with 'update' property
-              // tool_use block → acp_tool_call 消息，必须使用 ToolCallUpdate 格式（包含 update 属性）
+      if (msgRole === 'user' && Array.isArray(contentArray)) {
+        for (const block of contentArray) {
+          if (block?.type === 'text') {
+            const textContent = block.text || '';
+            if (textContent && textContent.trim()) {
               messages.push({
                 id: `${conversationId}-${messageIndex++}`,
-                msg_id: block.id || `${conversationId}-${messageIndex}`,
+                conversation_id: conversationId,
+                type: 'text',
+                role: 'user',
+                position: 'right',
+                content: { content: textContent },
+                create_time: timestamp,
+                status: 'finished',
+              } as unknown as TMessage);
+            }
+          } else if (block?.type === 'tool_result') {
+            const toolUseId = block.tool_use_id || block.toolCallId;
+            const isError = block.is_error;
+            const resultContent = block.content || '';
+
+            if (isError) {
+              messages.push({
+                id: `${conversationId}-${messageIndex++}`,
+                msg_id: toolUseId,
+                conversation_id: conversationId,
+                type: 'tips',
+                position: 'left',
+                content: { content: resultContent || 'Tool execution failed', type: 'error' },
+                create_time: timestamp,
+                status: 'finished',
+              } as unknown as TMessage);
+            } else {
+              messages.push({
+                id: `${conversationId}-${messageIndex++}`,
+                msg_id: toolUseId,
                 conversation_id: conversationId,
                 type: 'acp_tool_call',
                 position: 'left',
                 content: {
                   sessionId: mossSessionId,
                   update: {
-                    sessionUpdate: 'tool_call',
-                    toolCallId: block.id || `${conversationId}-${messageIndex}`,
+                    sessionUpdate: 'tool_call_update',
+                    toolCallId: toolUseId,
                     status: 'completed',
-                    title: block.name,
-                    kind: 'execute',
-                    rawInput: block.input,
-                    content: [],
+                    content: [{ type: 'content', content: { type: 'text', text: resultContent } }],
                   },
                 },
                 create_time: timestamp,
@@ -612,32 +401,226 @@ export class RemoteConversationProvider implements IConversationProvider {
               } as unknown as TMessage);
             }
           }
-        } else if (msgRole === 'assistant') {
-          // Fallback: handle string content
-          // 后备处理：字符串内容
-          const textContent = typeof contentArray === 'string' ? contentArray : '';
-          if (textContent && textContent.trim()) {
+        }
+        continue;
+      }
+
+      if (msgRole === 'user') {
+        const textContent = Array.isArray(contentArray)
+          ? contentArray
+              .filter((c: any) => c?.type === 'text')
+              .map((c: any) => c.text || '')
+              .join('\n')
+          : typeof contentArray === 'string' ? contentArray : '';
+        if (textContent && textContent.trim()) {
+          messages.push({
+            id: `${conversationId}-${messageIndex++}`,
+            conversation_id: conversationId,
+            type: 'text',
+            role: 'user',
+            position: 'right',
+            content: { content: textContent },
+            create_time: timestamp,
+            status: 'finished',
+          } as unknown as TMessage);
+        }
+        continue;
+      }
+
+      if (msgRole === 'assistant' && Array.isArray(contentArray)) {
+        for (const block of contentArray) {
+          if (block?.type === 'thinking') {
+            // thinking content is not displayed in UI
+          } else if (block?.type === 'text') {
+            const textContent = block.text || '';
+            if (textContent && textContent.trim()) {
+              messages.push({
+                id: `${conversationId}-${messageIndex++}`,
+                conversation_id: conversationId,
+                type: 'text',
+                role: 'assistant',
+                position: 'left',
+                content: { content: textContent },
+                create_time: timestamp,
+                status: 'finished',
+              } as unknown as TMessage);
+            }
+          } else if (block?.type === 'tool_use') {
             messages.push({
               id: `${conversationId}-${messageIndex++}`,
+              msg_id: block.id || `${conversationId}-${messageIndex}`,
               conversation_id: conversationId,
-              type: 'text',
-              role: 'assistant',
+              type: 'acp_tool_call',
               position: 'left',
-              content: { content: textContent },
+              content: {
+                sessionId: mossSessionId,
+                update: {
+                  sessionUpdate: 'tool_call',
+                  toolCallId: block.id || `${conversationId}-${messageIndex}`,
+                  status: 'completed',
+                  title: block.name,
+                  kind: 'execute',
+                  rawInput: block.input,
+                  content: [],
+                },
+              },
               create_time: timestamp,
               status: 'finished',
             } as unknown as TMessage);
           }
         }
+      } else if (msgRole === 'assistant') {
+        const textContent = typeof contentArray === 'string' ? contentArray : '';
+        if (textContent && textContent.trim()) {
+          messages.push({
+            id: `${conversationId}-${messageIndex++}`,
+            conversation_id: conversationId,
+            type: 'text',
+            role: 'assistant',
+            position: 'left',
+            content: { content: textContent },
+            create_time: timestamp,
+            status: 'finished',
+          } as unknown as TMessage);
+        }
+      }
+    }
+
+    return { messages, foundModel };
+  }
+
+  /**
+   * Get messages - LOCAL-FIRST approach
+   * 获取消息 - 本地优先策略
+   *
+   * 1. Check local DB first → return if messages exist (fast, offline-capable)
+   * 2. If no local messages AND mossSessionId available → try Moss Server, save locally, return
+   * 3. If mossSessionPending or no mossSessionId → return empty
+   * 4. If Moss Server unavailable → log only, return empty (no throw)
+   */
+  async getMessages(conversationId: string, _page = 0, _pageSize = 10000): Promise<TMessage[]> {
+    try {
+      const db = getDatabase();
+      const existing = db.getConversation(conversationId);
+
+      const extra = existing.data?.extra as { mossSessionPending?: boolean; mossSessionId?: string } | undefined;
+      if (!existing.success || !existing.data || extra?.mossSessionPending || !extra?.mossSessionId) {
+        return [];
       }
 
-      // Store model info for getModelInfo API (not as TMessage)
-      // 存储模型信息供 getModelInfo API 使用（不作为 TMessage）
-      // Note: Model info is sent via acp_model_info message type during realtime streaming
-      // 注意：实时流式消息时通过 acp_model_info 消息类型发送
+      // 1. Check local DB first / 先检查本地数据库
+      const localMessages = db.getConversationMessages(conversationId, 0, 10000);
+      if (localMessages.data && localMessages.data.length > 0) {
+        return localMessages.data;
+      }
+
+      // 2. No local messages - try Moss Server and save locally
+      // 没有本地消息 - 尝试从 Moss Server 获取并保存到本地
+      const mossSessionId = extra.mossSessionId;
+      try {
+        const api = await this.ensureMossApi();
+        const contextData = await api.getSessionContext(mossSessionId);
+
+        if (!contextData?.context?.messages?.length) {
+          return [];
+        }
+
+        const allMessages = contextData.context.messages;
+        const { messages, foundModel } = this.convertMossMessagesToTMessages(allMessages, conversationId, mossSessionId);
+
+        // Save to local DB for future local-first reads / 保存到本地数据库供后续本地优先读取
+        for (const msg of messages) {
+          try {
+            db.insertMessage(msg);
+          } catch (insertErr) {
+            mainError('RemoteProvider', `Failed to insert message to local DB: ${insertErr}`);
+          }
+        }
+        mainLog('RemoteProvider', `Saved ${messages.length} messages to local DB from Moss session ${mossSessionId}`);
+
+        if (foundModel) {
+          this.cachedModelInfo.set(conversationId, {
+            source: 'models',
+            currentModelId: foundModel,
+            currentModelLabel: foundModel,
+            canSwitch: false,
+            availableModels: [],
+          });
+        }
+
+        // Sync customTitle from Moss Server if available / 同步 Moss Server 的 customTitle
+        const customTitle = contextData.context?.customTitle;
+        if (customTitle && existing.data.name !== customTitle) {
+          db.updateConversation(conversationId, { name: customTitle } as Partial<TChatConversation>);
+        }
+
+        return messages;
+      } catch (mossError) {
+        // Moss Server unavailable - log only, don't throw / Moss Server 不可用 - 仅记录日志，不抛出
+        mainLog('RemoteProvider', `Moss Server unavailable for getMessages, conversation ${conversationId}: ${mossError instanceof Error ? mossError.message : String(mossError)}`);
+        return [];
+      }
+    } catch (error) {
+      mainLog('RemoteProvider', `Failed to get messages for ${conversationId}: ${error instanceof Error ? error.message : String(error)}`);
+      return [];
+    }
+  }
+
+  /**
+   * Sync messages from Moss Server to local DB
+   * 从 Moss Server 同步消息到本地数据库
+   *
+   * Called when user clicks on a history conversation to ensure local data is up-to-date.
+   * 当用户点击历史会话时调用，确保本地数据是最新的。
+   *
+   * 1. Fetch messages from Moss Server via getSessionContext API
+   * 2. Clear existing local messages (avoid duplicates)
+   * 3. Insert all converted messages to local DB
+   * 4. Sync conversation name from Moss Server's customTitle
+   * 5. Update mossSessionUpdatedAt timestamp
+   */
+  async syncFromMossServer(conversationId: string): Promise<{ syncedCount: number; nameUpdated: boolean }> {
+    try {
+      const db = getDatabase();
+      const existing = db.getConversation(conversationId);
+
+      if (!existing.success || !existing.data) {
+        mainLog('RemoteProvider', `Conversation ${conversationId} not found for sync`);
+        return { syncedCount: 0, nameUpdated: false };
+      }
+
+      const extra = existing.data.extra as { mossSessionPending?: boolean; mossSessionId?: string } | undefined;
+      if (extra?.mossSessionPending || !extra?.mossSessionId) {
+        mainLog('RemoteProvider', `Conversation ${conversationId} is pending or no Moss session ID, skip sync`);
+        return { syncedCount: 0, nameUpdated: false };
+      }
+
+      const mossSessionId = extra.mossSessionId;
+      const api = await this.ensureMossApi();
+      const contextData = await api.getSessionContext(mossSessionId);
+
+      if (!contextData?.context?.messages?.length) {
+        mainLog('RemoteProvider', `No messages found for Moss session ${mossSessionId} during sync`);
+        return { syncedCount: 0, nameUpdated: false };
+      }
+
+      const allMessages = contextData.context.messages;
+      const { messages, foundModel } = this.convertMossMessagesToTMessages(allMessages, conversationId, mossSessionId);
+
+      // Clear existing local messages to avoid duplicates / 清除现有本地消息避免重复
+      db.deleteConversationMessages(conversationId);
+
+      // Insert all converted messages / 插入所有转换后的消息
+      for (const msg of messages) {
+        try {
+          db.insertMessage(msg);
+        } catch (insertErr) {
+          mainError('RemoteProvider', `Failed to insert message during sync: ${insertErr}`);
+        }
+      }
+
+      // Update model info cache / 更新模型信息缓存
       if (foundModel) {
-        // Cache model info for this conversation (will be returned by getModelInfo)
-        // 缓存此会话的模型信息（由 getModelInfo 返回）
         this.cachedModelInfo.set(conversationId, {
           source: 'models',
           currentModelId: foundModel,
@@ -647,11 +630,34 @@ export class RemoteConversationProvider implements IConversationProvider {
         });
       }
 
-      mainLog('RemoteProvider', `Loaded ${messages.length} messages from Moss for session ${mossSessionId}`);
-      return messages;
+      // Sync customTitle from Moss Server / 同步 Moss Server 的 customTitle
+      let nameUpdated = false;
+      const customTitle = contextData.context?.customTitle;
+      if (customTitle && existing.data.name !== customTitle) {
+        db.updateConversation(conversationId, {
+          name: customTitle,
+          extra: {
+            ...existing.data.extra,
+            mossSessionUpdatedAt: Date.now(),
+          },
+        } as Partial<TChatConversation>);
+        nameUpdated = true;
+        mainLog('RemoteProvider', `Synced conversation name from Moss Server: "${existing.data.name}" → "${customTitle}"`);
+      } else {
+        // Update mossSessionUpdatedAt timestamp only / 仅更新时间戳
+        db.updateConversation(conversationId, {
+          extra: {
+            ...existing.data.extra,
+            mossSessionUpdatedAt: Date.now(),
+          },
+        } as Partial<TChatConversation>);
+      }
+
+      mainLog('RemoteProvider', `Synced ${messages.length} messages from Moss Server for session ${mossSessionId}`);
+      return { syncedCount: messages.length, nameUpdated };
     } catch (error) {
-      mainError('RemoteProvider', `Failed to get messages: ${error instanceof Error ? error.message : String(error)}`);
-      return [];
+      mainError('RemoteProvider', `Failed to sync from Moss Server: ${error instanceof Error ? error.message : String(error)}`);
+      return { syncedCount: 0, nameUpdated: false };
     }
   }
 

--- a/src/process/providers/types.ts
+++ b/src/process/providers/types.ts
@@ -86,6 +86,20 @@ export interface IConversationProvider {
    * @returns Response with success status / 响应状态
    */
   stop(conversationId: string): Promise<IBridgeResponse>;
+
+  /**
+   * Sync messages from remote server to local DB (enterprise mode only)
+   * 从远程服务器同步消息到本地数据库（仅企业模式）
+   *
+   * Only implemented by RemoteConversationProvider.
+   * 仅由 RemoteConversationProvider 实现。
+   * Called when user clicks on a history conversation to ensure local data is up-to-date.
+   * 当用户点击历史会话时调用，确保本地数据是最新的。
+   *
+   * @param conversationId Conversation ID / 会话 ID
+   * @returns Sync result with count and name update status / 同步结果（消息数量和名称更新状态）
+   */
+  syncFromMossServer?(conversationId: string): Promise<{ syncedCount: number; nameUpdated: boolean }>;
 }
 
 /**

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -13,6 +13,7 @@ import { uuid } from '@/common/utils';
 import { mainLog, mainError } from '../utils/mainLogger';
 import { getDatabase } from '../database/export';
 import { getConversationProvider } from '../providers';
+import { addOrUpdateMessage } from '../message';
 
 /**
  * RemoteAgent data interface
@@ -327,12 +328,72 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
     const enrichedMsg = { ...msg, conversation_id: this.conversation_id };
     ipcBridge.conversation.responseStream.emit(enrichedMsg);
 
+    // Persist messages to local DB for enterprise mode local-first reads
+    // 将消息持久化到本地数据库，支持企业模式本地优先读取
+    if (msg.type === 'content' || msg.type === 'user_content' || msg.type === 'acp_tool_call' || msg.type === 'error') {
+      try {
+        const tMessage = this.streamMsgToTMessage(enrichedMsg);
+        if (tMessage) {
+          addOrUpdateMessage(this.conversation_id, tMessage);
+        }
+      } catch (err) {
+        mainLog('RemoteAgent', `Failed to persist stream message to local DB: ${err}`);
+      }
+    }
+
     // Only set finished status when receiving 'finish' message
     // 'content' messages are streaming and do NOT indicate session end
     // 只有收到 'finish' 消息才设置 finished 状态
     // 'content' 消息是流式的，不代表会话结束
     if (msg.type === 'finish') {
       this.status = 'finished';
+    }
+  }
+
+  /**
+   * Convert stream IResponseMessage to TMessage for local DB persistence
+   * 将流式 IResponseMessage 转换为 TMessage 用于本地数据库持久化
+   */
+  private streamMsgToTMessage(msg: IResponseMessage): import('@/common/chatLib').TMessage | null {
+    switch (msg.type) {
+      case 'content':
+        return {
+          id: uuid(),
+          type: 'text',
+          msg_id: msg.msg_id,
+          position: 'left',
+          conversation_id: msg.conversation_id,
+          content: { content: msg.data as string },
+        } as any;
+      case 'user_content':
+        return {
+          id: uuid(),
+          type: 'text',
+          msg_id: msg.msg_id,
+          position: 'right',
+          conversation_id: msg.conversation_id,
+          content: { content: msg.data as string },
+        } as any;
+      case 'acp_tool_call':
+        return {
+          id: uuid(),
+          type: 'acp_tool_call',
+          msg_id: msg.msg_id,
+          position: 'left',
+          conversation_id: msg.conversation_id,
+          content: msg.data as any,
+        } as any;
+      case 'error':
+        return {
+          id: uuid(),
+          type: 'tips',
+          msg_id: msg.msg_id,
+          position: 'left',
+          conversation_id: msg.conversation_id,
+          content: { content: msg.data as string, type: 'error' },
+        } as any;
+      default:
+        return null;
     }
   }
 

--- a/src/renderer/pages/conversation/index.tsx
+++ b/src/renderer/pages/conversation/index.tsx
@@ -41,6 +41,32 @@ const ChatConversationIndex: React.FC = () => {
     });
   }, [id, mutate]);
 
+  // Enterprise mode: sync messages from Moss Server when clicking a history conversation
+  // 企业模式：点击历史会话时从 Moss Server 同步消息到本地数据库
+  useEffect(() => {
+    if (!data || data.type !== 'remote-agent') return;
+    const extra = data.extra as { mossSessionId?: string; mossSessionPending?: boolean } | undefined;
+    if (!extra?.mossSessionId || extra?.mossSessionPending) return;
+
+    ipcBridge.conversation.syncMessages
+      .invoke({ conversation_id: id! })
+      .then((result) => {
+        if (result.success && result.data) {
+          if (result.data.syncedCount > 0) {
+            console.log(`[ConversationSync] Synced ${result.data.syncedCount} messages from Moss Server`);
+          }
+          if (result.data.syncedCount > 0 || result.data.nameUpdated) {
+            // Refresh sidebar and conversation data / 刷新侧边栏和会话数据
+            emitter.emit('chat.history.refresh');
+            void mutate();
+          }
+        }
+      })
+      .catch((err) => {
+        console.warn('[ConversationSync] Failed to sync messages from Moss Server:', err);
+      });
+  }, [data?.id, data?.type]);
+
   useEffect(() => {
     if (!id) return;
 


### PR DESCRIPTION
## Summary

- 企业会话历史存储从"完全云端"改为"本地存储 + 点击同步"模型
- `getMessages()` 本地优先：先查本地 DB，无则从 Moss Server 拉取并保存
- 新增 `syncFromMossServer()` 方法，点击历史会话时触发从 Moss Server 同步消息到本地 DB
- `RemoteAgent.handleStreamMessage()` 新增 `addOrUpdateMessage()` 持久化实时流式消息到本地 DB
- `getConversation()` 直接返回本地记录不阻塞，修复白屏问题
- 同步完成后触发 `chat.history.refresh` + `mutate()` 刷新消息列表

## Bugs Fixed

1. **白屏** — `getConversation()` 阻塞等待 Moss Server API → 改为直接返回本地记录
2. **历史消息不显示** — RemoteAgent 未持久化消息 + 同步后未刷新 UI → 新增持久化 + 触发刷新
3. **Moss 不可用时日志过激** — `mainError` 降级为 `mainLog`，独立 try-catch 不抛异常

## Test plan

- [ ] 新建企业会话 → 侧边栏历史显示正确名称
- [ ] 发送消息 → 消息持久化到本地 DB
- [ ] 关闭并重开应用 → 历史列表显示正确会话名称
- [ ] 点击历史会话 → 先从本地 DB 加载消息，然后后台从 Moss Server 同步
- [ ] 同步完成后本地消息与 Moss Server 消息一致，名称如有变更则更新
- [ ] 断开 Moss Server → 已查看过的会话仍可从本地 DB 加载消息
- [ ] 非企业模式（ACP/OpenClaw）会话不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)