### PR TITLE
fix: strip Windows extended-length path prefix \\?\ from image paths

### DIFF
--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -613,8 +613,10 @@ export const handleImageGenerationWithWorkspace = (message: TMessage, workspace:
           return match;
         }
         // Windows 绝对路径：标准化反斜杠为正斜杠
+        // 同时去除 Windows 扩展长度路径前缀 \\?\
         if (/^[A-Za-z]:/.test(imagePath) || imagePath.startsWith('\\')) {
-          const normalizedPath = imagePath.replace(/\\/g, '/');
+          const cleanPath = imagePath.replace(/^\\\\\?\\/, '');
+          const normalizedPath = cleanPath.replace(/\\/g, '/');
           return `![${alt}](${normalizedPath})`;
         }
         // Unix 绝对路径，保持不变

--- a/src/process/task/acp/AcpMessagePipeline.ts
+++ b/src/process/task/acp/AcpMessagePipeline.ts
@@ -127,11 +127,16 @@ export function filterThinkTagsFromMessage(message: IResponseMessage): IResponse
  * the backslashes are interpreted as escape characters by the markdown parser (remark),
  * corrupting the path (e.g. `\.` becomes `.`). This function converts such paths to
  * forward slashes before the content reaches the frontend markdown renderer.
+ *
+ * Also handles the Windows extended-length path prefix `\\?\` (e.g. `\\?\C:\Users\...\image.png`),
+ * which is stripped before normalization.
  */
 export function normalizeWindowsImagePaths(content: string): string {
-  // Match markdown image syntax where the path starts with a Windows drive letter (e.g. C:\)
+  // Match markdown image syntax where the path starts with an optional \\?\ prefix
+  // followed by a Windows drive letter (e.g. \\?\C:\ or C:\).
+  // The \\?\ prefix is a Windows extended-length path prefix and must be stripped.
   return content.replace(
-    /!\[([^\]]*)\]\(([A-Za-z]:\\[^)]+)\)/g,
+    /!\[([^\]]*)\]\((?:\\\\\?\\)?([A-Za-z]:\\[^)]+)\)/g,
     (_match, alt: string, imagePath: string) => {
       const normalizedPath = imagePath.replace(/\\/g, '/');
       return `![${alt}](${normalizedPath})`;

--- a/src/renderer/components/LocalImageView.tsx
+++ b/src/renderer/components/LocalImageView.tsx
@@ -23,10 +23,12 @@ const LocalImageView: React.FC<{
 
   const absolutePath = useMemo(() => {
     if (!root) return src;
-    if (src.startsWith('http') || src.startsWith('data:') || src.startsWith('/') || src.startsWith('file:') || src.startsWith('\\') || /^[A-Za-z]:/.test(src)) {
-      return src;
+    // Strip Windows extended-length path prefix \\?\ if present
+    const cleanSrc = src.replace(/^\\\\\?\\/, '');
+    if (cleanSrc.startsWith('http') || cleanSrc.startsWith('data:') || cleanSrc.startsWith('/') || cleanSrc.startsWith('file:') || cleanSrc.startsWith('\\') || /^[A-Za-z]:/.test(cleanSrc)) {
+      return cleanSrc;
     }
-    return joinPath(root, src);
+    return joinPath(root, cleanSrc);
   }, [src, root]);
 
   // Initialize loading state and update when absolutePath changes

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -555,8 +555,9 @@ const MarkdownView: React.FC<MarkdownViewProps> = ({ hiddenCodeCopyButton, codeS
       // Normalize Windows backslash paths in markdown image syntax to forward slashes.
       // Without this, the markdown parser treats backslashes as escape characters,
       // corrupting paths like C:\Users\...\image.png (e.g. \. becomes just .)
+      // Also strips the Windows extended-length path prefix \\?\ if present.
       text = text.replace(
-        /!\[([^\]]*)\]\(([A-Za-z]:\\[^)]+)\)/g,
+        /!\[([^\]]*)\]\((?:\\\\\?\\)?([A-Za-z]:\\[^)]+)\)/g,
         (_match, alt: string, imagePath: string) => `![${alt}](${imagePath.replace(/\\/g, '/')})`,
       );
       text = convertLatexDelimiters(text);

--- a/tests/unit/windowsImagePaths.test.ts
+++ b/tests/unit/windowsImagePaths.test.ts
@@ -80,6 +80,30 @@ describe('normalizeWindowsImagePaths', () => {
     const input = '![](C:/Users/16674/.nexus/sudoclaw/workspace/shaobing.png)';
     expect(normalizeWindowsImagePaths(input)).toBe(input);
   });
+
+  it('should strip Windows extended-length path prefix \\\\?\\', () => {
+    const input = '![](\\\\?\\C:\\Users\\zouqi\\.nexus\\scode-temp-1778554568911\\cute_little_girl.png)';
+    const expected = '![](C:/Users/zouqi/.nexus/scode-temp-1778554568911/cute_little_girl.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should strip \\\\?\\ prefix with alt text', () => {
+    const input = '![一个可爱的小女孩，卡通风格](\\\\?\\C:\\Users\\zouqi\\.nexus\\scode-temp-1778554568911\\cute_little_girl.png)';
+    const expected = '![一个可爱的小女孩，卡通风格](C:/Users/zouqi/.nexus/scode-temp-1778554568911/cute_little_girl.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should handle \\\\?\\ prefix in mixed content', () => {
+    const input = 'I have successfully generated the image.\n\n![](\\\\?\\C:\\Users\\zouqi\\.nexus\\scode-temp-1778554568911\\cute_little_girl.png)\n\nHere it is!';
+    const expected = 'I have successfully generated the image.\n\n![](C:/Users/zouqi/.nexus/scode-temp-1778554568911/cute_little_girl.png)\n\nHere it is!';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
+
+  it('should handle both \\\\?\\ prefixed and normal Windows paths in same content', () => {
+    const input = '![img1](\\\\?\\C:\\Users\\test\\a.png)\n![img2](D:\\photos\\b.png)';
+    const expected = '![img1](C:/Users/test/a.png)\n![img2](D:/photos/b.png)';
+    expect(normalizeWindowsImagePaths(input)).toBe(expected);
+  });
 });
 
 describe('defaultUrlTransform sanitization (root cause of empty src)', () => {
@@ -145,5 +169,16 @@ describe('preprocessContentMessage', () => {
     };
     const result = preprocessContentMessage(message);
     expect(result).toBe(message);
+  });
+
+  it('should strip \\\\?\\ prefix and normalize Windows paths in content messages', () => {
+    const message = {
+      type: 'content' as const,
+      conversation_id: 'test-conv',
+      msg_id: 'test-msg',
+      data: '![](\\\\?\\C:\\Users\\zouqi\\.nexus\\scode-temp-1778554568911\\cute_little_girl.png)',
+    };
+    const result = preprocessContentMessage(message);
+    expect(result.data).toBe('![](C:/Users/zouqi/.nexus/scode-temp-1778554568911/cute_little_girl.png)');
   });
 });


### PR DESCRIPTION
Fix Windows extended-length path prefix `\\?\` not being handled in markdown image paths.

Closes #563

Generated with [Claude Code](https://claude.ai/code)