### PR TITLE
fix: 修复启动界面加载问题和切换模式后 Nexus 无法启动

### DIFF
--- a/src/process/services/nexus/DynamicNexusService.ts
+++ b/src/process/services/nexus/DynamicNexusService.ts
@@ -129,6 +129,12 @@ class DynamicNexusService {
     return this._running;
   }
 
+  /** Reset running state - used when process is killed externally */
+  resetRunningState(): void {
+    this._running = false;
+    this.process = null;
+  }
+
   get port(): number {
     return this._port;
   }

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -766,10 +766,14 @@ export class ServiceManager {
     const deadline = startupOnlyChecks ? Number.POSITIVE_INFINITY : Date.now() + this.STARTUP_READINESS_TIMEOUT_MS;
     let lastFailedNames: string[] = [];
 
+    mainLog('ServiceManager', `Verifying startup readiness (startupOnlyChecks=${startupOnlyChecks})...`);
+
     while (Date.now() < deadline) {
       const scodeReadyPromise = Promise.resolve(isScodeInstalled());
       const nexusHealthyPromise = dynamicNexusService.checkActualRunning();
       const [scodeReady, nexusHealthy] = await Promise.all([scodeReadyPromise, nexusHealthyPromise]);
+
+      mainLog('ServiceManager', `Readiness check: Sudocode=${scodeReady}, Nexus=${nexusHealthy}`);
 
       const readinessChecks = [
         { name: 'Sudocode', ok: scodeReady },
@@ -778,7 +782,18 @@ export class ServiceManager {
 
       const failed = readinessChecks.filter((item) => !item.ok).map((item) => item.name);
       if (failed.length === 0) {
+        mainLog('ServiceManager', 'All components ready, exiting verifyStartupReadiness');
         return;
+      }
+
+      // Update UI to show actual waiting state instead of misleading 100%
+      if (failed.includes('Sudocode')) {
+        initStatusManager.setStepState('scode', 'active', '等待 Sudocode 服务就绪...');
+        initStatusManager.setStepProgress('scode', 95, '等待 Sudocode 服务就绪...');
+      }
+      if (failed.includes('Nexus')) {
+        initStatusManager.setStepState('nexus', 'active', '等待 Nexus 服务就绪...');
+        initStatusManager.setStepProgress('nexus', 95, '等待 Nexus 服务就绪...');
       }
 
       if (failed.join('、') !== lastFailedNames.join('、')) {

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -191,6 +191,9 @@ export class ServiceManager {
       for (let attempt = 1; attempt <= attempts; attempt += 1) {
         try {
           await this.preparePortForStart(12012, 'Nexus');
+          // Reset Nexus running state after killing port processes
+          // because preparePortForStart may have killed the process externally
+          dynamicNexusService.resetRunningState();
           const startupDetail = attempt > 1 ? (phase === 'reinstall' ? `重装后正在启动 Nexus 服务（第 ${attempt}/${attempts} 次）...` : `正在启动 Nexus 服务（第 ${attempt}/${attempts} 次）...`) : phase === 'reinstall' ? '重装后正在启动 Nexus 服务...' : '正在启动 Nexus 服务...';
           initStatusManager.setStepState('nexus', 'active', startupDetail);
           initStatusManager.setStepProgress('nexus', 92, initStatusManager.getStatus().stepDetails?.nexus);


### PR DESCRIPTION
## Summary
- 修复启动界面各组件 100% 加载后不进入工作界面的问题
- 修复切换模式后 Nexus 无法启动的问题

## Changes
1. **启动界面等待状态显示**
   - 在 `verifyStartupReadiness` 等待期间更新 UI 状态，显示实际等待状态而非误导性的 100%
   - 添加诊断日志记录每次就绪检查的结果，便于定位问题

2. **Nexus 启动状态重置**
   - 在 `DynamicNexusService` 中添加 `resetRunningState()` 方法
   - 在 `preparePortForStart` 后调用 `resetRunningState()` 重置状态
   - 解决切换模式时 `_running` 状态未同步导致新进程无法启动的问题

## Test plan
- [ ] 启动应用，观察启动界面是否正常进入工作界面
- [ ] 切换模式（从企业模式切换到消费者模式），验证 Nexus 是否正常启动
- [ ] 检查日志中 `Readiness check: Sudocode=..., Nexus=...` 的输出

🤖 Generated with [Claude Code](https://claude.com/claude-code)