### PR TITLE
feat(guid): enterprise Local mode with localAuth permission control

### DIFF
--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -13,7 +13,7 @@
 import type { ChildProcess, SpawnOptions } from 'child_process';
 import { execFile as execFileCb, execFileSync, spawn } from 'child_process';
 import { promisify } from 'util';
-import { promises as fs, readFileSync } from 'fs';
+import { mkdirSync, promises as fs, readFileSync, writeFileSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import { CLAUDE_ACP_NPX_PACKAGE, CODEBUDDY_ACP_NPX_PACKAGE, CODEX_ACP_BRIDGE_VERSION, CODEX_ACP_NPX_PACKAGE } from '@/types/acpTypes';
@@ -553,6 +553,31 @@ export async function spawnGenericBackend(backend: string, cliPath: string, work
     } catch {
       // Claude Code credentials not available — scode will use other auth methods
     }
+  }
+
+  // Ensure settings.json model is valid before spawning scode.
+  // scode reads settings.json on startup and crashes (exit 1) if the model is not in sudocode.json models.
+  // This prevents a death loop: crash → reconnect → read bad settings.json → crash again.
+  if (backend === 'scode') {
+    try {
+      const scodeDir = path.join(os.homedir(), '.nexus', 'sudocode');
+      const settingsPath = path.join(scodeDir, 'settings.json');
+      let settings: Record<string, unknown> = {};
+      try { settings = JSON.parse(readFileSync(settingsPath, 'utf-8')); } catch { /* no settings */ }
+      const scodeConfigPath = path.join(scodeDir, 'sudocode.json');
+      let scodeConfig: Record<string, unknown> = {};
+      try { scodeConfig = JSON.parse(readFileSync(scodeConfigPath, 'utf-8')); } catch { /* no config */ }
+      const availableModels = scodeConfig.models && typeof scodeConfig.models === 'object'
+        ? Object.keys(scodeConfig.models as Record<string, unknown>) : [];
+      const currentModel = typeof settings.model === 'string' ? settings.model : undefined;
+
+      if (currentModel && availableModels.length > 0 && !availableModels.includes(currentModel)) {
+        settings.model = availableModels[0];
+        mkdirSync(scodeDir, { recursive: true });
+        writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+        mainLog('[ACP scode]', `Corrected settings.json model from "${currentModel}" to "${availableModels[0]}"`);
+      }
+    } catch { /* best-effort */ }
   }
 
   ensureMinNodeVersion(cleanEnv, 18, 17, `${backend} ACP`);

--- a/src/common/enterpriseDebugConfig.ts
+++ b/src/common/enterpriseDebugConfig.ts
@@ -36,6 +36,9 @@ import { isEnterpriseMode as eeclawIsEnterpriseMode } from './eeclawMode';
 let cachedAppMode: 'c' | 'e' | null = null;
 let cachedServerUrl: string = '';
 let cachedAuthToken: string = '';
+// Cache for guid session mode (remote/local), updated by refreshEnterpriseCache and setSessionMode IPC
+// guid session 模式缓存（remote/local），由 refreshEnterpriseCache 和 setSessionMode IPC 更新
+let cachedSessionMode: 'remote' | 'local' = 'remote';
 
 // Dynamic import for ProcessConfig (main process only)
 // ProcessConfig 的动态导入（仅主进程）
@@ -63,6 +66,7 @@ export async function refreshEnterpriseCache(): Promise<void> {
     const authStorage = config.getSync('eeclaw.authStorage');
     cachedAuthToken = authStorage?.access_token || '';
     cachedServerUrl = config.getSync('eeclaw.serverUrl') || '';
+    cachedSessionMode = config.getSync('guid.sessionMode') || 'remote';
   } catch {
     // Keep existing cache values on error
   }
@@ -214,4 +218,20 @@ export function getEnterpriseConfig(): {
     mossServerUrl: cachedServerUrl,
     authToken: cachedAuthToken,
   };
+}
+
+/**
+ * Get cached session mode (remote/local) for enterprise mode
+ * 获取缓存的 session 模式（remote/local），用于企业模式
+ */
+export function getCachedSessionMode(): 'remote' | 'local' {
+  return cachedSessionMode;
+}
+
+/**
+ * Set cached session mode (called by setSessionMode IPC handler)
+ * 设置缓存的 session 模式（由 setSessionMode IPC handler 调用）
+ */
+export function setCachedSessionMode(mode: 'remote' | 'local'): void {
+  cachedSessionMode = mode;
 }

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -524,7 +524,7 @@ export const openclawConversation = {
 // Database operations
 export const database = {
   getConversationMessages: bridge.buildProvider<import('@/common/chatLib').TMessage[], { conversation_id: string; page?: number; pageSize?: number }>('database.get-conversation-messages'),
-  getUserConversations: bridge.buildProvider<import('@/common/storage').TChatConversation[], { page?: number; pageSize?: number }>('database.get-user-conversations'),
+  getUserConversations: bridge.buildProvider<import('@/common/storage').TChatConversation[], { page?: number; pageSize?: number; sessionMode?: 'remote' | 'local' }>('database.get-user-conversations'),
   /** 渠道对话创建/更新/删除时，主进程通知渲染进程刷新对话列表 */
   conversationChanged: bridge.buildEmitter<{
     conversationId: string;
@@ -1009,6 +1009,8 @@ export interface ICreateConversationParams {
     presetAssistantId?: string;
     /** Initial session mode selected on Guid page (from AgentModeSelector) */
     sessionMode?: string;
+    /** Session mode (remote/local) for enterprise mode Provider selection - distinct from sessionMode (yolo/auto) */
+    sessionModeParam?: 'remote' | 'local';
     /** Pre-selected ACP model from Guid page (cached model list) */
     currentModelId?: string;
     /** Runtime validation snapshot used for post-switch strong checks (OpenClaw) */
@@ -1776,6 +1778,8 @@ export const eeclaw = {
   >('eeclaw.login'),
   /** Set app mode and update main process cache */
   setAppMode: bridge.buildProvider<void, { mode: 'c' | 'e' }>('eeclaw.set-app-mode'),
+  /** Set session mode (remote/local) for enterprise mode and update main process cache */
+  setSessionMode: bridge.buildProvider<void, { mode: 'remote' | 'local' }>('eeclaw.set-session-mode'),
   /** Logout from enterprise server and clear local credentials */
   logout: bridge.buildProvider<IBridgeResponse<{}>, void>('eeclaw.logout'),
   /** Emitted when the main process refreshes the enterprise auth token */

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1772,7 +1772,10 @@ export const eeclaw = {
       access_token: string;
       refresh_token?: string;
       expires_in: number;
-      user: { id: string; name: string; role: string; orgId: string };
+      user: { id: string; name: string; role: string; orgId: string; localAuth: boolean };
+      sudorouter_key?: string;
+      model_service_url?: string;
+      models?: string[];
     }>,
     { serverUrl: string; body: { grant_type: string; username?: string; password?: string; api_key?: string }; deviceId: string }
   >('eeclaw.login'),

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -71,6 +71,8 @@ export interface IConfigStorageRefer {
   'workspace.pasteConfirm'?: boolean;
   // guid 页面上次选择的 agent 类型 / Last selected agent type on guid page
   'guid.lastSelectedAgent'?: string;
+  // guid 页面 session 模式（E端 Local/Remote 切换）/ Guid page session mode (Enterprise Local/Remote toggle)
+  'guid.sessionMode'?: 'remote' | 'local';
   // 迁移标记：修复老版本中助手 enabled 默认值问题 / Migration flag: fix assistant enabled default value issue
   'migration.assistantEnabledFixed'?: boolean;
   // 迁移标记：为 cowork 助手添加默认启用的 skills / Migration flag: add default enabled skills for cowork assistant

--- a/src/process/bridge/acpConversationBridge.ts
+++ b/src/process/bridge/acpConversationBridge.ts
@@ -16,7 +16,7 @@ import { mcpService } from '@/process/services/mcpServices/McpService';
 import { mainLog, mainWarn } from '@/process/utils/mainLogger';
 import { ipcBridge } from '../../common';
 import * as os from 'os';
-import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { isEnterpriseMode, getCachedSessionMode } from '@/common/enterpriseDebugConfig';
 import { getConversationProvider } from '@/process/providers';
 import RemoteConversationProvider from '@/process/providers/RemoteConversationProvider';
 
@@ -62,8 +62,9 @@ export function initAcpConversationBridge(): void {
   // Enrich with MCP transport support info so the frontend can show accurate counts
   ipcBridge.acpConversation.getAvailableAgents.provider(() => {
     try {
-      // Enterprise mode: ONLY show remote-agent (Moss Server), hide all local agents
-      if (isEnterpriseMode()) {
+      // Enterprise Remote mode: ONLY show remote-agent (Moss Server), hide all local agents
+      // Enterprise Local mode: fall through to local agent detection
+      if (isEnterpriseMode() && getCachedSessionMode() === 'remote') {
         return Promise.resolve({
           success: true,
           data: [{

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -465,15 +465,21 @@ export function initConversationBridge(): void {
     // 使用 Provider 抽象层创建会话
     mainLog('conversationBridge', `Creating conversation: type=${params.type}, name=${params.name}`);
 
-    // Enterprise mode: force remote-agent type for all conversations
-    // 企业模式：强制使用 remote-agent 类型
+    // Read sessionMode from extra.sessionModeParam (rendered process passes it explicitly)
+    // 从 extra.sessionModeParam 读取 sessionMode（渲染进程显式传递）
+    const sessionMode = params.extra?.sessionModeParam as 'remote' | 'local' | undefined;
+
+    // Enterprise mode Remote session: force remote-agent type for all conversations
+    // 企业模式 Remote 会话：强制使用 remote-agent 类型
+    // Local session in enterprise mode should NOT be forced to remote-agent
+    // 企业模式 Local 会话不应强制为 remote-agent
     let finalParams = params;
-    if (isRemoteProvider() && params.type !== 'remote-agent') {
-      mainLog('conversationBridge', `Enterprise mode: forcing remote-agent type`);
+    if (isRemoteProvider(sessionMode) && params.type !== 'remote-agent') {
+      mainLog('conversationBridge', `Enterprise remote mode: forcing remote-agent type`);
       finalParams = { ...params, type: 'remote-agent' };
     }
 
-    const provider = getConversationProvider();
+    const provider = getConversationProvider(sessionMode);
     const conversation = await provider.createConversation(finalParams);
 
     mainLog('conversationBridge', `Conversation created successfully: id=${conversation.id}`);

--- a/src/process/bridge/databaseBridge.ts
+++ b/src/process/bridge/databaseBridge.ts
@@ -27,9 +27,9 @@ export function initDatabaseBridge(): void {
 
   // Get user conversations (paginated) via Provider
   // 通过 Provider 获取用户会话（分页）
-  ipcBridge.database.getUserConversations.provider(async ({ page = 0, pageSize = 10000 }) => {
+  ipcBridge.database.getUserConversations.provider(async ({ page = 0, pageSize = 10000, sessionMode }) => {
     try {
-      const provider = getConversationProvider();
+      const provider = getConversationProvider(sessionMode);
 
       // For remote provider, this fetches from Moss Server
       // 对于远程 Provider，从 Moss Server 获取

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -248,7 +248,11 @@ export function initEeclawBridge(): void {
             name: data.user.name,
             role: data.user.role,
             orgId: data.user.orgId,
+            localAuth: data.user.localAuth === true,
           },
+          sudorouter_key: data.sudorouter_key,
+          model_service_url: data.model_service_url,
+          models: Array.isArray(data.models) ? data.models : undefined,
         },
       };
     } catch (error) {

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -7,7 +7,7 @@
 import { ipcBridge } from '@/common';
 import { ProcessConfig } from '@process/initStorage';
 import { mainWarn, mainLog } from '@process/utils/mainLogger';
-import { setCachedAuthToken, setCachedServerUrl, setCachedAppMode } from '@/common/enterpriseDebugConfig';
+import { setCachedAuthToken, setCachedServerUrl, setCachedAppMode, setCachedSessionMode } from '@/common/enterpriseDebugConfig';
 import { resetConversationProvider } from '../providers';
 
 let refreshPromise: Promise<string> | null = null;
@@ -167,6 +167,14 @@ export function initEeclawBridge(): void {
         mainLog('eeclawBridge', 'Failed to import ChannelManager: ' + String(error));
       }
     }
+  });
+
+  // Set session mode (remote/local) for enterprise mode
+  // 设置 session 模式（remote/local），用于企业模式
+  ipcBridge.eeclaw.setSessionMode.provider(async ({ mode }) => {
+    setCachedSessionMode(mode);
+    resetConversationProvider();
+    mainLog('eeclawBridge', `Session mode set to: ${mode}`);
   });
 
   ipcBridge.eeclaw.verifyServer.provider(async ({ serverUrl }) => {

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -74,9 +74,14 @@ export const initializeProcess = async () => {
   // uses BroadcastChannel IPC which doesn't work in the main process (no renderer yet).
   const appMode = ProcessConfig.getSync('system.appMode') ?? null;
 
-  if (appMode === 'e') {
-    // Enterprise mode: initialize ChannelManager for channel settings UI
-    // but skip local services (handled by Moss Server)
+  if (appMode) {
+    // Both Enterprise and Consumer modes: start local services + ChannelManager
+    // Enterprise mode now requires local services for Local session mode support
+    const serviceStart = Date.now();
+    const { serviceManager } = await import('./services/serviceManager');
+    void serviceManager.startup();
+    perfLog('serviceManager.startup', Date.now() - serviceStart);
+
     const channelStart = Date.now();
     try {
       await getChannelManager().initialize();
@@ -84,27 +89,6 @@ export const initializeProcess = async () => {
       mainError('Process', 'Failed to initialize ChannelManager', error);
     }
     perfLog('ChannelManager', Date.now() - channelStart);
-    initStatusManager.setStatus('ready', '初始化完成', 100);
-  } else if (appMode === 'c') {
-    // Consumer mode: normal full startup
-    const serviceStart = Date.now();
-    const { serviceManager } = await import('./services/serviceManager');
-    void serviceManager.startup();
-    perfLog('serviceManager.startup', Date.now() - serviceStart);
-
-    const parallelStart = Date.now();
-    await Promise.all([
-      (async () => {
-        const channelStart = Date.now();
-        try {
-          await getChannelManager().initialize();
-        } catch (error) {
-          mainError('Process', 'Failed to initialize ChannelManager', error);
-        }
-        perfLog('ChannelManager', Date.now() - channelStart);
-      })(),
-    ]);
-    perfLog('ChannelManager', Date.now() - parallelStart);
   } else {
     // New user (no appMode set): skip services, show ModeSetup
     // User selects C → startConsumerServices IPC + renderer reload (no app restart needed)

--- a/src/process/initBridge.ts
+++ b/src/process/initBridge.ts
@@ -8,7 +8,6 @@ import { logger } from '@office-ai/platform';
 import { initAllBridges } from './bridge';
 import { cronService } from '@process/services/cron/CronService';
 import { mainWarn, mainLog } from '@process/utils/mainLogger';
-import { isEnterpriseMode } from '@/common/eeclawMode';
 import { refreshEnterpriseCache } from '@/common/enterpriseDebugConfig';
 
 logger.config({ print: true });
@@ -23,12 +22,10 @@ initAllBridges();
   mainLog('initBridge', 'Enterprise config cache refreshed');
 })();
 
-// Initialize cron service only in consumer mode
-// CronService depends on local SQLite, local agents, local file system — all skipped in enterprise mode
+// Initialize cron service in all modes
+// CronService depends on local SQLite, local agents — now available in enterprise mode too
 (async () => {
-  if (!(await isEnterpriseMode())) {
-    void cronService.init().catch((error) => {
-      mainWarn('initBridge', 'CronService initialization failed:', error.message);
-    });
-  }
+  void cronService.init().catch((error) => {
+    mainWarn('initBridge', 'CronService initialization failed:', error.message);
+  });
 })();

--- a/src/process/providers/index.ts
+++ b/src/process/providers/index.ts
@@ -7,23 +7,29 @@
 import type { IConversationProvider, IProviderConfig } from './types';
 import { LocalConversationProvider } from './LocalConversationProvider';
 import { RemoteConversationProvider } from './RemoteConversationProvider';
-import { isEnterpriseMode, getEnterpriseConfig } from '@/common/enterpriseDebugConfig';
+import { isEnterpriseMode, getEnterpriseConfig, getCachedSessionMode } from '@/common/enterpriseDebugConfig';
 import { mainLog } from '@process/utils/mainLogger';
 import { ProcessConfig } from '@process/initStorage';
 
 let currentProvider: IConversationProvider | null = null;
 let currentProviderType: 'local' | 'remote' | null = null;
 
-export function getConversationProvider(): IConversationProvider {
+export function getConversationProvider(sessionMode?: 'remote' | 'local'): IConversationProvider {
   const isEnterprise = isEnterpriseMode();
+  // Determine effective target provider type based on sessionMode parameter or cache
+  // 根据 sessionMode 参数或缓存确定有效的目标 Provider 类型
+  const effectiveMode = isEnterprise
+    ? (sessionMode ?? getCachedSessionMode())
+    : 'local'; // C端始终 local
+  const targetType: 'local' | 'remote' = effectiveMode === 'remote' ? 'remote' : 'local';
 
-  if (currentProvider && currentProviderType === (isEnterprise ? 'remote' : 'local')) {
+  if (currentProvider && currentProviderType === targetType) {
     return currentProvider;
   }
 
-  if (isEnterprise) {
+  if (targetType === 'remote') {
     const config = getEnterpriseConfig();
-    
+
     // Read the freshest token from ProcessConfig (not from stale memory cache)
     let freshestToken = config.authToken;
     let serverUrl = config.mossServerUrl;
@@ -37,7 +43,7 @@ export function getConversationProvider(): IConversationProvider {
         serverUrl = storedUrl;
       }
     } catch { /* ignore */ }
-    
+
     mainLog('Provider', `Using REMOTE provider (Enterprise Mode) - Server: ${serverUrl || 'not set'}, Token: ${freshestToken ? 'set' : 'not set'}`);
 
     // In enterprise mode with a server URL, always use RemoteConversationProvider
@@ -83,8 +89,10 @@ export function resetConversationProvider(): void {
  * Check if currently using remote provider
  * 检查当前是否使用远程 Provider
  */
-export function isRemoteProvider(): boolean {
-  return isEnterpriseMode();
+export function isRemoteProvider(sessionMode?: 'remote' | 'local'): boolean {
+  if (!isEnterpriseMode()) return false;
+  if (sessionMode !== undefined) return sessionMode === 'remote';
+  return true; // 兼容旧调用方（无参数时保持原行为：E端默认 remote）
 }
 
 /**

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -19,6 +19,8 @@ export interface AuthUser {
   model_service_url?: string;
   models?: string[];
   phone?: string;
+  localAuth?: boolean;
+  localModeAvailable?: boolean;
   points?: {
     total: number;
     used: number;
@@ -130,7 +132,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const AUTH_USER_ENDPOINT = '/api/auth/user';
 const AUTH_STORAGE_KEY = 'sudowork_auth_v2';
-const EECLAW_AUTH_STORAGE_KEY = 'eeclaw_auth_v1';
+export const EECLAW_AUTH_STORAGE_KEY = 'eeclaw_auth_v1';
 const DEVICE_ID_KEY = 'sudowork_device_id';
 
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
@@ -235,13 +237,14 @@ async function fetchCurrentUser(signal?: AbortSignal): Promise<AuthUser | null> 
 }
 
 // Map MOSS enterprise user to AuthUser compatible type
-function mapEnterpriseUser(enterpriseUser: { id: string; name: string; role?: string }, token?: string): AuthUser {
+function mapEnterpriseUser(enterpriseUser: { id: string; name: string; role?: string; localAuth?: boolean }, token?: string): AuthUser {
   return {
     id: enterpriseUser.id,
     nickname: enterpriseUser.name,
     role: (enterpriseUser.role as AuthUser['role']) || 'USER',
     status: 1, // default active
     token,
+    localAuth: enterpriseUser.localAuth === true,
   };
 }
 
@@ -869,6 +872,11 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       // Map MOSS user to AuthUser compatible type
       const mappedUser = mapEnterpriseUser(data.user, data.access_token);
 
+      // --- localModeAvailable calculation (before localStorage serialization) ---
+      const localModeAvailable = !!(data.user.localAuth && data.sudorouter_key
+        && data.model_service_url && Array.isArray(data.models) && data.models.length > 0);
+      mappedUser.localModeAvailable = localModeAvailable;
+
       // Save to localStorage (eeclaw_auth_v1, separate from C-side)
       const eeclawAuthStorage: EeclawAuthStorage = {
         access_token: data.access_token,
@@ -878,6 +886,23 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         device_id: deviceId,
       };
       localStorage.setItem(EECLAW_AUTH_STORAGE_KEY, JSON.stringify(eeclawAuthStorage));
+
+      // --- sudocode.json generation/cleanup + sessionMode reset ---
+      if (isDesktopRuntime) {
+        if (localModeAvailable) {
+          const loginSudoclawPayload = extractLoginSudoclawPayload(result);
+          if (loginSudoclawPayload) {
+            const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload);
+            await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig }).catch((err) => {
+              console.warn('[Auth] Failed to save scode config on enterprise login:', err);
+            });
+          }
+        } else {
+          await ipcBridge.scode.saveConfig.invoke({ config: {} }).catch(() => {});
+          await ConfigStorage.set('guid.sessionMode', 'remote').catch(() => {});
+          await ipcBridge.eeclaw.setSessionMode.invoke({ mode: 'remote' }).catch(() => {});
+        }
+      }
 
       // Save user info to ConfigStorage
       try {
@@ -966,6 +991,13 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         await ipcBridge.eeclaw.logout.invoke();
       } catch (e) {
         console.warn('[Auth] Failed to invoke main-process logout:', e);
+      }
+
+      // Cleanup sudocode.json and reset sessionMode on enterprise logout
+      if (isDesktopRuntime) {
+        await ipcBridge.scode.saveConfig.invoke({ config: {} }).catch(() => {});
+        await ConfigStorage.set('guid.sessionMode', 'remote').catch(() => {});
+        await ipcBridge.eeclaw.setSessionMode.invoke({ mode: 'remote' }).catch(() => {});
       }
 
       // Clear enterprise ConfigStorage (but keep system.appMode = 'e')

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -896,6 +896,11 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig }).catch((err) => {
               console.warn('[Auth] Failed to save scode config on enterprise login:', err);
             });
+            // Sync settings.json model to first enterprise model so scode uses a valid model on startup
+            const firstModel = loginSudoclawPayload.models[0];
+            if (firstModel) {
+              await ipcBridge.scode.setDefaultModel.invoke({ modelId: firstModel }).catch(() => {});
+            }
           }
         } else {
           await ipcBridge.scode.saveConfig.invoke({ config: {} }).catch(() => {});

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -327,6 +327,11 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
         await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig }).catch((err) => {
           console.warn('[Auth] Failed to save scode config:', err);
         });
+        // 同步 settings.json 模型为 C端第一个有效模型，防止 E端残留模型 ID 导致 scode 崩溃
+        const firstModel = loginSudoclawPayload.models[0];
+        if (firstModel) {
+          await ipcBridge.scode.setDefaultModel.invoke({ modelId: firstModel }).catch(() => {});
+        }
       }
     } catch (error) {
       setSyncMessage(null);

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -77,21 +77,7 @@ const Main = () => {
     return <ModeSetup />;
   }
 
-  // Enterprise mode: skip InitLoading (no local services to wait for)
-  if (isEnterprise) {
-    return (
-      <div className='size-full relative'>
-        <Router layout={<Layout sider={<Sider />} />} />
-        {!authReady && (
-          <div style={{ position: 'fixed', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', zIndex: 9999, pointerEvents: 'none' }}>
-            <AppLoader />
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // Consumer mode: show InitLoading until services are ready.
+  // Show InitLoading until services are ready.
   // No separate AppLoader for "正在准备运行环境" — it caused a flash
   // when isModeResolved() resolved before primeStatusForStartup() set displayMode.
   if (!initReady && !isInitScreenSkipped) {
@@ -107,8 +93,8 @@ const Main = () => {
         </div>
       )}
 
-      {/* Product Improvement Dialog - shown only on first install for new users */}
-      <ProductImprovementDialog visible={showOptInDialog} onClose={handleOptInClose} />
+      {/* Product Improvement Dialog - shown only on first install for non-enterprise users */}
+      {!isEnterprise && <ProductImprovementDialog visible={showOptInDialog} onClose={handleOptInClose} />}
     </div>
   );
 };

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
@@ -8,6 +8,7 @@ import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import { addEventListener } from '@/renderer/utils/emitter';
 import { useAllCronJobs } from '@/renderer/pages/cron/hooks/useCronJobs';
+import { getRendererSessionMode } from '@/renderer/pages/guid/hooks/useGuidAgentSelection';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -41,8 +42,9 @@ export const useConversations = () => {
   // Fetch conversations via Provider abstraction layer (works for both local and enterprise mode)
   useEffect(() => {
     const refresh = () => {
+      const sessionMode = getRendererSessionMode();
       ipcBridge.database.getUserConversations
-        .invoke({ page: 0, pageSize: 10000 })
+        .invoke({ page: 0, pageSize: 10000, sessionMode })
         .then((data) => {
           if (data && Array.isArray(data)) {
             // Filter out health check conversations / 只过滤显式标记的健康检测临时会话，避免误伤用户自定义同名前缀会话

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -238,7 +238,7 @@ const GuidPage: React.FC = () => {
   );
 
   const mention = useGuidMention({
-    availableAgents: agentSelection.availableAgents,
+    availableAgents: agentSelection.mentionAvailableAgents,
     customAgentAvatarMap: agentSelection.customAgentAvatarMap,
     selectedAgentKey: agentSelection.selectedAgentKey,
     setSelectedAgentKey: agentSelection.setSelectedAgentKey,

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -14,6 +14,7 @@ import { useSkillSelectorController, type SkillSelectorItem } from '@/renderer/h
 import SkillSelectorMenu, { type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorMenu';
 import { resolveAssistantName } from '@/renderer/shared/agents/assistantAdapter';
 import { ipcBridge } from '@/common';
+import { useAuth } from '@/renderer/context/AuthContext';
 import { skillHub } from '@/common/ipcBridge';
 import AgentPillBar from './components/AgentPillBar';
 import AssistantSelectionArea from './components/AssistantSelectionArea';
@@ -60,6 +61,7 @@ const GuidPage: React.FC = () => {
   const { activeBorderColor, inactiveBorderColor, activeShadow } = useInputFocusRing();
   const localeKey = resolveLocaleKey(i18n.language);
   const { isEnterprise } = useAppMode();
+  const { user } = useAuth();
   // Read current menu and skill from URL query params
   const searchParams = new URLSearchParams(location.search);
   const selectedMenu = searchParams.get('menu');
@@ -641,7 +643,7 @@ const GuidPage: React.FC = () => {
                   {t('conversation.welcome.title')}
                 </p>
 
-                {agentSelection.availableAgents === undefined ? <AgentPillBarSkeleton /> : agentSelection.availableAgents.length > 0 ? <AgentPillBar availableAgents={agentSelection.availableAgents} selectedAgentKey={agentSelection.selectedAgentKey} getAgentKey={agentSelection.getAgentKey} onSelectAgent={handleSelectAgentFromPillBar} sessionMode={agentSelection.sessionMode} onSessionModeChange={agentSelection.setSessionMode} isEnterprise={isEnterprise} /> : null}
+                {agentSelection.availableAgents === undefined ? <AgentPillBarSkeleton /> : agentSelection.availableAgents.length > 0 ? <AgentPillBar availableAgents={agentSelection.availableAgents} selectedAgentKey={agentSelection.selectedAgentKey} getAgentKey={agentSelection.getAgentKey} onSelectAgent={handleSelectAgentFromPillBar} sessionMode={agentSelection.sessionMode} onSessionModeChange={agentSelection.setSessionMode} isEnterprise={isEnterprise} localModeAvailable={user?.localModeAvailable} /> : null}
 
                 <PromptTemplates
                   visible={!agentSelection.isPresetAgent && !guidInput.input.trim()}

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -33,7 +33,7 @@ import MentionDropdown from './components/MentionDropdown';
 import MentionSelectorBadge from './components/MentionSelectorBadge';
 import PromptTemplates from './components/PromptTemplates';
 import QuickActionButtons from './components/QuickActionButtons';
-import { useGuidAgentSelection } from './hooks/useGuidAgentSelection';
+import { useGuidAgentSelection, getRendererSessionMode } from './hooks/useGuidAgentSelection';
 import { useGuidInput } from './hooks/useGuidInput';
 import { useGuidMention } from './hooks/useGuidMention';
 import { useGuidModelSelection } from './hooks/useGuidModelSelection';
@@ -47,6 +47,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAddEventListener } from '@/renderer/utils/emitter';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { mutate } from 'swr';
 import styles from './index.module.css';
 
@@ -58,6 +59,7 @@ const GuidPage: React.FC = () => {
   const { closeAllTabs, openTab } = useConversationTabs();
   const { activeBorderColor, inactiveBorderColor, activeShadow } = useInputFocusRing();
   const localeKey = resolveLocaleKey(i18n.language);
+  const { isEnterprise } = useAppMode();
   // Read current menu and skill from URL query params
   const searchParams = new URLSearchParams(location.search);
   const selectedMenu = searchParams.get('menu');
@@ -263,6 +265,7 @@ const GuidPage: React.FC = () => {
     selectedMode: agentSelection.selectedMode,
     selectedAcpModel: agentSelection.selectedAcpModel,
     currentModel: modelSelection.currentModel,
+    sessionMode: agentSelection.sessionMode,
 
     // Agent helpers
     findAgentByKey: agentSelection.findAgentByKey,
@@ -638,7 +641,7 @@ const GuidPage: React.FC = () => {
                   {t('conversation.welcome.title')}
                 </p>
 
-                {agentSelection.availableAgents === undefined ? <AgentPillBarSkeleton /> : agentSelection.availableAgents.length > 0 ? <AgentPillBar availableAgents={agentSelection.availableAgents} selectedAgentKey={agentSelection.selectedAgentKey} getAgentKey={agentSelection.getAgentKey} onSelectAgent={handleSelectAgentFromPillBar} /> : null}
+                {agentSelection.availableAgents === undefined ? <AgentPillBarSkeleton /> : agentSelection.availableAgents.length > 0 ? <AgentPillBar availableAgents={agentSelection.availableAgents} selectedAgentKey={agentSelection.selectedAgentKey} getAgentKey={agentSelection.getAgentKey} onSelectAgent={handleSelectAgentFromPillBar} sessionMode={agentSelection.sessionMode} onSessionModeChange={agentSelection.setSessionMode} isEnterprise={isEnterprise} /> : null}
 
                 <PromptTemplates
                   visible={!agentSelection.isPresetAgent && !guidInput.input.trim()}
@@ -715,7 +718,7 @@ const GuidPage: React.FC = () => {
               )
             ) : (
               /* Assistant selection grid */
-              <>{agentSelection.availableAgents === undefined ? <AssistantsSkeleton /> : <AssistantSelectionArea customAgents={agentSelection.customAgents} localeKey={localeKey} onSelectAssistant={handleSelectAssistant} />}</>
+              <>{agentSelection.availableAgents === undefined ? <AssistantsSkeleton /> : <AssistantSelectionArea customAgents={agentSelection.customAgents} localeKey={localeKey} onSelectAssistant={handleSelectAssistant} availableAgents={agentSelection.availableAgents} sessionMode={agentSelection.sessionMode} isEnterprise={isEnterprise} />}</>
             )}
           </div>
         )}

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -76,6 +76,8 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
     <div className='w-full flex justify-center'>
       {/* Enterprise mode: Remote/Local tab */}
       {isEnterprise ? (
+        localModeAvailable ? (
+        /* Enterprise with Local mode: Remote | Local tab switcher */
         <div
           className='flex items-center justify-center'
           style={{
@@ -104,22 +106,45 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
           >
             <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Remote</span>
           </div>
-          {/* Divider + Local tab - only shown when localModeAvailable */}
-          {localModeAvailable && (
-            <>
-              <div className='text-16px lh-1 p-2px select-none opacity-30'>|</div>
-              <div
-                data-agent-pill='true'
-                data-session-mode='local'
-                className={`group relative flex items-center cursor-pointer whitespace-nowrap ${sessionMode === 'local' ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : 'opacity-60 p-4px hover:opacity-100'}`}
-                style={sessionMode === 'local' ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : { transition: 'opacity 0.2s ease' }}
-                onClick={() => onSessionModeChange?.('local')}
-              >
-                <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Local</span>
-              </div>
-            </>
-          )}
+          {/* Divider + Local tab */}
+          <>
+            <div className='text-16px lh-1 p-2px select-none opacity-30'>|</div>
+            <div
+              data-agent-pill='true'
+              data-session-mode='local'
+              className={`group relative flex items-center cursor-pointer whitespace-nowrap ${sessionMode === 'local' ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : 'opacity-60 p-4px hover:opacity-100'}`}
+              style={sessionMode === 'local' ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : { transition: 'opacity 0.2s ease' }}
+              onClick={() => onSessionModeChange?.('local')}
+            >
+              <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Local</span>
+            </div>
+          </>
         </div>
+        ) : (
+        /* Enterprise without Local mode: single pill with consumer style */
+        <div
+          className='flex items-center justify-center'
+          style={{
+            marginBottom: 20,
+            padding: '6px',
+            borderRadius: '30px',
+            backgroundColor: 'var(--color-guid-agent-bar, var(--aou-2))',
+            width: isMobile ? 'calc(100% + 28px)' : 'fit-content',
+            maxWidth: isMobile ? 'none' : '100%',
+            marginLeft: isMobile ? -14 : 0,
+            marginRight: isMobile ? -14 : 0,
+            color: 'var(--text-primary)',
+          }}
+        >
+          <div
+            className={`group relative flex items-center whitespace-nowrap px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}`}
+            style={{ transition: 'opacity 0.2s ease, background-color 0.2s ease' }}
+          >
+            <img src={getAgentLogo('remote-agent')} alt='Remote Agent' width={20} height={20} style={{ objectFit: 'contain', flexShrink: 0 }} />
+            <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Remote Agent</span>
+          </div>
+        </div>
+        )
       ) : (
       /* Consumer mode: original pill bar */
       <div

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -18,9 +18,15 @@ type AgentPillBarProps = {
   selectedAgentKey: string;
   getAgentKey: (agent: { backend: AcpBackendAll; customAgentId?: string }) => string;
   onSelectAgent: (key: string) => void;
+  /** Current session mode (remote/local) - only meaningful in enterprise mode */
+  sessionMode?: 'remote' | 'local';
+  /** Callback when session mode tab is clicked */
+  onSessionModeChange?: (mode: 'remote' | 'local') => void;
+  /** Whether the app is in enterprise mode */
+  isEnterprise?: boolean;
 };
 
-const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAgentKey, getAgentKey, onSelectAgent }) => {
+const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAgentKey, getAgentKey, onSelectAgent, sessionMode, onSessionModeChange, isEnterprise }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
 
@@ -66,6 +72,51 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
 
   return (
     <div className='w-full flex justify-center'>
+      {/* Enterprise mode: Remote/Local tab */}
+      {isEnterprise ? (
+        <div
+          className='flex items-center justify-center'
+          style={{
+            marginBottom: 20,
+            padding: '6px',
+            borderRadius: '30px',
+            backgroundColor: 'var(--color-guid-agent-bar, var(--aou-2))',
+            transition: 'background-color 0.35s ease',
+            width: isMobile ? 'calc(100% + 28px)' : 'fit-content',
+            maxWidth: isMobile ? 'none' : '100%',
+            marginLeft: isMobile ? -14 : 0,
+            marginRight: isMobile ? -14 : 0,
+            gap: 4,
+            color: 'var(--text-primary)',
+          }}
+        >
+          {/* Shared Remote icon */}
+          <img src={getAgentLogo('remote-agent')} alt='Remote' width={20} height={20} style={{ objectFit: 'contain', flexShrink: 0 }} />
+          {/* Remote tab */}
+          <div
+            data-agent-pill='true'
+            data-session-mode='remote'
+            className={`group relative flex items-center cursor-pointer whitespace-nowrap ${sessionMode === 'remote' ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : 'opacity-60 p-4px hover:opacity-100'}`}
+            style={sessionMode === 'remote' ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : { transition: 'opacity 0.2s ease' }}
+            onClick={() => onSessionModeChange?.('remote')}
+          >
+            <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Remote</span>
+          </div>
+          {/* Divider */}
+          <div className='text-16px lh-1 p-2px select-none opacity-30'>|</div>
+          {/* Local tab */}
+          <div
+            data-agent-pill='true'
+            data-session-mode='local'
+            className={`group relative flex items-center cursor-pointer whitespace-nowrap ${sessionMode === 'local' ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : 'opacity-60 p-4px hover:opacity-100'}`}
+            style={sessionMode === 'local' ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : { transition: 'opacity 0.2s ease' }}
+            onClick={() => onSessionModeChange?.('local')}
+          >
+            <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Local</span>
+          </div>
+        </div>
+      ) : (
+      /* Consumer mode: original pill bar */
       <div
         className='flex items-center justify-center'
         style={{
@@ -111,6 +162,7 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
             );
           })}
       </div>
+      )}
     </div>
   );
 };

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -24,9 +24,11 @@ type AgentPillBarProps = {
   onSessionModeChange?: (mode: 'remote' | 'local') => void;
   /** Whether the app is in enterprise mode */
   isEnterprise?: boolean;
+  /** Whether local mode is available (localAuth=true + config complete) */
+  localModeAvailable?: boolean;
 };
 
-const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAgentKey, getAgentKey, onSelectAgent, sessionMode, onSessionModeChange, isEnterprise }) => {
+const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAgentKey, getAgentKey, onSelectAgent, sessionMode, onSessionModeChange, isEnterprise, localModeAvailable }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
 
@@ -102,18 +104,21 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
           >
             <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Remote</span>
           </div>
-          {/* Divider */}
-          <div className='text-16px lh-1 p-2px select-none opacity-30'>|</div>
-          {/* Local tab */}
-          <div
-            data-agent-pill='true'
-            data-session-mode='local'
-            className={`group relative flex items-center cursor-pointer whitespace-nowrap ${sessionMode === 'local' ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : 'opacity-60 p-4px hover:opacity-100'}`}
-            style={sessionMode === 'local' ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : { transition: 'opacity 0.2s ease' }}
-            onClick={() => onSessionModeChange?.('local')}
-          >
-            <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Local</span>
-          </div>
+          {/* Divider + Local tab - only shown when localModeAvailable */}
+          {localModeAvailable && (
+            <>
+              <div className='text-16px lh-1 p-2px select-none opacity-30'>|</div>
+              <div
+                data-agent-pill='true'
+                data-session-mode='local'
+                className={`group relative flex items-center cursor-pointer whitespace-nowrap ${sessionMode === 'local' ? `opacity-100 px-12px py-8px rd-20px mx-2px ${styles.agentItemSelected}` : 'opacity-60 p-4px hover:opacity-100'}`}
+                style={sessionMode === 'local' ? { transition: 'opacity 0.2s ease, background-color 0.2s ease' } : { transition: 'opacity 0.2s ease' }}
+                onClick={() => onSessionModeChange?.('local')}
+              >
+                <span className='font-semibold text-14px ml-4px' style={{ color: 'var(--text-primary)' }}>Local</span>
+              </div>
+            </>
+          )}
         </div>
       ) : (
       /* Consumer mode: original pill bar */

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -5,7 +5,7 @@
  */
 
 import { CUSTOM_AVATAR_IMAGE_MAP } from '../constants';
-import type { AcpBackendConfig } from '../types';
+import type { AcpBackendConfig, AvailableAgent } from '../types';
 import { Plus, Robot } from '@icon-park/react';
 import React from 'react';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
@@ -16,6 +16,12 @@ type AssistantSelectionAreaProps = {
   customAgents: AcpBackendConfig[];
   localeKey: string;
   onSelectAssistant: (assistantId: string) => void;
+  /** Enterprise mode available agents (cloud assistants) for Remote mode */
+  availableAgents?: AvailableAgent[];
+  /** Current session mode (remote/local) for enterprise mode */
+  sessionMode?: 'remote' | 'local';
+  /** Whether the app is in enterprise mode */
+  isEnterprise?: boolean;
 };
 
 /**
@@ -23,11 +29,37 @@ type AssistantSelectionAreaProps = {
  * The selected assistant view (header, description, prompts) is now handled
  * directly in GuidPage for proper layout ordering.
  */
-const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ customAgents, localeKey, onSelectAssistant }) => {
+const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ customAgents, localeKey, onSelectAssistant, availableAgents, sessionMode, isEnterprise }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  // Only render if there are any assistants (preset or user-created)
+  // Enterprise Remote mode: render cloud assistants from availableAgents
+  // E端 Remote 模式：渲染 availableAgents 中的企业助手（不依赖 customAgents）
+  if (isEnterprise && sessionMode === 'remote' && availableAgents) {
+    const cloudAssistants = availableAgents.filter(
+      (a) => a.isPreset && a.customAgentId
+    );
+    if (cloudAssistants.length === 0) return null;
+
+    return (
+      <div className='mt-16px w-full'>
+        <div className='flex flex-wrap gap-8px justify-center'>
+          {cloudAssistants.map((assistant) => {
+            const avatarValue = assistant.avatar?.trim();
+            const isImageAvatar = Boolean(avatarValue && (/\.(svg|png|jpe?g|webp|gif)$/i.test(avatarValue) || /^(https?:|aion-asset:\/\/|file:\/\/|data:)/i.test(avatarValue)));
+            return (
+              <div key={assistant.customAgentId} className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid bg-fill-0 hover:bg-fill-1 select-none' style={{ borderWidth: '1px', borderColor: 'var(--bg-3)' }} onClick={() => onSelectAssistant(`custom:${assistant.customAgentId}`)}>
+                {isImageAvatar ? <img src={avatarValue} alt='' width={16} height={16} style={{ objectFit: 'contain' }} /> : avatarValue ? <span style={{ fontSize: 16, lineHeight: '18px' }}>{avatarValue}</span> : <Robot theme='outline' size={16} />}
+                <span className='text-14px text-2 hover:text-1'>{assistant.name}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // Local mode / C端：需要 customAgents 数据才能渲染
   if (!customAgents || customAgents.length === 0) return null;
 
   // Separate preset assistants (builtin + hub-installed) from user-created custom assistants

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -19,6 +19,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import { emitter } from '@/renderer/utils/emitter';
 
+// Module-level cache for cross-component-tree synchronous access (e.g., useConversations)
+// 模块级缓存，供非 GuidPage 组件树（如 useConversations）同步读取
+let rendererCachedSessionMode: 'remote' | 'local' = 'remote';
+
+/** 供 useConversations 等非 GuidPage 组件树同步读取当前 sessionMode */
+export function getRendererSessionMode(): 'remote' | 'local' {
+  return rendererCachedSessionMode;
+}
+
 /**
  * Moss Server assistant from cloud API
  */
@@ -95,6 +104,10 @@ export type GuidAgentSelectionResult = {
   isPresetAgent: boolean;
   availableAgents: AvailableAgent[] | undefined;
   customAgents: AcpBackendConfig[];
+  /** Current session mode (remote/local) - only meaningful in enterprise mode */
+  sessionMode: 'remote' | 'local';
+  /** Set session mode and trigger history refresh */
+  setSessionMode: (mode: 'remote' | 'local') => void;
   selectedMode: string;
   setSelectedMode: React.Dispatch<React.SetStateAction<string>>;
   acpCachedModels: Record<string, AcpModelInfo>;
@@ -143,6 +156,9 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   // Track availableAgents with ref for resetSelection to access
   const availableAgentsRef = useRef<AvailableAgent[] | undefined>(undefined);
   const [customAgents, setCustomAgents] = useState<AcpBackendConfig[]>([]);
+  // Session mode state (remote/local) - SSOT for enterprise mode
+  // sessionMode 状态（remote/local）— 企业模式的唯一权威来源
+  const [sessionMode, _setSessionMode] = useState<'remote' | 'local'>('remote');
   const [selectedMode, _setSelectedMode] = useState<string>('default');
   // Track whether mode was loaded from preferences to avoid overwriting during initial load
   const selectedAgentRef = useRef<string | null>(null);
@@ -191,6 +207,37 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       }
       return newModelId;
     });
+  }, []);
+
+  // --- sessionMode: initialization from ConfigStorage ---
+  // 应用启动时从 ConfigStorage 异步读取 sessionMode，同步更新模块缓存
+  useEffect(() => {
+    ConfigStorage.get('guid.sessionMode').then((stored) => {
+      const mode = stored ?? 'remote';
+      _setSessionMode(mode);
+      rendererCachedSessionMode = mode;
+      window.dispatchEvent(new Event('chat.history.refresh'));
+    });
+  }, []);
+
+  // --- sessionMode: setSessionMode wrapper with side effects ---
+  // setSessionMode 封装：同步模块缓存 + 持久化 + IPC + 刷新历史 + 重置 agent 选择
+  const setSessionMode = useCallback((mode: 'remote' | 'local') => {
+    _setSessionMode(mode);
+    rendererCachedSessionMode = mode;
+    ConfigStorage.set('guid.sessionMode', mode).catch(() => {});
+    ipcBridge.eeclaw.setSessionMode.invoke({ mode }).catch(() => {});
+    window.dispatchEvent(new Event('chat.history.refresh'));
+
+    // Reset selectedAgentKey to the default for the new mode
+    // 切换 mode 时重置 agent 选择为对应 mode 的默认值
+    if (mode === 'local') {
+      _setSelectedAgentKey('scode');
+      selectedAgentKeyRef.current = 'scode';
+    } else {
+      _setSelectedAgentKey('remote-agent');
+      selectedAgentKeyRef.current = 'remote-agent';
+    }
   }, []);
 
   // When isEnterprise changes, update the default agent selection
@@ -291,9 +338,12 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   }, [customAgents]);
 
   // --- SWR: Fetch available agents ---
-  const swrKey = isEnterprise ? 'eeclaw.agents.cloud' : 'acp.agents.available';
+  // E端 Remote 模式使用云端助手列表，其他模式使用本地 ACP agent 列表
+  const swrKey = (isEnterprise && sessionMode === 'remote')
+    ? 'eeclaw.agents.cloud'
+    : 'acp.agents.available';
   const { data: availableAgentsData } = useSWR(swrKey, async () => {
-    if (isEnterprise) {
+    if (isEnterprise && sessionMode === 'remote') {
       const result = await ipcBridge.eeclaw.getCloudAssistants.invoke();
       return result.data ?? [];
     }
@@ -303,8 +353,8 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
 
   useEffect(() => {
     if (availableAgentsData && Array.isArray(availableAgentsData)) {
-      if (isEnterprise) {
-        // Enterprise mode: Moss assistants go to customAgents, only Remote Agent in availableAgents
+      if (isEnterprise && sessionMode === 'remote') {
+        // Enterprise Remote mode: Moss assistants go to customAgents, only Remote Agent in availableAgents
         const enterpriseAgents = availableAgentsData as unknown as MossAssistant[];
 
         // Map Moss assistants to customAgents for bottom display
@@ -326,7 +376,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
         setAvailableAgents(availableAgentsData as AvailableAgent[]);
         availableAgentsRef.current = availableAgentsData as AvailableAgent[];
       }
-    } else if (isEnterprise) {
+    } else if (isEnterprise && sessionMode === 'remote') {
       // Enterprise mode: even if API fails, provide a default remote-agent
       // 企业模式：即使 API 失败，也提供默认的 remote-agent
       const defaultAgent: AvailableAgent = {
@@ -338,11 +388,11 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       availableAgentsRef.current = [defaultAgent];
       setCustomAgents([]); // Clear customAgents on API failure
     }
-  }, [availableAgentsData, isEnterprise]);
+  }, [availableAgentsData, isEnterprise, sessionMode]);
 
-  // Enterprise mode: keep current selection if valid
+  // Enterprise mode Remote session: keep current selection if valid
   useEffect(() => {
-    if (isEnterprise && availableAgents && availableAgents.length > 0) {
+    if (isEnterprise && sessionMode === 'remote' && availableAgents && availableAgents.length > 0) {
       const currentKey = selectedAgentKeyRef.current;
       // 'remote-agent' is always valid
       if (currentKey === 'remote-agent') return;
@@ -355,7 +405,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
         selectedAgentKeyRef.current = 'remote-agent';
       }
     }
-  }, [isEnterprise, availableAgents, customAgents]);
+  }, [isEnterprise, sessionMode, availableAgents, customAgents]);
 
   // Load last selected agent (skip when URL parameter takes priority)
   // Auto-select first available agent if current selection is not valid (enterprise mode case)
@@ -425,8 +475,9 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   }, [availableAgents, assistantFromUrl]); // Intentionally NOT including selectedAgentKey/state - use ref instead
 
   // Load custom agents + extension-contributed assistants
+  // E端 Remote 模式下跳过本地助手加载；E端 Local 模式和 C端都加载
   useEffect(() => {
-    if (isEnterprise) return; // 企业模式不需要本地自定义助手
+    if (isEnterprise && sessionMode === 'remote') return;
     let isActive = true;
     Promise.all([fetchAssistantsAsConfigs(), ipcBridge.extensions.getAssistants.invoke().catch(() => [] as Record<string, unknown>[])])
       .then(([agents, extAssistants]) => {
@@ -485,7 +536,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
     return () => {
       isActive = false;
     };
-  }, [isEnterprise, availableCustomAgentIds]);
+  }, [isEnterprise, sessionMode, availableCustomAgentIds]);
 
   // Pre-select assistant from URL parameter (assistantFromUrl)
   useEffect(() => {
@@ -843,7 +894,7 @@ This identity statement takes priority over the default identity in USER.md.
 
   const refreshCustomAgents = useCallback(async () => {
     try {
-      if (isEnterprise) {
+      if (isEnterprise && sessionMode === 'remote') {
         await mutate('eeclaw.agents.cloud');
         return;
       }
@@ -868,7 +919,7 @@ This identity statement takes priority over the default identity in USER.md.
     } catch (error) {
       console.error('Failed to refresh custom agents:', error);
     }
-  }, [isEnterprise]);
+  }, [isEnterprise, sessionMode]);
 
   useEffect(() => {
     void refreshCustomAgents();
@@ -881,7 +932,7 @@ This identity statement takes priority over the default identity in USER.md.
   // then revalidates the SWR cache so the UI picks up the change.
   useEffect(() => {
     const handler = () => {
-      if (isEnterprise) {
+      if (isEnterprise && sessionMode === 'remote') {
         void mutate('eeclaw.agents.cloud');
         return;
       }
@@ -893,14 +944,16 @@ This identity statement takes priority over the default identity in USER.md.
     return () => {
       emitter.off('guid.reset', handler);
     };
-  }, [isEnterprise]);
+  }, [isEnterprise, sessionMode]);
 
   // Reset agent selection to default state (no assistant selected)
   // In enterprise mode, directly select the first available agent (remote-agent)
   // 企业模式下直接选择第一个可用 agent
   const resetSelection = useCallback(() => {
-    _setSelectedAgentKey(isEnterprise ? 'remote-agent' : DEFAULT_PRESET_AGENT_TYPE);
-    selectedAgentKeyRef.current = isEnterprise ? 'remote-agent' : DEFAULT_PRESET_AGENT_TYPE;
+    // In enterprise remote mode, default to remote-agent; in local mode, default to scode
+    const defaultKey = isEnterprise && sessionMode === 'remote' ? 'remote-agent' : (isEnterprise && sessionMode === 'local' ? 'scode' : DEFAULT_PRESET_AGENT_TYPE);
+    _setSelectedAgentKey(defaultKey);
+    selectedAgentKeyRef.current = defaultKey;
     _setSelectedMode('default');
     _setSelectedAcpModel(null);
     hasAutoSelectedAgentRef.current = false;
@@ -939,7 +992,7 @@ This identity statement takes priority over the default identity in USER.md.
       _setSelectedAgentKey(DEFAULT_PRESET_AGENT_TYPE);
       selectedAgentKeyRef.current = DEFAULT_PRESET_AGENT_TYPE;
     }
-  }, [isEnterprise]);
+  }, [isEnterprise, sessionMode]);
 
   return {
     selectedAgentKey,
@@ -949,6 +1002,8 @@ This identity statement takes priority over the default identity in USER.md.
     isPresetAgent,
     availableAgents,
     customAgents,
+    sessionMode,
+    setSessionMode,
     selectedMode,
     setSelectedMode,
     acpCachedModels,

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -216,6 +216,13 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       const mode = stored ?? 'remote';
       _setSessionMode(mode);
       rendererCachedSessionMode = mode;
+      if (mode === 'local') {
+        _setSelectedAgentKey('scode');
+        selectedAgentKeyRef.current = 'scode';
+      } else {
+        _setSelectedAgentKey('remote-agent');
+        selectedAgentKeyRef.current = 'remote-agent';
+      }
       window.dispatchEvent(new Event('chat.history.refresh'));
     });
   }, []);

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -18,6 +18,7 @@ import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import { emitter } from '@/renderer/utils/emitter';
+import { EECLAW_AUTH_STORAGE_KEY } from '@/renderer/context/AuthContext';
 
 // Module-level cache for cross-component-tree synchronous access (e.g., useConversations)
 // 模块级缓存，供非 GuidPage 组件树（如 useConversations）同步读取
@@ -212,8 +213,22 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   // --- sessionMode: initialization from ConfigStorage ---
   // 应用启动时从 ConfigStorage 异步读取 sessionMode，同步更新模块缓存
   useEffect(() => {
-    ConfigStorage.get('guid.sessionMode').then((stored) => {
-      const mode = stored ?? 'remote';
+    ConfigStorage.get('guid.sessionMode').then(async (stored) => {
+      let mode = stored ?? 'remote';
+      // Validate localModeAvailable: fallback to remote if 'local' persisted but user lacks permission
+      if (mode === 'local') {
+        try {
+          const eeclawStored = localStorage.getItem(EECLAW_AUTH_STORAGE_KEY);
+          const authData = eeclawStored ? JSON.parse(eeclawStored) : null;
+          if (!authData?.user?.localModeAvailable) {
+            mode = 'remote';
+            await ConfigStorage.set('guid.sessionMode', 'remote').catch(() => {});
+          }
+        } catch {
+          mode = 'remote';
+          await ConfigStorage.set('guid.sessionMode', 'remote').catch(() => {});
+        }
+      }
       _setSessionMode(mode);
       rendererCachedSessionMode = mode;
       if (mode === 'local') {

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -236,6 +236,8 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
     ipcBridge.eeclaw.setSessionMode.invoke({ mode }).catch(() => {});
     emitter.emit('chat.history.refresh');
 
+    setCustomAgents([]);
+
     // Reset selectedAgentKey to the default for the new mode
     // 切换 mode 时重置 agent 选择为对应 mode 的默认值
     if (mode === 'local') {

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -223,7 +223,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
         _setSelectedAgentKey('remote-agent');
         selectedAgentKeyRef.current = 'remote-agent';
       }
-      window.dispatchEvent(new Event('chat.history.refresh'));
+      emitter.emit('chat.history.refresh');
     });
   }, []);
 
@@ -234,7 +234,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
     rendererCachedSessionMode = mode;
     ConfigStorage.set('guid.sessionMode', mode).catch(() => {});
     ipcBridge.eeclaw.setSessionMode.invoke({ mode }).catch(() => {});
-    window.dispatchEvent(new Event('chat.history.refresh'));
+    emitter.emit('chat.history.refresh');
 
     // Reset selectedAgentKey to the default for the new mode
     // 切换 mode 时重置 agent 选择为对应 mode 的默认值

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -468,7 +468,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
           return key === savedAgentKey;
         });
 
-        if (isInAvailable) {
+        if (isInAvailable && !(isEnterprise && sessionMode === 'local')) {
           _setSelectedAgentKeyWithRef(savedAgentKey);
         }
       } catch (error) {
@@ -1003,6 +1003,14 @@ This identity statement takes priority over the default identity in USER.md.
     }
   }, [isEnterprise, sessionMode]);
 
+  // For enterprise Local mode, only expose scode to the mention selector
+  const mentionAvailableAgents = useMemo(() => {
+    if (isEnterprise && sessionMode === 'local') {
+      return (availableAgents ?? []).filter(a => a.backend === 'scode');
+    }
+    return availableAgents;
+  }, [isEnterprise, sessionMode, availableAgents]);
+
   return {
     selectedAgentKey,
     setSelectedAgentKey,
@@ -1010,6 +1018,7 @@ This identity statement takes priority over the default identity in USER.md.
     selectedAgentInfo,
     isPresetAgent,
     availableAgents,
+    mentionAvailableAgents,
     customAgents,
     sessionMode,
     setSessionMode,

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -37,6 +37,9 @@ export type GuidSendDeps = {
   selectedAcpModel: string | null;
   currentModel: TProviderWithModel | undefined;
 
+  /** Current session mode (remote/local) for enterprise mode */
+  sessionMode: 'remote' | 'local';
+
   // Agent helpers
   findAgentByKey: (key: string) => AvailableAgent | undefined;
   getEffectiveAgentType: (agentInfo: { backend: AcpBackend; customAgentId?: string } | undefined) => EffectiveAgentInfo;
@@ -74,7 +77,7 @@ export type GuidSendResult = {
  * Hook that manages the send logic for all conversation types (acp/openclaw-gateway).
  */
 export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
-  const { input, setInput, files, setFiles, dir, setDir, setLoading, selectedSkills, selectedAgent, selectedAgentKey, selectedAgentInfo, isPresetAgent, selectedMode, selectedAcpModel, currentModel, findAgentByKey, getEffectiveAgentType, resolvePresetRulesAndSkills, resolveEnabledSkills, isMainAgentAvailable, getAvailableFallbackAgent, currentEffectiveAgentInfo, isGoogleAuth, setMentionOpen, setMentionQuery, setMentionSelectorOpen, setMentionActiveIndex, resetAgentSelection, setSelectedSkills, navigate, closeAllTabs, openTab, t } = deps;
+  const { input, setInput, files, setFiles, dir, setDir, setLoading, selectedSkills, selectedAgent, selectedAgentKey, selectedAgentInfo, isPresetAgent, selectedMode, selectedAcpModel, currentModel, sessionMode, findAgentByKey, getEffectiveAgentType, resolvePresetRulesAndSkills, resolveEnabledSkills, isMainAgentAvailable, getAvailableFallbackAgent, currentEffectiveAgentInfo, isGoogleAuth, setMentionOpen, setMentionQuery, setMentionSelectorOpen, setMentionActiveIndex, resetAgentSelection, setSelectedSkills, navigate, closeAllTabs, openTab, t } = deps;
 
   const { isEnterprise } = useAppMode();
 
@@ -108,11 +111,11 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
       }
     }
 
-    // Enterprise mode: always route through remote-agent, skip scode/gateway checks
-    // 企业模式：始终使用 remote-agent，跳过 scode/gateway 检查
-    // Note: custom agents in consumer mode should use local agents (acp/openclaw-gateway)
-    // 注意：个人模式下的自定义助手应该使用本地 Agent（acp/openclaw-gateway）
-    if (isEnterprise || selectedAgent === 'remote-agent' || selectedAgentKey === 'remote-agent') {
+    // Enterprise Remote mode: route through remote-agent
+    // 企业 Remote 模式：使用 remote-agent
+    // Local mode in enterprise: use ACP scode path (same as consumer)
+    // 企业 Local 模式：使用 ACP scode 路径（与 C 端相同）
+    if ((isEnterprise && sessionMode === 'remote') || selectedAgentKey === 'remote-agent') {
       console.log('Enterprise mode: Creating remote-agent conversation');
 
       try {
@@ -131,6 +134,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             presetAssistantId: agentInfo?.customAgentId || agentInfo?.name || 'Moss Server',
             sessionMode: selectedMode,
             dangerouslySkipPermissions: selectedMode === 'yolo',
+            sessionModeParam: 'remote',
           },
         });
 
@@ -285,6 +289,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             presetAssistantId: isPreset ? agentInfo?.customAgentId || acpAgentInfo?.customAgentId : undefined,
             sessionMode: isPreset ? resolveSessionMode(getPresetByAgentId(agentInfo?.customAgentId)?.defaultMode, acpBackend, selectedMode) : selectedMode,
             currentModelId: selectedAcpModel || undefined,
+            sessionModeParam: 'local',
           },
         });
 
@@ -314,7 +319,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
         throw error;
       }
     }
-  }, [input, files, dir, selectedAgent, selectedAgentKey, selectedAgentInfo, isPresetAgent, selectedMode, selectedAcpModel, currentModel, findAgentByKey, getEffectiveAgentType, resolvePresetRulesAndSkills, resolveEnabledSkills, isMainAgentAvailable, getAvailableFallbackAgent, navigate, closeAllTabs, openTab, t]);
+  }, [input, files, dir, selectedAgent, selectedAgentKey, selectedAgentInfo, isPresetAgent, selectedMode, selectedAcpModel, currentModel, sessionMode, findAgentByKey, getEffectiveAgentType, resolvePresetRulesAndSkills, resolveEnabledSkills, isMainAgentAvailable, getAvailableFallbackAgent, navigate, closeAllTabs, openTab, t]);
 
   const sendMessageHandler = useCallback(() => {
     setLoading(true);

--- a/src/renderer/pages/setup/ModeSetup.tsx
+++ b/src/renderer/pages/setup/ModeSetup.tsx
@@ -96,6 +96,9 @@ const ModeSetup: React.FC = () => {
         await ConfigStorage.set('eeclaw.serverUrl', normalizedUrl);
         await ConfigStorage.set('eeclaw.tenantName', result.data.app_company_name);
 
+        // Notify main process to start local services, then reload renderer
+        await ipcBridge.application.startConsumerServices.invoke();
+
         // Reload page — setAppMode triggers re-render that unmounts this component
         // before any navigation can execute, so use reload instead
         window.location.reload();


### PR DESCRIPTION
## Summary

- Add enterprise Local/Remote dual session mode based on `localAuth` field from Moss Server login response
- Control Local tab visibility via `localModeAvailable` (requires `localAuth=true` + complete config)
- Auto-generate/cleanup `sudocode.json` and sync `settings.json` model on login/logout
- Fix scode crash (exit code 1) when `settings.json` contains stale model not in current model list
- Show consumer-style single pill for enterprise users without Local access

## Key Changes

- **IPC chain**: Pass `localAuth`, `sudorouter_key`, `model_service_url`, `models` through `eeclawBridge` → `ipcBridge` → `AuthContext`
- **Permission control**: Local tab only visible when `localModeAvailable=true`; hidden for users without permission or with incomplete config
- **Credential management**: Generate `sudocode.json` on login, cleanup on logout; reset `sessionMode` to prevent stale state
- **Model sync**: Sync `settings.json` model to first valid model on both C-side and E-side login; pre-spawn validation as safety net
- **UI**: Enterprise users without Local access see a styled single "Remote Agent" pill instead of a bare Remote tab

## Test plan

- [ ] Login with admin account (localAuth=true) → verify Remote | Local tab switcher appears
- [ ] Login with test account (localAuth=false) → verify only "Remote Agent" single pill appears
- [ ] E-side Local mode → send message → verify scode works correctly
- [ ] E-side login → C-side login → verify settings.json model updated, scode starts without crash
- [ ] Manually set invalid model in settings.json → verify auto-corrected before spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)