### PR TITLE
feat: show success notification after model switch

### DIFF
--- a/src/renderer/components/AcpModelSelector.tsx
+++ b/src/renderer/components/AcpModelSelector.tsx
@@ -13,7 +13,7 @@ import type { AcpModelInfo } from '@/types/acpTypes';
 import { useLayoutContext } from '@/renderer/context/LayoutContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { getModelDisplayLabel } from '@/renderer/utils/agentUiDisplay';
-import { Button, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
+import { Button, Dropdown, Menu, Message, Tooltip } from '@arco-design/web-react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -191,13 +191,15 @@ const AcpModelSelector: React.FC<{
         .then((result) => {
           if (result.success && result.data?.modelInfo) {
             setModelInfo(result.data.modelInfo);
+            const modelLabel = result.data.modelInfo.currentModelLabel || modelId;
+            Message.success(t('common.modelSwitchSuccess', { model: modelLabel }));
           }
         })
         .catch((error) => {
           console.error('[AcpModelSelector] Failed to set model:', error);
         });
     },
-    [conversationId]
+    [conversationId, t]
   );
 
   const defaultModelLabel = t('common.defaultModel');

--- a/src/renderer/components/OpenClawModelSelector.tsx
+++ b/src/renderer/components/OpenClawModelSelector.tsx
@@ -7,7 +7,7 @@
 import { ipcBridge, type IOpenClawModelsResponse } from '@/common';
 import { useLayoutContext } from '@/renderer/context/LayoutContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
-import { Button, Dropdown, Menu } from '@arco-design/web-react';
+import { Button, Dropdown, Menu, Message } from '@arco-design/web-react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -163,9 +163,12 @@ const OpenClawModelSelector: React.FC<{
         return;
       }
 
-      await syncSelectedModel(model, { updateState: true, force: true, reason: 'manual' });
+      const success = await syncSelectedModel(model, { updateState: true, force: true, reason: 'manual' });
+      if (success) {
+        Message.success(t('common.modelSwitchSuccess', { model: model.model_id }));
+      }
     },
-    [models, syncSelectedModel]
+    [models, syncSelectedModel, t]
   );
 
   // Ensure the current model is synced on first load as well.

--- a/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/ChannelModalContent.tsx
@@ -120,7 +120,7 @@ const useChannelModelSelection = (configKey: ChannelModelConfigKey): GeminiModel
           })
           .catch((err) => console.warn(`[ChannelSettings] syncChannelSettings failed for ${platform}:`, err));
 
-        Message.success(t('settings.assistant.modelSwitched', 'Model switched successfully'));
+        // Toast notification is handled by useGeminiModelSelection hook
         return true;
       } catch (error) {
         console.error(`[ChannelSettings] Failed to save model for ${configKey}:`, error);

--- a/src/renderer/i18n/locales/en-US/common.json
+++ b/src/renderer/i18n/locales/en-US/common.json
@@ -47,6 +47,7 @@
   "deleteFailed": "Failed to delete",
   "default": "Default",
   "defaultModel": "Default Model",
+  "modelSwitchSuccess": "Switched to {{model}}",
   "escToCancel": "esc to cancel",
   "create": "Create",
   "createSuccess": "Created successfully",

--- a/src/renderer/i18n/locales/ja-JP/common.json
+++ b/src/renderer/i18n/locales/ja-JP/common.json
@@ -44,6 +44,7 @@
   "deleteFailed": "削除に失敗しました",
   "default": "デフォルト",
   "defaultModel": "デフォルトモデル",
+  "modelSwitchSuccess": "{{model}} に切り替えました",
   "escToCancel": "ESC でキャンセル",
   "create": "作成",
   "createSuccess": "作成に成功しました",

--- a/src/renderer/i18n/locales/ko-KR/common.json
+++ b/src/renderer/i18n/locales/ko-KR/common.json
@@ -44,6 +44,7 @@
   "deleteFailed": "삭제 실패",
   "default": "기본",
   "defaultModel": "기본 모델",
+  "modelSwitchSuccess": "{{model}}(으)로 전환되었습니다",
   "escToCancel": "취소하려면 esc",
   "create": "생성",
   "createSuccess": "생성 성공",

--- a/src/renderer/i18n/locales/tr-TR/common.json
+++ b/src/renderer/i18n/locales/tr-TR/common.json
@@ -43,6 +43,7 @@
   "deleteFailed": "Silme başarısız",
   "default": "Varsayılan",
   "defaultModel": "Varsayılan Model",
+  "modelSwitchSuccess": "{{model}} modeline geçildi",
   "escToCancel": "iptal için esc",
   "create": "Oluştur",
   "createSuccess": "Başarıyla oluşturuldu",

--- a/src/renderer/i18n/locales/zh-CN/common.json
+++ b/src/renderer/i18n/locales/zh-CN/common.json
@@ -47,6 +47,7 @@
   "deleteFailed": "删除失败",
   "default": "默认",
   "defaultModel": "默认模型",
+  "modelSwitchSuccess": "已切换为 {{model}}",
   "escToCancel": "按 ESC 取消",
   "create": "创建",
   "createSuccess": "创建成功",

--- a/src/renderer/i18n/locales/zh-TW/common.json
+++ b/src/renderer/i18n/locales/zh-TW/common.json
@@ -43,6 +43,7 @@
   "deleteFailed": "刪除失敗",
   "default": "預設",
   "defaultModel": "預設模型",
+  "modelSwitchSuccess": "已切換為 {{model}}",
   "escToCancel": "按 ESC 取消",
   "create": "建立",
   "createSuccess": "建立成功",

--- a/src/renderer/pages/conversation/gemini/useGeminiModelSelection.ts
+++ b/src/renderer/pages/conversation/gemini/useGeminiModelSelection.ts
@@ -1,7 +1,9 @@
 import type { IProvider, TProviderWithModel } from '@/common/storage';
 import type { GeminiModeOption } from '@/renderer/hooks/useModeModeList';
 import { useModelProviderList } from '@/renderer/hooks/useModelProviderList';
+import { Message } from '@arco-design/web-react';
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface GeminiModelSelection {
   currentModel?: TProviderWithModel;
@@ -20,6 +22,7 @@ export interface UseGeminiModelSelectionOptions {
 
 // Centralize model selection logic for reuse across header, send box, and channel settings
 export const useGeminiModelSelection = ({ initialModel, onSelectModel }: UseGeminiModelSelectionOptions): GeminiModelSelection => {
+  const { t } = useTranslation();
   const [currentModel, setCurrentModel] = useState<TProviderWithModel | undefined>(initialModel);
 
   useEffect(() => {
@@ -37,9 +40,11 @@ export const useGeminiModelSelection = ({ initialModel, onSelectModel }: UseGemi
       const ok = await onSelectModel(provider, modelName);
       if (ok) {
         setCurrentModel(selected);
+        const displayName = formatModelLabel(provider, modelName) || modelName;
+        Message.success(t('common.modelSwitchSuccess', { model: displayName }));
       }
     },
-    [onSelectModel]
+    [onSelectModel, formatModelLabel, t]
   );
 
   const getDisplayModelName = useCallback(


### PR DESCRIPTION
Add toast notification when user switches model in dropdown selectors. Displays "已切换为 xxx" after successful switch.

Closes #576

Generated with [Claude Code](https://claude.ai/code)