### PR TITLE
fix(workspace): 通道工作区隐藏 dot-file 显示

### DIFF
--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -16,7 +16,7 @@ import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { iconColors } from '@/renderer/theme/colors';
 import { emitter } from '@/renderer/utils/emitter';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { getLastDirectoryName, isTemporaryWorkspace as checkIsTemporaryWorkspace, getWorkspaceDisplayName as getDisplayName } from '@/renderer/utils/workspace';
+import { getLastDirectoryName, isTemporaryWorkspace as checkIsTemporaryWorkspace, isChannelWorkspace as checkIsChannelWorkspace, getWorkspaceDisplayName as getDisplayName } from '@/renderer/utils/workspace';
 import { Checkbox, Input, Message, Modal, Tooltip, Tree } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
 import { AudioFile, Cloudy, DownSmall, FileCode, FileExcel, FileGif, FileJpg, FilePdf, FilePpt, FileText, FileTxt, FileWord, FileZip, FolderOpen, Magic, Refresh, Search, VideoFile } from '@icon-park/react';
@@ -491,6 +491,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
   const rootName = treeHook.files[0]?.name ?? '';
   // Check if this is a temporary workspace (check both path and root folder name)
   const isTemporaryWorkspace = checkIsTemporaryWorkspace(workspace) || checkIsTemporaryWorkspace(rootName);
+  const isChannelWorkspace = checkIsChannelWorkspace(workspace) || checkIsChannelWorkspace(rootName);
 
   // 当只有一个根目录且有子文件时，隐藏根目录直接展示子文件，因为 Toolbar 已经作为一级目录
   // Hide root directory when there's a single root with children, as Toolbar serves as the first-level directory
@@ -498,7 +499,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
   const visibleTreeData = useMemo(() => {
     let data = rawTreeData;
 
-    if (isTemporaryWorkspace) {
+    if (isTemporaryWorkspace || isChannelWorkspace) {
       const filterNodes = (nodes: IDirOrFile[]): IDirOrFile[] =>
         nodes
           .filter((node) => !isHiddenWorkspaceEntry(node.name))
@@ -512,7 +513,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
 
     // 按文件名正序排列（文件夹优先）/ Sort by filename ascending (directories first)
     return sortTreeNodes(data);
-  }, [isTemporaryWorkspace, rawTreeData]);
+  }, [isTemporaryWorkspace, isChannelWorkspace, rawTreeData]);
 
   const treeData = useMemo(() => {
     const decorateNodes = (nodes: IDirOrFile[]): IDirOrFile[] =>

--- a/src/renderer/utils/workspace.ts
+++ b/src/renderer/utils/workspace.ts
@@ -84,3 +84,12 @@ export const getLastDirectoryName = (path: string): string => {
   const parts = splitPathSegments(path);
   return parts[parts.length - 1] || path;
 };
+
+/**
+ * Check if a workspace path is a channel workspace (e.g. channel-media/dingtalk)
+ * 检查工作空间路径是否为通道工作空间
+ */
+export const isChannelWorkspace = (workspacePath: string): boolean => {
+  const parts = splitPathSegments(workspacePath);
+  return parts.includes('channel-media');
+};


### PR DESCRIPTION
## Summary
- 新增 `isChannelWorkspace` 判定，在通道工作区（`channel-media/*`）中过滤以 `.` 开头的隐藏文件
- 与临时工作区行为一致，`.drafts` 草稿箱保留显示
- 适用于所有通道（钉钉、企微、飞书、微信、Telegram）

## Test plan
- [ ] 创建钉钉通道对话，确认临时空间不显示以 `.` 开头的隐藏文件/目录
- [ ] 创建 sudowork 直聊对话（临时工作区），确认行为不变
- [ ] 创建 sudowork 自定义工作区对话，确认 dot-file 仍正常显示
- [ ] 确认 `.drafts` 草稿箱在所有工作区类型中正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)