### PR TITLE
feat(auth-proxy): add Auth Proxy service for secret injection into skill requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "mammoth": "^1.11.0",
     "mdast-util-from-markdown": "^2.0.3",
     "mdast-util-gfm": "^3.1.0",
+    "minimatch": "^9.0.6",
     "officeparser": "^5.2.2",
     "openai": "^5.12.2",
     "pptx-preview": "^1.0.7",

--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -17,6 +17,7 @@ import { mainLog } from '@process/utils/mainLogger';
 import { resolveNpxPath } from '@process/utils/shellEnv';
 import { recordFirstToken } from '@process/telemetry';
 import { ACP_PERF_LOG, connectClaude, connectCodebuddy, connectCodex, prepareCleanEnv, spawnGenericBackend } from './acpConnectors';
+import { getAuthProxyPort, registerToken, revokeToken } from '@process/services/authProxy';
 import type { SpawnResult } from './acpConnectors';
 import { killChild, readTextFile, writeJsonRpcMessage, writeJsonRpcMessageLsp, writeTextFile } from './utils';
 
@@ -77,12 +78,21 @@ export class AcpConnection {
   // so scode must NOT be routed through this path.
   private useLspFraming = false;
 
+  // Auth Proxy token for this child process (generated before spawn, registered after)
+  private proxyToken: string | null = null;
+
   /**
    * Kill the current child process (if any) and clear process-related state.
    * Used by both disconnect() and retry paths. Does NOT reset session-level
    * state (sessionId, backend, etc.) — that is disconnect()'s responsibility.
    */
   private async terminateChild(): Promise<void> {
+    // Revoke Auth Proxy token before killing child
+    if (this.proxyToken) {
+      revokeToken(this.proxyToken);
+      this.proxyToken = null;
+    }
+
     if (!this.child) {
       this.isDetached = false;
       return;
@@ -100,6 +110,10 @@ export class AcpConnection {
   private async spawnAndSetup(result: SpawnResult, backend: string): Promise<void> {
     this.child = result.child;
     this.isDetached = result.isDetached;
+    // Register Auth Proxy token now that child.pid is available
+    if (this.proxyToken && this.child?.pid) {
+      registerToken(this.proxyToken, this.child.pid);
+    }
     await this.setupChildProcessHandlers(backend);
   }
 
@@ -173,6 +187,16 @@ export class AcpConnection {
       this.workingDir = workingDir;
     }
 
+    // Auth Proxy: generate token and inject into child process env
+    const authProxyPort = getAuthProxyPort();
+    if (authProxyPort) {
+      this.proxyToken = crypto.randomUUID();
+      const envWithProxy = { ...customEnv };
+      envWithProxy.SUDOWORK_AUTH_PROXY_URL = `http://127.0.0.1:${authProxyPort}/proxy`;
+      envWithProxy.SUDOWORK_AUTH_PROXY_TOKEN = this.proxyToken;
+      customEnv = envWithProxy;
+    }
+
     // Shared hooks for npx backends: wire spawned child into this connection
     const npxHooks = {
       setup: async (result: SpawnResult) => {
@@ -190,11 +214,11 @@ export class AcpConnection {
         break;
 
       case 'codebuddy':
-        await connectCodebuddy(workingDir, npxHooks);
+        await connectCodebuddy(workingDir, npxHooks, customEnv);
         break;
 
       case 'codex':
-        await connectCodex(workingDir, npxHooks);
+        await connectCodex(workingDir, npxHooks, customEnv);
         break;
 
       case 'gemini':
@@ -429,6 +453,12 @@ export class AcpConnection {
    * Similar to Codex's handleProcessExit implementation
    */
   private handleProcessExit(code: number | null, signal: NodeJS.Signals | null): void {
+    // Revoke Auth Proxy token (parallel cleanup path to terminateChild)
+    if (this.proxyToken) {
+      revokeToken(this.proxyToken);
+      this.proxyToken = null;
+    }
+
     // 1. Reject all pending requests with clear error message
     for (const [_id, request] of this.pendingRequests) {
       if (request.timeoutId) {

--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -357,8 +357,9 @@ function prepareClaude(customEnv?: Record<string, string>): NpxPrepareResult {
 }
 
 /** Prepare clean env + resolve npx + run diagnostics for Codex ACP bridge. */
-async function prepareCodex(): Promise<NpxPrepareResult> {
+async function prepareCodex(customEnv?: Record<string, string>): Promise<NpxPrepareResult> {
   const cleanEnv = prepareCleanEnv();
+  if (customEnv) Object.assign(cleanEnv, customEnv);
   ensureMinNodeVersion(cleanEnv, 20, 10, 'Codex ACP bridge');
 
   const codexCommand = process.platform === 'win32' ? 'codex.cmd' : 'codex';
@@ -408,8 +409,9 @@ async function prepareCodex(): Promise<NpxPrepareResult> {
 }
 
 /** Prepare clean env + resolve npx + load MCP config for CodeBuddy. */
-async function prepareCodebuddy(): Promise<NpxPrepareResult> {
+async function prepareCodebuddy(customEnv?: Record<string, string>): Promise<NpxPrepareResult> {
   const cleanEnv = prepareCleanEnv();
+  if (customEnv) Object.assign(cleanEnv, customEnv);
   ensureMinNodeVersion(cleanEnv, 20, 10, 'CodeBuddy ACP');
 
   // Load user's MCP config if available (~/.codebuddy/mcp.json)
@@ -577,11 +579,11 @@ export function connectClaude(workingDir: string, hooks: NpxConnectHooks, custom
 }
 
 /** Connect to Codex ACP bridge via npx. */
-export function connectCodex(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
-  return connectNpxBackend({ backend: 'codex', npxPackage: CODEX_ACP_NPX_PACKAGE, prepareFn: prepareCodex, workingDir, ...hooks });
+export function connectCodex(workingDir: string, hooks: NpxConnectHooks, customEnv?: Record<string, string>): Promise<void> {
+  return connectNpxBackend({ backend: 'codex', npxPackage: CODEX_ACP_NPX_PACKAGE, prepareFn: () => prepareCodex(customEnv), workingDir, ...hooks });
 }
 
 /** Connect to CodeBuddy ACP via npx. */
-export function connectCodebuddy(workingDir: string, hooks: NpxConnectHooks): Promise<void> {
-  return connectNpxBackend({ backend: 'codebuddy', npxPackage: CODEBUDDY_ACP_NPX_PACKAGE, prepareFn: prepareCodebuddy, workingDir, ...hooks, extraArgs: ['--acp'], detached: process.platform !== 'win32' });
+export function connectCodebuddy(workingDir: string, hooks: NpxConnectHooks, customEnv?: Record<string, string>): Promise<void> {
+  return connectNpxBackend({ backend: 'codebuddy', npxPackage: CODEBUDDY_ACP_NPX_PACKAGE, prepareFn: () => prepareCodebuddy(customEnv), workingDir, ...hooks, extraArgs: ['--acp'], detached: process.platform !== 'win32' });
 }

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1607,6 +1607,20 @@ export const telemetry = {
   flush: bridge.buildProvider<IBridgeResponse, void>('telemetry.flush'),
 };
 
+// ==================== Auth Proxy API ====================
+// Manage Auth Proxy server lifecycle, rules cache, and status
+
+import type { AuthProxyRule } from '@/common/types/authProxy';
+
+export const authProxy = {
+  /** Get all cached Config Items rules */
+  getRules: bridge.buildProvider<IBridgeResponse<AuthProxyRule[]>, void>('authProxy.getRules'),
+  /** Refresh Config Items rules from sudowork-server */
+  refreshRules: bridge.buildProvider<IBridgeResponse<void>, { accessToken: string; enabledConfigItemIds: number[] }>('authProxy.refreshRules'),
+  /** Get Auth Proxy server running status and port */
+  getStatus: bridge.buildProvider<IBridgeResponse<{ running: boolean; port: number | null }>, void>('authProxy.getStatus'),
+};
+
 // ==================== Crash API ====================
 // Crash/Exception reporting for sudoclaw-qms CrashReporter
 // Crash/异常上报 (替代 Sentry SDK)

--- a/src/common/nexus/secret-cache.ts
+++ b/src/common/nexus/secret-cache.ts
@@ -112,6 +112,15 @@ class SecretCacheImpl {
   }
 
   /**
+   * Remove a cache entry.
+   * Keeps the entry in the migrated set (secret remains migrated in Nexus,
+   * just not available locally). After delete, resolveSecret() returns empty string.
+   */
+  delete(namespace: string, key: string): void {
+    this.cache.delete(`${namespace}:${key}`);
+  }
+
+  /**
    * Async write to Nexus only (no cache update).
    * Used for initial migration.
    */
@@ -201,4 +210,13 @@ export function putSecretToNexus(namespace: string, key: string, value: string):
  */
 export function markMigrated(namespace: string, key: string, value: string): void {
   secretCache.markMigrated(namespace, key, value);
+}
+
+/**
+ * Synchronous removal of a cache entry.
+ * Used after soft-deleting a secret from Nexus to ensure Auth Proxy
+ * no longer injects the deleted secret.
+ */
+export function cacheDelete(namespace: string, key: string): void {
+  secretCache.delete(namespace, key);
 }

--- a/src/common/types/authProxy.ts
+++ b/src/common/types/authProxy.ts
@@ -1,0 +1,22 @@
+/**
+ * Auth Proxy Rule type definitions.
+ *
+ * Shared between main process (Auth Proxy Server, configItemsLoader)
+ * and common layer (IPC bridge definitions).
+ */
+
+export interface AuthProxyRuleEntry {
+  configKey: string;
+  name: string;
+  required: boolean;
+}
+
+export interface AuthProxyRule {
+  configItemId: number;
+  name: string;
+  urlPattern: string | null;
+  scheme: string | null;
+  bearerPrefix: string | null;
+  secretNamespace: string;
+  entries: AuthProxyRuleEntry[];
+}

--- a/src/process/bridge/authProxyBridge.ts
+++ b/src/process/bridge/authProxyBridge.ts
@@ -1,0 +1,43 @@
+/**
+ * Auth Proxy IPC Bridge - connects renderer to Auth Proxy services in main process.
+ */
+
+import { ipcBridge } from '@/common';
+import {
+  getAuthProxyRules,
+  refreshAuthProxyRules,
+  getAuthProxyPort,
+} from '@process/services/authProxy';
+import { mainError } from '@process/utils/mainLogger';
+
+export function initAuthProxyBridge(): void {
+  ipcBridge.authProxy.getRules.provider(async () => {
+    try {
+      const rules = getAuthProxyRules();
+      return { success: true, data: rules };
+    } catch (err) {
+      mainError('AuthProxyBridge', 'Failed to get rules:', err);
+      return { success: false, data: [] };
+    }
+  });
+
+  ipcBridge.authProxy.refreshRules.provider(async ({ accessToken, enabledConfigItemIds }) => {
+    try {
+      await refreshAuthProxyRules(accessToken, enabledConfigItemIds);
+      return { success: true };
+    } catch (err) {
+      mainError('AuthProxyBridge', 'Failed to refresh rules:', err);
+      return { success: false, msg: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcBridge.authProxy.getStatus.provider(async () => {
+    try {
+      const port = getAuthProxyPort();
+      return { success: true, data: { running: port !== null, port } };
+    } catch (err) {
+      mainError('AuthProxyBridge', 'Failed to get status:', err);
+      return { success: false, data: { running: false, port: null } };
+    }
+  });
+}

--- a/src/process/bridge/index.ts
+++ b/src/process/bridge/index.ts
@@ -48,6 +48,7 @@ import { initSecretBridge } from './secretBridge';
 import { initPwdLoginBridge } from './pwdLoginBridge';
 import { initWorkspaceBridge } from './workspaceBridge';
 import { initTelemetryBridge } from './telemetryBridge';
+import { initAuthProxyBridge } from './authProxyBridge';
 import { initMossBridge } from './mossBridge';
 // Crash bridge is initialized early in src/process/index.ts before storage
 // to handle renderer errors during startup
@@ -98,6 +99,7 @@ export function initAllBridges(): void {
   initHealthMonitorBridge();
   initImageGenerationBridge();
   initSecretBridge();
+  initAuthProxyBridge();
   initPwdLoginBridge();
   initWorkspaceBridge();
   initTelemetryBridge();

--- a/src/process/bridge/secretBridge.ts
+++ b/src/process/bridge/secretBridge.ts
@@ -6,6 +6,7 @@
 
 import { ipcBridge } from '../../common';
 import { getSecretStoreClient } from '@common/nexus/secret-store';
+import { cachePut, cacheDelete } from '@common/nexus/secret-cache';
 import { mainLog, mainError } from '@process/utils/mainLogger';
 
 export function initSecretBridge(): void {
@@ -24,6 +25,7 @@ export function initSecretBridge(): void {
     try {
       const client = getSecretStoreClient();
       await client.putSecret(namespace, key, value, description);
+      cachePut(namespace, key, value);
       mainLog('SecretBridge', `Secret saved [${namespace}/${key}]`);
       return { success: true };
     } catch (err) {
@@ -47,6 +49,7 @@ export function initSecretBridge(): void {
     try {
       const client = getSecretStoreClient();
       const deleted = await client.deleteSecret(namespace, key);
+      cacheDelete(namespace, key);
       mainLog('SecretBridge', `Secret deleted [${namespace}/${key}]`);
       return { success: true, data: deleted };
     } catch (err) {
@@ -59,6 +62,9 @@ export function initSecretBridge(): void {
     try {
       const client = getSecretStoreClient();
       const restored = await client.restoreSecret(namespace, key);
+      // Re-load the restored value into cache from Nexus
+      const value = await client.getSecret(namespace, key);
+      cachePut(namespace, key, value);
       mainLog('SecretBridge', `Secret restored [${namespace}/${key}]`);
       return { success: true, data: restored };
     } catch (err) {

--- a/src/process/services/authProxy/AuthProxyServer.ts
+++ b/src/process/services/authProxy/AuthProxyServer.ts
@@ -1,0 +1,397 @@
+/**
+ * Auth Proxy Server - local HTTP proxy that injects secrets into upstream requests.
+ *
+ * - Listens on 127.0.0.1 only (no external access)
+ * - Requires proxy token for authentication
+ * - Injects secrets based on Config Items rules or explicit headers
+ * - Streams requests/responses through to upstream
+ */
+
+import http from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
+import { URL } from 'url';
+import type { AuthProxyRule } from '@/common/types/authProxy';
+import { resolveSecret } from '@/common/nexus/secret-cache';
+import { mainLog } from '@process/utils/mainLogger';
+import { injectAuth, injectMultiAuth } from './authInjectors';
+import { validateRemoteUrl } from './ssrfGuard';
+import { findRuleForUrl, getRules } from './configItemsLoader';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ProxyRequestInfo {
+  token: string | null;
+  remoteUrl: string | null;
+  secretNamespace: string | null;
+  secretKey: string | null;
+  authScheme: string | null;
+  authHeader: string | null;
+  authPrefix: string | null;
+}
+
+// ============================================================================
+// Headers to strip before forwarding
+// ============================================================================
+
+const CONTROL_HEADERS = [
+  'authorization',
+  'x-secret-namespace',
+  'x-secret-key',
+  'x-auth-scheme',
+  'x-auth-header',
+  'x-auth-prefix',
+  'x-remote-url',
+  'host',
+  'connection',
+];
+
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+// ============================================================================
+// Auth Proxy Server
+// ============================================================================
+
+export class AuthProxyServer {
+  private server: http.Server | null = null;
+  private tokenRegistry = new Map<string, number>();
+  private port: number | null = null;
+  private minimatchFn: (str: string, pattern: string) => boolean;
+
+  constructor(minimatchFn: (str: string, pattern: string) => boolean) {
+    this.minimatchFn = minimatchFn;
+  }
+
+  // --------------------------------------------------------------------------
+  // Token management
+  // --------------------------------------------------------------------------
+
+  registerToken(token: string, pid: number): void {
+    this.tokenRegistry.set(token, pid);
+  }
+
+  revokeToken(token: string): void {
+    this.tokenRegistry.delete(token);
+  }
+
+  isValidToken(token: string): boolean {
+    return this.tokenRegistry.has(token);
+  }
+
+  // --------------------------------------------------------------------------
+  // Server lifecycle
+  // --------------------------------------------------------------------------
+
+  async start(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer((req, res) => this.handleRequest(req, res));
+
+      // Bind to 127.0.0.1 only - no external access
+      this.server.listen(0, '127.0.0.1', () => {
+        const addr = this.server!.address();
+        if (typeof addr === 'object' && addr) {
+          this.port = addr.port;
+          mainLog('AuthProxy', `Listening on 127.0.0.1:${this.port}`);
+          resolve(this.port);
+        } else {
+          reject(new Error('Failed to get server address'));
+        }
+      });
+
+      this.server.on('error', (err) => {
+        mainLog('AuthProxy', `Server error:`, err);
+        reject(err);
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    return new Promise((resolve) => {
+      this.server!.closeAllConnections?.();
+      this.server!.close(() => {
+        this.server = null;
+        this.port = null;
+        mainLog('AuthProxy', 'Stopped');
+        resolve();
+      });
+    });
+  }
+
+  getPort(): number | null {
+    return this.port;
+  }
+
+  // --------------------------------------------------------------------------
+  // Request handling
+  // --------------------------------------------------------------------------
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Health check endpoint (no auth required)
+    if (req.method === 'GET' && req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', port: this.port }));
+      return;
+    }
+
+    // Only handle /proxy
+    if (req.url !== '/proxy') {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+      return;
+    }
+
+    try {
+      // 1. Extract and validate proxy token
+      const info = this.parseRequestInfo(req);
+      if (!info.token || !this.isValidToken(info.token)) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid or missing proxy token' }));
+        return;
+      }
+
+      // 2. Validate remote URL
+      if (!info.remoteUrl) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Missing X-Remote-URL header' }));
+        return;
+      }
+
+      const urlValidation = await validateRemoteUrl(info.remoteUrl);
+      if (!urlValidation.valid) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: `SSRF blocked: ${urlValidation.error}` }));
+        return;
+      }
+
+      // 3. Determine secret source and inject auth
+      const authResult = await this.resolveAndInjectAuth(info);
+      if (authResult.error) {
+        const statusCode = authResult.statusCode ?? 502;
+        res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: authResult.error }));
+        return;
+      }
+
+      // 4. Build upstream headers
+      const upstreamHeaders = this.buildUpstreamHeaders(req, authResult.headers);
+
+      // 5. Merge query params (for scheme=query) into target URL
+      let targetUrl = info.remoteUrl!;
+      if (authResult.url) {
+        const separator = targetUrl.includes('?') ? '&' : '?';
+        targetUrl = `${targetUrl}${separator}${authResult.url}`;
+      }
+
+      // 6. Stream proxy request
+      await this.proxyRequest(targetUrl, req, res, upstreamHeaders);
+    } catch (error) {
+      mainLog('AuthProxy', `Request error:`, error);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal proxy error' }));
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Auth resolution
+  // --------------------------------------------------------------------------
+
+  private async resolveAndInjectAuth(
+    info: ProxyRequestInfo,
+  ): Promise<{ headers: Record<string, string>; url?: string; error?: string; statusCode?: number }> {
+    let secretValue: string;
+    let scheme: string | null;
+    let bearerPrefix: string | null;
+    let rule: AuthProxyRule | null = null;
+
+    // Priority 1: Explicit X-Secret-Namespace + X-Secret-Key
+    if (info.secretNamespace && info.secretKey) {
+      secretValue = resolveSecret(info.secretNamespace, info.secretKey, '');
+      scheme = info.authScheme;
+      bearerPrefix = null;
+    } else {
+      // Priority 2: URL pattern matching
+      rule = findRuleForUrl(info.remoteUrl!, this.minimatchFn);
+      if (!rule) {
+        return { headers: {}, error: 'No matching secret found. Provide X-Secret-Namespace + X-Secret-Key, or configure a URL pattern rule.' };
+      }
+
+      // Determine scheme: request headers can override server config
+      scheme = info.authScheme ?? rule.scheme;
+      bearerPrefix = rule.bearerPrefix;
+
+      // Single-entry schemes (bearer/basic)
+      if ((scheme === 'bearer' || scheme === 'basic') && rule.entries.length >= 1) {
+        const entry = rule.entries[0];
+        secretValue = resolveSecret(rule.secretNamespace, entry.configKey, '');
+      } else if (scheme === 'header' || scheme === 'query') {
+        // Multi-entry schemes
+        return this.resolveMultiEntryAuth(rule, scheme);
+      } else {
+        // scheme is null or unknown, try single entry
+        if (rule.entries.length >= 1) {
+          secretValue = resolveSecret(rule.secretNamespace, rule.entries[0].configKey, '');
+          scheme = 'bearer';
+        } else {
+          return { headers: {}, error: `Config item "${rule.name}" has no entries with secret values` };
+        }
+      }
+    }
+
+    if (!secretValue) {
+      const missingKey = rule ? rule.entries[0]?.configKey : info.secretKey;
+      return { headers: {}, error: `Secret not found: ${rule ? rule.secretNamespace : info.secretNamespace}/${missingKey}` };
+    }
+
+    // Inject auth
+    const prefix = info.authPrefix ?? bearerPrefix ?? 'Bearer';
+    return injectAuth({
+      scheme: scheme ?? 'bearer',
+      secret: secretValue,
+      headerName: info.authHeader,
+      prefix,
+    });
+  }
+
+  private resolveMultiEntryAuth(
+    rule: AuthProxyRule,
+    scheme: string,
+  ): { headers: Record<string, string>; url?: string; error?: string; statusCode?: number } {
+    const entries: Array<{ configKey: string; secret: string }> = [];
+
+    for (const entry of rule.entries) {
+      const secret = resolveSecret(rule.secretNamespace, entry.configKey, '');
+      if (!secret) {
+        // For header/query: skip missing entries with warning
+        mainLog('AuthProxy', `Missing secret for ${rule.secretNamespace}/${entry.configKey}, skipping`);
+        continue;
+      }
+      entries.push({ configKey: entry.configKey, secret });
+    }
+
+    if (entries.length === 0) {
+      return { headers: {}, error: `No secrets found for config item "${rule.name}"` };
+    }
+
+    return injectMultiAuth(scheme, entries);
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  private parseRequestInfo(req: IncomingMessage): ProxyRequestInfo {
+    const token = extractBearerToken(req.headers.authorization);
+    return {
+      token,
+      remoteUrl: req.headers['x-remote-url'] as string | null,
+      secretNamespace: req.headers['x-secret-namespace'] as string | null,
+      secretKey: req.headers['x-secret-key'] as string | null,
+      authScheme: req.headers['x-auth-scheme'] as string | null,
+      authHeader: req.headers['x-auth-header'] as string | null,
+      authPrefix: req.headers['x-auth-prefix'] as string | null,
+    };
+  }
+
+  private buildUpstreamHeaders(
+    req: IncomingMessage,
+    authHeaders: Record<string, string>,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    // Copy original headers, excluding control headers
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (typeof value !== 'string') continue;
+      if (CONTROL_HEADERS.includes(key.toLowerCase())) continue;
+      headers[key] = value;
+    }
+
+    // Merge auth headers (may override upstream auth)
+    Object.assign(headers, authHeaders);
+
+    // Set Host to the target host
+    const remoteUrl = req.headers['x-remote-url'] as string | null;
+    if (remoteUrl) {
+      try {
+        const parsed = new URL(remoteUrl);
+        headers['host'] = parsed.host;
+      } catch {
+        // Ignore invalid URL
+      }
+    }
+
+    return headers;
+  }
+
+  private proxyRequest(
+    targetUrl: string,
+    req: IncomingMessage,
+    res: ServerResponse,
+    headers: Record<string, string>,
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      const parsed = new URL(targetUrl);
+
+      const options: http.RequestOptions = {
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: parsed.pathname + parsed.search,
+        method: req.method,
+        headers,
+        timeout: UPSTREAM_TIMEOUT_MS,
+      };
+
+      const isHttps = parsed.protocol === 'https:';
+      const requestModule = isHttps ? require('https') : http;
+
+      const upstream = requestModule.request(options, (upstreamRes: http.IncomingMessage) => {
+        // Forward status code and headers
+        const upstreamHeaders: Record<string, string> = {};
+        for (const [key, value] of Object.entries(upstreamRes.headers)) {
+          if (typeof value !== 'string') continue;
+          if (key.toLowerCase() === 'transfer-encoding') continue;
+          upstreamHeaders[key] = value;
+        }
+        res.writeHead(upstreamRes.statusCode!, upstreamHeaders);
+
+        // Stream response body
+        upstreamRes.pipe(res);
+        upstreamRes.on('end', resolve);
+      });
+
+      upstream.on('error', (err: Error) => {
+        mainLog('AuthProxy', `Upstream error:`, err.message);
+        if (!res.headersSent) {
+          res.writeHead(502, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: `Upstream request failed: ${err.message}` }));
+        }
+        resolve();
+      });
+
+      upstream.on('timeout', () => {
+        upstream.destroy();
+        if (!res.headersSent) {
+          res.writeHead(504, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Upstream request timed out' }));
+        }
+        resolve();
+      });
+
+      // Stream request body to upstream
+      req.pipe(upstream);
+    });
+  }
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+function extractBearerToken(authHeader: string | undefined): string | null {
+  if (!authHeader) return null;
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}

--- a/src/process/services/authProxy/authInjectors.ts
+++ b/src/process/services/authProxy/authInjectors.ts
@@ -1,0 +1,100 @@
+/**
+ * Auth injection strategies for the Auth Proxy.
+ *
+ * Pure functions that receive a secret value and scheme,
+ * and return the headers/query to inject into the upstream request.
+ */
+
+import { Buffer } from 'buffer';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface InjectAuthParams {
+  scheme: string;
+  secret: string;
+  /** Custom header name (for scheme=header) or query param name (for scheme=query) */
+  headerName?: string;
+  /** Custom prefix for scheme=bearer (default: 'Bearer') */
+  prefix?: string;
+}
+
+export interface InjectAuthResult {
+  headers: Record<string, string>;
+  /** Modified URL with query params appended (only for scheme=query) */
+  url?: string;
+}
+
+// ============================================================================
+// Injection functions
+// ============================================================================
+
+/**
+ * Inject authentication based on the specified scheme.
+ *
+ * | Scheme   | Injection                                    |
+ * |----------|---------------------------------------------|
+ * | bearer   | Authorization: <prefix> <secret>             |
+ * | header   | <headerName>: <secret>                       |
+ * | query    | <headerName>=<secret> appended to URL        |
+ * | basic    | Authorization: Basic <base64(secret)>        |
+ */
+export function injectAuth(params: InjectAuthParams): InjectAuthResult {
+  const { scheme, secret, headerName, prefix } = params;
+
+  switch (scheme) {
+    case 'bearer': {
+      const effectivePrefix = prefix ?? 'Bearer';
+      return { headers: { Authorization: `${effectivePrefix} ${secret}` } };
+    }
+
+    case 'header': {
+      const name = headerName ?? 'X-API-Key';
+      return { headers: { [name]: secret } };
+    }
+
+    case 'query': {
+      const name = headerName ?? 'api_key';
+      // Return url with appended query param; caller is responsible for merging
+      return { headers: {}, url: `${name}=${encodeURIComponent(secret)}` };
+    }
+
+    case 'basic': {
+      const encoded = Buffer.from(secret, 'utf-8').toString('base64');
+      return { headers: { Authorization: `Basic ${encoded}` } };
+    }
+
+    default: {
+      // Fallback: treat as bearer
+      const effectivePrefix = prefix ?? 'Bearer';
+      return { headers: { Authorization: `${effectivePrefix} ${secret}` } };
+    }
+  }
+}
+
+/**
+ * Inject multiple headers for header/query schemes with multiple entries.
+ * Each entry has its own configKey as the header name / query param name.
+ */
+export function injectMultiAuth(
+  scheme: string,
+  entries: Array<{ configKey: string; secret: string }>,
+): InjectAuthResult {
+  const headers: Record<string, string> = {};
+  const queryParts: string[] = [];
+
+  for (const entry of entries) {
+    if (scheme === 'header') {
+      headers[entry.configKey] = entry.secret;
+    } else if (scheme === 'query') {
+      queryParts.push(`${entry.configKey}=${encodeURIComponent(entry.secret)}`);
+    }
+  }
+
+  if (scheme === 'query' && queryParts.length > 0) {
+    return { headers, url: queryParts.join('&') };
+  }
+
+  return { headers };
+}

--- a/src/process/services/authProxy/configItemsAdapter.ts
+++ b/src/process/services/authProxy/configItemsAdapter.ts
@@ -1,0 +1,90 @@
+/**
+ * Config Items Adapter - converts sudowork-server API responses
+ * into Auth Proxy internal rule format (AuthProxyRule).
+ *
+ * The namespace convention (service:{pinyin}) must match
+ * useTenantConfigItems.ts buildNamespace() in the renderer process.
+ */
+
+import type { AuthProxyRule } from '@/common/types/authProxy';
+
+// ============================================================================
+// Sudowork-server API types
+// ============================================================================
+
+interface ConfigEntry {
+  id: number;
+  config_key: string;
+  name: string;
+  config_desc: string | null;
+  required: number;
+}
+
+interface ConfigItem {
+  id: number;
+  name: string;
+  icon: string | null;
+  icon_url: string | null;
+  pinyin: string | null;
+  url_pattern: string | null;
+  scheme: string | null;
+  bearer_prefix: string | null;
+  entries: ConfigEntry[];
+}
+
+interface ConfigItemsResponse {
+  success: boolean;
+  data: ConfigItem[];
+  msg?: string;
+}
+
+// ============================================================================
+// Adapter
+// ============================================================================
+
+/**
+ * Build the Nexus secret namespace from a config item's pinyin.
+ * Must match useTenantConfigItems.ts buildNamespace().
+ */
+export function buildNamespace(pinyin: string): string {
+  return `service:${pinyin}`;
+}
+
+/**
+ * Convert a single Config Item from the sudowork-server API
+ * into an AuthProxyRule for internal use.
+ */
+export function adaptConfigItem(item: ConfigItem): AuthProxyRule {
+  return {
+    configItemId: item.id,
+    name: item.name,
+    urlPattern: item.url_pattern,
+    scheme: item.scheme,
+    bearerPrefix: item.bearer_prefix,
+    secretNamespace: buildNamespace(item.pinyin ?? ''),
+    entries: item.entries.map((e) => ({
+      configKey: e.config_key,
+      name: e.name,
+      required: e.required === 1,
+    })),
+  };
+}
+
+/**
+ * Convert the full Config Items API response into AuthProxyRule[],
+ * filtered by enabledConfigItemIds.
+ */
+export function adaptConfigItems(
+  response: ConfigItemsResponse,
+  enabledConfigItemIds: number[],
+): AuthProxyRule[] {
+  if (!response.success) {
+    throw new Error(response.msg || 'Failed to fetch config items');
+  }
+
+  const enabledSet = new Set(enabledConfigItemIds);
+
+  return response.data
+    .filter((item) => enabledSet.has(item.id))
+    .map(adaptConfigItem);
+}

--- a/src/process/services/authProxy/configItemsLoader.ts
+++ b/src/process/services/authProxy/configItemsLoader.ts
@@ -1,0 +1,90 @@
+/**
+ * Config Items Loader - fetches Config Items from sudowork-server
+ * and maintains an in-memory cache for Auth Proxy URL matching.
+ */
+
+import type { AuthProxyRule } from '@/common/types/authProxy';
+import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import { adaptConfigItems } from './configItemsAdapter';
+
+// ============================================================================
+// Cache
+// ============================================================================
+
+const CONFIG_ITEMS_API = `${SUDOWORK_SERVER_BASE_URL}/api/v1/config/items`;
+
+let rulesCache: Map<number, AuthProxyRule> = new Map();
+let lastSuccessfulRules: AuthProxyRule[] = [];
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Get all cached rules.
+ */
+export function getRules(): AuthProxyRule[] {
+  return Array.from(rulesCache.values());
+}
+
+/**
+ * Get cached rules that have a urlPattern (for URL auto-matching).
+ */
+export function getRulesWithPattern(): AuthProxyRule[] {
+  return Array.from(rulesCache.values()).filter((r) => r.urlPattern !== null);
+}
+
+/**
+ * Find a matching rule for the given URL using glob pattern matching.
+ * Returns the first matching rule, or null if no match.
+ */
+export function findRuleForUrl(url: string, minimatchFn: (str: string, pattern: string) => boolean): AuthProxyRule | null {
+  const patternRules = getRulesWithPattern();
+  for (const rule of patternRules) {
+    if (rule.urlPattern && minimatchFn(url, rule.urlPattern)) {
+      return rule;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch Config Items from sudowork-server and update the cache.
+ *
+ * @param accessToken - User's access token for sudowork-server API
+ * @param enabledConfigItemIds - IDs of config items the user has enabled
+ */
+export async function refreshRules(
+  accessToken: string,
+  enabledConfigItemIds: number[],
+): Promise<AuthProxyRule[]> {
+  try {
+    const response = await fetch(CONFIG_ITEMS_API, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) {
+      mainWarn('ConfigItemsLoader', `API returned ${response.status}: ${response.statusText}`);
+      // Degrade: return last successful cache
+      return lastSuccessfulRules;
+    }
+
+    const result = await response.json();
+    const rules = adaptConfigItems(result, enabledConfigItemIds);
+
+    // Update cache
+    rulesCache.clear();
+    for (const rule of rules) {
+      rulesCache.set(rule.configItemId, rule);
+    }
+    lastSuccessfulRules = rules;
+
+    mainLog('ConfigItemsLoader', `Loaded ${rules.length} rules (${rules.filter((r) => r.urlPattern).length} with URL patterns)`);
+    return rules;
+  } catch (error) {
+    mainWarn('ConfigItemsLoader', `Failed to fetch config items:`, error);
+    // Degrade: return last successful cache
+    return lastSuccessfulRules;
+  }
+}

--- a/src/process/services/authProxy/index.ts
+++ b/src/process/services/authProxy/index.ts
@@ -1,0 +1,105 @@
+/**
+ * Auth Proxy - lifecycle management and public API.
+ *
+ * This module manages:
+ * - Starting/stopping the Auth Proxy HTTP server
+ * - Token registry (for ACP child process authentication)
+ * - Config Items cache refresh (for URL pattern matching)
+ */
+
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { AuthProxyServer } from './AuthProxyServer';
+import { refreshRules, getRules } from './configItemsLoader';
+
+// ============================================================================
+// Module state
+// ============================================================================
+
+let server: AuthProxyServer | null = null;
+let serverPort: number | null = null;
+
+// ============================================================================
+// Public API - Server lifecycle
+// ============================================================================
+
+/**
+ * Start the Auth Proxy server.
+ * Must be called after secretCache.preload() completes.
+ * Returns the port the server is listening on.
+ */
+export async function startAuthProxy(): Promise<number> {
+  if (server) {
+    return server.getPort()!;
+  }
+
+  try {
+    // Dynamic import minimatch to avoid bundling issues
+    const { match } = await import('minimatch' as string) as { match: (str: string, pattern: string) => boolean };
+
+    server = new AuthProxyServer(match);
+    serverPort = await server.start();
+    return serverPort;
+  } catch (error) {
+    mainError('AuthProxy', 'Failed to start:', error);
+    throw error;
+  }
+}
+
+/**
+ * Stop the Auth Proxy server gracefully.
+ */
+export async function stopAuthProxy(): Promise<void> {
+  if (!server) return;
+  const port = serverPort;
+  await server.stop();
+  server = null;
+  serverPort = null;
+  mainLog('AuthProxy', `Stopped (was on port ${port})`);
+}
+
+/**
+ * Get the current Auth Proxy port, or null if not running.
+ */
+export function getAuthProxyPort(): number | null {
+  return serverPort;
+}
+
+// ============================================================================
+// Public API - Token management (for AcpConnection)
+// ============================================================================
+
+/**
+ * Register a proxy token for a child process.
+ */
+export function registerToken(token: string, pid: number): void {
+  server?.registerToken(token, pid);
+}
+
+/**
+ * Revoke a proxy token (e.g., when child process exits).
+ */
+export function revokeToken(token: string): void {
+  server?.revokeToken(token);
+}
+
+// ============================================================================
+// Public API - Config Items (for IPC bridge)
+// ============================================================================
+
+/**
+ * Get all cached Config Items rules.
+ */
+export function getAuthProxyRules() {
+  return getRules();
+}
+
+/**
+ * Refresh Config Items from sudowork-server.
+ * Called from renderer via IPC bridge.
+ */
+export async function refreshAuthProxyRules(
+  accessToken: string,
+  enabledConfigItemIds: number[],
+): Promise<void> {
+  await refreshRules(accessToken, enabledConfigItemIds);
+}

--- a/src/process/services/authProxy/ssrfGuard.ts
+++ b/src/process/services/authProxy/ssrfGuard.ts
@@ -1,0 +1,48 @@
+/**
+ * URL validation for the Auth Proxy.
+ *
+ * Validates that target URLs use allowed protocols (http/https only).
+ *
+ * Note: IP-level SSRF protection (blocking 127.0.0.1, 10.x, 192.168.x, etc.)
+ * is intentionally NOT applied. The Auth Proxy:
+ * - Listens on 127.0.0.1 only (no external access)
+ * - Requires token authentication (only Skill child processes can use it)
+ * - Runs on the user's own machine — the Skill process could directly access
+ *   any local/LAN service without the proxy, so IP blocking adds no real
+ *   security value and would prevent legitimate use cases (local dev servers,
+ *   self-hosted APIs, on-premise services, etc.).
+ */
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export interface ValidateUrlResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate that a URL uses an allowed protocol.
+ */
+export async function validateRemoteUrl(rawUrl: string): Promise<ValidateUrlResult> {
+  return validateRemoteUrlSync(rawUrl);
+}
+
+/**
+ * Synchronous URL validation — protocol check only.
+ */
+export function validateRemoteUrlSync(rawUrl: string): ValidateUrlResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { valid: false, error: `Invalid URL: ${rawUrl}` };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { valid: false, error: `Blocked protocol: ${parsed.protocol}` };
+  }
+
+  return { valid: true };
+}

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -126,6 +126,13 @@ export class ServiceManager {
 
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
+    // Stop Auth Proxy first — no new requests should be accepted after shutdown begins
+    try {
+      const { stopAuthProxy } = await import('@process/services/authProxy');
+      await stopAuthProxy();
+    } catch {
+      /* ignore */
+    }
     try {
       const { componentHealthMonitor } = await import('./ComponentHealthMonitor');
       await componentHealthMonitor.stop();
@@ -232,7 +239,17 @@ export class ServiceManager {
         this.secretsReadyResolve = resolve;
       });
       this.initializeSecrets()
-        .then(() => this.secretsReadyResolve?.(true))
+        .then(async () => {
+          // Start Auth Proxy after secrets are initialized
+          try {
+            const { startAuthProxy } = await import('@process/services/authProxy');
+            const port = await startAuthProxy();
+            mainLog('ServiceManager', `Auth Proxy started on port ${port}`);
+          } catch (err) {
+            mainWarn('ServiceManager', 'Auth Proxy start failed (non-critical):', err);
+          }
+          this.secretsReadyResolve?.(true);
+        })
         .catch((err) => {
           mainWarn('ServiceManager', 'Secrets initialization failed (non-critical):', err);
           this.secretsReadyResolve?.(false);

--- a/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
+++ b/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { secret } from '@/common/ipcBridge';
+import { secret, authProxy } from '@/common/ipcBridge';
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
 import { ConfigStorage } from '@/common/storage';
 import { useAuth } from '@/renderer/context/AuthContext';
@@ -182,11 +182,20 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
       setEnabledMap(newMap);
       try {
         await ConfigStorage.set(TENANT_ENABLED_STORAGE_KEY, newMap);
+
+        // Notify Auth Proxy to refresh rules cache
+        const token = await ensureValidToken();
+        if (token) {
+          const enabledIds = Object.entries(newMap).filter(([, v]) => v).map(([k]) => Number(k));
+          authProxy.refreshRules.invoke({ accessToken: token, enabledConfigItemIds: enabledIds }).catch((err) => {
+            console.warn('[TenantConfig] Failed to refresh Auth Proxy rules:', err);
+          });
+        }
       } catch (err) {
         console.error('[TenantConfig] Failed to save enabled state:', err);
       }
     },
-    [enabledMap],
+    [enabledMap, ensureValidToken],
   );
 
   const saveItem = useCallback(

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -135,6 +135,37 @@ const DEVICE_ID_KEY = 'sudowork_device_id';
 
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
 
+/**
+ * Refresh Auth Proxy rules after successful login.
+ * Reads enabled config item IDs from storage and triggers a rules refresh.
+ */
+async function refreshAuthProxyRulesAfterLogin(): Promise<void> {
+  try {
+    const enabledMap = await ConfigStorage.get('settings.tenant.enabled') as Record<number, boolean> | undefined;
+    const enabledIds = enabledMap
+      ? Object.entries(enabledMap).filter(([, v]) => v).map(([k]) => Number(k))
+      : [];
+
+    if (enabledIds.length === 0) return;
+
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!stored) return;
+    const authStorage: AuthStorage = JSON.parse(stored);
+
+    const result = await ipcBridge.authProxy.refreshRules.invoke({
+      accessToken: authStorage.access_token,
+      enabledConfigItemIds: enabledIds,
+    });
+    if (result.success) {
+      console.log('[Auth] Auth Proxy rules refreshed after login');
+    } else {
+      console.warn('[Auth] Auth Proxy rules refresh failed after login:', result.msg);
+    }
+  } catch (err) {
+    console.warn('[Auth] Auth Proxy rules refresh error after login:', err);
+  }
+}
+
 function hasSudoclawApiKey(config: { models?: { providers?: Record<string, { apiKey?: string }> } } | null | undefined): boolean {
   return Object.values(config?.models?.providers || {}).some((provider) => !!provider?.apiKey?.trim());
 }
@@ -300,6 +331,11 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
   setUser(authData);
   setStatus('authenticated');
   setReady(true);
+
+  // Trigger Auth Proxy rules refresh after login
+  if (isDesktopRuntime) {
+    void refreshAuthProxyRulesAfterLogin();
+  }
 
   if (isDesktopRuntime) {
     void ipcBridge.sudoclaw.restartGateway

--- a/src/webserver/routes/apiRoutes.ts
+++ b/src/webserver/routes/apiRoutes.ts
@@ -12,6 +12,8 @@ import https from 'https';
 import { URL } from 'url';
 import { TokenMiddleware } from '@/webserver/auth/middleware/TokenMiddleware';
 import { ExtensionRegistry } from '@/extensions';
+import { getSecretStoreClient } from '@common/nexus/secret-store';
+import { cachePut, cacheDelete } from '@common/nexus/secret-cache';
 import directoryApi from '../directoryApi';
 import { apiRateLimiter } from '../middleware/security';
 
@@ -313,6 +315,74 @@ export function registerApiRoutes(app: Express): void {
       res.json({ success: true, data: data.data });
     } catch (error) {
       console.error('[SkillHub API] Failed to fetch skill detail:', error);
+      res.status(500).json({ success: false, msg: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  // ==========================================================================
+  // Secret CRUD API
+  // ==========================================================================
+
+  /**
+   * GET /api/secrets - List secret metadata (no values)
+   * ?namespace=xxx - optional filter by namespace
+   */
+  app.get('/api/secrets', apiRateLimiter, validateApiAccess, async (req: Request, res: Response) => {
+    try {
+      const namespace = typeof req.query.namespace === 'string' ? req.query.namespace : undefined;
+      const client = getSecretStoreClient();
+      const secrets = await client.listSecrets(namespace, false);
+      // Strip values - only return metadata
+      const metadata = secrets.map((s) => ({
+        namespace: s.namespace,
+        key: s.key,
+        description: s.description,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+        version: s.currentVersion,
+      }));
+      res.json({ success: true, data: metadata });
+    } catch (error) {
+      console.error('[SecretAPI] Failed to list secrets:', error);
+      res.status(500).json({ success: false, msg: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  /**
+   * PUT /api/secrets/:namespace/:key - Create or update a secret
+   * Body: { value: string, description?: string }
+   */
+  app.put('/api/secrets/:namespace/:key', apiRateLimiter, validateApiAccess, async (req: Request, res: Response) => {
+    try {
+      const namespace = req.params.namespace as string;
+      const key = req.params.key as string;
+      const { value, description } = req.body;
+      if (typeof value !== 'string') {
+        return res.status(400).json({ success: false, msg: 'Missing or invalid "value" field' });
+      }
+      const client = getSecretStoreClient();
+      const result = await client.putSecret(namespace, key, value, description);
+      cachePut(namespace, key, value);
+      res.json({ success: true, data: result });
+    } catch (error) {
+      console.error('[SecretAPI] Failed to put secret:', error);
+      res.status(500).json({ success: false, msg: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  /**
+   * DELETE /api/secrets/:namespace/:key - Soft-delete a secret
+   */
+  app.delete('/api/secrets/:namespace/:key', apiRateLimiter, validateApiAccess, async (req: Request, res: Response) => {
+    try {
+      const namespace = req.params.namespace as string;
+      const key = req.params.key as string;
+      const client = getSecretStoreClient();
+      const result = await client.deleteSecret(namespace, key);
+      cacheDelete(namespace, key);
+      res.json({ success: true, data: result });
+    } catch (error) {
+      console.error('[SecretAPI] Failed to delete secret:', error);
       res.status(500).json({ success: false, msg: error instanceof Error ? error.message : String(error) });
     }
   });


### PR DESCRIPTION
## Summary
- Add Auth Proxy HTTP server that intercepts child process requests and injects authentication credentials based on Config Items rules
- Support 4 auth schemes: bearer, header, query, basic with multi-entry support
- Integrate proxy lifecycle into ServiceManager (start after secrets, stop first on shutdown)
- Add Secret CRUD REST API for external access to Nexus secrets
- Sync secret cache on put/delete/restore operations for proxy consistency

## Changes
- **Phase 0**: Secret cache sync (`cacheDelete` in secret-cache.ts, secretBridge.ts, Secret REST API in apiRoutes.ts)
- **Phase 1**: Auth Proxy Server (AuthProxyServer.ts, authInjectors.ts, ssrfGuard.ts, index.ts)
- **Phase 2**: Config Items URL pattern matching (configItemsAdapter.ts, configItemsLoader.ts, minimatch dependency)
- **Phase 3**: Environment variable injection + token management (AcpConnection.ts, acpConnectors.ts)
- **Phase 4**: IPC Bridge (ipcBridge.ts, authProxyBridge.ts, bridge/index.ts)
- **Phase 5**: Lifecycle integration (ServiceManager.ts, AuthContext.tsx, useTenantConfigItems.ts)

## Test plan
- [ ] Verify Auth Proxy starts on app launch and stops on shutdown
- [ ] Verify secret CRUD API works (GET/PUT/DELETE /api/secrets)
- [ ] Verify login triggers Auth Proxy rules refresh
- [ ] Verify Config Item toggle triggers rules refresh
- [ ] Verify child processes receive proxy env vars (SUDOWORK_AUTH_PROXY_URL, SUDOWORK_AUTH_PROXY_TOKEN)
- [ ] Verify token lifecycle (register on spawn, revoke on exit/terminate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)