### PR TITLE
fix(sendbox): wire @file selection to atPath for thumbnail display

### DIFF
--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -58,7 +58,9 @@ const SendBox: React.FC<{
   onSkillsChange?: (skills: string[]) => void;
   /** Workspace files for @ file references */
   workspaceFiles?: WorkspaceFileItem[];
-}> = ({ onSend, onStop, prefix, className, loading, tools, disabled, placeholder, value: input = '', onChange: setInput = constVoid, onFilesAdded, supportedExts = allSupportedExts, defaultMultiLine = false, lockMultiLine = false, sendButtonPrefix, slashCommands = [], onSlashBuiltinCommand, onSkillsChange, workspaceFiles }) => {
+  /** Called when a file is selected via @ selector, allowing parent to track the file */
+  onAtFileSelected?: (file: WorkspaceFileItem) => void;
+}> = ({ onSend, onStop, prefix, className, loading, tools, disabled, placeholder, value: input = '', onChange: setInput = constVoid, onFilesAdded, supportedExts = allSupportedExts, defaultMultiLine = false, lockMultiLine = false, sendButtonPrefix, slashCommands = [], onSlashBuiltinCommand, onSkillsChange, workspaceFiles, onAtFileSelected }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const { t } = useTranslation();
@@ -353,6 +355,7 @@ const SendBox: React.FC<{
       // Replace @query with @relativePath in input
       const newInput = replaceAtQuery(input, `@${file.relativePath}`, cursorPosition);
       setInput(newInput);
+      onAtFileSelected?.(file);
     },
   });
 

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -865,6 +865,17 @@ const AcpSendBox: React.FC<{
         }}
         sendButtonPrefix={tokenUsage ? <ContextUsageIndicator tokenUsage={tokenUsage} contextLimit={contextLimit > 0 ? contextLimit : undefined} size={24} /> : undefined}
         workspaceFiles={workspaceFiles}
+        onAtFileSelected={(file) => {
+          const item: FileOrFolderItem = {
+            path: file.fullPath,
+            name: file.name,
+            isFile: file.isFile,
+            relativePath: file.relativePath,
+          };
+          const newAtPath = mergeFileSelectionItems([...atPath], [item]);
+          setAtPath(newAtPath);
+          emitter.emit('acp.selected.file.append', [item]);
+        }}
       ></SendBox>
       <BdpanFileSelector
         visible={bdpanSelectorVisible}


### PR DESCRIPTION
## Summary

- Wire the `onSelectFile` callback in `SendBox` to update `atPath` state via new `onAtFileSelected` prop
- Fix missing file thumbnails in message bubbles when selecting files via `@` mention

## Root Cause

`onSelectFile` only updated input text (`setInput`) without adding the file to `atPath`, so `allFiles` was empty at send time and the backend didn't include `[[NEXUS_FILES]]` markers.

## Test plan

- [ ] In SudoCode conversation, type `@`, switch to Files tab, select an image → send → verify thumbnail appears in message bubble
- [ ] Click thumbnail → verify full-size view opens
- [ ] Select non-image files (PDF/Word/Excel/PPT) → verify file icon + name displayed
- [ ] E-side conversation → verify @file selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)