### PR TITLE
fix(channel): 修复钉钉图片消息重复显示问题

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -8,7 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import type { TMessage } from '@/common/chatLib';
 import { database as databaseBridge } from '@/common/ipcBridge';
-import { appendNexusFilesMarker, parseNexusFilesMarker } from '@/common/nexusFiles';
+import { parseNexusFilesMarker } from '@/common/nexusFiles';
 import { getDatabase } from '@/process/database';
 import { ProcessConfig } from '@/process/initStorage';
 import { getDataPath } from '@/process/utils';
@@ -573,9 +573,7 @@ export class ActionExecutor {
         // paths into image content blocks via processAtFileReferences().
         const files = content.attachments?.map((a) => a.fileId).filter((id) => !!id) || [];
         const plainText = content.text || `[${content.type} message]`;
-        const workspacePath = session.workspace || getChannelWorkspacePath(platform);
-        const displayMessage = appendNexusFilesMarker(plainText, files, workspacePath);
-        await this.handleChatMessage(context, displayMessage, files);
+        await this.handleChatMessage(context, plainText, files);
       } else {
         // Unsupported content type
         await context.sendMessage({


### PR DESCRIPTION
## Summary
- 移除 ActionExecutor 中多余的 `appendNexusFilesMarker` 调用，避免与 AcpAgent 二次拼接 `[[NEXUS_FILES]]` 标记
- 修复钉钉发送图片时 sudocode 对话框显示"图片 文件(NEXUS_FILES) 图片"三个元素的问题

## Test plan
- [ ] 钉钉客户端发送一张图片，sudocode 对话框只显示一张图片
- [ ] 验证飞书、企业微信等其他 channel 的图片消息不受影响
- [ ] 运行 `npx vitest run tests/unit/nexusFiles.test.ts` 确认工具函数未受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)