### PR TITLE
fix: 统一token刷新入口，避免渲染/主进程竞争导致refresh token失效

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1709,4 +1709,6 @@ export const eeclaw = {
   logout: bridge.buildProvider<IBridgeResponse<{}>, void>('eeclaw.logout'),
   /** Emitted when the main process refreshes the enterprise auth token */
   tokenRefreshed: bridge.buildEmitter<{ access_token: string; refresh_token: string; expires_at: number }>('eeclaw.token-refreshed'),
+  /** Refresh enterprise auth token via main process (single entry point to avoid race conditions) */
+  refreshToken: bridge.buildProvider<IBridgeResponse<{ access_token: string; refresh_token?: string; expires_at: number }>, void>('eeclaw.refresh-token'),
 };

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -60,6 +60,53 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
       const data = await response.json();
 
       if (!response.ok) {
+        // If "Invalid refresh token", the renderer may have already rotated it.
+        // Invalidate cache and retry once with the latest token from file.
+        if (data?.error === 'Invalid refresh token' || response.status === 401) {
+          mainLog('eeclawBridge', '[getValidToken] Got Invalid refresh token, invalidating cache and retrying with latest from file');
+          ProcessConfig.invalidateCache();
+          const latestAuth = ProcessConfig.getSync('eeclaw.authStorage');
+          if (latestAuth?.refresh_token && latestAuth.refresh_token !== refresh_token) {
+            mainLog('eeclawBridge', `[getValidToken] Found different refresh_token in file, retrying with ${latestAuth.refresh_token.slice(0, 20)}...`);
+            const retryResponse = await fetch(`${serverUrl}/api/v1/auth/token`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Device-Id': latestAuth.device_id,
+              },
+              body: JSON.stringify({
+                grant_type: 'refresh_token',
+                refresh_token: latestAuth.refresh_token,
+              }),
+              signal: AbortSignal.timeout(15000),
+            });
+            const retryData = await retryResponse.json();
+            if (retryResponse.ok && retryData.access_token) {
+              const newAuthStorage = {
+                access_token: retryData.access_token,
+                refresh_token: retryData.refresh_token || latestAuth.refresh_token,
+                expires_at: Date.now() + (retryData.expires_in || 3600) * 1000,
+                device_id: latestAuth.device_id,
+              };
+              mainLog('eeclawBridge', `[getValidToken] Retry refresh successful! new_expires_at=${newAuthStorage.expires_at}`);
+              await ProcessConfig.set('eeclaw.authStorage', newAuthStorage);
+              setCachedAuthToken(retryData.access_token);
+              try {
+                ipcBridge.eeclaw.tokenRefreshed.emit({
+                  access_token: retryData.access_token,
+                  refresh_token: retryData.refresh_token || latestAuth.refresh_token,
+                  expires_at: newAuthStorage.expires_at,
+                });
+              } catch (e) {
+                mainLog('eeclawBridge', 'Failed to emit token refresh event:', e);
+              }
+              return retryData.access_token;
+            }
+            mainWarn('eeclawBridge', `[getValidToken] Retry also failed: status=${retryResponse.status}, error=${retryData?.error || 'unknown'}`);
+          } else {
+            mainWarn('eeclawBridge', '[getValidToken] No different refresh_token found in file after cache invalidation');
+          }
+        }
         mainWarn('eeclawBridge', `[getValidToken] Refresh failed: status=${response.status}, error=${data?.error || 'unknown'}`);
         throw new Error(data?.error || 'token_refresh_failed');
       }
@@ -90,8 +137,6 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
       return data.access_token;
     } catch (error) {
       mainWarn('eeclawBridge', 'Token refresh failed:', error);
-      // Do NOT clear authStorage on refresh failure - the refresh_token may still be valid
-      // and the user can retry. Only clear the in-memory cache.
       setCachedAuthToken('');
       throw error;
     } finally {
@@ -269,6 +314,24 @@ export function initEeclawBridge(): void {
     } catch (error) {
       mainWarn('eeclawBridge', 'getCloudAssistants error:', error);
       return { success: false, error: 'network_error' as const, data: undefined };
+    }
+  });
+
+  ipcBridge.eeclaw.refreshToken.provider(async () => {
+    try {
+      const token = await getValidToken(true);
+      const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
+      return {
+        success: true,
+        data: {
+          access_token: token,
+          refresh_token: authStorage?.refresh_token,
+          expires_at: authStorage?.expires_at,
+        },
+      };
+    } catch (error) {
+      mainWarn('eeclawBridge', 'refreshToken error:', error);
+      return { success: false, error: String((error as Error)?.message || error), data: undefined };
     }
   });
 

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -380,64 +380,32 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
     refreshPromiseRef.current = (async () => {
       try {
-        // Enterprise mode: refresh via MOSS server directly (CORS supported)
+        // Enterprise mode: delegate to main process getValidToken via IPC to avoid race conditions
         const eeclawStored = localStorage.getItem(EECLAW_AUTH_STORAGE_KEY);
         if (eeclawStored) {
           try {
             const authStorage: EeclawAuthStorage = JSON.parse(eeclawStored);
-            if (!authStorage.refresh_token) {
-              console.warn('[Auth] No enterprise refresh_token available, cannot refresh');
-              return false;
-            }
 
-            const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
-            if (!serverUrl) {
-              console.warn('[Auth] No enterprise server URL available');
-              return false;
-            }
-
-            const response = await fetch(`${serverUrl}/api/v1/auth/token`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                grant_type: 'refresh_token',
-                refresh_token: authStorage.refresh_token,
-              }),
-            });
-
-            const data = await response.json();
-            if (response.ok && data.access_token) {
+            const result = await ipcBridge.eeclaw.refreshToken.invoke();
+            if (result.success && result.data) {
               const newStorage: EeclawAuthStorage = {
-                access_token: data.access_token,
-                refresh_token: data.refresh_token || authStorage.refresh_token,
-                expires_at: Date.now() + (data.expires_in || 3600) * 1000,
+                access_token: result.data.access_token,
+                refresh_token: result.data.refresh_token || authStorage.refresh_token,
+                expires_at: result.data.expires_at || Date.now() + 3600 * 1000,
                 user: authStorage.user,
                 device_id: authStorage.device_id,
               };
 
               localStorage.setItem(EECLAW_AUTH_STORAGE_KEY, JSON.stringify(newStorage));
-
-              // Sync to ConfigStorage for eeclawBridge
-              try {
-                await ConfigStorage.set('eeclaw.authStorage', {
-                  access_token: data.access_token,
-                  refresh_token: data.refresh_token || authStorage.refresh_token,
-                  expires_at: newStorage.expires_at,
-                  device_id: authStorage.device_id,
-                });
-              } catch (e) {
-                console.warn('[Auth] Failed to sync refreshed enterprise token to ConfigStorage:', e);
-              }
-
-              setUser({ ...authStorage.user, token: data.access_token });
+              setUser({ ...authStorage.user, token: result.data.access_token });
               lastRefreshAtRef.current = Date.now();
-              console.log('[Auth] Enterprise token refreshed successfully');
+              console.log('[Auth] Enterprise token refreshed successfully via IPC');
               return true;
             }
-            console.error('[Auth] Enterprise token refresh failed:', data?.error || 'unknown');
+            console.error('[Auth] Enterprise token refresh via IPC failed');
             return false;
           } catch (error) {
-            console.error('[Auth] Enterprise token refresh failed:', error);
+            console.error('[Auth] Enterprise token refresh via IPC failed:', error);
             return false;
           }
         }


### PR DESCRIPTION
## Summary
- 渲染进程企业模式token刷新改为IPC调主进程`getValidToken()`，不再直接fetch MOSS服务端，避免两进程竞争refresh_token轮换导致"Invalid refresh token"
- 新增`ipcBridge.eeclaw.refreshToken` IPC方法，作为渲染进程刷新token的唯一入口
- `getValidToken`遇到"Invalid refresh token"时invalidate缓存并从文件重新读取refresh_token重试一次

## 根因
渲染进程`refreshTokens()`和主进程`getValidToken()`各自独立调用MOSS `/api/v1/auth/token`刷新接口，服务器轮换refresh_token后，后调用的一方使用已作废的旧refresh_token，导致401。