### PR TITLE
feat(guid): display Moss assistants at bottom in enterprise mode

### DIFF
--- a/docs/plans/2026-05-12-enterprise-assistants-display-design.md
+++ b/docs/plans/2026-05-12-enterprise-assistants-display-design.md
@@ -1,0 +1,177 @@
+# Enterprise Mode Assistants Display Design
+
+## Problem Statement
+
+In enterprise mode, assistants returned from Moss Server are currently displayed in the top `AgentPillBar` alongside the "Remote Agent" option. This is inconsistent with consumer mode, where local custom assistants are displayed at the bottom via `AssistantSelectionArea` component.
+
+**Current behavior:**
+- Enterprise mode: Moss assistants → `availableAgents` → displayed in top `AgentPillBar`
+- Consumer mode: Local assistants → `customAgents` → displayed in bottom `AssistantSelectionArea`
+
+**Expected behavior:**
+- Enterprise mode: Moss assistants should be displayed at the bottom, similar to consumer mode
+- Keep "Remote Agent" as the default option in the top `AgentPillBar`
+
+## Solution Overview
+
+Map Moss Server assistants to `customAgents` instead of `availableAgents`, enabling them to be displayed via `AssistantSelectionArea` component at the bottom of the Guid page.
+
+## Data Flow
+
+### Before (Current)
+
+```
+Enterprise Mode:
+Moss API → availableAgents: [Remote Agent, Assistant1, Assistant2, ...]
+           customAgents: [] (skipped)
+
+Consumer Mode:
+Local detection → availableAgents: [gemini, claude, scode, ...]
+Local config → customAgents: [builtin assistants, user assistants]
+```
+
+### After (Proposed)
+
+```
+Enterprise Mode:
+Moss API → availableAgents: [Remote Agent] (default option only)
+        → customAgents: [Moss Assistant1, Moss Assistant2, ...]
+
+Consumer Mode: (unchanged)
+Local detection → availableAgents: [gemini, claude, scode, ...]
+Local config → customAgents: [builtin assistants, user assistants]
+```
+
+## Implementation Details
+
+### 1. Moss Assistant Data Mapping
+
+**File:** `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts`
+
+Map Moss Server assistant to `AcpBackendConfig`:
+
+```typescript
+interface MossAssistant {
+  key: string;
+  name: string;
+  avatar?: string;
+  emoji?: string;
+  description?: string;
+}
+
+function mapMossAssistantToConfig(assistant: MossAssistant): AcpBackendConfig {
+  return {
+    id: `moss:${assistant.key}`,
+    name: assistant.name,
+    avatar: assistant.emoji || assistant.avatar,
+    description: assistant.description,
+    isPreset: true,
+    enabled: true,
+    presetAgentType: 'remote-agent',
+  };
+}
+```
+
+### 2. Hook Changes
+
+**File:** `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts`
+
+Modify the SWR data processing for enterprise mode:
+
+```typescript
+// In the SWR effect for availableAgentsData
+useEffect(() => {
+  if (availableAgentsData && Array.isArray(availableAgentsData)) {
+    if (isEnterprise) {
+      const enterpriseAgents = availableAgentsData as unknown as MossAssistant[];
+
+      // Map Moss assistants to customAgents
+      const mossCustomAgents: AcpBackendConfig[] = enterpriseAgents.map(mapMossAssistantToConfig);
+      setCustomAgents(mossCustomAgents);
+
+      // availableAgents only contains Remote Agent
+      const mapped: AvailableAgent[] = [
+        {
+          backend: 'remote-agent' as AcpBackend,
+          name: 'Remote Agent',
+          customAgentId: undefined,
+        },
+      ];
+      setAvailableAgents(mapped);
+    } else {
+      // Consumer mode: unchanged
+      setAvailableAgents(availableAgentsData as AvailableAgent[]);
+    }
+  }
+}, [availableAgentsData, isEnterprise]);
+```
+
+### 3. Selection Key Format
+
+When user selects a Moss assistant:
+- Selection key: `custom:moss:{assistant.key}`
+- Backend type: `remote-agent`
+- Custom agent ID: `moss:{assistant.key}`
+
+### 4. Send Logic
+
+**File:** `src/renderer/pages/guid/hooks/useGuidSend.ts`
+
+The existing logic already handles `remote-agent` type. When `selectedAgentKey` starts with `custom:moss:`, the conversation will be created with:
+- `type: 'remote-agent'`
+- `presetAssistantId: moss:{key}` (for Moss Server to identify the assistant)
+
+### 5. UI Layout
+
+**File:** `src/renderer/pages/guid/GuidPage.tsx`
+
+No changes needed. The existing layout already renders `AssistantSelectionArea` at the bottom when not in assistant mode.
+
+```
+┌────────────────────────────────────────────────┐
+│  [Title]                                       │
+│  [AgentPillBar: Remote Agent]                  │  ← Top: default option
+│  [PromptTemplates]                             │
+├────────────────────────────────────────────────┤
+│  [Input Card]                                  │
+│  [Action Row: Send button, etc.]               │
+├────────────────────────────────────────────────┤
+│  [AssistantSelectionArea: Moss assistants]     │  ← Bottom: specific assistants
+│  [Assistant 1] [Assistant 2] [Assistant 3] ... │
+└────────────────────────────────────────────────┘
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts` | Map Moss assistants to `customAgents` in enterprise mode |
+| `src/renderer/pages/guid/components/AssistantSelectionArea.tsx` | May need minor adjustments for Moss assistant rendering |
+
+## Safety Considerations
+
+1. **Consumer mode isolation:** The enterprise mode logic is gated by `isEnterprise` check. Consumer mode code path remains unchanged.
+
+2. **Fallback handling:** If Moss API fails, provide default Remote Agent option.
+
+3. **Backward compatibility:** Existing conversations with `remote-agent` type continue to work.
+
+## Testing Plan
+
+1. **Enterprise mode:**
+   - Verify Moss assistants appear in bottom `AssistantSelectionArea`
+   - Verify Remote Agent appears in top `AgentPillBar`
+   - Verify selecting a Moss assistant creates correct conversation type
+   - Verify Moss API failure shows only Remote Agent
+
+2. **Consumer mode:**
+   - Verify local assistants still appear in bottom `AssistantSelectionArea`
+   - Verify local agents appear in top `AgentPillBar`
+   - Verify no regression in existing functionality
+
+## Success Criteria
+
+- Enterprise mode assistants display at the bottom, consistent with consumer mode
+- Remote Agent remains as default option in enterprise mode
+- Consumer mode functionality unchanged
+- No visual or functional regressions

--- a/docs/plans/2026-05-12-enterprise-assistants-display.md
+++ b/docs/plans/2026-05-12-enterprise-assistants-display.md
@@ -1,0 +1,434 @@
+# Enterprise Mode Assistants Display Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move Moss Server assistants from top AgentPillBar to bottom AssistantSelectionArea in enterprise mode, matching consumer mode behavior.
+
+**Architecture:** Map Moss assistants to `customAgents` instead of `availableAgents`, reusing existing `AssistantSelectionArea` component for display. Keep "Remote Agent" as default in top `AgentPillBar`.
+
+**Tech Stack:** React, TypeScript, SWR, Arco Design
+
+---
+
+## Task 1: Add Moss Assistant Mapping Function
+
+**Files:**
+- Modify: `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts`
+
+**Step 1: Add MossAssistant type and mapping function**
+
+Add after the existing imports (around line 20):
+
+```typescript
+/**
+ * Moss Server assistant from cloud API
+ */
+type MossAssistant = {
+  key: string;
+  name: string;
+  avatar?: string;
+  emoji?: string;
+  description?: string;
+};
+
+/**
+ * Map Moss Server assistant to AcpBackendConfig for display in AssistantSelectionArea
+ */
+function mapMossAssistantToConfig(assistant: MossAssistant): AcpBackendConfig {
+  return {
+    id: `moss:${assistant.key}`,
+    name: assistant.name,
+    avatar: assistant.emoji || assistant.avatar,
+    description: assistant.description,
+    isPreset: true,
+    enabled: true,
+    presetAgentType: 'remote-agent',
+  };
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npx tsc --noEmit --skipLibCheck src/renderer/pages/guid/hooks/useGuidAgentSelection.ts 2>&1 | head -20`
+
+Expected: No errors related to the new code
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+git commit -m "feat(guid): add Moss assistant mapping function
+
+Add type definition and mapping function to convert Moss Server
+assistants to AcpBackendConfig format for AssistantSelectionArea.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Modify SWR Data Processing for Enterprise Mode
+
+**Files:**
+- Modify: `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts:256-295`
+
+**Step 1: Update the useEffect that processes availableAgentsData**
+
+Replace the existing useEffect (lines 256-295) with:
+
+```typescript
+  useEffect(() => {
+    if (availableAgentsData && Array.isArray(availableAgentsData)) {
+      if (isEnterprise) {
+        // Enterprise mode: Moss assistants go to customAgents, only Remote Agent in availableAgents
+        const enterpriseAgents = availableAgentsData as unknown as MossAssistant[];
+
+        // Map Moss assistants to customAgents for bottom display
+        const mossCustomAgents: AcpBackendConfig[] = enterpriseAgents.map(mapMossAssistantToConfig);
+        setCustomAgents(mossCustomAgents);
+
+        // availableAgents only contains Remote Agent for top AgentPillBar
+        const mapped: AvailableAgent[] = [
+          {
+            backend: 'remote-agent' as AcpBackend,
+            name: 'Remote Agent',
+            customAgentId: undefined,
+          },
+        ];
+        setAvailableAgents(mapped);
+        availableAgentsRef.current = mapped;
+      } else {
+        // Consumer mode: unchanged
+        setAvailableAgents(availableAgentsData as AvailableAgent[]);
+        availableAgentsRef.current = availableAgentsData as AvailableAgent[];
+      }
+    } else if (isEnterprise) {
+      // Enterprise mode: even if API fails, provide a default remote-agent
+      // 企业模式：即使 API 失败，也提供默认的 remote-agent
+      const defaultAgent: AvailableAgent = {
+        backend: 'remote-agent' as AcpBackend,
+        name: 'Remote Agent',
+        customAgentId: undefined,
+      };
+      setAvailableAgents([defaultAgent]);
+      availableAgentsRef.current = [defaultAgent];
+      setCustomAgents([]); // Clear customAgents on API failure
+    }
+  }, [availableAgentsData, isEnterprise]);
+```
+
+**Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npx tsc --noEmit --skipLibCheck 2>&1 | head -30`
+
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+git commit -m "feat(guid): map Moss assistants to customAgents in enterprise mode
+
+Change enterprise mode data flow:
+- availableAgents: only Remote Agent (for top AgentPillBar)
+- customAgents: Moss Server assistants (for bottom AssistantSelectionArea)
+
+This matches consumer mode behavior where assistants appear at the bottom.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Update AssistantSelectionArea for Moss Assistants
+
+**Files:**
+- Modify: `src/renderer/pages/guid/components/AssistantSelectionArea.tsx`
+
+**Step 1: Update the component to handle Moss assistant IDs**
+
+The component already handles `custom:` prefix. We need to ensure Moss assistants with `moss:` ID prefix are handled correctly.
+
+Update line 62 to handle Moss assistant IDs:
+
+```typescript
+              <div key={assistant.id} className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid bg-fill-0 hover:bg-fill-1 select-none' style={{ borderWidth: '1px', borderColor: 'var(--bg-3)' }} onClick={() => onSelectAssistant(`custom:${assistant.id}`)}>
+```
+
+No changes needed - the existing code already uses `assistant.id` which will be `moss:{key}` format.
+
+**Step 2: Verify the component renders correctly**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npx tsc --noEmit --skipLibCheck 2>&1 | head -20`
+
+Expected: No TypeScript errors
+
+**Step 3: Commit (if changes were made)**
+
+```bash
+git add src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+git commit -m "refactor(guid): ensure AssistantSelectionArea handles Moss IDs
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Update Selection Validation Logic
+
+**Files:**
+- Modify: `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts:297-309`
+
+**Step 1: Update the enterprise mode selection validation**
+
+The existing validation needs to check both `availableAgents` and `customAgents` for enterprise mode.
+
+Replace lines 297-309 with:
+
+```typescript
+  // Enterprise mode: keep current selection if valid
+  useEffect(() => {
+    if (isEnterprise && availableAgents && availableAgents.length > 0) {
+      const currentKey = selectedAgentKeyRef.current;
+      // 'remote-agent' is always valid
+      if (currentKey === 'remote-agent') return;
+
+      // Check if current selection is a valid Moss assistant
+      const isValidMossAssistant = customAgents.some(
+        (a) => `custom:${a.id}` === currentKey
+      );
+
+      if (!isValidMossAssistant) {
+        _setSelectedAgentKey('remote-agent');
+        selectedAgentKeyRef.current = 'remote-agent';
+      }
+    }
+  }, [isEnterprise, availableAgents, customAgents]);
+```
+
+**Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npx tsc --noEmit --skipLibCheck 2>&1 | head -20`
+
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+git commit -m "fix(guid): validate enterprise mode selection against customAgents
+
+Update selection validation to check both availableAgents and customAgents
+for enterprise mode, ensuring Moss assistant selections are preserved.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Update findAgentByKey for Moss Assistants
+
+**Files:**
+- Modify: `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts:215-234`
+
+**Step 1: Update findAgentByKey to handle Moss assistants**
+
+Replace lines 215-234 with:
+
+```typescript
+  /**
+   * Find agent by key.
+   * Supports both "custom:uuid" format and plain backend type.
+   * For enterprise mode, also checks customAgents for Moss assistants.
+   */
+  const findAgentByKey = (key: string): AvailableAgent | undefined => {
+    if (key.startsWith('custom:')) {
+      const customAgentId = key.slice(7);
+
+      // First check availableAgents (for non-enterprise custom agents)
+      const foundInAvailable = availableAgents?.find((a) => a.customAgentId === customAgentId);
+      if (foundInAvailable) return foundInAvailable;
+
+      // For enterprise mode, check customAgents (Moss assistants)
+      if (isEnterprise) {
+        const mossAssistant = customAgents.find((a) => a.id === customAgentId);
+        if (mossAssistant) {
+          return {
+            backend: 'remote-agent' as AcpBackend,
+            name: mossAssistant.name,
+            customAgentId: mossAssistant.id,
+            isPreset: true,
+            avatar: mossAssistant.avatar,
+            context: mossAssistant.description,
+          };
+        }
+      }
+
+      // Fallback: check customAgents for non-enterprise
+      const assistant = customAgents.find((a) => a.id === customAgentId);
+      if (assistant) {
+        return {
+          backend: 'custom' as AcpBackend,
+          name: assistant.name,
+          customAgentId: assistant.id,
+          isPreset: true,
+          context: '',
+          avatar: assistant.avatar,
+        };
+      }
+    }
+    return availableAgents?.find((a) => a.backend === key);
+  };
+```
+
+**Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npx tsc --noEmit --skipLibCheck 2>&1 | head -20`
+
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+git commit -m "feat(guid): support Moss assistants in findAgentByKey
+
+Update findAgentByKey to look up Moss assistants from customAgents
+in enterprise mode, enabling proper agent info resolution.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Update resetSelection for Enterprise Mode
+
+**Files:**
+- Modify: `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts:849-888`
+
+**Step 1: Update resetSelection to clear customAgents in enterprise mode**
+
+The existing resetSelection function needs to also clear customAgents for enterprise mode.
+
+Find the resetSelection function (around line 849) and update it:
+
+```typescript
+  // Reset agent selection to default state (no assistant selected)
+  // In enterprise mode, directly select the first available agent (remote-agent)
+  // 企业模式下直接选择第一个可用 agent
+  const resetSelection = useCallback(() => {
+    _setSelectedAgentKey(isEnterprise ? 'remote-agent' : DEFAULT_PRESET_AGENT_TYPE);
+    selectedAgentKeyRef.current = isEnterprise ? 'remote-agent' : DEFAULT_PRESET_AGENT_TYPE;
+    _setSelectedMode('default');
+    _setSelectedAcpModel(null);
+    hasAutoSelectedAgentRef.current = false;
+
+    // Clear persisted agent key so it won't be restored on next mount
+    ConfigStorage.set('guid.lastSelectedAgent', '').catch((error) => {
+      console.error('Failed to clear saved agent:', error);
+    });
+
+    // Enterprise mode: clear customAgents and select remote-agent
+    if (isEnterprise) {
+      setCustomAgents([]);
+      return;
+    }
+
+    // Consumer mode: check for scode/openclaw-gateway availability
+    const agents = availableAgentsRef.current;
+    const scodeAvailable = agents?.some((a) => a.backend === 'scode');
+    const openclawAvailable = agents?.some((a) => a.backend === 'openclaw-gateway');
+    if (scodeAvailable) {
+      _setSelectedAgentKey('scode');
+      selectedAgentKeyRef.current = 'scode';
+    } else if (openclawAvailable) {
+      _setSelectedAgentKey('openclaw-gateway');
+      selectedAgentKeyRef.current = 'openclaw-gateway';
+    } else if (agents && agents.length > 0) {
+      const firstAgent = agents[0];
+      const firstKey = firstAgent.backend === 'custom' && firstAgent.customAgentId ? `custom:${firstAgent.customAgentId}` : firstAgent.backend;
+      _setSelectedAgentKey(firstKey);
+      selectedAgentKeyRef.current = firstKey;
+      ConfigStorage.set('guid.lastSelectedAgent', firstKey).catch((error) => {
+        console.error('Failed to save auto-selected agent:', error);
+      });
+    } else {
+      _setSelectedAgentKey(DEFAULT_PRESET_AGENT_TYPE);
+      selectedAgentKeyRef.current = DEFAULT_PRESET_AGENT_TYPE;
+    }
+  }, [isEnterprise]);
+```
+
+**Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npx tsc --noEmit --skipLibCheck 2>&1 | head -20`
+
+Expected: No TypeScript errors
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+git commit -m "fix(guid): clear customAgents in resetSelection for enterprise mode
+
+Ensure customAgents are cleared when resetting selection in enterprise mode,
+preventing stale Moss assistants from persisting across sessions.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Build and Test
+
+**Files:**
+- None (testing only)
+
+**Step 1: Run full TypeScript check**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npx tsc --noEmit --skipLibCheck`
+
+Expected: No errors
+
+**Step 2: Run build**
+
+Run: `cd /Users/yobach/Downloads/sudowork && npm run build`
+
+Expected: Build succeeds
+
+**Step 3: Manual testing checklist**
+
+Test in enterprise mode:
+- [ ] Moss assistants appear in bottom AssistantSelectionArea
+- [ ] Remote Agent appears in top AgentPillBar
+- [ ] Clicking a Moss assistant selects it correctly
+- [ ] Sending message with Moss assistant creates correct conversation
+- [ ] Moss API failure shows only Remote Agent
+
+Test in consumer mode:
+- [ ] Local assistants still appear in bottom AssistantSelectionArea
+- [ ] Local agents appear in top AgentPillBar
+- [ ] No regression in existing functionality
+
+**Step 4: Final commit (if any fixes needed)**
+
+```bash
+git add -A
+git commit -m "fix(guid): address any issues found during testing
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Summary
+
+| Task | Description | Files Modified |
+|------|-------------|----------------|
+| 1 | Add Moss assistant mapping function | `useGuidAgentSelection.ts` |
+| 2 | Modify SWR data processing | `useGuidAgentSelection.ts` |
+| 3 | Update AssistantSelectionArea | `AssistantSelectionArea.tsx` (minimal) |
+| 4 | Update selection validation | `useGuidAgentSelection.ts` |
+| 5 | Update findAgentByKey | `useGuidAgentSelection.ts` |
+| 6 | Update resetSelection | `useGuidAgentSelection.ts` |
+| 7 | Build and test | None |

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -20,6 +20,32 @@ import useSWR, { mutate } from 'swr';
 import { emitter } from '@/renderer/utils/emitter';
 
 /**
+ * Moss Server assistant from cloud API
+ */
+type MossAssistant = {
+  key: string;
+  name: string;
+  avatar?: string;
+  emoji?: string;
+  description?: string;
+};
+
+/**
+ * Map Moss Server assistant to AcpBackendConfig for display in AssistantSelectionArea
+ */
+function mapMossAssistantToConfig(assistant: MossAssistant): AcpBackendConfig {
+  return {
+    id: `moss:${assistant.key}`,
+    name: assistant.name,
+    avatar: assistant.emoji || assistant.avatar,
+    description: assistant.description,
+    isPreset: true,
+    enabled: true,
+    presetAgentType: 'remote-agent',
+  };
+}
+
+/**
  * Check if rules contain explicit identity statement like "你是 XX 助手" or "You are XX"
  * Also detects [Identity Override] blocks that we inject
  */
@@ -211,13 +237,32 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   /**
    * Find agent by key.
    * Supports both "custom:uuid" format and plain backend type.
+   * For enterprise mode, also checks customAgents for Moss assistants.
    */
   const findAgentByKey = (key: string): AvailableAgent | undefined => {
     if (key.startsWith('custom:')) {
       const customAgentId = key.slice(7);
+
+      // First check availableAgents (for non-enterprise custom agents)
       const foundInAvailable = availableAgents?.find((a) => a.customAgentId === customAgentId);
       if (foundInAvailable) return foundInAvailable;
 
+      // For enterprise mode, check customAgents (Moss assistants)
+      if (isEnterprise) {
+        const mossAssistant = customAgents.find((a) => a.id === customAgentId);
+        if (mossAssistant) {
+          return {
+            backend: 'remote-agent' as AcpBackend,
+            name: mossAssistant.name,
+            customAgentId: mossAssistant.id,
+            isPreset: true,
+            avatar: mossAssistant.avatar,
+            context: mossAssistant.description,
+          };
+        }
+      }
+
+      // Fallback: check customAgents for non-enterprise
       const assistant = customAgents.find((a) => a.id === customAgentId);
       if (assistant) {
         return {
@@ -256,28 +301,25 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   useEffect(() => {
     if (availableAgentsData && Array.isArray(availableAgentsData)) {
       if (isEnterprise) {
-        // Enterprise agents: always include generic 'Remote Agent' first, then server assistants
-        const enterpriseAgents = availableAgentsData as unknown as Array<{ key: string; name: string; avatar?: string; emoji?: string; description?: string }>;
-        const serverAgents: AvailableAgent[] = enterpriseAgents.map((a) => ({
-          backend: 'remote-agent' as AcpBackend,
-          name: a.name,
-          customAgentId: a.key,
-          isPreset: true,
-          avatar: a.emoji || a.avatar || undefined,
-          context: a.description || undefined,
-        }));
-        // Generic Remote Agent is always the first option
+        // Enterprise mode: Moss assistants go to customAgents, only Remote Agent in availableAgents
+        const enterpriseAgents = availableAgentsData as unknown as MossAssistant[];
+
+        // Map Moss assistants to customAgents for bottom display
+        const mossCustomAgents: AcpBackendConfig[] = enterpriseAgents.map(mapMossAssistantToConfig);
+        setCustomAgents(mossCustomAgents);
+
+        // availableAgents only contains Remote Agent for top AgentPillBar
         const mapped: AvailableAgent[] = [
           {
             backend: 'remote-agent' as AcpBackend,
             name: 'Remote Agent',
             customAgentId: undefined,
           },
-          ...serverAgents,
         ];
         setAvailableAgents(mapped);
         availableAgentsRef.current = mapped;
       } else {
+        // Consumer mode: unchanged
         setAvailableAgents(availableAgentsData as AvailableAgent[]);
         availableAgentsRef.current = availableAgentsData as AvailableAgent[];
       }
@@ -291,22 +333,26 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       };
       setAvailableAgents([defaultAgent]);
       availableAgentsRef.current = [defaultAgent];
+      setCustomAgents([]); // Clear customAgents on API failure
     }
   }, [availableAgentsData, isEnterprise]);
 
-  // Enterprise mode: keep current selection if valid (remote-agent is always valid)
+  // Enterprise mode: keep current selection if valid
   useEffect(() => {
     if (isEnterprise && availableAgents && availableAgents.length > 0) {
-      // 'remote-agent' is always a valid selection in enterprise mode
-      // If user selected a specific custom agent, keep it
       const currentKey = selectedAgentKeyRef.current;
-      const isValid = currentKey === 'remote-agent' || availableAgents.find(a => getAgentKey(a) === currentKey);
-      if (!isValid) {
+      // 'remote-agent' is always valid
+      if (currentKey === 'remote-agent') return;
+
+      // Check if current selection is a valid Moss assistant
+      const isValidMossAssistant = customAgents.some((a) => `custom:${a.id}` === currentKey);
+
+      if (!isValidMossAssistant) {
         _setSelectedAgentKey('remote-agent');
         selectedAgentKeyRef.current = 'remote-agent';
       }
     }
-  }, [isEnterprise, availableAgents]);
+  }, [isEnterprise, availableAgents, customAgents]);
 
   // Load last selected agent (skip when URL parameter takes priority)
   // Auto-select first available agent if current selection is not valid (enterprise mode case)
@@ -855,13 +901,19 @@ This identity statement takes priority over the default identity in USER.md.
     _setSelectedMode('default');
     _setSelectedAcpModel(null);
     hasAutoSelectedAgentRef.current = false;
+
     // Clear persisted agent key so it won't be restored on next mount
     ConfigStorage.set('guid.lastSelectedAgent', '').catch((error) => {
       console.error('Failed to clear saved agent:', error);
     });
 
-    // Check if scode is available first, then fallback to openclaw-gateway (non-enterprise mode)
-    // If neither available (enterprise mode), select first available agent directly
+    // Enterprise mode: re-fetch Moss assistants from server
+    if (isEnterprise) {
+      void mutate('eeclaw.agents.cloud');
+      return;
+    }
+
+    // Consumer mode: check for scode/openclaw-gateway availability
     const agents = availableAgentsRef.current;
     const scodeAvailable = agents?.some((a) => a.backend === 'scode');
     const openclawAvailable = agents?.some((a) => a.backend === 'openclaw-gateway');
@@ -872,7 +924,6 @@ This identity statement takes priority over the default identity in USER.md.
       _setSelectedAgentKey('openclaw-gateway');
       selectedAgentKeyRef.current = 'openclaw-gateway';
     } else if (agents && agents.length > 0) {
-      // Enterprise mode: select first available agent (remote-agent)
       const firstAgent = agents[0];
       const firstKey = firstAgent.backend === 'custom' && firstAgent.customAgentId ? `custom:${firstAgent.customAgentId}` : firstAgent.backend;
       _setSelectedAgentKey(firstKey);

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -251,10 +251,13 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       if (isEnterprise) {
         const mossAssistant = customAgents.find((a) => a.id === customAgentId);
         if (mossAssistant) {
+          // Extract original Moss key from id (remove 'moss:' prefix)
+          // Moss Server expects the original key, not 'moss:{key}'
+          const mossKey = mossAssistant.id.startsWith('moss:') ? mossAssistant.id.slice(5) : mossAssistant.id;
           return {
             backend: 'remote-agent' as AcpBackend,
             name: mossAssistant.name,
-            customAgentId: mossAssistant.id,
+            customAgentId: mossKey, // Use original Moss key for Moss Server
             isPreset: true,
             avatar: mossAssistant.avatar,
             context: mossAssistant.description,


### PR DESCRIPTION
## Summary

- Move Moss Server assistants from top AgentPillBar to bottom AssistantSelectionArea in enterprise mode
- Keep "Remote Agent" as the default option in top AgentPillBar
- Match consumer mode behavior where assistants appear at the bottom

## Changes

- Add `MossAssistant` type and `mapMossAssistantToConfig` mapping function
- Map Moss assistants to `customAgents` for bottom display via `AssistantSelectionArea`
- Update `findAgentByKey` to support Moss assistants lookup in enterprise mode
- Update selection validation to check `customAgents` for valid Moss assistant selection
- Fix `resetSelection` to re-fetch data via SWR instead of clearing `customAgents`

## Test Plan

- [ ] Enterprise mode: Moss assistants appear in bottom AssistantSelectionArea
- [ ] Enterprise mode: Remote Agent appears in top AgentPillBar
- [ ] Enterprise mode: Clicking a Moss assistant selects it correctly
- [ ] Enterprise mode: Sending message with Moss assistant creates correct conversation
- [ ] Enterprise mode: Clicking "New Chat" preserves assistants list
- [ ] Consumer mode: Local assistants still appear in bottom AssistantSelectionArea
- [ ] Consumer mode: No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)