### PR TITLE
fix: add scode agent modes and fix temp workspace detection

### DIFF
--- a/src/process/task/draftsCleanup.ts
+++ b/src/process/task/draftsCleanup.ts
@@ -249,6 +249,21 @@ export async function cleanupIntermediateFiles(workspace: string): Promise<void>
 }
 
 /**
+ * Pattern to match temporary workspace naming convention: <backend>-temp-<timestamp>
+ * Matches any workspace ending with -temp- followed by digits (Unix timestamp)
+ * Examples: scode-temp-1234567890, sudoclaw-temp-1234567890, claude-temp-1234567890
+ */
+const TEMP_WORKSPACE_REGEX = /-temp-\d+$/;
+
+/**
+ * Check if a directory name is a temporary workspace
+ * 检查目录名是否为临时工作空间
+ */
+function isTempWorkspace(name: string): boolean {
+  return TEMP_WORKSPACE_REGEX.test(name);
+}
+
+/**
  * Clean up files that were mistakenly written to the parent workspace directory
  * 清理错误写入父工作空间目录的文件
  *
@@ -256,7 +271,7 @@ export async function cleanupIntermediateFiles(workspace: string): Promise<void>
  * instead of the session-specific workspace. This function detects and moves
  * those files to the correct session workspace.
  *
- * @param sessionWorkspace - The session workspace path (e.g., /.../workspace/sudoclaw-temp-xxx)
+ * @param sessionWorkspace - The session workspace path (e.g., /.../workspace/scode-temp-xxx)
  * @param parentWorkspace - The parent workspace path (e.g., /.../workspace)
  * @param maxAgeMs - Maximum file age to consider (default: 5 minutes)
  */
@@ -292,7 +307,8 @@ export async function cleanupMisplacedFiles(sessionWorkspace: string, parentWork
       // Skip directories (except if it's a non-session temp directory)
       if (!entry.isFile()) {
         // Check if it's a directory that might be misplaced (like unpacked_docx)
-        if (entry.isDirectory() && !PARENT_EXCLUDED_NAMES.has(entry.name) && !entry.name.startsWith('sudoclaw-temp-')) {
+        // Skip temp workspace directories (e.g., scode-temp-xxx, sudoclaw-temp-xxx)
+        if (entry.isDirectory() && !PARENT_EXCLUDED_NAMES.has(entry.name) && !isTempWorkspace(entry.name)) {
           const dirPath = path.join(parentWorkspace, entry.name);
           try {
             const stat = await fs.stat(dirPath);
@@ -312,8 +328,8 @@ export async function cleanupMisplacedFiles(sessionWorkspace: string, parentWork
         continue;
       }
 
-      // Skip excluded names and session workspace directories
-      if (PARENT_EXCLUDED_NAMES.has(entry.name) || entry.name.startsWith('sudoclaw-temp-')) {
+      // Skip excluded names and temp workspace directories
+      if (PARENT_EXCLUDED_NAMES.has(entry.name) || isTempWorkspace(entry.name)) {
         continue;
       }
 

--- a/src/renderer/constants/agentModes.ts
+++ b/src/renderer/constants/agentModes.ts
@@ -65,6 +65,11 @@ export const AGENT_MODES: Record<string, AgentModeOption[]> = {
     { value: 'autoEdit', label: 'Auto Edit' },
     { value: 'yolo', label: 'Full Auto' },
   ],
+  scode: [
+    { value: 'default', label: 'Default' },
+    { value: 'plan', label: 'Plan' },
+    { value: 'bypassPermissions', label: 'YOLO' },
+  ],
   sudoclaw: [
     { value: 'default', label: 'Default' },
     { value: 'yolo', label: 'YOLO' },


### PR DESCRIPTION
## Summary
- Add `scode` backend to `AGENT_MODES` with same modes as `claude` (default, plan, YOLO)
- Replace hardcoded `sudoclaw-temp-` prefix with generic `TEMP_WORKSPACE_REGEX` for temp workspace detection
- Add `isTempWorkspace()` helper function to support all backend types

## Details

### agentModes.ts
- Added `scode` entry with `default`, `plan`, `bypassPermissions` (YOLO) modes
- This ensures the mode selector works correctly when Sudocode is the default agent

### draftsCleanup.ts
- Replaced hardcoded `startsWith('sudoclaw-temp-')` with generic regex `/-temp-\d+$/`
- Now correctly identifies temp workspaces for all backends: `scode-temp-xxx`, `sudoclaw-temp-xxx`, `claude-temp-xxx`, etc.
- Updated JSDoc examples to use `scode-temp-xxx` format

## Test plan
- [ ] Verify mode selector shows options when using scode backend
- [ ] Verify temp workspace detection works for scode-temp-* directories
- [ ] Verify backward compatibility with existing sudoclaw-temp-* directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)