### PR TITLE
fix(auth-proxy): 修复minimatch导入及应用重启后Config Items不加载

### DIFF
--- a/src/process/services/authProxy/index.ts
+++ b/src/process/services/authProxy/index.ts
@@ -34,9 +34,9 @@ export async function startAuthProxy(): Promise<number> {
 
   try {
     // Dynamic import minimatch to avoid bundling issues
-    const { match } = await import('minimatch' as string) as { match: (str: string, pattern: string) => boolean };
+    const minimatchDefault = (await import('minimatch' as string) as unknown as { default: (str: string, pattern: string) => boolean }).default;
 
-    server = new AuthProxyServer(match);
+    server = new AuthProxyServer(minimatchDefault);
     serverPort = await server.start();
     return serverPort;
   } catch (error) {

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -332,11 +332,6 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
   setStatus('authenticated');
   setReady(true);
 
-  // Trigger Auth Proxy rules refresh after login
-  if (isDesktopRuntime) {
-    void refreshAuthProxyRulesAfterLogin();
-  }
-
   if (isDesktopRuntime) {
     void ipcBridge.sudoclaw.restartGateway
       .invoke()
@@ -714,6 +709,13 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       abortRef.current?.abort();
     };
   }, [refresh]);
+
+  // Auth Proxy: 登录状态变化时自动刷新 rules
+  useEffect(() => {
+    if (status === 'authenticated' && isDesktopRuntime) {
+      void refreshAuthProxyRulesAfterLogin();
+    }
+  }, [status]);
 
   // Sync token refresh events from main process to renderer localStorage
   // Main process (MossSessionApi/eeclawBridge) may refresh tokens, revoking the old


### PR DESCRIPTION
## Summary
- 修复 minimatch 动态导入方式：使用默认导出而非解构命名导出，解决 `minimatchFn is not a function` 错误
- 修复应用重启恢复登录状态后 Auth Proxy Config Items 不加载的问题：改用 `useEffect` 监听 `status` 变化统一触发 `refreshAuthProxyRulesAfterLogin()`，移除 `handleLoginSuccess` 中的手动调用

## Test plan
- [ ] 启动桌面应用，确认已登录状态恢复后，控制台出现 `[Auth] Auth Proxy rules refreshed after login` 日志
- [ ] 通过 `ipcBridge.authProxy.getRules` 确认 rules 缓存非空
- [ ] 首次登录场景同样正常触发 rules 刷新（回归验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)