### PR TITLE
fix(guid): custom agents in consumer mode should use local agents, not remote-agent

### DIFF
--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -109,7 +109,10 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     }
 
     // Enterprise mode: always route through remote-agent, skip scode/gateway checks
-    if (isEnterprise || selectedAgent === 'remote-agent' || selectedAgentKey === 'remote-agent' || selectedAgentKey.startsWith('custom:')) {
+    // 企业模式：始终使用 remote-agent，跳过 scode/gateway 检查
+    // Note: custom agents in consumer mode should use local agents (acp/openclaw-gateway)
+    // 注意：个人模式下的自定义助手应该使用本地 Agent（acp/openclaw-gateway）
+    if (isEnterprise || selectedAgent === 'remote-agent' || selectedAgentKey === 'remote-agent') {
       console.log('Enterprise mode: Creating remote-agent conversation');
 
       try {


### PR DESCRIPTION
## Summary
- Fixed a bug where selecting a custom assistant (digital assistant) in consumer mode incorrectly created a `remote-agent` type conversation
- The condition `selectedAgentKey.startsWith('custom:')` was causing custom agents in consumer mode to route to the enterprise-only `remote-agent` path
- Removed this condition so custom agents in consumer mode correctly route to `openclaw-gateway` or `acp` based on their `effectiveAgentType`

## Problem
In consumer mode, when a user selected a digital assistant, the app would throw:
```
[ERROR] Moss Server URL not configured for remote-agent conversation
```

This happened because `remote-agent` is enterprise-only and requires Moss Server URL configuration, which consumer mode doesn't have.

## Test plan
- [ ] In consumer mode, select a custom assistant (digital assistant)
- [ ] Verify the conversation is created successfully without Moss Server URL error
- [ ] Verify the conversation type is `openclaw-gateway` or `acp` (not `remote-agent`)
- [ ] In enterprise mode, verify custom assistants still work correctly with `remote-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)