### PR TITLE
fix(acp): show file thumbnails in Sudocode conversation user messages

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -19,6 +19,7 @@ import type { CronMessageMeta, TMessage } from '@/common/chatLib';
 import type { SlashCommandItem } from '@/common/slash/types';
 import { transformMessage } from '@/common/chatLib';
 import { NEXUS_FILES_MARKER } from '@/common/constants';
+import { appendNexusFilesMarker } from '@/common/nexusFiles';
 import type { IResponseMessage } from '@/common/ipcBridge';
 import { NavigationInterceptor } from '@/common/navigation';
 import { parseError, uuid } from '@/common/utils';
@@ -618,6 +619,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
 
       // Emit/persist user message immediately
       if (data.msg_id && data.content) {
+        const displayContent = appendNexusFilesMarker(data.content, data.files || [], this.workspace);
         const userMessage: TMessage = {
           id: data.msg_id,
           msg_id: data.msg_id,
@@ -625,7 +627,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
           position: 'right',
           conversation_id: this.conversation_id,
           content: {
-            content: data.content,
+            content: displayContent,
             ...(data.cronMeta && { cronMeta: data.cronMeta }),
           },
           createdAt: Date.now(),
@@ -640,7 +642,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
           type: 'user_content',
           conversation_id: this.conversation_id,
           msg_id: data.msg_id,
-          data: data.cronMeta ? { content: userMessage.content.content, cronMeta: data.cronMeta } : userMessage.content.content,
+          data: data.cronMeta ? { content: displayContent, cronMeta: data.cronMeta } : displayContent,
         };
         ipcBridge.acpConversation.responseStream.emit(userResponseMessage);
       }


### PR DESCRIPTION
## Summary
- Fix missing image thumbnails in Sudocode (ACP) conversation user messages
- Use `appendNexusFilesMarker` to include file references in display content so `MessagetText.tsx` can render image thumbnails via `[[NEXUS_FILES]]` marker
- Reuse existing `appendNexusFilesMarker` utility (already validated in Channel plugin via `ActionExecutor.ts:577`)

## Test plan
- [ ] 创建 Sudocode 对话，通过粘贴/拖拽/文件选择器发送图片，确认用户消息侧显示缩略图
- [ ] 点击缩略图确认可以预览大图
- [ ] 确认 AI agent 仍能正常接收并理解图片内容
- [ ] 发送纯文本消息，确认不受影响
- [ ] 发送非图片文件（如 .pdf、.txt），确认显示文件卡片
- [ ] 同时发送文本 + 多张图片 + 非图片文件，确认展示正确
- [ ] 关闭应用后重新打开，确认历史消息中的缩略图仍能正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)