### PR TITLE
fix(dingtalk): 修复钉钉连接睡眠唤醒后无响应及 i18n 问题

### DIFF
--- a/src/channels/core/ChannelManager.ts
+++ b/src/channels/core/ChannelManager.ts
@@ -700,6 +700,25 @@ export class ChannelManager {
     return cleanedUp;
   }
 
+  // ==================== System Resume ====================
+
+  /**
+   * Resume all running plugins after system wake from sleep.
+   * Called from powerMonitor.on('resume').
+   */
+  async resumePlugins(): Promise<void> {
+    if (!this.pluginManager) return;
+
+    const plugins = this.pluginManager.getAllPlugins();
+    for (const plugin of plugins) {
+      try {
+        await plugin.resume();
+      } catch (error) {
+        console.error('[ChannelManager] Failed to resume plugin:', error);
+      }
+    }
+  }
+
   // ==================== Accessors ====================
 
   /**

--- a/src/channels/plugins/BasePlugin.ts
+++ b/src/channels/plugins/BasePlugin.ts
@@ -239,6 +239,14 @@ export abstract class BasePlugin {
    */
   abstract getBotInfo(): { username?: string; displayName?: string } | null;
 
+  /**
+   * Resume connection after system wake from sleep.
+   * Override in subclasses that need to re-establish connections.
+   */
+  async resume(): Promise<void> {
+    // Default: no-op
+  }
+
   // ==================== Static Methods ====================
 
   /**

--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -28,6 +28,12 @@ import type { DingTalkStreamMessage } from './DingTalkAdapter';
 const EVENT_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const EVENT_CACHE_CLEANUP_INTERVAL = 60 * 1000; // 1 minute
 
+// Reconnection settings
+const RECONNECT_INITIAL_DELAY = 1000;  // 1 second
+const RECONNECT_MAX_DELAY = 60 * 1000; // 60 seconds
+const RECONNECT_BACKOFF_FACTOR = 2;
+const HEALTH_CHECK_INTERVAL = 30 * 1000; // 30 seconds
+
 // DingTalk API base URL (new version)
 const DINGTALK_API_BASE = 'https://api.dingtalk.com';
 
@@ -86,6 +92,12 @@ export class DingTalkPlugin extends BasePlugin {
   // Store sessionWebhook per chatId for fallback sending
   private webhookCache: Map<string, string> = new Map();
 
+  // Reconnection state
+  private shouldReconnect: boolean = false;
+  private reconnectDelay: number = RECONNECT_INITIAL_DELAY;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
+
   // Local directory for downloaded media files (lazy-initialized)
   private mediaDir: string | null = null;
 
@@ -105,6 +117,60 @@ export class DingTalkPlugin extends BasePlugin {
   }
 
   /**
+   * Create DWClient instance and register callbacks.
+   * Extracted from onStart() for reuse during reconnection.
+   */
+  private async createClient(): Promise<void> {
+    // Use `as any` to bypass SDK type declaration deficiency: the DWClient constructor's
+    // TypeScript signature (client.d.ts:62-68) does not include autoReconnect, but the
+    // runtime merges it via {...defaultConfig, ...opts} (client.mjs:41-44).
+    // Must explicitly disable autoReconnect: otherwise the SDK's auto-reconnect (1s delay)
+    // fires before our health check (30s), causing heartbeat interval leaks
+    // (close handler doesn't clear old interval, client.mjs:166-176).
+    this.client = new DWClient({
+      clientId: this.clientId,
+      clientSecret: this.clientSecret,
+      keepAlive: true,
+      autoReconnect: false,
+      debug: false,
+    } as any);
+
+    // Register robot message listener (TOPIC_ROBOT uses CALLBACK type in Stream protocol)
+    this.client.registerCallbackListener(TOPIC_ROBOT, (msg: DWClientDownStream) => {
+      // Immediately acknowledge the message to prevent retry
+      this.client?.socketCallBackResponse(msg.headers.messageId, EventAck.SUCCESS);
+
+      // Process message asynchronously
+      try {
+        const data: DingTalkStreamMessage = JSON.parse(msg.data);
+        void this.handleRobotMessage(data, msg.headers.messageId).catch((error) => {
+          mainError('DingTalkPlugin', 'Error handling robot message', error);
+        });
+      } catch (error) {
+        mainError('DingTalkPlugin', 'Failed to parse robot message', error);
+      }
+    });
+
+    // Register card callback listener
+    this.client.registerCallbackListener(TOPIC_CARD, (msg: DWClientDownStream) => {
+      // Acknowledge card callback
+      this.client?.socketCallBackResponse(msg.headers.messageId, EventAck.SUCCESS);
+
+      // Process card action asynchronously
+      try {
+        const data = JSON.parse(msg.data);
+        void this.handleCardCallback(data, msg.headers.messageId).catch((error) => {
+          mainError('DingTalkPlugin', 'Error handling card callback', error);
+        });
+      } catch (error) {
+        mainError('DingTalkPlugin', 'Failed to parse card callback', error);
+      }
+    });
+
+    await this.client.connect();
+  }
+
+  /**
    * Start WebSocket Stream connection
    */
   protected async onStart(): Promise<void> {
@@ -113,56 +179,12 @@ export class DingTalkPlugin extends BasePlugin {
     }
 
     try {
-      // Refresh access token first
       await this.refreshAccessToken();
-
-      // Create DWClient
-      this.client = new DWClient({
-        clientId: this.clientId,
-        clientSecret: this.clientSecret,
-        keepAlive: true,
-        debug: false,
-      });
-
-      // Register robot message listener (TOPIC_ROBOT uses CALLBACK type in Stream protocol)
-      this.client.registerCallbackListener(TOPIC_ROBOT, (msg: DWClientDownStream) => {
-        // Immediately acknowledge the message to prevent retry
-        this.client?.socketCallBackResponse(msg.headers.messageId, EventAck.SUCCESS);
-
-        // Process message asynchronously
-        try {
-          const data: DingTalkStreamMessage = JSON.parse(msg.data);
-          void this.handleRobotMessage(data, msg.headers.messageId).catch((error) => {
-            mainError('DingTalkPlugin', 'Error handling robot message', error);
-          });
-        } catch (error) {
-          mainError('DingTalkPlugin', 'Failed to parse robot message', error);
-        }
-      });
-
-      // Register card callback listener
-      this.client.registerCallbackListener(TOPIC_CARD, (msg: DWClientDownStream) => {
-        // Acknowledge card callback
-        this.client?.socketCallBackResponse(msg.headers.messageId, EventAck.SUCCESS);
-
-        // Process card action asynchronously
-        try {
-          const data = JSON.parse(msg.data);
-          void this.handleCardCallback(data, msg.headers.messageId).catch((error) => {
-            mainError('DingTalkPlugin', 'Error handling card callback', error);
-          });
-        } catch (error) {
-          mainError('DingTalkPlugin', 'Failed to parse card callback', error);
-        }
-      });
-
-      // Connect
-      await this.client.connect();
+      this.shouldReconnect = true;
+      await this.createClient();
       this.isConnected = true;
-
-      // Start event cache cleanup timer
       this.startEventCleanup();
-
+      this.startHealthCheck();
       mainLog('DingTalkPlugin', `Started for client ${this.clientId}`);
     } catch (error) {
       mainError('DingTalkPlugin', 'Failed to start', error);
@@ -174,6 +196,9 @@ export class DingTalkPlugin extends BasePlugin {
    * Stop connection and cleanup
    */
   protected async onStop(): Promise<void> {
+    this.shouldReconnect = false;
+    this.stopHealthCheck();
+    this.stopReconnect();
     this.stopEventCleanup();
 
     if (this.client) {
@@ -193,6 +218,132 @@ export class DingTalkPlugin extends BasePlugin {
     this.isConnected = false;
 
     mainLog('DingTalkPlugin', 'Stopped and cleaned up');
+  }
+
+  // ==================== Reconnection ====================
+
+  /**
+   * Reconnect to DingTalk Stream with a fresh DWClient instance.
+   * Destroys the old instance (clearing its heartbeat interval),
+   * refreshes the access token, then creates a new connection.
+   */
+  private async reconnect(): Promise<void> {
+    // Defensively stop health check to prevent timer leaks from any future call path
+    this.stopHealthCheck();
+
+    // Guard: if connection is already alive, skip reconnect.
+    // Prevents resume() and health check from triggering a double reconnect
+    // that would kill the first one's newly established connection.
+    if (this.client && this.client.connected && this.client.registered) {
+      this.isConnected = true;
+      this.reconnectDelay = RECONNECT_INITIAL_DELAY;
+      this.startHealthCheck();
+      return;
+    }
+
+    // 1. Destroy old instance (disconnect clears heartbeat interval)
+    if (this.client) {
+      try {
+        this.client.disconnect();
+      } catch {}
+      this.client = null;
+    }
+
+    this.isConnected = false;
+
+    // 2. Refresh token
+    await this.refreshAccessToken();
+
+    // 3. Create fresh DWClient instance and connect
+    await this.createClient();
+
+    // 4. Update state and restart health check
+    this.isConnected = true;
+    this.reconnectDelay = RECONNECT_INITIAL_DELAY;
+    this.startHealthCheck();
+    mainLog('DingTalkPlugin', 'Reconnected successfully');
+  }
+
+  /**
+   * Schedule a reconnection attempt with exponential backoff.
+   */
+  private scheduleReconnect(): void {
+    if (!this.shouldReconnect) return;
+    this.stopReconnect();
+
+    mainLog('DingTalkPlugin', `Reconnecting in ${this.reconnectDelay / 1000}s...`);
+
+    this.reconnectTimer = setTimeout(() => {
+      void this.reconnect()
+        .then(() => {
+          this.setStatus('running');
+        })
+        .catch((error) => {
+          mainError('DingTalkPlugin', 'Reconnection failed:', error);
+          this.reconnectDelay = Math.min(
+            this.reconnectDelay * RECONNECT_BACKOFF_FACTOR,
+            RECONNECT_MAX_DELAY
+          );
+          this.scheduleReconnect();
+        });
+    }, this.reconnectDelay);
+  }
+
+  private stopReconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // ==================== Health Check ====================
+
+  /**
+   * Periodically check SDK connection state.
+   * SDK sets client.connected=false / client.registered=false on SYSTEM "disconnect"
+   * without closing the WebSocket, so we poll these flags.
+   */
+  private startHealthCheck(): void {
+    this.stopHealthCheck();
+    this.healthCheckTimer = setInterval(() => {
+      if (this.shouldReconnect && this.client) {
+        if (!this.client.connected || !this.client.registered) {
+          mainWarn('DingTalkPlugin', 'Connection lost detected by health check', {
+            connected: this.client.connected,
+            registered: this.client.registered,
+          });
+          this.isConnected = false;
+          this.scheduleReconnect();
+          this.stopHealthCheck();
+        }
+      }
+    }, HEALTH_CHECK_INTERVAL);
+  }
+
+  private stopHealthCheck(): void {
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = null;
+    }
+  }
+
+  // ==================== System Resume ====================
+
+  /**
+   * Resume connection after system wake from sleep.
+   * Called by ChannelManager.resumePlugins() from powerMonitor.on('resume').
+   */
+  async resume(): Promise<void> {
+    if (!this.shouldReconnect || !this.client) return;
+
+    // Check if connection has died
+    if (!this.client.connected || !this.client.registered) {
+      mainLog('DingTalkPlugin', 'System resume: connection lost, triggering reconnect');
+      this.isConnected = false;
+      this.reconnectDelay = RECONNECT_INITIAL_DELAY;
+      this.stopHealthCheck();
+      this.scheduleReconnect();
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1030,6 +1030,15 @@ const handleAppReady = async (): Promise<void> => {
       .catch((error) => {
         console.error('[App] Failed to handle system resume for cron:', error);
       });
+
+    // Resume channel plugins (re-establish connections lost during sleep)
+    import('@/channels')
+      .then(({ getChannelManager }) => {
+        void getChannelManager().resumePlugins();
+      })
+      .catch((error) => {
+        console.error('[App] Failed to handle system resume for channels:', error);
+      });
   });
 };
 

--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -388,7 +388,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
         required
       >
         {hasExistingUsers ? (
-          <Tooltip content={t('settings.assistant.tokenLocked', 'Please close the Channel and delete all authorized users before modifying')}>
+          <Tooltip content={t('settings.assistant.tokenLocked', '请先关闭 Channel 并删除所有已授权用户后，再尝试修改')}>
             <span>
               <Input
                 value={clientId}
@@ -441,7 +441,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
         required
       >
         {hasExistingUsers ? (
-          <Tooltip content={t('settings.assistant.tokenLocked', 'Please close the Channel and delete all authorized users before modifying')}>
+          <Tooltip content={t('settings.assistant.tokenLocked', '请先关闭 Channel 并删除所有已授权用户后，再尝试修改')}>
             <span>
               <Input.Password
                 value={clientSecret}

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -385,7 +385,6 @@
   "assistant.copyCode": "Copy pairing code",
   "assistant.modelSaved": "Model saved",
   "assistant.modelSaveFailed": "Failed to save model",
-  "assistant.tokenLocked": "Please close the Channel and delete all authorized users before modifying the configuration",
   "assistant.tokenValid": "Token valid",
   "assistant.defaultModel": "Default Model",
   "assistant.defaultModelDesc": "Model used for Telegram conversations. Default uses GEMINI CLI as Agent",
@@ -654,7 +653,8 @@
     "agentDescTelegram": "Used for Telegram conversations",
     "autoFollowCliModel": "Automatically follow the model when CLI is running",
     "agentSwitched": "Agent switched successfully",
-    "modelSwitched": "Model switched successfully"
+    "modelSwitched": "Model switched successfully",
+    "tokenLocked": "Please close the Channel and delete all authorized users before modifying the configuration"
   },
   "lark": {
     "appId": "App ID",

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -372,7 +372,6 @@
   "assistant.copyCode": "Eşleştirme kodunu kopyala",
   "assistant.modelSaved": "Model kaydedildi",
   "assistant.modelSaveFailed": "Model kaydedilemedi",
-  "assistant.tokenLocked": "Yapılandırmayı değiştirmeden önce lütfen Channel'ı kapatın ve tüm yetkili kullanıcıları silin",
   "assistant.tokenValid": "Token geçerli",
   "assistant.defaultModel": "Varsayılan Model",
   "assistant.defaultModelDesc": "Telegram sohbetleri için kullanılan model. Varsayılan olarak GEMINI CLI Ajanı kullanılır.",
@@ -623,7 +622,8 @@
     "agentDescTelegram": "Telegram sohbetleri icin kullanilir",
     "autoFollowCliModel": "CLI calisirken modeli otomatik olarak takip et",
     "agentSwitched": "Agent basariyla degistirildi",
-    "modelSwitched": "Model basariyla degistirildi"
+    "modelSwitched": "Model basariyla degistirildi",
+    "tokenLocked": "Yapılandırmayı değiştirmeden önce lütfen Channel'ı kapatın ve tüm yetkili kullanıcıları silin"
   },
   "lark": {
     "appId": "App ID",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -385,7 +385,6 @@
   "assistant.copyCode": "复制配对码",
   "assistant.modelSaved": "模型已保存",
   "assistant.modelSaveFailed": "保存模型失败",
-  "assistant.tokenLocked": "请先关闭 Channel 并删除所有已授权用户后，再尝试修改",
   "assistant.tokenValid": "Token 有效",
   "assistant.defaultModel": "对话模型",
   "assistant.defaultModelDesc": "用于Agent对话时调用",
@@ -654,7 +653,8 @@
     "agentDescTelegram": "用于与Channel进行对话",
     "autoFollowCliModel": "自动跟随CLI运行时的模型",
     "agentSwitched": "Agent 切换成功",
-    "modelSwitched": "模型切换成功"
+    "modelSwitched": "模型切换成功",
+    "tokenLocked": "请先关闭 Channel 并删除所有已授权用户后，再尝试修改"
   },
   "lark": {
     "appId": "App ID",


### PR DESCRIPTION
## Summary
- 增加应用层健康检查（30s）和指数退避重连（1s→60s），绕过 `dingtalk-stream` SDK 心跳间隔泄漏 bug
- 增加 `powerMonitor.on('resume')` 系统唤醒后主动恢复插件连接
- 修复 Tooltip `tokenLocked` 提示不支持 i18n，将翻译 key 迁移到嵌套对象并清理死代码

## Test plan
- [ ] 配置钉钉连接，确认正常收发消息
- [ ] 断开网络，观察健康检查日志和指数退避重连
- [ ] 合上笔记本睡眠后再唤醒，确认钉钉自动重连并正常工作
- [ ] 系统语言设为中文时，Tooltip 显示中文提示
- [ ] 切换其他语言时，Tooltip 显示对应语言

🤖 Generated with [Claude Code](https://claude.com/claude-code)