### PR TITLE
fix(skill): handle skill names with leading/trailing spaces

### DIFF
--- a/src/process/SkillManager.ts
+++ b/src/process/SkillManager.ts
@@ -286,6 +286,9 @@ export class SkillManager {
   }
   // 查找技能目录
   private async findSkillDir(skillName: string, includeDisabled = true): Promise<{ dir: string; category: SkillCategory; isDisabled: boolean } | null> {
+    // Trim skillName to handle cases where metadata had leading/trailing spaces
+    const trimmedName = skillName.trim();
+
     // 搜索启用目录
     const searchDirs = [
       { dir: this.customDir, category: 'custom' as SkillCategory },
@@ -294,20 +297,27 @@ export class SkillManager {
       { dir: path.join(this.systemDir, '_builtin'), category: 'system' as SkillCategory },
     ];
 
-    for (const { dir, category } of searchDirs) {
-      const skillDir = path.join(dir, skillName);
-      if (existsSync(skillDir)) {
-        return { dir: skillDir, category, isDisabled: false };
+    // Try trimmed name first, then original name (for backward compatibility with dirs created with spaces)
+    const namesToTry = [trimmedName, skillName].filter((n, i, arr) => arr.indexOf(n) === i);
+
+    for (const name of namesToTry) {
+      for (const { dir, category } of searchDirs) {
+        const skillDir = path.join(dir, name);
+        if (existsSync(skillDir)) {
+          return { dir: skillDir, category, isDisabled: false };
+        }
       }
     }
 
     // 搜索禁用目录
     if (includeDisabled) {
-      for (const { dir, category } of searchDirs) {
-        const disableDir = this.getDisableDir(dir);
-        const skillDir = path.join(disableDir, skillName);
-        if (existsSync(skillDir)) {
-          return { dir: skillDir, category, isDisabled: true };
+      for (const name of namesToTry) {
+        for (const { dir, category } of searchDirs) {
+          const disableDir = this.getDisableDir(dir);
+          const skillDir = path.join(disableDir, name);
+          if (existsSync(skillDir)) {
+            return { dir: skillDir, category, isDisabled: true };
+          }
         }
       }
     }

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -632,7 +632,9 @@ export function initSkillHubBridge(): void {
   // Download and install skill
   ipcBridge.skillHub.downloadAndInstallSkill.provider(async ({ skillName, displayName, sourceUrl, version, checksum, skillMeta }) => {
     try {
-      mainLog('SkillHub', `Downloading skill: ${skillName} version: ${version}`);
+      // Trim skillName to prevent directory names with leading/trailing spaces
+      const trimmedSkillName = skillName.trim();
+      mainLog('SkillHub', `Downloading skill: ${trimmedSkillName} version: ${version}`);
 
       // Download zip file
       const zipBuffer = await downloadFile(sourceUrl, (percent) => {
@@ -651,12 +653,12 @@ export function initSkillHubBridge(): void {
       const hubSkillsDir = getHubSkillsDir();
       await fs.mkdir(hubSkillsDir, { recursive: true });
 
-      const skillDir = path.join(hubSkillsDir, skillName);
+      const skillDir = path.join(hubSkillsDir, trimmedSkillName);
 
       await removeExistingInstalledSkillDirs({
         userSkillsDir: hubSkillsDir,
-        requestedSkillName: skillName,
-        finalSkillDirName: skillName,
+        requestedSkillName: trimmedSkillName,
+        finalSkillDirName: trimmedSkillName,
       });
       await fs.mkdir(skillDir, { recursive: true });
 
@@ -668,7 +670,7 @@ export function initSkillHubBridge(): void {
       const metaFilePath = path.join(skillDir, SKILL_HUB_META_FILE);
       const meta = {
         id: skillMeta?.id ?? '',
-        name: skillName,
+        name: trimmedSkillName,
         display_name: skillMeta?.display_name ?? displayName,
         description: skillMeta?.description ?? '',
         icon: skillMeta?.icon ?? '',
@@ -687,7 +689,7 @@ export function initSkillHubBridge(): void {
       };
       await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
 
-      mainLog('SkillHub', `Successfully installed skill "${skillName}" v${version} to ${skillDir}`);
+      mainLog('SkillHub', `Successfully installed skill "${trimmedSkillName}" v${version} to ${skillDir}`);
 
       // Reload Sudoclaw gateway to pick up new skills.
       // - On Unix: use SIGUSR1 for hot-reload (keeps sessions alive)
@@ -704,7 +706,7 @@ export function initSkillHubBridge(): void {
       return {
         success: true,
         data: {
-          skillName,
+          skillName: trimmedSkillName,
           installedVersion: version,
         },
       };


### PR DESCRIPTION
## Summary
- Add `trim()` to `skillName` in `downloadAndInstallSkill` to prevent creating directories with leading/trailing spaces
- Update `findSkillDir` to search both trimmed and original names for backward compatibility with existing skills installed with spaces

## Problem
When a skill in the hub has a `name` field with leading/trailing spaces (e.g., ` markitdown-skill`), the installation creates a directory with that space. However, `readSkillInfo` uses `meta.name.trim()` to return the skill name, causing a mismatch between the displayed name and the actual directory name. This leads to "Skill not found" errors when trying to disable or uninstall such skills.

## Solution
1. Trim the skill name during installation to ensure clean directory names
2. In `findSkillDir`, try both the trimmed name and original name to find existing skills that may have been installed with spaces

## Test plan
- [ ] Install a skill from the hub
- [ ] Disable the skill - should work without "Skill not found" error
- [ ] Enable the skill - should work
- [ ] Uninstall the skill - should work
- [ ] Test with existing skills that have spaces in directory names

🤖 Generated with [Claude Code](https://claude.com/claude-code)