### PR TITLE
fix(acp): inject HOME env for scode on Windows packaged Electron

### DIFF
--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -523,6 +523,14 @@ export async function spawnGenericBackend(backend: string, cliPath: string, work
     mainLog('[ACP scode]', `Injected SUDOCODE_CONFIG_PATH: ${cleanEnv.SUDOCODE_CONFIG_PATH}`);
   }
 
+  // Inject HOME for scode (Rust binary) to locate ~/.nexus/sudocode/sudocode.json
+  // On Windows packaged Electron, HOME is not set (Windows uses USERPROFILE instead)
+  // scode has 5+ paths that depend on HOME without USERPROFILE fallback
+  if (backend === 'scode' && !cleanEnv.HOME) {
+    cleanEnv.HOME = os.homedir();
+    mainLog('[ACP scode]', `Injected HOME: ${cleanEnv.HOME}`);
+  }
+
   // Inject web search base URL for scode so WebSearch tool is available in ACP mode
   if (backend === 'scode' && !cleanEnv.SUDOCODE_WEB_SEARCH_BASE_URL) {
     cleanEnv.SUDOCODE_WEB_SEARCH_BASE_URL = 'https://html.duckduckgo.com/html/';


### PR DESCRIPTION
## Summary
- 修复 Windows 打包版中 scode 因 HOME 环境变量缺失导致 "Internal error" 的问题
- 在 `acpConnectors.ts` 中为 scode 后端注入 `HOME=os.homedir()`，仅在 HOME 缺失时生效
- scode (Rust) 有 5+ 处关键逻辑仅依赖 HOME 而无 USERPROFILE 回退，注入 HOME 从根源解决整个类问题

## Test plan
- [ ] Windows 打包版启动后与 scode 对话，确认不再出现 "Internal error"
- [ ] 检查日志确认 `[ACP scode] Injected HOME:` 输出
- [ ] macOS/Linux 确认 HOME 注入未触发（HOME 已存在）
- [ ] 其他 ACP 后端（claude、codex 等）未受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)