### PR TITLE
fix: check _disable directory in isUserSkillEnabled() #584

### DIFF
--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -1147,8 +1147,17 @@ const skillsContentCache = new Map<string, string>();
 const SKILL_HUB_META_FILE = '_sudowork_meta.json';
 
 export async function isUserSkillEnabled(skillName: string): Promise<boolean> {
-  // Search in all subdirectories for the skill metadata
   const subdirs = [SKILL_SUBDIRS.custom, SKILL_SUBDIRS.hub, SKILL_SUBDIRS.system];
+
+  // First check if skill exists in any _disable directory (disabled via directory move)
+  for (const subdir of subdirs) {
+    const disabledSkillDir = path.join(getSkillsDir(), subdir, '_disable', skillName);
+    if (existsSync(disabledSkillDir)) {
+      return false;
+    }
+  }
+
+  // Search in all subdirectories for the skill metadata
   for (const subdir of subdirs) {
     const skillMetaPath = path.join(getSkillsDir(), subdir, skillName, SKILL_HUB_META_FILE);
     try {


### PR DESCRIPTION
Fix disabled skills still being loadable by checking the `_disable` directory in `isUserSkillEnabled()`.

When a skill is disabled via `SkillManager.disableSkill()`, it gets moved to a `_disable` subdirectory. However, `isUserSkillEnabled()` only checked the normal skill directories for the meta file, and fell through to `return true` when it wasn't found — making disabled skills appear enabled.

This fix adds a check for the skill directory in `_disable` subdirectories before checking meta files.

Fixes #584

Generated with [Claude Code](https://claude.ai/code)