### PR TITLE
feat(channels): migrate channel agent backend from openclaw-gateway to scode

### DIFF
--- a/src/channels/actions/SystemActions.ts
+++ b/src/channels/actions/SystemActions.ts
@@ -146,7 +146,7 @@ export const handleSessionNew: ActionHandler = async (context) => {
   } catch {
     // ignore
   }
-  const backend = (savedAgent && typeof savedAgent === 'object' && typeof (savedAgent as any).backend === 'string' ? (savedAgent as any).backend : 'claude') as string;
+  const backend = (savedAgent && typeof savedAgent === 'object' && typeof (savedAgent as any).backend === 'string' ? (savedAgent as any).backend : 'scode') as string;
   const customAgentId = savedAgent && typeof savedAgent === 'object' ? ((savedAgent as any).customAgentId as string | undefined) : undefined;
   const agentName = savedAgent && typeof savedAgent === 'object' ? ((savedAgent as any).name as string | undefined) : undefined;
 
@@ -156,6 +156,10 @@ export const handleSessionNew: ActionHandler = async (context) => {
   // Always create a NEW conversation for "session.new" (scoped by chatId)
   const channelChatId = context.chatId;
   const { convType, convBackend } = resolveChannelConvType(backend);
+
+  // Resolve cliPath from detected agents so AcpAgent can spawn the CLI correctly
+  const detectedAgent = acpDetector.getDetectedAgents().find((a) => a.backend === backend);
+  const cliPath = detectedAgent?.cliPath;
   // 使用用户昵称作为初始标题（与自动创建会话保持一致），后续首条消息会自动更新标题
   // Use user display name as initial title (consistent with auto-created conversations),
   // the title will be auto-updated on the first message
@@ -178,6 +182,7 @@ export const handleSessionNew: ActionHandler = async (context) => {
           channelChatId,
           extra: {
             backend: backend as AcpBackend,
+            cliPath,
             customAgentId,
             agentName,
           },
@@ -509,7 +514,7 @@ export const handleAgentSelect: ActionHandler = async (context, params) => {
 function getAgentDisplayName(agentType: ChannelAgentType): string {
   const names: Record<ChannelAgentType, string> = {
     acp: '🧠 Claude',
-    'openclaw-gateway': '🦞 Sudoclaw',
+    'openclaw-gateway': '⚡ Sudo Code',
   };
   return names[agentType] || agentType;
 }
@@ -519,7 +524,7 @@ function getAgentDisplayName(agentType: ChannelAgentType): string {
  * Only returns types that are supported by channels
  */
 function backendToChannelAgentType(backend: string): ChannelAgentType | null {
-  if (backend === 'openclaw-gateway') return 'openclaw-gateway';
+  if (backend === 'scode') return 'acp';
   // All other detected backends (claude, gemini, codex, qwen, etc.) use ACP
   return 'acp';
 }
@@ -533,7 +538,7 @@ function getAgentEmoji(backend: string): string {
     gemini: '🤖',
     codex: '⚡',
     qwen: '🔮',
-    'openclaw-gateway': '🦞',
+    'openclaw-gateway': '⚡',
   };
   return emojis[backend] || '🤖';
 }

--- a/src/channels/actions/SystemActions.ts
+++ b/src/channels/actions/SystemActions.ts
@@ -164,29 +164,19 @@ export const handleSessionNew: ActionHandler = async (context) => {
   // Use user display name as initial title (consistent with auto-created conversations),
   // the title will be auto-updated on the first message
   const name = context.channelUser?.displayName || context.displayName || getChannelConversationName(platform, convType, convBackend, channelChatId);
-  const result =
-    backend === 'openclaw-gateway'
-      ? await ConversationService.createConversation({
-          type: 'openclaw-gateway',
-          model,
-          source,
-          name,
-          channelChatId,
-          extra: {},
-        })
-      : await ConversationService.createConversation({
-          type: 'acp',
-          model,
-          source,
-          name,
-          channelChatId,
-          extra: {
-            backend: backend as AcpBackend,
-            cliPath,
-            customAgentId,
-            agentName,
-          },
-        });
+  const result = await ConversationService.createConversation({
+    type: 'acp',
+    model,
+    source,
+    name,
+    channelChatId,
+    extra: {
+      backend: backend as AcpBackend,
+      cliPath,
+      customAgentId,
+      agentName,
+    },
+  });
 
   if (!result.success || !result.conversation) {
     return createErrorResponse(`Failed to create session: ${result.error || 'Unknown error'}`);
@@ -514,7 +504,6 @@ export const handleAgentSelect: ActionHandler = async (context, params) => {
 function getAgentDisplayName(agentType: ChannelAgentType): string {
   const names: Record<ChannelAgentType, string> = {
     acp: '🧠 Claude',
-    'openclaw-gateway': '⚡ Sudo Code',
   };
   return names[agentType] || agentType;
 }
@@ -524,8 +513,6 @@ function getAgentDisplayName(agentType: ChannelAgentType): string {
  * Only returns types that are supported by channels
  */
 function backendToChannelAgentType(backend: string): ChannelAgentType | null {
-  if (backend === 'scode') return 'acp';
-  // All other detected backends (claude, gemini, codex, qwen, etc.) use ACP
   return 'acp';
 }
 
@@ -538,7 +525,7 @@ function getAgentEmoji(backend: string): string {
     gemini: '🤖',
     codex: '⚡',
     qwen: '🔮',
-    'openclaw-gateway': '⚡',
+    scode: '⚡',
   };
   return emojis[backend] || '🤖';
 }

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -31,6 +31,7 @@ import { createMainMenuKeyboard, createToolConfirmationKeyboard } from '../plugi
 import { escapeHtml } from '../plugins/telegram/TelegramAdapter';
 import type { PluginManager } from './PluginManager';
 import type { AcpBackend } from '@/types/acpTypes';
+import { acpDetector } from '@/agent/acp/AcpDetector';
 
 function getChannelWorkspacePath(platform: string): string {
   const dir = path.join(getDataPath(), 'channel-media', platform);
@@ -488,7 +489,7 @@ export class ActionExecutor {
         } catch {
           // ignore
         }
-        const backend = (savedAgent && typeof savedAgent === 'object' && typeof (savedAgent as any).backend === 'string' ? (savedAgent as any).backend : 'openclaw-gateway') as string;
+        const backend = (savedAgent && typeof savedAgent === 'object' && typeof (savedAgent as any).backend === 'string' ? (savedAgent as any).backend : 'scode') as string;
         const customAgentId = savedAgent && typeof savedAgent === 'object' ? ((savedAgent as any).customAgentId as string | undefined) : undefined;
         const agentName = savedAgent && typeof savedAgent === 'object' ? ((savedAgent as any).name as string | undefined) : undefined;
 
@@ -497,6 +498,10 @@ export class ActionExecutor {
 
         // Map backend to conversation type for lookup
         const { convType, convBackend } = resolveChannelConvType(backend);
+
+        // Resolve cliPath from detected agents so AcpAgent can spawn the CLI correctly
+        const detectedAgent = acpDetector.getDetectedAgents().find((a) => a.backend === backend);
+        const cliPath = detectedAgent?.cliPath;
 
         // Build human-readable conversation name (just the user's display name)
         // TODO: WeChat API doesn't provide user display names in messages — find a way to resolve human-readable names (e.g., via a contacts/profile API)
@@ -527,6 +532,7 @@ export class ActionExecutor {
                 channelChatId: chatId,
                 extra: {
                   backend: backend as AcpBackend,
+                  cliPath,
                   customAgentId,
                   agentName,
                   workspace: getChannelWorkspacePath(source),

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -515,29 +515,20 @@ export class ActionExecutor {
 
         const result = existing
           ? { success: true as const, conversation: existing }
-          : backend === 'openclaw-gateway'
-            ? await ConversationService.createConversation({
-                type: 'openclaw-gateway',
-                model,
-                name: conversationName,
-                source,
-                channelChatId: chatId,
-                extra: { workspace: getChannelWorkspacePath(source) },
-              })
-            : await ConversationService.createConversation({
-                type: 'acp',
-                model,
-                name: conversationName,
-                source,
-                channelChatId: chatId,
-                extra: {
-                  backend: backend as AcpBackend,
-                  cliPath,
-                  customAgentId,
-                  agentName,
-                  workspace: getChannelWorkspacePath(source),
-                },
-              });
+          : await ConversationService.createConversation({
+              type: 'acp',
+              model,
+              name: conversationName,
+              source,
+              channelChatId: chatId,
+              extra: {
+                backend: backend as AcpBackend,
+                cliPath,
+                customAgentId,
+                agentName,
+                workspace: getChannelWorkspacePath(source),
+              },
+            });
 
         if (result.success && result.conversation) {
           const { convType: agentType } = resolveChannelConvType(backend);

--- a/src/channels/plugins/telegram/TelegramPlugin.ts
+++ b/src/channels/plugins/telegram/TelegramPlugin.ts
@@ -387,7 +387,7 @@ export class TelegramPlugin extends BasePlugin {
     // 处理 agent 选择回调，格式: agent:{agentType}
     // Handle agent selection callback, format: agent:{agentType}
     if (category === 'agent') {
-      const agentType = extractAction(data); // acp, openclaw-gateway
+      const agentType = extractAction(data); // acp
       const unifiedMessage = toUnifiedIncomingMessage(ctx);
       if (unifiedMessage && this.messageHandler) {
         unifiedMessage.content.type = 'action';

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -177,7 +177,7 @@ export interface IChannelUserRow {
 /**
  * Agent types supported in assistant sessions
  */
-export type ChannelAgentType = 'acp' | 'openclaw-gateway';
+export type ChannelAgentType = 'acp';
 
 /**
  * User session in the assistant system
@@ -540,8 +540,7 @@ export function isChannelPlatform(value: string): value is ChannelPlatform {
  * Centralizes the backend → convType mapping used across channels.
  */
 export function resolveChannelConvType(backend: string): { convType: string; convBackend?: string } {
-  if (backend === 'openclaw-gateway') return { convType: 'openclaw-gateway' };
-  // All other backends (claude, qwen, etc.) use ACP protocol
+  // All backends (scode, claude, gemini, codex, qwen, etc.) use ACP protocol
   return { convType: 'acp', convBackend: backend };
 }
 

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -82,6 +82,8 @@ export interface IConfigStorageRefer {
   'migration.promptsI18nAdded'?: boolean;
   /** Migration flag: skill subdirectory restructuring completed */
   'migration.skillSubdirectoriesMigrated'?: boolean;
+  /** Migration flag: channel agent migrated from openclaw-gateway (Sudoclaw) to scode (Sudo Code) */
+  'migration.channelAgentMigratedToScode'?: boolean;
   // 关闭窗口时最小化到系统托盘 / Minimize to system tray when closing window
   'system.closeToTray'?: boolean;
   // 桌面 avatar 浮窗开关 / Floating desktop avatar window enabled

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -1078,6 +1078,35 @@ const initStorage = async () => {
   // Wait for both assistant config and database init to complete
   await Promise.all([assistantsPromise, dbPromise]);
 
+  // 7. Migrate channel agent from openclaw-gateway (Sudoclaw) to scode (Sudo Code)
+  // 渠道 agent 从 openclaw-gateway (Sudoclaw) 迁移到 scode (Sudo Code)
+  const CHANNEL_AGENT_MIGRATION_KEY = 'migration.channelAgentMigratedToScode';
+  const channelAgentMigrationDone = await configFile.get(CHANNEL_AGENT_MIGRATION_KEY).catch(() => false);
+  if (!channelAgentMigrationDone) {
+    try {
+      const CHANNEL_AGENT_KEYS = [
+        'assistant.telegram.agent',
+        'assistant.lark.agent',
+        'assistant.dingtalk.agent',
+        'assistant.wechat.agent',
+        'assistant.wecom.agent',
+      ] as const;
+      for (const key of CHANNEL_AGENT_KEYS) {
+        const saved = await configFile.get(key).catch(() => undefined);
+        if (saved && typeof saved === 'object' && (saved as any).backend === 'openclaw-gateway') {
+          (saved as any).backend = 'scode';
+          (saved as any).name = 'Sudo Code';
+          await configFile.set(key, saved);
+          mainLog('Sudowork', `Migrated ${key} from openclaw-gateway to scode`);
+        }
+      }
+      await configFile.set(CHANNEL_AGENT_MIGRATION_KEY, true);
+      mainLog('Sudowork', 'Channel agent migration to scode completed');
+    } catch (error) {
+      mainError('Sudowork', 'Failed to migrate channel agent:', error);
+    }
+  }
+
   perfLog('initStorage.total', Date.now() - startTime);
 
   application.systemInfo.provider(() => {

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -83,6 +83,15 @@ export class ServiceManager {
 
     this.shuttingDown = false;
     this.startupInProgress = true;
+
+    // 提前创建 secrets promise，让消费者可以立即 await
+    // Promise 在 startNexusOnce() 中通过 initializeSecrets() resolve
+    if (!this.secretsReadyPromise) {
+      this.secretsReadyPromise = new Promise<boolean>((resolve) => {
+        this.secretsReadyResolve = resolve;
+      });
+    }
+
     runtimeInstaller.primeStatusForStartup();
     initStatusManager.clearRetry();
 
@@ -115,6 +124,7 @@ export class ServiceManager {
       initStatusManager.setDetail('核心服务启动失败，请手动点击重试或重装。');
       initStatusManager.addLog(`⚠ 启动失败：${message}`);
       mainError('ServiceManager', 'Startup readiness verification failed', err);
+      this.secretsReadyResolve?.(false);
     } finally {
       this.startupInProgress = false;
     }
@@ -235,9 +245,7 @@ export class ServiceManager {
 
       // Initialize secrets system after Nexus is healthy
       // This runs migration (if needed) and preloads the secret cache
-      this.secretsReadyPromise = new Promise<boolean>((resolve) => {
-        this.secretsReadyResolve = resolve;
-      });
+      // secretsReadyPromise 已在 startup() 入口处创建
       this.initializeSecrets()
         .then(async () => {
           // Start Auth Proxy after secrets are initialized
@@ -860,19 +868,12 @@ export class ServiceManager {
   /**
    * Wait for the secrets system to be initialized.
    * Channel plugins call this before loading to ensure credentials are available.
-   * Polls until the promise is created (Nexus may still be starting),
-   * then awaits its resolution.
+   * secretsReadyPromise 在 startup() 入口处创建，此处直接 await 其 resolve。
    */
   async waitForSecrets(): Promise<boolean> {
-    // Poll until the promise is created by startNexusOnce()
-    const POLL_INTERVAL_MS = 200;
-    while (!this.secretsReadyPromise) {
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-      // startup 已结束但未创建 secretsReadyPromise → startup 在到达 startNexusOnce 之前失败
-      if (!this.startupInProgress) {
-        mainWarn('ServiceManager', 'waitForSecrets: startup completed without creating secretsReadyPromise');
-        return false;
-      }
+    if (!this.secretsReadyPromise) {
+      // startup 未被调用（如 enterprise 模式或新用户模式）
+      return false;
     }
     return this.secretsReadyPromise;
   }

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -345,7 +345,8 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
       await this.connect();
 
       // Re-apply persisted mode after session start/resume
-      if (this.currentMode && this.currentMode !== 'default') {
+      // codex/scode 不支持 session/set_mode，跳过
+      if (this.currentMode && this.currentMode !== 'default' && this.options.backend !== 'codex' && this.options.backend !== 'scode') {
         try {
           await this.connection.setSessionMode(this.currentMode);
           mainLog('[AcpAgent]', `Re-applied persisted mode: ${this.currentMode}`);
@@ -1261,7 +1262,7 @@ This identity statement takes priority over the default identity in USER.md.
   }
 
   async setMode(mode: string): Promise<{ success: boolean; msg?: string; data?: { mode: string } }> {
-    if (this.options.backend === 'codex') {
+    if (this.options.backend === 'codex' || this.options.backend === 'scode') {
       const prev = this.currentMode;
       this.currentMode = mode;
       this.yoloMode = this.isYoloMode(mode);

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -10,6 +10,7 @@ import { AcpAdapter } from '@/agent/acp/AcpAdapter';
 import { AcpApprovalStore, createAcpApprovalKey } from '@/agent/acp/ApprovalStore';
 import { AcpConnection } from '@/agent/acp/AcpConnection';
 import { CLAUDE_YOLO_SESSION_MODE, CODEBUDDY_YOLO_SESSION_MODE, IFLOW_YOLO_SESSION_MODE, QWEN_YOLO_SESSION_MODE } from '@/agent/acp/constants';
+import { acpDetector } from '@/agent/acp/AcpDetector';
 import { getClaudeModel } from '@/agent/acp/utils';
 import { buildAcpModelInfo, summarizeAcpModelInfo } from '@/agent/acp/modelInfo';
 import { channelEventBus } from '@/channels/agent/ChannelEventBus';
@@ -263,6 +264,13 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
         const config = await ProcessConfig.get('acp.config');
         if (!cliPath && config?.[data.backend]?.cliPath) {
           cliPath = config[data.backend].cliPath;
+        }
+        // Fallback: resolve from acpDetector (handles channel conversations and restored sessions)
+        if (!cliPath) {
+          const detected = acpDetector.getDetectedAgents().find((a) => a.backend === data.backend);
+          if (detected?.cliPath) {
+            cliPath = detected.cliPath;
+          }
         }
         const legacyYoloMode = data.yoloMode ?? (config?.[data.backend] as any)?.yoloMode;
 

--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -10,7 +10,7 @@ import { ConfigStorage } from '@/common/storage';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
-import type { AcpBackendAll } from '@/types/acpTypes';
+import { CHANNEL_DEFAULT_AGENT_BACKEND, type AcpBackendAll } from '@/types/acpTypes';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
@@ -60,8 +60,6 @@ interface DingTalkConfigFormProps {
 }
 
 const DINGTALK_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/dingtalk.html';
-const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
-
 const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
@@ -167,7 +165,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.dingtalk.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_VISIBLE_AGENT_BACKEND);
+          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_DEFAULT_AGENT_BACKEND);
           const list = visibleAgents.map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset, isExtension: a.isExtension }));
           setAvailableAgents(list);
         }
@@ -365,7 +363,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
 
   const hasExistingUsers = authorizedUsers.length > 0;
   const isGeminiAgent = selectedAgent.backend === 'gemini';
-  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_VISIBLE_AGENT_BACKEND, name: 'Sudoclaw' }];
+  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_DEFAULT_AGENT_BACKEND, name: 'Sudo Code' }];
 
   return (
     <div className='flex flex-col gap-24px'>
@@ -519,7 +517,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
             }
           >
             <Button type='secondary' className='min-w-160px flex items-center justify-between gap-8px'>
-              <span className='truncate'>{agentOptions[0]?.name || 'Sudoclaw'}</span>
+              <span className='truncate'>{agentOptions[0]?.name || 'Sudo Code'}</span>
               <Down theme='outline' size={14} />
             </Button>
           </Dropdown>

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -10,7 +10,7 @@ import { ConfigStorage } from '@/common/storage';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
-import type { AcpBackendAll } from '@/types/acpTypes';
+import { CHANNEL_DEFAULT_AGENT_BACKEND, type AcpBackendAll } from '@/types/acpTypes';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
@@ -60,8 +60,6 @@ interface LarkConfigFormProps {
 }
 
 const LARK_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/feishu.html';
-const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
-
 const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
@@ -174,7 +172,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.lark.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_VISIBLE_AGENT_BACKEND);
+          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_DEFAULT_AGENT_BACKEND);
           const list = visibleAgents.map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset, isExtension: a.isExtension }));
           setAvailableAgents(list);
         }
@@ -376,7 +374,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
 
   const hasExistingUsers = authorizedUsers.length > 0;
   const isGeminiAgent = selectedAgent.backend === 'gemini';
-  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_VISIBLE_AGENT_BACKEND, name: 'Sudoclaw' }];
+  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_DEFAULT_AGENT_BACKEND, name: 'Sudo Code' }];
 
   return (
     <div className='flex flex-col gap-24px'>
@@ -609,7 +607,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
             }
           >
             <Button type='secondary' className='min-w-160px flex items-center justify-between gap-8px'>
-              <span className='truncate'>{agentOptions[0]?.name || 'Sudoclaw'}</span>
+              <span className='truncate'>{agentOptions[0]?.name || 'Sudo Code'}</span>
               <Down theme='outline' size={14} />
             </Button>
           </Dropdown>

--- a/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
@@ -9,7 +9,7 @@ import { acpConversation, channel } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
-import type { AcpBackendAll } from '@/types/acpTypes';
+import { CHANNEL_DEFAULT_AGENT_BACKEND, type AcpBackendAll } from '@/types/acpTypes';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
@@ -53,8 +53,6 @@ interface TelegramConfigFormProps {
   onStatusChange: (status: IChannelPluginStatus | null) => void;
   onTokenChange?: (token: string) => void;
 }
-
-const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onTokenChange }) => {
   const { t } = useTranslation();
@@ -146,7 +144,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.telegram.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_VISIBLE_AGENT_BACKEND);
+          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_DEFAULT_AGENT_BACKEND);
           const list = visibleAgents.map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset, isExtension: a.isExtension }));
           setAvailableAgents(list);
         }
@@ -332,7 +330,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
   };
 
   const isGeminiAgent = selectedAgent.backend === 'gemini';
-  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_VISIBLE_AGENT_BACKEND, name: 'Sudoclaw' }];
+  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_DEFAULT_AGENT_BACKEND, name: 'Sudo Code' }];
 
   return (
     <div className='flex flex-col gap-24px'>
@@ -395,7 +393,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
             }
           >
             <Button type='secondary' className='min-w-160px flex items-center justify-between gap-8px'>
-              <span className='truncate'>{agentOptions[0]?.name || 'Sudoclaw'}</span>
+              <span className='truncate'>{agentOptions[0]?.name || 'Sudo Code'}</span>
               <Down theme='outline' size={14} />
             </Button>
           </Dropdown>

--- a/src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx
@@ -10,7 +10,7 @@ import { acpConversation, channel } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
-import type { AcpBackendAll } from '@/types/acpTypes';
+import { CHANNEL_DEFAULT_AGENT_BACKEND, type AcpBackendAll } from '@/types/acpTypes';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Menu, Message, Spin } from '@arco-design/web-react';
 import { Down, Refresh } from '@icon-park/react';
@@ -44,7 +44,6 @@ interface WeChatConfigFormProps {
 }
 
 type LoginPhase = 'idle' | 'loading' | 'qrcode' | 'scanned' | 'success' | 'error';
-const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
   const { t } = useTranslation();
@@ -57,7 +56,7 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
 
   // Agent selection
   const [availableAgents, setAvailableAgents] = useState<Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isPreset?: boolean }>>([]);
-  const [selectedAgent, setSelectedAgent] = useState<{ backend: AcpBackendAll; name?: string; customAgentId?: string }>({ backend: 'openclaw-gateway' });
+  const [selectedAgent, setSelectedAgent] = useState<{ backend: AcpBackendAll; name?: string; customAgentId?: string }>({ backend: CHANNEL_DEFAULT_AGENT_BACKEND });
 
   // Sync connected status to phase
   useEffect(() => {
@@ -75,7 +74,7 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.wechat.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_VISIBLE_AGENT_BACKEND);
+          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_DEFAULT_AGENT_BACKEND);
           const list = visibleAgents.map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset, isExtension: a.isExtension }));
           setAvailableAgents(list);
         }
@@ -188,7 +187,7 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
   }, []);
 
   const isGeminiAgent = selectedAgent.backend === 'gemini';
-  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_VISIBLE_AGENT_BACKEND, name: 'Sudoclaw' }];
+  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_DEFAULT_AGENT_BACKEND, name: 'Sudo Code' }];
 
   const renderQRCodeSection = () => {
     if (phase !== 'qrcode' && phase !== 'scanned') return null;
@@ -305,7 +304,7 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
             }
           >
             <Button type='secondary' className='min-w-160px flex items-center justify-between gap-8px'>
-              <span className='truncate'>{agentOptions[0]?.name || 'Sudoclaw'}</span>
+              <span className='truncate'>{agentOptions[0]?.name || 'Sudo Code'}</span>
               <Down theme='outline' size={14} />
             </Button>
           </Dropdown>

--- a/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
@@ -10,7 +10,7 @@ import { ConfigStorage } from '@/common/storage';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
-import type { AcpBackendAll } from '@/types/acpTypes';
+import { CHANNEL_DEFAULT_AGENT_BACKEND, type AcpBackendAll } from '@/types/acpTypes';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
@@ -60,8 +60,6 @@ interface WeComConfigFormProps {
 }
 
 const WECOM_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/wecom.html';
-const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
-
 const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
@@ -169,7 +167,7 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
         const [agentsResp, saved] = await Promise.all([acpConversation.getAvailableAgents.invoke(), ConfigStorage.get('assistant.wecom.agent')]);
 
         if (agentsResp.success && agentsResp.data) {
-          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_VISIBLE_AGENT_BACKEND);
+          const visibleAgents = agentsResp.data.filter((a) => !a.isPreset && a.backend === CHANNEL_DEFAULT_AGENT_BACKEND);
           const list = visibleAgents.map((a) => ({ backend: a.backend, name: a.name, customAgentId: a.customAgentId, isPreset: a.isPreset, isExtension: a.isExtension }));
           setAvailableAgents(list);
         }
@@ -385,7 +383,7 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
   // Check if we have valid credentials (either from input or hasToken)
   const hasValidCredentials = !!(botId.trim() && secret.trim()) || !!pluginStatus?.hasToken;
   const isGeminiAgent = selectedAgent.backend === 'gemini';
-  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_VISIBLE_AGENT_BACKEND, name: 'Sudoclaw' }];
+  const agentOptions: Array<{ backend: AcpBackendAll; name: string; customAgentId?: string; isExtension?: boolean }> = availableAgents.length > 0 ? availableAgents : [{ backend: CHANNEL_DEFAULT_AGENT_BACKEND, name: 'Sudo Code' }];
 
   return (
     <div className='flex flex-col gap-24px'>
@@ -552,7 +550,7 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
             }
           >
             <Button type='secondary' className='min-w-160px flex items-center justify-between gap-8px'>
-              <span className='truncate'>{agentOptions[0]?.name || 'Sudoclaw'}</span>
+              <span className='truncate'>{agentOptions[0]?.name || 'Sudo Code'}</span>
               <Down theme='outline' size={14} />
             </Button>
           </Dropdown>

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -21,6 +21,12 @@
 export const DEFAULT_PRESET_AGENT_TYPE = 'scode' as const;
 export const LEGACY_SUDOCLAW_PRESET_AGENT_TYPE = 'sudoclaw' as const;
 
+/**
+ * 渠道（Telegram/Lark/钉钉/微信/企业微信）默认使用的 Agent 后端
+ * Default agent backend for channels (Telegram/Lark/DingTalk/WeChat/WeCom)
+ */
+export const CHANNEL_DEFAULT_AGENT_BACKEND = 'scode' as const;
+
 export type PresetAgentType = 'claude' | 'codebuddy' | 'opencode' | 'qwen' | 'gemini' | typeof DEFAULT_PRESET_AGENT_TYPE | typeof LEGACY_SUDOCLAW_PRESET_AGENT_TYPE;
 
 /**


### PR DESCRIPTION
## Summary
- 将渠道 agent 后端从 openclaw-gateway (Sudoclaw) 迁移到 scode (Sudo Code)，所有渠道统一走 ACP 协议
- 新增数据迁移逻辑，将已有 openclaw-gateway 配置自动迁移至 scode
- 5 个渠道配置表单统一使用全局常量，移除 openclaw-gateway 分支逻辑
- 修复 re-apply mode 时 scode/codex 的 "Method not found" 报错
- 优化 ServiceManager secretsReadyPromise 创建时机，消除轮询

## Test plan
- [ ] 首次登录场景下渠道 agent 正常使用 scode 后端
- [ ] 应用重启后 session 恢复正常，不出现 "Method not found" 日志
- [ ] 现有 openclaw-gateway 配置自动迁移到 scode
- [ ] 渠道配置表单显示 "Sudo Code" 而非 "Sudoclaw"
- [ ] UI 上对 scode/codex 会话切换 mode 不报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)