### PR TITLE
feat(channels): add enterprise channel provider with local/remote mode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,7 @@ ${env.ELECTRON_CACHE}/
 # Agent Kit
 .agent
 .codebuddy/
+.scode/
 wiki/
 
 # Keep CLAUDE.md for project documentation

--- a/docs/channels_enterprise_impl.md
+++ b/docs/channels_enterprise_impl.md
@@ -1,0 +1,107 @@
+# Sudowork Channels 混合模式（个人/企业）实现方案
+
+## 1. 概述
+
+本方案旨在将 Sudowork 的 Channels（渠道/通道）功能适配为支持“个人模式”与“企业模式”的混合架构。
+
+- **个人模式**：保持现状，逻辑完全在本地运行，连接本地 Agent。
+- **企业模式**：复用 Sudowork 的 UI 配置界面，但后端逻辑与 Agent 运行均迁移至 Moss Server。
+
+## 2. 软件架构
+
+### 2.1 整体架构图
+
+```mermaid
+graph TB
+    subgraph "Sudowork (Client)"
+        UI["Channels Settings UI\n(Reuse UI Components)"]
+        
+        Bridge["channelBridge (IPC)"]
+        
+        subgraph "Main Process"
+            CM["ChannelManager\n(Orchestrator)"]
+            
+            LocalProvider["LocalChannelProvider\n(Existing Logic: SQLite + Local Run)"]
+            
+            RemoteProvider["RemoteChannelProvider\n(New Logic: Proxy to Moss API)"]
+        end
+    end
+
+    subgraph "Moss Server"
+        API["Channels API Endpoints\n(REST + WebSocket)"]
+        
+        subgraph "Core"
+            MM["Moss ChannelManager\n(Migrated from Sudowork)"]
+            DB[("Moss DB\n(Postgres/SQLite)")]
+            Agent["Moss Remote Agent\n(Running Tasks)"]
+        end
+    end
+
+    UI <--> Bridge
+    Bridge <--> CM
+    
+    CM -- "If Mode='c' (Consumer)" --> LocalProvider
+    CM -- "If Mode='e' (Enterprise)" --> RemoteProvider
+    
+    RemoteProvider -- "HTTPS / JWT Auth" --> API
+    API <--> MM
+    MM <--> DB
+    MM <--> Agent
+```
+
+### 2.2 核心逻辑流
+
+1. **模式检测**：Sudowork 启动及运行时通过 `eeclawMode.isEnterpriseMode()` 检测当前运行模式。
+2. **Provider 抽象**：引入 `IChannelProvider` 接口，屏蔽本地存储与远程 API 的差异。
+3. **UI 同步**：Channels 配置页面通过 `channelBridge` 发送指令。`ChannelManager` 根据模式决定是操作本地数据库还是调用远程 Moss API。
+4. **Agent 触发**：企业模式下，IM 渠道收到的消息由 Moss Server 内部处理，并触发 Moss 上的 Remote Agent，实现全链路云端化。
+
+## 3. 接口设计 (API Design)
+
+Moss Server 需要新增以下 API 以支持远程管理：
+
+### 3.1 渠道插件管理 (REST)
+- **GET** `/api/v1/channels/plugins`
+  - 说明：获取当前用户的所有渠道插件及其状态（运行中/停止）。
+- **POST** `/api/v1/channels/plugins/:id/enable`
+  - 说明：启用并配置渠道插件。Payload 包含凭据（credentials）与配置（config）。
+- **POST** `/api/v1/channels/plugins/:id/disable`
+  - 说明：禁用并停止渠道插件。
+- **POST** `/api/v1/channels/plugins/:id/test`
+  - 说明：测试渠道连通性。
+
+### 3.2 配对与授权 (REST)
+- **GET** `/api/v1/channels/pairings/pending`
+  - 说明：获取待审批的 IM 用户配对请求。
+- **POST** `/api/v1/channels/pairings/:code/approve`
+  - 说明：批准配对码。
+- **GET** `/api/v1/channels/users`
+  - 说明：获取已授权的 IM 用户列表。
+- **DELETE** `/api/v1/channels/users/:id`
+  - 说明：撤销用户授权。
+
+## 4. 任务拆分 (Task List)
+
+### 4.1 Sudowork 侧任务
+1. **Provider 模式实现**：
+   - 定义 `IChannelProvider` 接口。
+   - 实现 `LocalChannelProvider` (封装现有逻辑)。
+   - 实现 `RemoteChannelProvider` (调用 Moss 远程接口)。
+2. **模式路由转发**：
+   - 修改 `ChannelManager`，在初始化和 IPC 调用时注入正确的 Provider。
+3. **凭据安全处理**：
+   - 企业模式下，确保凭据在网络传输前的加密处理。
+
+### 4.2 Moss Server 侧任务
+1. **代码迁移与集成**：
+   - 将 Sudowork 的 `src/channels/` 完整逻辑迁移至 Moss Server。
+   - 适配 Moss 的权限模型（通过 JWT 中的 User/Org 隔离数据）。
+2. **API 控制器开发**：
+   - 实现上述 REST 接口。
+   - 开发与 Moss 原生 Agent（AssistantService）的交互逻辑。
+3. **管理后台开发**：
+   - 在 Moss Admin 管理页面集成渠道监控与配置界面。
+
+## 5. 开发建议
+- **凭据传输加密**：建议在企业模式下，Sudowork 使用 Moss Server 的公钥对 Token 等敏感凭据进行加密后再通过 HTTPS 发送。
+- **状态轮询与通知**：企业模式下，渠道状态变更建议通过 WebSocket 推送至 Sudowork 客户端，以保证 UI 的实时刷新。

--- a/docs/channels_technical_spec.md
+++ b/docs/channels_technical_spec.md
@@ -1,0 +1,90 @@
+# Sudowork Channels 核心技术规格文档
+
+## 1. 简介
+Channels 是 Sudowork 的多平台助手框架，旨在通过统一的消息协议将 AI 能力集成到 IM 平台（Telegram, Lark, DingTalk, WeChat, WeCom）。
+
+## 2. 目录结构与功能
+- `core/`: 核心编排（ChannelManager, SessionManager）。
+- `gateway/`: 网关层（ActionExecutor, PluginManager），处理路由与插件生命周期。
+- `plugins/`: 平台插件实现。
+- `adapters/`: 协议适配器（平台原生 ↔ 统一格式）。
+- `agent/`: AI 集成层（EventBus, MessageService）。
+- `actions/`: 业务逻辑处理器。
+- `pairing/`: 授权配对系统。
+
+## 3. 统一消息协议 (Unified Protocol)
+
+### 3.1 IUnifiedIncomingMessage
+```typescript
+interface IUnifiedIncomingMessage {
+  id: string;           // 消息唯一标识
+  platform: string;     // 平台标识
+  chatId: string;       // 隔离标识 (user:xxx / group:xxx)
+  user: IUnifiedUser;   // 用户信息
+  content: {
+    type: string;       // text, photo, document, action, etc.
+    text: string;
+    attachments?: IUnifiedAttachment[];
+  };
+  action?: IMessageAction; // 交互按钮触发的动作
+}
+```
+
+### 3.2 IUnifiedOutgoingMessage
+```typescript
+interface IUnifiedOutgoingMessage {
+  type: 'text' | 'image' | 'file' | 'buttons';
+  text?: string;
+  buttons?: IActionButton[][]; // 矩阵式按钮
+  parseMode?: 'Markdown' | 'HTML';
+}
+```
+
+## 4. 平台适配详情
+
+### 4.1 Telegram (grammY)
+- **模式**: Long Polling。
+- **消息长度**: 4096 字符。
+- **流式实现**: 通过不断 `editMessageText` 更新同一条消息。
+
+### 4.2 飞书 Lark (@larksuiteoapi/node-sdk)
+- **模式**: WebSocket。
+- **特性**: 使用 **Interactive Cards**。所有文字回复都在卡片中更新，以支持流式显示。
+- **去重**: 必须处理飞书重复推送的事件。
+
+### 4.3 钉钉 DingTalk (dingtalk-stream)
+- **模式**: WebSocket Stream。
+- **特性**: 使用 **AI Card**。通过 `streaming` 接口增量写入内容。
+
+### 4.4 微信 WeChat (iLink)
+- **模式**: Long Polling。
+- **多媒体**: 微信多媒体文件采用 AES-ECB 加密，下载后需解密。
+- **合并**: 微信经常将文字和图片拆分为两个包，系统会在 5 秒内尝试合并。
+
+### 4.5 企业微信 WeCom
+- **模式**: 官方 AI Bot WebSocket 协议。
+- **流式**: 支持 `aibot_respond_msg` 流式分片发送。
+- **多媒体**: 使用 AES-256-CBC 对文件进行加解密。
+
+## 5. 核心逻辑流程
+
+### 5.1 配对审批 (Pairing)
+1. 匿名用户发送消息 → 触发 `PairingService` 生成配对码。
+2. 内部通过 `channelBridge` 推送到 Sudowork UI。
+3. 本地用户点击“审批” → 创建 `assistant_users` 记录。
+
+### 5.2 消息处理 (ActionExecutor)
+1. 接收 `IUnifiedIncomingMessage`。
+2. 授权检查（是否已配对）。
+3. 会话获取/创建（`userId:chatId` 复合键）。
+4. 调用 `ChannelMessageService` 将消息转交给对应的 Agent。
+5. 监听 `ChannelEventBus` 的流式输出。
+
+### 5.3 流式节流 (Throttle)
+- 设定 500ms 计时器。
+- 只有在计时器到期或流结束时，才真正调用平台 API 进行消息编辑，防止触发平台频率限制。
+
+## 6. 迁移要点
+1. **数据库**: 确保迁移所有 `assistant_*` 开头的表。
+2. **凭据加密**: 迁移 `utils/credentialCrypto.ts` 及其依赖，确保配置数据可读。
+3. **EventBus**: 这是一个内存单例，如果跨进程迁移，需要考虑使用 Redis Pub/Sub 或类似的外部总线。

--- a/src/channels/core/ChannelManager.ts
+++ b/src/channels/core/ChannelManager.ts
@@ -441,6 +441,10 @@ export class ChannelManager {
         const success = await provider.updatePluginEnabled(pluginId, false, 'stopped');
         if (success) {
           console.log(`[ChannelManager] Enterprise mode: plugin ${pluginId} disabled on Moss Server`);
+
+          // For WeCom and WeChat: Moss Server handles user/session cleanup internally
+          // so we don't need to call provider.deleteUsersByPlatform here.
+
           return { success: true };
         } else {
           return { success: false, error: 'Failed to disable plugin on Moss Server' };
@@ -494,7 +498,10 @@ export class ChannelManager {
         const credentials: Record<string, any> = {};
         if (pluginType === 'telegram') {
           credentials.token = token;
-        } else if (pluginType === 'lark' || pluginType === 'dingtalk') {
+        } else if (pluginType === 'dingtalk') {
+          credentials.clientId = extraConfig?.appId;
+          credentials.clientSecret = extraConfig?.appSecret;
+        } else if (pluginType === 'lark') {
           credentials.appId = extraConfig?.appId;
           credentials.appSecret = extraConfig?.appSecret;
         } else if (pluginType === 'wecom') {

--- a/src/channels/core/ChannelManager.ts
+++ b/src/channels/core/ChannelManager.ts
@@ -7,6 +7,7 @@
 import { getDatabase } from '@/process/database';
 import { serviceManager } from '@process/services/serviceManager';
 import { ExtensionRegistry } from '@/extensions';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { getChannelMessageService } from '../agent/ChannelMessageService';
 import { getChannelDefaultModel } from '../actions/SystemActions';
 import { ActionExecutor } from '../gateway/ActionExecutor';
@@ -21,6 +22,9 @@ import { ZentaoPlugin } from '../plugins/zentao/ZentaoPlugin';
 import { isBuiltinChannelPlatform, resolveChannelConvType } from '../types';
 import type { ChannelPlatform, IChannelPluginConfig, PluginType } from '../types';
 import { SessionManager } from './SessionManager';
+import { LocalChannelProvider } from './LocalChannelProvider';
+import { RemoteChannelProvider } from './RemoteChannelProvider';
+import type { IChannelProvider } from './IChannelProvider';
 
 /**
  * ChannelManager - Main orchestrator for the Channel subsystem
@@ -47,6 +51,7 @@ export class ChannelManager {
   private sessionManager: SessionManager | null = null;
   private pairingService: PairingService | null = null;
   private actionExecutor: ActionExecutor | null = null;
+  private provider: IChannelProvider | null = null;
 
   private constructor() {
     // Private constructor for singleton pattern
@@ -81,6 +86,10 @@ export class ChannelManager {
     console.log('[ChannelManager] Initializing...');
 
     try {
+      // Initialize provider based on mode
+      const isEnterprise = isEnterpriseMode();
+      this.provider = isEnterprise ? new RemoteChannelProvider() : new LocalChannelProvider();
+
       // Register extension-contributed channel plugins (from ExtensionRegistry)
       this.registerExtensionChannelPlugins();
 
@@ -98,18 +107,18 @@ export class ChannelManager {
       this.pluginManager.setConfirmHandler(async (userId: string, platform: string, callId: string, value: string) => {
         // 查找用户
         // Find user
-        const db = getDatabase();
-        const userResult = db.getChannelUserByPlatform(userId, platform as PluginType);
-        if (!userResult.data) {
+        const provider = this.getProvider();
+        const user = await provider.getUserByPlatform(userId, platform as PluginType);
+        if (!user) {
           console.error(`[ChannelManager] User not found: ${userId}@${platform}`);
           return;
         }
 
         // 查找 session 获取 conversationId
         // Find session to get conversationId
-        const session = this.sessionManager?.getSession(userResult.data.id);
+        const session = this.sessionManager?.getSession(user.id);
         if (!session?.conversationId) {
-          console.error(`[ChannelManager] Session not found for user: ${userResult.data.id}`);
+          console.error(`[ChannelManager] Session not found for user: ${user.id}`);
           return;
         }
 
@@ -141,6 +150,12 @@ export class ChannelManager {
    * channel plugins attempt to read them via resolveSecret().
    */
   private async waitForSecretsReady(): Promise<boolean> {
+    // Enterprise mode: secrets managed by Moss Server, skip waiting
+    if (isEnterpriseMode()) {
+      console.log('[ChannelManager] Enterprise mode: skipping secrets wait (managed by Moss Server)');
+      return true;
+    }
+
     try {
       const secretsReady = await serviceManager.waitForSecrets();
       if (!secretsReady) {
@@ -198,15 +213,15 @@ export class ChannelManager {
    * Load and start enabled plugins from database
    */
   private async loadEnabledPlugins(): Promise<void> {
-    const db = getDatabase();
-    const result = db.getChannelPlugins();
-
-    if (!result.success || !result.data) {
-      console.warn('[ChannelManager] Failed to load plugins:', result.error);
+    if (isEnterpriseMode()) {
+      console.log('[ChannelManager] Enterprise Mode: Plugins managed by Moss Server');
       return;
     }
 
-    const enabledPlugins = result.data.filter((p) => p.enabled);
+    const provider = this.getProvider();
+    const plugins = await provider.getPlugins();
+
+    const enabledPlugins = plugins.filter((p) => p.enabled);
     const builtinStartableTypes = new Set<PluginType>(['telegram', 'lark', 'dingtalk', 'wechat', 'wecom', 'zentao']);
     const extensionRegistry = ExtensionRegistry.getInstance();
 
@@ -223,7 +238,7 @@ export class ChannelManager {
           status: 'stopped',
           updatedAt: Date.now(),
         };
-        db.upsertChannelPlugin(nextConfig);
+        await provider.upsertPlugin(nextConfig);
         continue;
       }
 
@@ -232,7 +247,7 @@ export class ChannelManager {
       } catch (error) {
         console.error(`[ChannelManager] Failed to start plugin ${plugin.id}:`, error);
         // Update status to error
-        db.updateChannelPluginStatus(plugin.id, 'error');
+        await provider.updatePluginStatus(plugin.id, 'error');
       }
     }
   }
@@ -253,17 +268,24 @@ export class ChannelManager {
    * For extension plugins, fields are extracted from manifest metadata.
    */
   async enablePlugin(pluginId: string, config: Record<string, unknown>): Promise<{ success: boolean; error?: string }> {
-    // Ensure manager is initialized
-    if (!this.initialized || !this.pluginManager) {
-      console.error('[ChannelManager] Cannot enable plugin: manager not initialized');
-      return { success: false, error: 'Assistant manager not initialized' };
+    // Enterprise mode: only need provider, not pluginManager
+    if (isEnterpriseMode()) {
+      if (!this.initialized) {
+        console.error('[ChannelManager] Cannot enable plugin: manager not initialized');
+        return { success: false, error: 'Channel manager not initialized' };
+      }
+    } else {
+      // Consumer mode: need both initialized and pluginManager
+      if (!this.initialized || !this.pluginManager) {
+        console.error('[ChannelManager] Cannot enable plugin: manager not initialized');
+        return { success: false, error: 'Assistant manager not initialized' };
+      }
     }
 
-    const db = getDatabase();
+    const provider = this.getProvider();
 
     // Get existing plugin or create new one
-    const existingResult = db.getChannelPlugin(pluginId);
-    const existing = existingResult.data;
+    const existing = await provider.getPlugin(pluginId);
 
     // Resolve plugin type
     const pluginType = (existing?.type || this.getPluginTypeFromId(pluginId)) as PluginType;
@@ -377,9 +399,26 @@ export class ChannelManager {
       updatedAt: Date.now(),
     };
 
-    const saveResult = db.upsertChannelPlugin(pluginConfig);
-    if (!saveResult.success) {
-      return { success: false, error: saveResult.error };
+    const success = await provider.upsertPlugin(pluginConfig);
+    if (!success) {
+      return { success: false, error: 'Failed to save plugin configuration' };
+    }
+
+    // Enterprise mode: plugin is managed by Moss Server, no local start needed
+    if (isEnterpriseMode()) {
+      console.log(`[ChannelManager] Enterprise mode: plugin ${pluginId} enabled on Moss Server`);
+
+      // Update status to reflect the enabled state from Moss Server
+      try {
+        const updatedPlugin = await provider.getPlugin(pluginId);
+        if (updatedPlugin) {
+          await provider.updatePluginStatus(pluginId, updatedPlugin.status, updatedPlugin.lastConnected);
+        }
+      } catch {
+        // Best-effort status refresh
+      }
+
+      return { success: true };
     }
 
     try {
@@ -394,31 +433,42 @@ export class ChannelManager {
    * Disable and stop a plugin
    */
   async disablePlugin(pluginId: string): Promise<{ success: boolean; error?: string }> {
-    const db = getDatabase();
+    const provider = this.getProvider();
 
     try {
+      // Enterprise mode: plugin is managed by Moss Server
+      if (isEnterpriseMode()) {
+        const success = await provider.updatePluginEnabled(pluginId, false, 'stopped');
+        if (success) {
+          console.log(`[ChannelManager] Enterprise mode: plugin ${pluginId} disabled on Moss Server`);
+          return { success: true };
+        } else {
+          return { success: false, error: 'Failed to disable plugin on Moss Server' };
+        }
+      }
+
       // Stop the plugin
       await this.pluginManager?.stopPlugin(pluginId);
 
       // Update database
-      const existingResult = db.getChannelPlugin(pluginId);
-      if (existingResult.data) {
+      const existing = await provider.getPlugin(pluginId);
+      if (existing) {
         const updated: IChannelPluginConfig = {
-          ...existingResult.data,
+          ...existing,
           enabled: false,
           status: 'stopped',
           updatedAt: Date.now(),
         };
-        db.upsertChannelPlugin(updated);
+        await provider.upsertPlugin(updated);
 
         // For WeCom and WeChat: clear all authorized users and sessions when disabled
         // This allows reconfiguring with new bot credentials
         // Note: We keep credentials so user can re-enable without re-entering
-        const pluginType = existingResult.data.type;
+        const pluginType = existing.type;
         if (pluginType === 'wecom' || pluginType === 'wechat') {
           console.log(`[ChannelManager] Clearing all users and sessions for ${pluginType} on disable`);
           // Delete all channel users for this platform
-          db.deleteChannelUsersByPlatform(pluginType);
+          await provider.deleteUsersByPlatform(pluginType);
           // Note: We keep credentials so user can re-enable without re-entering
         }
       }
@@ -436,6 +486,29 @@ export class ChannelManager {
    */
   async testPlugin(pluginId: string, token: string, extraConfig?: { appId?: string; appSecret?: string }): Promise<{ success: boolean; botUsername?: string; error?: string }> {
     const pluginType = this.getPluginTypeFromId(pluginId);
+
+    // Enterprise mode: delegate test to Moss Server via RemoteChannelProvider
+    if (isEnterpriseMode()) {
+      const provider = this.getProvider();
+      if ('testConnection' in provider) {
+        const credentials: Record<string, any> = {};
+        if (pluginType === 'telegram') {
+          credentials.token = token;
+        } else if (pluginType === 'lark' || pluginType === 'dingtalk') {
+          credentials.appId = extraConfig?.appId;
+          credentials.appSecret = extraConfig?.appSecret;
+        } else if (pluginType === 'wecom') {
+          credentials.botId = extraConfig?.appId;
+          credentials.secret = extraConfig?.appSecret;
+        } else {
+          // For extension plugins, pass all config
+          if (token) credentials.token = token;
+          if (extraConfig?.appId) credentials.appId = extraConfig.appId;
+          if (extraConfig?.appSecret) credentials.appSecret = extraConfig.appSecret;
+        }
+        return await (provider as any).testConnection(pluginId, credentials);
+      }
+    }
 
     if (pluginType === 'telegram') {
       const result = await TelegramPlugin.testConnection(token);
@@ -481,21 +554,6 @@ export class ChannelManager {
         return { success: false, error: 'Bot ID and Secret are required for WeCom' };
       }
       const result = await WeComPlugin.testConnection(botId, secret);
-      return {
-        success: result.success,
-        botUsername: result.botInfo?.name,
-        error: result.error,
-      };
-    }
-
-    if (pluginType === 'zentao') {
-      const serverUrl = extraConfig?.appId;
-      const zentaoUsername = token;
-      const zentaoPassword = extraConfig?.appSecret;
-      if (!serverUrl || !zentaoUsername || !zentaoPassword) {
-        return { success: false, error: 'Server URL, username and password are required for Zentao' };
-      }
-      const result = await ZentaoPlugin.testConnection(serverUrl, zentaoUsername, zentaoPassword);
       return {
         success: result.success,
         botUsername: result.botInfo?.name,
@@ -572,7 +630,16 @@ export class ChannelManager {
    * which conversation to use.
    */
   async syncChannelSettings(platform: ChannelPlatform, agent: { backend: string; customAgentId?: string; name?: string }, model?: { id: string; useModel: string }): Promise<{ success: boolean; error?: string }> {
-    if (!this.initialized || !this.sessionManager) {
+    if (!this.initialized) {
+      return { success: false, error: 'Channel manager not initialized' };
+    }
+
+    // Enterprise mode: delegate to Moss Server via provider
+    if (isEnterpriseMode()) {
+      return this.getProvider().syncChannelSettings(platform, agent, model);
+    }
+
+    if (!this.sessionManager) {
       return { success: false, error: 'Channel manager not initialized' };
     }
 
@@ -627,6 +694,18 @@ export class ChannelManager {
   }
 
   // ==================== Accessors ====================
+
+  /**
+   * Get the active channel provider
+   */
+  getProvider(): IChannelProvider {
+    if (!this.provider) {
+      // Fallback if not initialized (should not happen in practice)
+      const isEnterprise = isEnterpriseMode();
+      this.provider = isEnterprise ? new RemoteChannelProvider() : new LocalChannelProvider();
+    }
+    return this.provider;
+  }
 
   getPluginManager(): PluginManager | null {
     return this.pluginManager;

--- a/src/channels/core/IChannelProvider.ts
+++ b/src/channels/core/IChannelProvider.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IChannelPluginConfig, IChannelPluginStatus, IChannelUser, IChannelPairingRequest, IChannelSession, PluginType, PluginStatus, ChannelPlatform } from '../types';
+
+/**
+ * IChannelProvider - Interface for channel data and management operations
+ * abstracts difference between local (SQLite) and remote (Moss API) storage/execution.
+ */
+export interface IChannelProvider {
+  // Plugin management
+  getPlugins(): Promise<IChannelPluginConfig[]>;
+  getPlugin(pluginId: string): Promise<IChannelPluginConfig | null>;
+  upsertPlugin(plugin: IChannelPluginConfig): Promise<boolean>;
+  updatePluginStatus(pluginId: string, status: PluginStatus, lastConnected?: number): Promise<boolean>;
+  updatePluginEnabled(pluginId: string, enabled: boolean, status: PluginStatus): Promise<boolean>;
+  deletePlugin(pluginId: string): Promise<boolean>;
+
+  // User management
+  getUsers(): Promise<IChannelUser[]>;
+  getUserByPlatform(platformUserId: string, platformType: PluginType): Promise<IChannelUser | null>;
+  deleteUser(userId: string): Promise<boolean>;
+  deleteUsersByPlatform(platformType: string): Promise<number>;
+
+  // Session management
+  getSessions(): Promise<IChannelSession[]>;
+
+  // Pairing management
+  getPendingPairingRequests(): Promise<IChannelPairingRequest[]>;
+  approvePairing(code: string): Promise<boolean>;
+  rejectPairing(code: string): Promise<boolean>;
+
+  // Connection testing
+  testConnection(pluginId: string, credentials: Record<string, any>): Promise<{ success: boolean; botUsername?: string; error?: string }>;
+
+  // Settings sync
+  syncChannelSettings(platform: ChannelPlatform, agent: { backend: string; customAgentId?: string; name?: string }, model?: { id: string; useModel: string }): Promise<{ success: boolean; error?: string }>;
+}

--- a/src/channels/core/LocalChannelProvider.ts
+++ b/src/channels/core/LocalChannelProvider.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getDatabase } from '@/process/database';
+import type { IChannelPluginConfig, PluginStatus, IChannelUser, PluginType, IChannelPairingRequest, IChannelSession, ChannelPlatform } from '../types';
+import type { IChannelProvider } from './IChannelProvider';
+import { TelegramPlugin } from '../plugins/telegram/TelegramPlugin';
+import { LarkPlugin } from '../plugins/lark/LarkPlugin';
+import { DingTalkPlugin } from '../plugins/dingtalk/DingTalkPlugin';
+import { WeComPlugin } from '../plugins/wecom/WeComPlugin';
+
+/**
+ * LocalChannelProvider - Implementation of IChannelProvider using local SQLite database
+ */
+export class LocalChannelProvider implements IChannelProvider {
+  async getPlugins(): Promise<IChannelPluginConfig[]> {
+    const result = getDatabase().getChannelPlugins();
+    return result.success ? (result.data || []) : [];
+  }
+
+  async getPlugin(pluginId: string): Promise<IChannelPluginConfig | null> {
+    const result = getDatabase().getChannelPlugin(pluginId);
+    return result.success ? (result.data || null) : null;
+  }
+
+  async upsertPlugin(plugin: IChannelPluginConfig): Promise<boolean> {
+    const result = getDatabase().upsertChannelPlugin(plugin);
+    return result.success;
+  }
+
+  async updatePluginStatus(pluginId: string, status: PluginStatus, lastConnected?: number): Promise<boolean> {
+    const result = getDatabase().updateChannelPluginStatus(pluginId, status, lastConnected);
+    return result.success;
+  }
+
+  async updatePluginEnabled(pluginId: string, enabled: boolean, status: PluginStatus): Promise<boolean> {
+    const result = getDatabase().updateChannelPluginEnabled(pluginId, enabled, status);
+    return result.success;
+  }
+
+  async deletePlugin(pluginId: string): Promise<boolean> {
+    const result = getDatabase().deleteChannelPlugin(pluginId);
+    return result.success;
+  }
+
+  async getUsers(): Promise<IChannelUser[]> {
+    const result = getDatabase().getChannelUsers();
+    return result.success ? (result.data || []) : [];
+  }
+
+  async getUserByPlatform(platformUserId: string, platformType: PluginType): Promise<IChannelUser | null> {
+    const result = getDatabase().getChannelUserByPlatform(platformUserId, platformType);
+    return result.success ? (result.data || null) : null;
+  }
+
+  async deleteUser(userId: string): Promise<boolean> {
+    const result = getDatabase().deleteChannelUser(userId);
+    return result.success;
+  }
+
+  async deleteUsersByPlatform(platformType: string): Promise<number> {
+    const result = getDatabase().deleteChannelUsersByPlatform(platformType);
+    return result.success ? (result.data || 0) : 0;
+  }
+
+  async getSessions(): Promise<IChannelSession[]> {
+    const result = getDatabase().getChannelSessions();
+    return result.success ? (result.data || []) : [];
+  }
+
+  async getPendingPairingRequests(): Promise<IChannelPairingRequest[]> {
+    const result = getDatabase().getPendingPairingRequests();
+    return result.success ? (result.data || []) : [];
+  }
+
+  async approvePairing(code: string): Promise<boolean> {
+    // Local approval is handled through PairingService which talks to DB
+    // This provider method can be a simple pass-through if needed,
+    // but PairingService is already a singleton in Sudowork.
+    // For consistency with RemoteChannelProvider, we'll keep it in the interface.
+    const { getPairingService } = await import('../pairing/PairingService');
+    const result = await getPairingService().approvePairing(code);
+    return result.success;
+  }
+
+  async rejectPairing(code: string): Promise<boolean> {
+    const { getPairingService } = await import('../pairing/PairingService');
+    const result = await getPairingService().rejectPairing(code);
+    return result.success;
+  }
+
+  async testConnection(pluginId: string, credentials: Record<string, any>): Promise<{ success: boolean; botUsername?: string; error?: string }> {
+    // Logic extracted from ChannelManager.testPlugin
+    const pluginType = this.getPluginTypeFromId(pluginId);
+
+    if (pluginType === 'telegram') {
+      const result = await TelegramPlugin.testConnection(credentials.token);
+      return { success: result.success, botUsername: result.botInfo?.username, error: result.error };
+    }
+
+    if (pluginType === 'lark') {
+      const result = await LarkPlugin.testConnection(credentials.appId, credentials.appSecret);
+      return { success: result.success, botUsername: result.botInfo?.name, error: result.error };
+    }
+
+    if (pluginType === 'dingtalk') {
+      const result = await DingTalkPlugin.testConnection(credentials.clientId, credentials.clientSecret);
+      return { success: result.success, botUsername: result.botInfo?.name, error: result.error };
+    }
+
+    if (pluginType === 'wecom') {
+      const result = await WeComPlugin.testConnection(credentials.botId, credentials.secret);
+      return { success: result.success, botUsername: result.botInfo?.name, error: result.error };
+    }
+
+    return { success: true };
+  }
+
+  async syncChannelSettings(platform: ChannelPlatform, agent: { backend: string; customAgentId?: string; name?: string }, model?: { id: string; useModel: string }): Promise<{ success: boolean; error?: string }> {
+    // Local mode: no-op, ChannelManager handles session clearing directly
+    return { success: true };
+  }
+
+  private getPluginTypeFromId(pluginId: string): string {
+    if (pluginId.startsWith('telegram')) return 'telegram';
+    if (pluginId.startsWith('lark')) return 'lark';
+    if (pluginId.startsWith('dingtalk')) return 'dingtalk';
+    if (pluginId.startsWith('wechat')) return 'wechat';
+    if (pluginId.startsWith('wecom')) return 'wecom';
+    if (pluginId.startsWith('zentao')) return 'zentao';
+    return pluginId;
+  }
+}

--- a/src/channels/core/RemoteChannelProvider.ts
+++ b/src/channels/core/RemoteChannelProvider.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getMossServerUrl, getAuthToken } from '@/common/enterpriseDebugConfig';
+import type { IChannelPluginConfig, PluginStatus, IChannelUser, PluginType, IChannelPairingRequest, IChannelSession, ChannelPlatform } from '../types';
+import type { IChannelProvider } from './IChannelProvider';
+
+/**
+ * RemoteChannelProvider - Implementation of IChannelProvider talking to Moss Server REST API
+ */
+export class RemoteChannelProvider implements IChannelProvider {
+  private get baseUrl(): string {
+    const url = getMossServerUrl();
+    if (!url) {
+      console.error('[RemoteChannelProvider] Moss Server URL not configured');
+      throw new Error('Moss Server URL not configured for Enterprise Mode');
+    }
+    return `${url.replace(/\/+$/, '')}/api/v1/channels`;
+  }
+
+  private get headers(): Record<string, string> {
+    const token = getAuthToken();
+    if (!token) {
+      console.error('[RemoteChannelProvider] Auth token not configured');
+    }
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    };
+  }
+
+  async getPlugins(): Promise<IChannelPluginConfig[]> {
+    const resp = await fetch(`${this.baseUrl}/plugins`, { headers: this.headers });
+    if (!resp.ok) throw new Error(`Failed to fetch plugins: ${resp.statusText}`);
+    const data = await resp.json();
+    // API returns { plugins: [...] } with 'platform' field instead of 'type'
+    const plugins = data.plugins || data;
+    return plugins.map((p: any) => ({
+      id: p.id,
+      type: p.platform || p.type,
+      name: p.name || p.platform || p.type,
+      enabled: p.enabled,
+      credentials: p.credentials && Object.keys(p.credentials).length > 0 ? p.credentials : (p.config && Object.keys(p.config).length > 0 ? p.config : undefined),
+      config: p.config || {},
+      status: p.status || 'stopped',
+      lastConnected: p.lastConnected,
+      createdAt: p.createdAt || Date.now(),
+      updatedAt: p.updatedAt || Date.now(),
+    }));
+  }
+
+  async getPlugin(pluginId: string): Promise<IChannelPluginConfig | null> {
+    const resp = await fetch(`${this.baseUrl}/plugins/${pluginId}`, { headers: this.headers });
+    if (resp.status === 404) return null;
+    if (!resp.ok) throw new Error(`Failed to fetch plugin ${pluginId}: ${resp.statusText}`);
+    const p = await resp.json();
+    // Adapt API response format
+    return {
+      id: p.id,
+      type: p.platform || p.type,
+      name: p.name || p.platform || p.type,
+      enabled: p.enabled,
+      credentials: p.credentials && Object.keys(p.credentials).length > 0 ? p.credentials : (p.config && Object.keys(p.config).length > 0 ? p.config : undefined),
+      config: p.config || {},
+      status: p.status || 'stopped',
+      lastConnected: p.lastConnected,
+      createdAt: p.createdAt || Date.now(),
+      updatedAt: p.updatedAt || Date.now(),
+    };
+  }
+
+  async upsertPlugin(plugin: IChannelPluginConfig): Promise<boolean> {
+    // API expects credentials directly as body (not wrapped in { credentials, config })
+    try {
+      const resp = await fetch(`${this.baseUrl}/plugins/${plugin.id}/enable`, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify(plugin.credentials || {}),
+      });
+      if (!resp.ok) {
+        console.error(`[RemoteChannelProvider] upsertPlugin failed: HTTP ${resp.status} ${resp.statusText}`);
+        return false;
+      }
+      const data = await resp.json();
+      if (data.ok !== true && data.success !== true) {
+        console.error(`[RemoteChannelProvider] upsertPlugin failed: response`, data);
+      }
+      return data.ok === true || data.success === true;
+    } catch (error) {
+      console.error('[RemoteChannelProvider] upsertPlugin error:', error);
+      return false;
+    }
+  }
+
+  async updatePluginStatus(pluginId: string, status: PluginStatus, lastConnected?: number): Promise<boolean> {
+    // Enterprise mode: plugin status is managed by Moss Server internally.
+    // No API endpoint needed — status changes are reflected automatically.
+    return true;
+  }
+
+  async updatePluginEnabled(pluginId: string, enabled: boolean, status: PluginStatus): Promise<boolean> {
+    const action = enabled ? 'enable' : 'disable';
+
+    // When enabling, include existing credentials in the request body to prevent
+    // the server from overwriting stored credentials with an empty object.
+    let body: string | undefined;
+    if (enabled) {
+      try {
+        const existing = await this.getPlugin(pluginId);
+        if (existing?.credentials && Object.keys(existing.credentials).length > 0) {
+          body = JSON.stringify(existing.credentials);
+        }
+      } catch {
+        // Best-effort: if we can't fetch existing credentials, proceed without body
+      }
+    }
+
+    const resp = await fetch(`${this.baseUrl}/plugins/${pluginId}/${action}`, {
+      method: 'POST',
+      headers: this.headers,
+      body,
+    });
+    if (!resp.ok) return false;
+    const data = await resp.json();
+    return data.ok === true || data.success === true;
+  }
+
+  async deletePlugin(pluginId: string): Promise<boolean> {
+    // No specific delete API in spec, but disable might be enough or we add DELETE /plugins/:id
+    const resp = await fetch(`${this.baseUrl}/plugins/${pluginId}/disable`, {
+      method: 'POST',
+      headers: this.headers,
+    });
+    if (!resp.ok) return false;
+    const data = await resp.json();
+    return data.ok === true || data.success === true;
+  }
+
+  async getUsers(): Promise<IChannelUser[]> {
+    const resp = await fetch(`${this.baseUrl}/users`, { headers: this.headers });
+    if (!resp.ok) throw new Error(`Failed to fetch users: ${resp.statusText}`);
+    const data = await resp.json();
+    // API returns { users: [...] } with camelCase fields
+    const users = data.users || data;
+    return users.map((u: any) => ({
+      id: u.id,
+      platformUserId: u.platformUserId || u.platform_user_id,
+      platformType: u.platform || u.platformType || u.platform_type,
+      displayName: u.platformDisplayName || u.displayName || u.display_name,
+      authorizedAt: u.pairedAt || u.authorizedAt || u.authorized_at,
+      lastActive: u.lastSeenAt || u.lastActive || u.last_active,
+      sessionId: u.sessionId || u.session_id,
+    }));
+  }
+
+  async getUserByPlatform(platformUserId: string, platformType: PluginType): Promise<IChannelUser | null> {
+    // Need an API for this or filter from getUsers
+    const users = await this.getUsers();
+    return users.find((u) => u.platformUserId === platformUserId && u.platformType === platformType) || null;
+  }
+
+  async deleteUser(userId: string): Promise<boolean> {
+    const resp = await fetch(`${this.baseUrl}/users/${userId}`, {
+      method: 'DELETE',
+      headers: this.headers,
+    });
+    return resp.ok;
+  }
+
+  async deleteUsersByPlatform(platformType: string): Promise<number> {
+    try {
+      const resp = await fetch(`${this.baseUrl}/users?platform=${encodeURIComponent(platformType)}`, {
+        method: 'DELETE',
+        headers: this.headers,
+      });
+      if (!resp.ok) return 0;
+      const data = await resp.json();
+      return data.count || 0;
+    } catch (error) {
+      console.error('[RemoteChannelProvider] deleteUsersByPlatform error:', error);
+      return 0;
+    }
+  }
+
+  async getSessions(): Promise<IChannelSession[]> {
+    const resp = await fetch(`${this.baseUrl}/sessions`, { headers: this.headers });
+    if (!resp.ok) throw new Error(`Failed to fetch sessions: ${resp.statusText}`);
+    const data = await resp.json();
+    // API may return { sessions: [...] } or direct array
+    const sessions = data.sessions || data;
+    return sessions.map((s: any) => ({
+      id: s.id,
+      userId: s.userId || s.user_id,
+      agentType: s.agentType || s.agent_type,
+      conversationId: s.conversationId || s.conversation_id,
+      workspace: s.workspace,
+      chatId: s.chatId || s.chat_id,
+      createdAt: s.createdAt || s.created_at,
+      lastActivity: s.lastActivity || s.last_activity,
+    }));
+  }
+
+  async getPendingPairingRequests(): Promise<IChannelPairingRequest[]> {
+    const resp = await fetch(`${this.baseUrl}/pairings/pending`, { headers: this.headers });
+    if (!resp.ok) throw new Error(`Failed to fetch pairings: ${resp.statusText}`);
+    const data = await resp.json();
+    // API returns { pairings: [...] } with camelCase fields
+    const pairings = data.pairings || data;
+    return pairings.map((p: any) => ({
+      code: p.pairingCode || p.code,
+      platformUserId: p.platformUserId || p.platform_user_id,
+      platformType: p.platform || p.platformType || p.platform_type,
+      displayName: p.platformDisplayName || p.displayName || p.display_name,
+      requestedAt: p.requestedAt || p.requested_at || Date.now(),
+      expiresAt: p.expiresAt || p.expires_at,
+      status: p.status || 'pending',
+    }));
+  }
+
+  async approvePairing(code: string): Promise<boolean> {
+    const resp = await fetch(`${this.baseUrl}/pairings/${code}/approve`, {
+      method: 'POST',
+      headers: this.headers,
+    });
+    if (!resp.ok) return false;
+    const data = await resp.json();
+    return data.ok === true || data.success === true;
+  }
+
+  async rejectPairing(code: string): Promise<boolean> {
+    const resp = await fetch(`${this.baseUrl}/pairings/${code}/reject`, {
+      method: 'POST',
+      headers: this.headers,
+    });
+    if (!resp.ok) return false;
+    const data = await resp.json();
+    return data.ok === true || data.success === true;
+  }
+
+  async testConnection(pluginId: string, credentials: Record<string, any>): Promise<{ success: boolean; botUsername?: string; error?: string }> {
+    const resp = await fetch(`${this.baseUrl}/plugins/${pluginId}/test`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(credentials),
+    });
+    if (!resp.ok) return { success: false, error: resp.statusText };
+    const data = await resp.json();
+    return {
+      success: data.ok === true,
+      botUsername: data.ok ? data.message : undefined,
+      error: data.ok ? undefined : data.message,
+    };
+  }
+
+  async syncChannelSettings(platform: ChannelPlatform, agent: { backend: string; customAgentId?: string; name?: string }, model?: { id: string; useModel: string }): Promise<{ success: boolean; error?: string }> {
+    try {
+      const resp = await fetch(`${this.baseUrl}/settings/sync`, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({ platform, agent, model }),
+      });
+      if (!resp.ok) return { success: false, error: resp.statusText };
+      const data = await resp.json();
+      return { success: data.ok === true, error: data.ok ? undefined : data.message };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  }
+}

--- a/src/channels/core/RemoteChannelProvider.ts
+++ b/src/channels/core/RemoteChannelProvider.ts
@@ -129,7 +129,6 @@ export class RemoteChannelProvider implements IChannelProvider {
   }
 
   async deletePlugin(pluginId: string): Promise<boolean> {
-    // No specific delete API in spec, but disable might be enough or we add DELETE /plugins/:id
     const resp = await fetch(`${this.baseUrl}/plugins/${pluginId}/disable`, {
       method: 'POST',
       headers: this.headers,
@@ -198,6 +197,9 @@ export class RemoteChannelProvider implements IChannelProvider {
       conversationId: s.conversationId || s.conversation_id,
       workspace: s.workspace,
       chatId: s.chatId || s.chat_id,
+      title: s.title,
+      source: s.source,
+      status: s.status,
       createdAt: s.createdAt || s.created_at,
       lastActivity: s.lastActivity || s.last_activity,
     }));

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -189,6 +189,9 @@ export interface IChannelSession {
   conversationId?: string;
   workspace?: string;
   chatId?: string; // Channel chat isolation ID (e.g. user:xxx, group:xxx)
+  title?: string;
+  source?: string;
+  status?: string;
   createdAt: number;
   lastActivity: number;
 }

--- a/src/process/bridge/channelBridge.ts
+++ b/src/process/bridge/channelBridge.ts
@@ -5,9 +5,8 @@
  */
 
 import { channel } from '@/common/ipcBridge';
-import { getDatabase } from '@/process/database';
 import { getChannelManager } from '@/channels/core/ChannelManager';
-import { getPairingService } from '@/channels/pairing/PairingService';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { ExtensionRegistry } from '@/extensions';
 import { toAssetUrl } from '@/extensions/assetProtocol';
 import * as path from 'path';
@@ -33,11 +32,7 @@ export function initChannelBridge(): void {
 
       let dbPlugins: import('@/channels/types').IChannelPluginConfig[] = [];
       try {
-        const db = getDatabase();
-        const result = db.getChannelPlugins();
-        if (result.success && Array.isArray(result.data)) {
-          dbPlugins = result.data;
-        }
+        dbPlugins = await getChannelManager().getProvider().getPlugins();
       } catch (dbError) {
         mainWarn('ChannelBridge', 'getChannelPlugins failed, proceeding with builtin-only list:', dbError);
       }
@@ -165,20 +160,17 @@ export function initChannelBridge(): void {
    */
   channel.getPluginCredentials.provider(async ({ pluginId }) => {
     try {
-      const db = getDatabase();
-      // getChannelPlugin already decrypts credentials via decryptCredentials
-      const result = db.getChannelPlugin(pluginId);
+      const plugin = await getChannelManager().getProvider().getPlugin(pluginId);
 
-      if (!result.success || !result.data) {
-        return { success: false, msg: result.error || 'Plugin not found' };
+      if (!plugin) {
+        return { success: false, msg: 'Plugin not found' };
       }
 
-      const plugin = result.data;
       if (!plugin.credentials) {
         return { success: true, data: null };
       }
 
-      // Credentials are already decrypted by getChannelPlugin (via decryptCredentials)
+      // Credentials are already decrypted by provider (Local: getChannelPlugin via decryptCredentials, Remote: Moss server)
       // Just return them directly
       return { success: true, data: plugin.credentials };
     } catch (error: any) {
@@ -246,19 +238,14 @@ export function initChannelBridge(): void {
    */
   channel.getPendingPairings.provider(async () => {
     try {
-      const db = getDatabase();
-      const result = db.getPendingPairingRequests();
+      const pairings = await getChannelManager().getProvider().getPendingPairingRequests();
 
-      mainLog('ChannelBridge', `getPendingPairings: success=${result.success}, count=${result.data?.length || 0}`);
-      if (result.data && result.data.length > 0) {
-        mainLog('ChannelBridge', `getPendingPairings: codes=${result.data.map((p) => `${p.code}(${p.platformType})`).join(', ')}`);
+      mainLog('ChannelBridge', `getPendingPairings: count=${pairings.length}`);
+      if (pairings.length > 0) {
+        mainLog('ChannelBridge', `getPendingPairings: codes=${pairings.map((p) => `${p.code}(${p.platformType})`).join(', ')}`);
       }
 
-      if (!result.success || !result.data) {
-        return { success: false, msg: result.error };
-      }
-
-      return { success: true, data: result.data };
+      return { success: true, data: pairings };
     } catch (error: any) {
       mainError('ChannelBridge', 'getPendingPairings error:', error);
       return { success: false, msg: error.message };
@@ -267,15 +254,13 @@ export function initChannelBridge(): void {
 
   /**
    * Approve a pairing request
-   * Delegates to PairingService to avoid duplicate logic
    */
   channel.approvePairing.provider(async ({ code }) => {
     try {
-      const pairingService = getPairingService();
-      const result = await pairingService.approvePairing(code);
+      const success = await getChannelManager().getProvider().approvePairing(code);
 
-      if (!result.success) {
-        return { success: false, msg: result.error };
+      if (!success) {
+        return { success: false, msg: 'Failed to approve pairing' };
       }
 
       mainLog('ChannelBridge', `Approved pairing for code ${code}`);
@@ -288,15 +273,13 @@ export function initChannelBridge(): void {
 
   /**
    * Reject a pairing request
-   * Delegates to PairingService to avoid duplicate logic
    */
   channel.rejectPairing.provider(async ({ code }) => {
     try {
-      const pairingService = getPairingService();
-      const result = await pairingService.rejectPairing(code);
+      const success = await getChannelManager().getProvider().rejectPairing(code);
 
-      if (!result.success) {
-        return { success: false, msg: result.error };
+      if (!success) {
+        return { success: false, msg: 'Failed to reject pairing' };
       }
 
       mainLog('ChannelBridge', `Rejected pairing code ${code}`);
@@ -314,14 +297,8 @@ export function initChannelBridge(): void {
    */
   channel.getAuthorizedUsers.provider(async () => {
     try {
-      const db = getDatabase();
-      const result = db.getChannelUsers();
-
-      if (!result.success || !result.data) {
-        return { success: false, msg: result.error };
-      }
-
-      return { success: true, data: result.data };
+      const users = await getChannelManager().getProvider().getUsers();
+      return { success: true, data: users };
     } catch (error: any) {
       mainError('ChannelBridge', 'getAuthorizedUsers error:', error);
       return { success: false, msg: error.message };
@@ -333,13 +310,10 @@ export function initChannelBridge(): void {
    */
   channel.revokeUser.provider(async ({ userId }) => {
     try {
-      const db = getDatabase();
+      const success = await getChannelManager().getProvider().deleteUser(userId);
 
-      // Delete user (cascades to sessions)
-      const result = db.deleteChannelUser(userId);
-
-      if (!result.success) {
-        return { success: false, msg: result.error };
+      if (!success) {
+        return { success: false, msg: 'Failed to revoke user authorization' };
       }
 
       mainLog('ChannelBridge', `Revoked user ${userId}`);
@@ -357,14 +331,8 @@ export function initChannelBridge(): void {
    */
   channel.getActiveSessions.provider(async () => {
     try {
-      const db = getDatabase();
-      const result = db.getChannelSessions();
-
-      if (!result.success || !result.data) {
-        return { success: false, msg: result.error };
-      }
-
-      return { success: true, data: result.data };
+      const sessions = await getChannelManager().getProvider().getSessions();
+      return { success: true, data: sessions };
     } catch (error: any) {
       mainError('ChannelBridge', 'getActiveSessions error:', error);
       return { success: false, msg: error.message };
@@ -495,6 +463,11 @@ export function initChannelBridge(): void {
    * Cancel WeChat QR login flow
    */
   channel.wechatCancelQrLogin.provider(async () => {
+    // Enterprise mode: no local WeChat process to cancel
+    if (isEnterpriseMode()) {
+      return { success: true };
+    }
+
     if (wechatQrLoginAbort) {
       wechatQrLoginAbort.abort();
       wechatQrLoginAbort = null;

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -20,6 +20,7 @@ import { getChannelManager } from '@/channels';
 import { ExtensionRegistry } from '@/extensions';
 import { initStatusManager } from './services/initStatus';
 import { mainLog, mainError, perfLog } from './utils/mainLogger';
+import { refreshEnterpriseCache } from '@/common/enterpriseDebugConfig';
 // Crash bridge must be initialized early to handle renderer errors before other bridges
 import { initCrashBridge } from './bridge/crashBridge';
 
@@ -49,6 +50,9 @@ export const initializeProcess = async () => {
   const bridgeStart = Date.now();
   try {
     await import('./initBridge');
+    // Refresh enterprise config cache before mode branching
+    // This ensures isEnterpriseMode() returns correct value in ChannelManager
+    await refreshEnterpriseCache();
     mainLog('Process', 'Bridge initialized successfully');
   } catch (error) {
     mainError('Process', 'Bridge initialization failed', error);
@@ -71,7 +75,15 @@ export const initializeProcess = async () => {
   const appMode = ProcessConfig.getSync('system.appMode') ?? null;
 
   if (appMode === 'e') {
-    // Enterprise mode: bridge is ready, skip local services, set ready immediately
+    // Enterprise mode: initialize ChannelManager for channel settings UI
+    // but skip local services (handled by Moss Server)
+    const channelStart = Date.now();
+    try {
+      await getChannelManager().initialize();
+    } catch (error) {
+      mainError('Process', 'Failed to initialize ChannelManager', error);
+    }
+    perfLog('ChannelManager', Date.now() - channelStart);
     initStatusManager.setStatus('ready', '初始化完成', 100);
   } else if (appMode === 'c') {
     // Consumer mode: normal full startup

--- a/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
@@ -16,6 +16,7 @@ import { Input, InputNumber, Message, Select, Switch } from '@arco-design/web-re
 import { CheckOne } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useSettingsViewMode } from '../settingsViewContext';
 import ChannelItem from './channels/ChannelItem';
 import type { ChannelConfig } from './channels/types';
@@ -139,6 +140,7 @@ const useChannelModelSelection = (configKey: ChannelModelConfigKey): GeminiModel
 const ChannelModalContent: React.FC = () => {
   const { t } = useTranslation();
   const viewMode = useSettingsViewMode();
+  const { isEnterprise } = useAppMode();
   const isPageMode = viewMode === 'page';
 
   // Plugin state
@@ -163,6 +165,12 @@ const ChannelModalContent: React.FC = () => {
 
   // Track the token entered in TelegramConfigForm so the toggle handler can use it
   const telegramTokenRef = React.useRef<string>('');
+
+  // Track Lark credentials entered in LarkConfigForm (for enterprise mode switch toggle)
+  const larkCredentialsRef = React.useRef<{ appId: string; appSecret: string; encryptKey?: string; verificationToken?: string }>({ appId: '', appSecret: '' });
+
+  // Track DingTalk credentials entered in DingTalkConfigForm (for enterprise mode switch toggle)
+  const dingtalkCredentialsRef = React.useRef<{ clientId: string; clientSecret: string }>({ clientId: '', clientSecret: '' });
 
   // Track WeCom credentials entered in WeComConfigForm
   const wecomCredentialsRef = React.useRef<{ botId: string; secret: string }>({ botId: '', secret: '' });
@@ -326,19 +334,29 @@ const ChannelModalContent: React.FC = () => {
 
   // Enable/Disable Lark plugin
   const handleToggleLarkPlugin = async (enabled: boolean) => {
-    setLarkEnableLoading(true);
-    try {
-      if (enabled) {
-        // Check if we have credentials - already saved in database
-        if (!larkPluginStatus?.hasToken) {
-          Message.warning(t('settings.lark.credentialsRequired', 'Please configure Lark credentials first'));
-          setLarkEnableLoading(false);
-          return;
-        }
+    if (enabled) {
+      const hasPendingCreds = !!(larkCredentialsRef.current.appId.trim() && larkCredentialsRef.current.appSecret.trim());
+
+      // In enterprise mode, credentials may exist on Moss Server even if hasToken is false
+      // (e.g. after page refresh before status refreshes). Try to enable with empty config
+      // which will preserve server-side credentials.
+      if (!isEnterprise && !larkPluginStatus?.hasToken && !hasPendingCreds) {
+        setCollapseKeys((prev) => ({ ...prev, lark: false }));
+        return;
+      }
+
+      setLarkEnableLoading(true);
+      try {
+        // Pass pending credentials from form if available
+        const pendingCreds = larkCredentialsRef.current;
+        const hasFormCreds = !!(pendingCreds.appId.trim() && pendingCreds.appSecret.trim());
+        const config = hasFormCreds
+          ? { appId: pendingCreds.appId.trim(), appSecret: pendingCreds.appSecret.trim(), encryptKey: pendingCreds.encryptKey, verificationToken: pendingCreds.verificationToken }
+          : {};
 
         const result = await channel.enablePlugin.invoke({
           pluginId: 'lark_default',
-          config: {},
+          config,
         });
 
         if (result.success) {
@@ -347,7 +365,14 @@ const ChannelModalContent: React.FC = () => {
         } else {
           Message.error(result.msg || t('settings.lark.enableFailed', 'Failed to enable Lark plugin'));
         }
-      } else {
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setLarkEnableLoading(false);
+      }
+    } else {
+      setLarkEnableLoading(true);
+      try {
         const result = await channel.disablePlugin.invoke({ pluginId: 'lark_default' });
 
         if (result.success) {
@@ -356,28 +381,38 @@ const ChannelModalContent: React.FC = () => {
         } else {
           Message.error(result.msg || t('settings.assistant.disableFailed', 'Failed to disable plugin'));
         }
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setLarkEnableLoading(false);
       }
-    } catch (error: any) {
-      Message.error(error.message);
-    } finally {
-      setLarkEnableLoading(false);
     }
   };
 
   // Enable/Disable DingTalk plugin
   const handleToggleDingtalkPlugin = async (enabled: boolean) => {
-    setDingtalkEnableLoading(true);
-    try {
-      if (enabled) {
-        if (!dingtalkPluginStatus?.hasToken) {
-          Message.warning(t('settings.dingtalk.credentialsRequired', 'Please configure DingTalk credentials first'));
-          setDingtalkEnableLoading(false);
-          return;
-        }
+    if (enabled) {
+      const hasPendingCreds = !!(dingtalkCredentialsRef.current.clientId.trim() && dingtalkCredentialsRef.current.clientSecret.trim());
+
+      // In enterprise mode, credentials may exist on Moss Server even if hasToken is false.
+      // Try to enable with empty config which will preserve server-side credentials.
+      if (!isEnterprise && !dingtalkPluginStatus?.hasToken && !hasPendingCreds) {
+        setCollapseKeys((prev) => ({ ...prev, dingtalk: false }));
+        return;
+      }
+
+      setDingtalkEnableLoading(true);
+      try {
+        // Pass pending credentials from form if available
+        const pendingCreds = dingtalkCredentialsRef.current;
+        const hasFormCreds = !!(pendingCreds.clientId.trim() && pendingCreds.clientSecret.trim());
+        const config = hasFormCreds
+          ? { clientId: pendingCreds.clientId.trim(), clientSecret: pendingCreds.clientSecret.trim() }
+          : {};
 
         const result = await channel.enablePlugin.invoke({
           pluginId: 'dingtalk_default',
-          config: {},
+          config,
         });
 
         if (result.success) {
@@ -386,7 +421,14 @@ const ChannelModalContent: React.FC = () => {
         } else {
           Message.error(result.msg || t('settings.dingtalk.enableFailed', 'Failed to enable DingTalk plugin'));
         }
-      } else {
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setDingtalkEnableLoading(false);
+      }
+    } else {
+      setDingtalkEnableLoading(true);
+      try {
         const result = await channel.disablePlugin.invoke({ pluginId: 'dingtalk_default' });
 
         if (result.success) {
@@ -395,19 +437,20 @@ const ChannelModalContent: React.FC = () => {
         } else {
           Message.error(result.msg || t('settings.dingtalk.disableFailed', 'Failed to disable DingTalk plugin'));
         }
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setDingtalkEnableLoading(false);
       }
-    } catch (error: any) {
-      Message.error(error.message);
-    } finally {
-      setDingtalkEnableLoading(false);
     }
   };
 
   // WeChat toggle handler — uses standard channel enable/disable flow
   const handleToggleWechatPlugin = async (enabled: boolean) => {
     if (enabled) {
-      // If not yet configured, expand to show config form
-      if (!wechatPluginStatus?.hasToken) {
+      // In enterprise mode, credentials may exist on Moss Server even if hasToken is false.
+      // Try to enable with empty config which will preserve server-side credentials.
+      if (!isEnterprise && !wechatPluginStatus?.hasToken) {
         setCollapseKeys((prev) => ({ ...prev, wechat: false }));
         return;
       }
@@ -693,7 +736,7 @@ const ChannelModalContent: React.FC = () => {
       disabled: larkEnableLoading,
       isConnected: larkPluginStatus?.connected || false,
       defaultModel: larkModelSelection.currentModel?.useModel,
-      content: <LarkConfigForm pluginStatus={larkPluginStatus} modelSelection={larkModelSelection} onStatusChange={setLarkPluginStatus} />,
+      content: <LarkConfigForm pluginStatus={larkPluginStatus} modelSelection={larkModelSelection} onStatusChange={setLarkPluginStatus} onCredentialsChange={(creds) => { larkCredentialsRef.current = creds; }} />,
     };
 
     const dingtalkChannel: ChannelConfig = {
@@ -705,7 +748,7 @@ const ChannelModalContent: React.FC = () => {
       disabled: dingtalkEnableLoading,
       isConnected: dingtalkPluginStatus?.connected || false,
       defaultModel: dingtalkModelSelection.currentModel?.useModel,
-      content: <DingTalkConfigForm pluginStatus={dingtalkPluginStatus} modelSelection={dingtalkModelSelection} onStatusChange={setDingtalkPluginStatus} />,
+      content: <DingTalkConfigForm pluginStatus={dingtalkPluginStatus} modelSelection={dingtalkModelSelection} onStatusChange={setDingtalkPluginStatus} onCredentialsChange={(creds) => { dingtalkCredentialsRef.current = creds; }} />,
     };
 
     const wechatChannel: ChannelConfig = {

--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -125,6 +125,17 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
     void loadAuthorizedUsers();
   }, [loadPendingPairings, loadAuthorizedUsers]);
 
+  // Refresh when plugin status changes
+  useEffect(() => {
+    if (pluginStatus?.enabled) {
+      void loadPendingPairings();
+      void loadAuthorizedUsers();
+    } else {
+      setPendingPairings([]);
+      setAuthorizedUsers([]);
+    }
+  }, [pluginStatus?.enabled]);
+
   // Load saved credentials for backfill
   useEffect(() => {
     // Skip if user has already entered values in the form

--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -11,6 +11,7 @@ import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
 import type { AcpBackendAll } from '@/types/acpTypes';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -55,17 +56,26 @@ interface DingTalkConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange: (status: IChannelPluginStatus | null) => void;
+  onCredentialsChange?: (creds: { clientId: string; clientSecret: string }) => void;
 }
 
 const DINGTALK_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/dingtalk.html';
 const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
-const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
+const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
   const { t } = useTranslation();
+  const { isEnterprise } = useAppMode();
 
   // DingTalk credentials
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
+
+  // Notify parent of credential changes (for enterprise mode switch toggle)
+  useEffect(() => {
+    if (onCredentialsChange) {
+      onCredentialsChange({ clientId, clientSecret });
+    }
+  }, [clientId, clientSecret, onCredentialsChange]);
 
   const [testLoading, setTestLoading] = useState(false);
   const [_credentialsTested, setCredentialsTested] = useState(false);
@@ -117,8 +127,12 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
 
   // Load saved credentials for backfill
   useEffect(() => {
-    // Only load if plugin has credentials configured and no values are currently entered
-    if (!pluginStatus?.hasToken || clientId || clientSecret) return;
+    // Skip if user has already entered values in the form
+    if (clientId || clientSecret) return;
+
+    // In enterprise mode, always try to load credentials from Moss Server
+    // In consumer mode, only load if plugin has credentials configured
+    if (!isEnterprise && !pluginStatus?.hasToken) return;
 
     const loadCredentials = async () => {
       try {
@@ -133,7 +147,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
     };
 
     void loadCredentials();
-  }, [pluginStatus]);
+  }, [pluginStatus, isEnterprise]);
 
   // Load available agents + saved selection
   useEffect(() => {
@@ -226,6 +240,9 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
       if (result.success && result.data?.success) {
         setCredentialsTested(true);
         Message.success(t('settings.dingtalk.connectionSuccess', 'Connected to DingTalk API!'));
+
+        // Auto-enable bot after successful test
+        // In enterprise mode, this persists credentials to Moss Server via enablePlugin API
         await handleAutoEnable();
       } else {
         setCredentialsTested(false);
@@ -453,13 +470,14 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
       {!hasExistingUsers && !pluginStatus?.connected && (
         <div className='flex justify-end'>
           {pluginStatus?.hasToken && !clientId.trim() && !clientSecret.trim() ? <span className='text-12px text-t-tertiary mr-12px self-center'>{t('settings.dingtalk.credentialsSaved', 'Credentials already configured. Enter new values to update.')}</span> : null}
-          <Button type='primary' loading={testLoading} onClick={handleTestConnection} disabled={pluginStatus?.hasToken && !clientId.trim() && !clientSecret.trim()}>
+          <Button type='primary' loading={testLoading} onClick={handleTestConnection} disabled={(!isEnterprise && pluginStatus?.hasToken && !clientId.trim() && !clientSecret.trim()) || (isEnterprise && !clientId.trim() && !clientSecret.trim())}>
             {t('settings.dingtalk.testAndConnect', 'Test & Connect')}
           </Button>
         </div>
       )}
 
-      {/* Agent Selection */}
+      {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {!isEnterprise && (
       <div className='flex flex-col gap-8px'>
         <PreferenceRow label={t('settings.dingtalk.agent', 'Agent')} description={t('settings.dingtalk.agentDesc', 'Used for DingTalk conversations')}>
           <Dropdown
@@ -496,11 +514,14 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
           </Dropdown>
         </PreferenceRow>
       </div>
+      )}
 
-      {/* Default Model Selection */}
+      {/* Default Model Selection - hidden in enterprise mode */}
+      {!isEnterprise && (
       <PreferenceRow label={t('settings.assistant.defaultModel', 'Model')} description={t('settings.dingtalk.defaultModelDesc', 'Used for Agent conversations')}>
         <GeminiModelSelector selection={isGeminiAgent ? modelSelection : undefined} disabled={!isGeminiAgent} label={!isGeminiAgent ? t('settings.assistant.autoFollowCliModel', 'Auto-follow CLI runtime model') : undefined} variant='settings' />
       </PreferenceRow>
+      )}
 
       {/* Connection Status */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -11,6 +11,7 @@ import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
 import type { AcpBackendAll } from '@/types/acpTypes';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -55,19 +56,28 @@ interface LarkConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange: (status: IChannelPluginStatus | null) => void;
+  onCredentialsChange?: (creds: { appId: string; appSecret: string; encryptKey?: string; verificationToken?: string }) => void;
 }
 
 const LARK_DEV_DOCS_URL = 'https://sudoclaw.sudoprivacy.com/guides/feishu.html';
 const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
-const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
+const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
   const { t } = useTranslation();
+  const { isEnterprise } = useAppMode();
 
   // Lark credentials
   const [appId, setAppId] = useState('');
   const [appSecret, setAppSecret] = useState('');
   const [encryptKey, setEncryptKey] = useState('');
   const [verificationToken, setVerificationToken] = useState('');
+
+  // Notify parent of credential changes (for enterprise mode switch toggle)
+  useEffect(() => {
+    if (onCredentialsChange) {
+      onCredentialsChange({ appId, appSecret, encryptKey: encryptKey.trim() || undefined, verificationToken: verificationToken.trim() || undefined });
+    }
+  }, [appId, appSecret, encryptKey, verificationToken, onCredentialsChange]);
 
   const [showOptional, setShowOptional] = useState(false);
   const [testLoading, setTestLoading] = useState(false);
@@ -122,8 +132,12 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
 
   // Load saved credentials for backfill
   useEffect(() => {
-    // Only load if plugin has credentials configured and no values are currently entered
-    if (!pluginStatus?.hasToken || appId || appSecret) return;
+    // Skip if user has already entered values in the form
+    if (appId || appSecret) return;
+
+    // In enterprise mode, always try to load credentials from Moss Server
+    // In consumer mode, only load if plugin has credentials configured
+    if (!isEnterprise && !pluginStatus?.hasToken) return;
 
     const loadCredentials = async () => {
       try {
@@ -140,7 +154,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     };
 
     void loadCredentials();
-  }, [pluginStatus]);
+  }, [pluginStatus, isEnterprise]);
 
   // Load available agents + saved selection
   useEffect(() => {
@@ -236,6 +250,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         Message.success(t('settings.lark.connectionSuccess', 'Connected to Lark API!'));
 
         // Auto-enable bot after successful test
+        // In enterprise mode, this persists credentials to Moss Server via enablePlugin API
         await handleAutoEnable();
       } else {
         setCredentialsTested(false);
@@ -538,20 +553,21 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         </>
       )}
 
-      {/* Test Connection Button - only show when not connected or no existing users */}
+      {/* Test Connection Button - show when not connected or no existing users */}
       {!hasExistingUsers && !pluginStatus?.connected && (
         <div className='flex justify-end'>
           {pluginStatus?.hasToken && !appId.trim() && !appSecret.trim() ? (
             // Credentials already saved but not entered in UI - show info message
             <span className='text-12px text-t-tertiary mr-12px self-center'>{t('settings.lark.credentialsSaved', 'Credentials already configured. Enter new values to update.')}</span>
           ) : null}
-          <Button type='primary' loading={testLoading} onClick={handleTestConnection} disabled={pluginStatus?.hasToken && !appId.trim() && !appSecret.trim()}>
+          <Button type='primary' loading={testLoading} onClick={handleTestConnection} disabled={(!isEnterprise && pluginStatus?.hasToken && !appId.trim() && !appSecret.trim()) || (isEnterprise && !appId.trim() && !appSecret.trim())}>
             {t('settings.lark.testAndConnect', 'Test & Connect')}
           </Button>
         </div>
       )}
 
-      {/* Agent Selection */}
+      {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {!isEnterprise && (
       <div className='flex flex-col gap-8px'>
         <PreferenceRow label={t('settings.lark.agent', 'Agent')} description={t('settings.lark.agentDesc', 'Used for Lark conversations')}>
           <Dropdown
@@ -588,11 +604,14 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
           </Dropdown>
         </PreferenceRow>
       </div>
+      )}
 
-      {/* Default Model Selection */}
+      {/* Default Model Selection - hidden in enterprise mode */}
+      {!isEnterprise && (
       <PreferenceRow label={t('settings.assistant.defaultModel', '对话模型')} description={t('settings.lark.defaultModelDesc', '用于Agent对话时调用')}>
         <GeminiModelSelector selection={isGeminiAgent ? modelSelection : undefined} disabled={!isGeminiAgent} label={!isGeminiAgent ? t('settings.assistant.autoFollowCliModel', '自动跟随CLI运行时的模型') : undefined} variant='settings' />
       </PreferenceRow>
+      )}
 
       {/* Connection Status - show when bot is enabled */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -130,6 +130,17 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     void loadAuthorizedUsers();
   }, [loadPendingPairings, loadAuthorizedUsers]);
 
+  // Refresh when plugin status changes
+  useEffect(() => {
+    if (pluginStatus?.enabled) {
+      void loadPendingPairings();
+      void loadAuthorizedUsers();
+    } else {
+      setPendingPairings([]);
+      setAuthorizedUsers([]);
+    }
+  }, [pluginStatus?.enabled]);
+
   // Load saved credentials for backfill
   useEffect(() => {
     // Skip if user has already entered values in the form

--- a/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
@@ -79,7 +79,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
     try {
       const result = await channel.getPendingPairings.invoke();
       if (result.success && result.data) {
-        setPendingPairings(result.data);
+        setPendingPairings(result.data.filter((p) => p.platformType === 'telegram'));
       }
     } catch (error) {
       console.error('[ChannelSettings] Failed to load pending pairings:', error);
@@ -108,6 +108,17 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
     void loadPendingPairings();
     void loadAuthorizedUsers();
   }, [loadPendingPairings, loadAuthorizedUsers]);
+
+  // Refresh when plugin status changes
+  useEffect(() => {
+    if (pluginStatus?.enabled) {
+      void loadPendingPairings();
+      void loadAuthorizedUsers();
+    } else {
+      setPendingPairings([]);
+      setAuthorizedUsers([]);
+    }
+  }, [pluginStatus?.enabled]);
 
   // Load saved credentials for backfill
   useEffect(() => {

--- a/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/TelegramConfigForm.tsx
@@ -10,6 +10,7 @@ import { ConfigStorage } from '@/common/storage';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
 import type { AcpBackendAll } from '@/types/acpTypes';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -57,6 +58,7 @@ const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onTokenChange }) => {
   const { t } = useTranslation();
+  const { isEnterprise } = useAppMode();
 
   const [telegramToken, setTelegramToken] = useState('');
   const [testLoading, setTestLoading] = useState(false);
@@ -350,7 +352,8 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
         </div>
       </PreferenceRow>
 
-      {/* Agent Selection */}
+      {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {!isEnterprise && (
       <div className='flex flex-col gap-8px'>
         <PreferenceRow label={t('settings.lark.agent', 'Agent')} description={t('settings.assistant.agentDescTelegram', 'Used for Telegram conversations')}>
           <Dropdown
@@ -387,11 +390,14 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
           </Dropdown>
         </PreferenceRow>
       </div>
+      )}
 
-      {/* Default Model Selection */}
+      {/* Default Model Selection - hidden in enterprise mode */}
+      {!isEnterprise && (
       <PreferenceRow label={t('settings.assistant.defaultModel', '对话模型')} description={t('settings.assistant.defaultModelDesc', '用于Agent对话时调用')}>
         <GeminiModelSelector selection={isGeminiAgent ? modelSelection : undefined} disabled={!isGeminiAgent} label={!isGeminiAgent ? t('settings.assistant.autoFollowCliModel', '自动跟随CLI运行时的模型') : undefined} variant='settings' />
       </PreferenceRow>
+      )}
 
       {/* Next Steps Guide - show when bot is enabled and no authorized users yet */}
       {pluginStatus?.enabled && pluginStatus?.connected && authorizedUsers.length === 0 && (

--- a/src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/WeChatConfigForm.tsx
@@ -11,6 +11,7 @@ import { ConfigStorage } from '@/common/storage';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
 import type { AcpBackendAll } from '@/types/acpTypes';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Menu, Message, Spin } from '@arco-design/web-react';
 import { Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -47,6 +48,7 @@ const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
   const { t } = useTranslation();
+  const { isEnterprise } = useAppMode();
 
   const isConnected = pluginStatus?.connected || false;
   const [phase, setPhase] = useState<LoginPhase>(isConnected ? 'success' : 'idle');
@@ -271,7 +273,8 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
       {renderConnectionSection()}
       {renderQRCodeSection()}
 
-      {/* Agent Selection */}
+      {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {!isEnterprise && (
       <div className='flex flex-col gap-8px'>
         <PreferenceRow label={t('settings.channels.wechat.agent', 'Agent')} description={t('settings.channels.wechat.agentDesc', 'Used for WeChat conversations')}>
           <Dropdown
@@ -308,11 +311,14 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
           </Dropdown>
         </PreferenceRow>
       </div>
+      )}
 
-      {/* Default Model Selection */}
+      {/* Default Model Selection - hidden in enterprise mode */}
+      {!isEnterprise && (
       <PreferenceRow label={t('settings.assistant.defaultModel', 'Model')} description={t('settings.channels.wechat.defaultModelDesc', 'Used for Agent conversations')}>
         <GeminiModelSelector selection={isGeminiAgent ? modelSelection : undefined} disabled={!isGeminiAgent} label={!isGeminiAgent ? t('settings.assistant.autoFollowCliModel', 'Auto-follow CLI runtime model') : undefined} variant='settings' />
       </PreferenceRow>
+      )}
     </div>
   );
 };

--- a/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
@@ -11,6 +11,7 @@ import { openExternalUrl } from '@/renderer/utils/platform';
 import GeminiModelSelector from '@/renderer/pages/conversation/gemini/GeminiModelSelector';
 import type { GeminiModelSelection } from '@/renderer/pages/conversation/gemini/useGeminiModelSelection';
 import type { AcpBackendAll } from '@/types/acpTypes';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
 import { CheckOne, CloseOne, Copy, Delete, Down, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -63,6 +64,7 @@ const CHANNEL_VISIBLE_AGENT_BACKEND: AcpBackendAll = 'openclaw-gateway';
 
 const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
   const { t } = useTranslation();
+  const { isEnterprise } = useAppMode();
 
   // WeCom credentials
   const [botId, setBotId] = useState('');
@@ -519,7 +521,8 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
         </div>
       )}
 
-      {/* Agent Selection */}
+      {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {!isEnterprise && (
       <div className='flex flex-col gap-8px'>
         <PreferenceRow label={t('settings.wecom.agent', 'Agent')} description={t('settings.wecom.agentDesc', 'Used for WeCom conversations')}>
           <Dropdown
@@ -556,11 +559,14 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
           </Dropdown>
         </PreferenceRow>
       </div>
+      )}
 
-      {/* Default Model Selection */}
+      {/* Default Model Selection - hidden in enterprise mode */}
+      {!isEnterprise && (
       <PreferenceRow label={t('settings.assistant.defaultModel', 'Model')} description={t('settings.wecom.defaultModelDesc', 'Used for Agent conversations')}>
         <GeminiModelSelector selection={isGeminiAgent ? modelSelection : undefined} disabled={!isGeminiAgent} label={!isGeminiAgent ? t('settings.assistant.autoFollowCliModel', 'Auto-follow CLI runtime model') : undefined} variant='settings' />
       </PreferenceRow>
+      )}
 
       {/* Connection Status - always show when enabled */}
       {pluginStatus?.enabled && (

--- a/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/WeComConfigForm.tsx
@@ -118,15 +118,14 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
     void loadAuthorizedUsers();
   }, [loadPendingPairings, loadAuthorizedUsers]);
 
-  // Clear local state when plugin is disabled
-  // This ensures the input fields are unlocked after disabling
+  // Refresh when plugin status changes
   useEffect(() => {
-    if (pluginStatus && !pluginStatus.enabled) {
-      // Plugin is disabled - clear local state immediately
-      // No need to reload from backend since we know users were deleted
-      console.log('[WeComConfig] Plugin disabled, clearing local state');
-      setAuthorizedUsers([]);
+    if (pluginStatus?.enabled) {
+      void loadPendingPairings();
+      void loadAuthorizedUsers();
+    } else {
       setPendingPairings([]);
+      setAuthorizedUsers([]);
     }
   }, [pluginStatus?.enabled]);
 

--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -17,6 +17,7 @@ import { CheckOne, Communication, Copy, Earth, EditTwo, Refresh } from '@icon-pa
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSettingsViewMode } from '../settingsViewContext';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 
 /**
  * 偏好设置行组件
@@ -57,6 +58,7 @@ const WebuiModalContent: React.FC = () => {
   const { t } = useTranslation();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
+  const { isEnterprise } = useAppMode();
   const [activeTab, setActiveTab] = useState<'channels' | 'secrets'>('channels');
 
   // 检测是否在 Electron 桌面环境 / Check if running in Electron desktop environment
@@ -722,14 +724,16 @@ const WebuiModalContent: React.FC = () => {
             </span>
           }
         />
-        <Tabs.TabPane
-          key='secrets'
-          title={
-            <span data-webui-tab='secrets' className={`inline-flex items-center gap-6px transition-colors ${activeTab === 'secrets' ? 'text-t-primary font-600' : 'text-t-secondary'}`}>
-              <span className='text-14px'>{t('settings.secrets', '秘钥管理')}</span>
-            </span>
-          }
-        />
+        {!isEnterprise && (
+          <Tabs.TabPane
+            key='secrets'
+            title={
+              <span data-webui-tab='secrets' className={`inline-flex items-center gap-6px transition-colors ${activeTab === 'secrets' ? 'text-t-primary font-600' : 'text-t-secondary'}`}>
+                <span className='text-14px'>{t('settings.secrets', '秘钥管理')}</span>
+              </span>
+            }
+          />
+        )}
       </Tabs>
 
       {/* {activeTab === 'webui' ? (

--- a/src/renderer/pages/settings/SettingsSider.tsx
+++ b/src/renderer/pages/settings/SettingsSider.tsx
@@ -17,7 +17,7 @@ import { useAuth } from '../../context/AuthContext';
 const BUILTIN_TAB_IDS = ['profile', 'recharge', 'members', 'agent', 'tools', 'skill', 'security', 'display', 'webui', 'runtime', 'system', 'about'] as const; // 隐藏'copilot', 'cron'已移至左侧边栏
 
 /** Enterprise mode builtin tab IDs (restricted subset). */
-const ENTERPRISE_BUILTIN_TAB_IDS = ['profile', 'enterprise', 'display', 'system', 'about'] as const;
+const ENTERPRISE_BUILTIN_TAB_IDS = ['profile', 'enterprise', 'display', 'webui', 'system', 'about'] as const;
 
 type SiderItem = {
   id: string;

--- a/src/renderer/pages/settings/components/SettingsPageWrapper.tsx
+++ b/src/renderer/pages/settings/components/SettingsPageWrapper.tsx
@@ -11,7 +11,7 @@ import { useExtI18n } from '@/renderer/hooks/useExtI18n';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 
 /** Enterprise mode builtin tab IDs (restricted subset) - synced with SettingsSider */
-const ENTERPRISE_BUILTIN_TAB_IDS = ['profile', 'enterprise', 'display', 'system', 'about'] as const;
+const ENTERPRISE_BUILTIN_TAB_IDS = ['profile', 'enterprise', 'display', 'webui', 'system', 'about'] as const;
 interface SettingsPageWrapperProps {
   children: React.ReactNode;
   className?: string;

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -36,7 +36,7 @@ const withRouteFallback = (Component: React.LazyExoticComponent<React.ComponentT
 );
 
 // Enterprise-allowed settings paths
-const ENTERPRISE_ALLOWED_PATHS = ['/settings/profile', '/settings/enterprise', '/settings/display', '/settings/system', '/settings/about'];
+const ENTERPRISE_ALLOWED_PATHS = ['/settings/profile', '/settings/enterprise', '/settings/display', '/settings/webui', '/settings/system', '/settings/about'];
 
 // Mode-aware default settings route
 const SettingsDefaultRoute: React.FC = () => {


### PR DESCRIPTION
## Summary
- Add enterprise channel provider architecture with `LocalChannelProvider` and `RemoteChannelProvider` implementations
- Support local/remote mode switching based on enterprise settings for channel management
- Separate DingTalk credentials mapping (clientId/clientSecret) from Lark (appId/appSecret)
- Add title, source, status fields to IChannelSession for richer session info
- Add plugin status change effect to refresh/clear pairings and authorized users in all config forms (DingTalk, Lark, Telegram, WeCom)
- Filter Telegram pending pairings by platform type

## Test plan
- [ ] Verify channel config forms correctly load/clear pairings and users when plugin is enabled/disabled
- [ ] Verify DingTalk credentials are sent with clientId/clientSecret and Lark with appId/appSecret
- [ ] Verify session fields (title, source, status) are properly mapped from remote API
- [ ] Verify enterprise mode plugin disable does not call deleteUsersByPlatform for WeCom/WeChat
- [ ] Verify Telegram pending pairings are filtered by platform type

🤖 Generated with [Claude Code](https://claude.com/claude-code)