### PR TITLE
feat: add privacy policy link to About page (#580)

### DIFF
--- a/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AboutModalContent.tsx
@@ -18,6 +18,7 @@ import sudoIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import { openExternalUrl } from '@/renderer/utils/platform';
 
 const OFFICIAL_WEBSITE_URL = 'https://sudoclaw.sudoprivacy.com';
+const PRIVACY_POLICY_URL = 'https://sudoclaw.sudoprivacy.com/privacy.html';
 
 const AboutModalContent: React.FC = () => {
   const viewMode = useSettingsViewMode();
@@ -38,10 +39,17 @@ const AboutModalContent: React.FC = () => {
               {config.about_name}
             </Typography.Title>
             <div className='text-12px text-t-tertiary'>{config.app_company_name}</div>
-            <button type='button' className='mt-6px mb-10px inline-flex items-center gap-4px bg-transparent border-none p-0 text-12px text-primary cursor-pointer underline-offset-3 hover:underline' onClick={() => void openExternalUrl(OFFICIAL_WEBSITE_URL).catch(console.error)}>
-              <span>{t('settings.officialWebsite')}</span>
-              <IconLink className='text-12px' />
-            </button>
+            <div className='flex items-center gap-12px mt-6px mb-10px'>
+              <button type='button' className='inline-flex items-center gap-4px bg-transparent border-none p-0 text-12px text-primary cursor-pointer underline-offset-3 hover:underline' onClick={() => void openExternalUrl(OFFICIAL_WEBSITE_URL).catch(console.error)}>
+                <span>{t('settings.officialWebsite')}</span>
+                <IconLink className='text-12px' />
+              </button>
+              <span className='text-12px text-t-quaternary'>·</span>
+              <button type='button' className='inline-flex items-center gap-4px bg-transparent border-none p-0 text-12px text-primary cursor-pointer underline-offset-3 hover:underline' onClick={() => void openExternalUrl(PRIVACY_POLICY_URL).catch(console.error)}>
+                <span>{t('settings.privacyPolicy')}</span>
+                <IconLink className='text-12px' />
+              </button>
+            </div>
             <div className='flex items-center gap-6px'>
               <span className='px-10px py-3px rd-20px text-12px bg-fill-2 text-t-secondary font-mono font-500'>{buildVersion}</span>
               {isNightlyBuild && <span className='px-8px py-2px rd-10px text-11px bg-orange-1 text-orange-6 font-500 dark:bg-orange-9/20'>{t('update.nightlyBadge', { defaultValue: 'Nightly Preview' })}</span>}

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -526,6 +526,7 @@
   "feedback": "Feedback",
   "contactMe": "Contact Me",
   "officialWebsite": "Official Website",
+  "privacyPolicy": "Privacy Policy",
   "checkForUpdates": "Check for updates",
   "includePrereleaseUpdates": "Include prerelease/dev builds",
   "saveModelConfigFailed": "Failed to save model configuration",

--- a/src/renderer/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/i18n/locales/ja-JP/settings.json
@@ -504,6 +504,7 @@
   "feedback": "フィードバック",
   "contactMe": "お問い合わせ",
   "officialWebsite": "公式サイト",
+  "privacyPolicy": "プライバシーポリシー",
   "checkForUpdates": "更新を確認",
   "includePrereleaseUpdates": "プレリリース/dev ビルドを含める",
   "saveModelConfigFailed": "モデル設定の保存に失敗しました",

--- a/src/renderer/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/i18n/locales/ko-KR/settings.json
@@ -504,6 +504,7 @@
   "feedback": "피드백",
   "contactMe": "연락처",
   "officialWebsite": "공식 웹사이트",
+  "privacyPolicy": "개인정보 처리방침",
   "checkForUpdates": "업데이트 확인",
   "includePrereleaseUpdates": "프리릴리즈/dev 빌드 포함",
   "saveModelConfigFailed": "모델 구성 저장 실패",

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -502,6 +502,7 @@
   "feedback": "Geri Bildirim",
   "contactMe": "Bana Ulaşın",
   "officialWebsite": "Resmi Web Sitesi",
+  "privacyPolicy": "Gizlilik Politikası",
   "checkForUpdates": "Güncellemeleri kontrol et",
   "includePrereleaseUpdates": "Ön sürüm/geliştirici sürümlerini dahil et",
   "saveModelConfigFailed": "Model yapılandırması kaydedilemedi",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -526,6 +526,7 @@
   "feedback": "意见反馈",
   "contactMe": "联系我",
   "officialWebsite": "官网",
+  "privacyPolicy": "隐私声明",
   "checkForUpdates": "检查更新",
   "includePrereleaseUpdates": "包含预发布/dev 版本",
   "saveModelConfigFailed": "保存模型配置失败",

--- a/src/renderer/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/i18n/locales/zh-TW/settings.json
@@ -504,6 +504,7 @@
   "feedback": "意見反饋",
   "contactMe": "聯繫我",
   "officialWebsite": "官網",
+  "privacyPolicy": "隱私聲明",
   "checkForUpdates": "檢查更新",
   "includePrereleaseUpdates": "包含預發佈/dev 版本",
   "saveModelConfigFailed": "儲存模型設定失敗",


### PR DESCRIPTION
## Summary

- Add a privacy policy link to the About page next to the official website link
- Link opens https://sudoclaw.sudoprivacy.com/privacy.html in external browser
- Updated i18n translations for all 6 supported locales

Closes #580

Generated with [Claude Code](https://claude.ai/code)