### PR TITLE
feat(timer): preserve processing timer across conversation switches

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -209,6 +209,8 @@ interface IChatConversation<T, Extra> {
   extra: Extra;
   model: TProviderWithModel;
   status?: 'pending' | 'running' | 'finished' | undefined;
+  /** 处理开始时间戳（毫秒），用于恢复计时器 / Processing start timestamp in milliseconds for timer restoration */
+  processingStartTime?: number;
   /** 会话来源，默认为 aionui / Conversation source, defaults to aionui */
   source?: ConversationSource;
   /** Channel chat isolation ID (e.g. user:xxx, group:xxx) */

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -730,6 +730,10 @@ export function initConversationBridge(): void {
         const task = WorkerManage.getTaskById(id);
         const taskStatus = task?.status === 'idle' ? 'finished' : task?.status;
         conversation.status = taskStatus || 'finished';
+        // Update processingStartTime from running task / 从运行中的任务更新处理开始时间
+        if (task?.processingStartTime) {
+          conversation.processingStartTime = task.processingStartTime;
+        }
       }
 
       return conversation;

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -625,6 +625,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
     const managerSendStart = Date.now();
     cronBusyGuard.setProcessing(this.conversation_id, true);
     this.status = 'running';
+    this.processingStartTime = Date.now();
 
     // Reset user cancelled flag for new message
     this.userCancelled = false;

--- a/src/process/task/BaseAgent.ts
+++ b/src/process/task/BaseAgent.ts
@@ -18,6 +18,8 @@ class BaseAgent<Data, ConfirmationOption extends any = any> {
   protected conversation_id: string;
   protected confirmations: Array<IConfirmation<ConfirmationOption>> = [];
   status: 'pending' | 'running' | 'finished' | 'idle' | undefined;
+  /** 处理开始时间戳（毫秒）/ Processing start timestamp in milliseconds */
+  processingStartTime: number | undefined;
 
   /**
    * Whether this agent is in yolo mode (auto-approve)

--- a/src/process/task/OpenClawAgent.ts
+++ b/src/process/task/OpenClawAgent.ts
@@ -446,6 +446,7 @@ class OpenClawAgent extends BaseAgent<OpenClawAgentData> {
   async sendMessage(data: { content: string; agentContent?: string; files?: string[]; msg_id?: string; skills?: string[] }) {
     cronBusyGuard.setProcessing(this.conversation_id, true);
     this.status = 'running';
+    this.processingStartTime = Date.now();
     mainLog('OpenClawAgent', `sendMessage called: content="${data.content?.substring(0, 50)}..."`);
     try {
       await this.bootstrap;

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -241,6 +241,7 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
     mainLog('RemoteAgent', `sendMessage called for conversation ${this.conversation_id}`);
     mainLog('RemoteAgent', `content length: ${data.content?.length || 0}, files: ${data.files?.length || 0}`);
     this.status = 'running';
+    this.processingStartTime = Date.now();
 
     try {
       mainLog('RemoteAgent', 'Calling initAgent...');

--- a/src/renderer/components/ThoughtDisplay.tsx
+++ b/src/renderer/components/ThoughtDisplay.tsx
@@ -19,6 +19,8 @@ interface ThoughtDisplayProps {
   style?: 'default' | 'compact';
   running?: boolean;
   onStop?: () => void;
+  /** 处理开始时间戳（毫秒），用于恢复计时器 / Processing start timestamp in milliseconds for timer restoration */
+  startTime?: number;
 }
 
 // 背景渐变常量 Background gradient constants
@@ -35,16 +37,11 @@ const formatElapsedTime = (seconds: number): string => {
   return `${minutes}m ${remainingSeconds}s`;
 };
 
-const ThoughtDisplay: React.FC<ThoughtDisplayProps> = ({ thought, style = 'default', running = false, onStop: _onStop }) => {
+const ThoughtDisplay: React.FC<ThoughtDisplayProps> = ({ thought, style = 'default', running = false, onStop: _onStop, startTime }) => {
   const { theme } = useThemeContext();
   const { t } = useTranslation();
   const [elapsedTime, setElapsedTime] = useState(0);
   const startTimeRef = useRef<number>(0);
-
-  // 初始化 startTimeRef
-  useEffect(() => {
-    startTimeRef.current = Date.now();
-  }, []);
 
   // 计时器 Timer for elapsed time
   useEffect(() => {
@@ -53,9 +50,13 @@ const ThoughtDisplay: React.FC<ThoughtDisplayProps> = ({ thought, style = 'defau
       return;
     }
 
-    // 开始新的计时
-    startTimeRef.current = Date.now();
-    setElapsedTime(0);
+    // 使用传入的 startTime 或当前时间 Use provided startTime or current time
+    const effectiveStartTime = startTime ?? Date.now();
+    startTimeRef.current = effectiveStartTime;
+
+    // 如果有 startTime，计算初始已用时间 Calculate initial elapsed time if startTime was provided
+    const initialElapsed = startTime ? Math.floor((Date.now() - startTime) / 1000) : 0;
+    setElapsedTime(Math.max(0, initialElapsed));
 
     const timer = setInterval(() => {
       const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
@@ -63,7 +64,7 @@ const ThoughtDisplay: React.FC<ThoughtDisplayProps> = ({ thought, style = 'defau
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [running, thought?.subject]);
+  }, [running, thought?.subject, startTime]);
 
   // 根据主题和样式计算最终样式 Calculate final style based on theme and style prop
   const containerStyle = useMemo(() => {

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -52,6 +52,7 @@ const useAcpMessage = (conversation_id: string) => {
   const [aiProcessing, setAiProcessing] = useState(false); // New loading state for AI response
   const [tokenUsage, setTokenUsage] = useState<TokenUsageData | null>(null);
   const [contextLimit, setContextLimit] = useState<number>(0);
+  const [processingStartTime, setProcessingStartTime] = useState<number | undefined>(undefined);
 
   // Use refs to sync state for immediate access in event handlers
   // 使用 ref 同步状态，以便在事件处理程序中立即访问
@@ -347,6 +348,7 @@ const useAcpMessage = (conversation_id: string) => {
         runningRef.current = false;
         setAiProcessing(false);
         aiProcessingRef.current = false;
+        setProcessingStartTime(undefined);
         return;
       }
       const isRunning = res.status === 'running';
@@ -354,6 +356,14 @@ const useAcpMessage = (conversation_id: string) => {
       runningRef.current = isRunning;
       setAiProcessing(isRunning);
       aiProcessingRef.current = isRunning;
+
+      // Restore processingStartTime for timer restoration
+      // 恢复 processingStartTime 用于计时器恢复
+      if (res.processingStartTime) {
+        setProcessingStartTime(res.processingStartTime);
+      } else {
+        setProcessingStartTime(undefined);
+      }
 
       // Restore persisted context usage data
       if (res.type === 'acp' && res.extra?.lastTokenUsage) {
@@ -384,7 +394,7 @@ const useAcpMessage = (conversation_id: string) => {
     hasContentInTurnRef.current = false;
   }, []);
 
-  return { thought, setThought, running, acpStatus, aiProcessing, setAiProcessing, resetState, tokenUsage, contextLimit };
+  return { thought, setThought, running, acpStatus, aiProcessing, setAiProcessing, resetState, tokenUsage, contextLimit, processingStartTime };
 };
 
 const EMPTY_AT_PATH: Array<string | FileOrFolderItem> = [];
@@ -429,7 +439,7 @@ const AcpSendBox: React.FC<{
   agentName?: string;
   onAiProcessingChange?: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({ conversation_id, backend, sessionMode, agentName, onAiProcessingChange }) => {
-  const { thought, running, acpStatus, aiProcessing, setAiProcessing, resetState, tokenUsage, contextLimit } = useAcpMessage(conversation_id);
+  const { thought, running, acpStatus, aiProcessing, setAiProcessing, resetState, tokenUsage, contextLimit, processingStartTime } = useAcpMessage(conversation_id);
   const { t } = useTranslation();
   const workspaceFiles = useWorkspaceFiles();
   const { checkAndUpdateTitle } = useAutoTitle();
@@ -740,7 +750,7 @@ const AcpSendBox: React.FC<{
   return (
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
       {messageContextHolder}
-      <ThoughtDisplay thought={thought} running={running || aiProcessing} onStop={handleStop} />
+      <ThoughtDisplay thought={thought} running={running || aiProcessing} onStop={handleStop} startTime={processingStartTime} />
 
       <SendBox
         value={content}

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -115,6 +115,7 @@ const OpenClawSendBox: React.FC<{
     description: '',
     subject: '',
   });
+  const [processingStartTime, setProcessingStartTime] = useState<number | undefined>(undefined);
 
   // Use ref to sync state for immediate access in event handlers
   // 使用 ref 同步状态，以便在事件处理程序中立即访问
@@ -233,11 +234,20 @@ const OpenClawSendBox: React.FC<{
       if (!res) {
         setAiProcessing(false);
         aiProcessingRef.current = false;
+        setProcessingStartTime(undefined);
         return;
       }
       const isRunning = res.status === 'running';
       setAiProcessing(isRunning);
       aiProcessingRef.current = isRunning;
+
+      // Restore processingStartTime for timer restoration
+      // 恢复 processingStartTime 用于计时器恢复
+      if (res.processingStartTime) {
+        setProcessingStartTime(res.processingStartTime);
+      } else {
+        setProcessingStartTime(undefined);
+      }
     });
 
     // Eagerly initialize the OpenClaw agent and recover its connection status.
@@ -594,7 +604,7 @@ const OpenClawSendBox: React.FC<{
   return (
     <div className='max-w-800px w-full mx-auto flex flex-col mt-auto mb-16px'>
       {messageContextHolder}
-      <ThoughtDisplay thought={thought} running={aiProcessing} onStop={handleStop} />
+      <ThoughtDisplay thought={thought} running={aiProcessing} onStop={handleStop} startTime={processingStartTime} />
 
       <SendBox
         value={content}


### PR DESCRIPTION
## Summary
- Save `processingStartTime` in backend when agent starts running
- Restore timer from saved start time when switching conversations
- Prevents timer from resetting to 0 on every conversation switch

## Changes

### Backend
- Added `processingStartTime` field to `IChatConversation` interface
- Added `processingStartTime` property to `BaseAgent` class
- Set `processingStartTime = Date.now()` in `AcpAgent`, `OpenClawAgent`, `RemoteAgent` when status becomes running
- Pass `processingStartTime` from task to conversation in `conversationBridge`

### Frontend
- Added `startTime` prop to `ThoughtDisplay` component
- Restore `processingStartTime` from `conversation.get` response in `AcpSendBox` and `OpenClawSendBox`
- Pass `processingStartTime` to `ThoughtDisplay` for timer restoration

## Test plan
- [ ] Start a conversation and send a message
- [ ] While processing, switch to another conversation
- [ ] Switch back to the running conversation
- [ ] Verify timer shows correct elapsed time (not 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)