### PR TITLE
feat: use file-type-specific icons in chat messages and file attachments

### DIFF
--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -10,7 +10,7 @@ import type { PreviewContentType } from '@/common/types/preview';
 import { getFileExtension } from '@/renderer/services/FileService';
 import { ipcBridge } from '@/common';
 import { Image } from '@arco-design/web-react';
-import fileIcon from '@/renderer/assets/file-icon.svg';
+import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
 
 const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg'];
@@ -155,7 +155,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
         onClick={handlePreviewClick}
       >
         <div className='w-40px h-40px rd-8px flex items-center justify-center flex-shrink-0'>
-          <img className='w-full h-full object-contain' src={fileIcon} alt='File Icon' />
+          {resolveFileIcon(fileName, { size: 28, theme: 'filled' })}
         </div>
         <div className='flex flex-col gap-2px min-w-0'>
           <span className='text-14px text-t-primary max-w-150px truncate'>{fileName}</span>

--- a/src/renderer/messages/MessageFileSend.tsx
+++ b/src/renderer/messages/MessageFileSend.tsx
@@ -7,7 +7,8 @@
 import type { IMessageFileSend } from '@/common/chatLib';
 import type { PreviewContentType } from '@/common/types/preview';
 import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';
-import { FileText, Picture } from '@icon-park/react';
+import { resolveFileIcon } from '@/renderer/utils/fileIcon';
+import { Picture } from '@icon-park/react';
 import React, { useCallback } from 'react';
 
 const FILE_TYPE_LABELS: Record<string, string> = {
@@ -86,7 +87,7 @@ const MessageFileSend: React.FC<{ message: IMessageFileSend }> = ({ message }) =
   return (
     <div className='w-full'>
       <div className='bg-message-tips rd-8px p-x-12px p-y-8px flex items-center gap-8px' {...clickableProps}>
-        <FileText theme='filled' size='18' className='flex-shrink-0 text-t-secondary' />
+        <span className='flex-shrink-0'>{resolveFileIcon(fileName, { size: 18, theme: 'filled' })}</span>
         <div className='flex flex-col gap-2px'>
           <span className='text-t-primary text-14px'>{fileName}</span>
           <span className='text-t-tertiary text-12px'>{typeLabel}</span>

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -19,7 +19,7 @@ import { isElectronDesktop } from '@/renderer/utils/platform';
 import { getLastDirectoryName, isTemporaryWorkspace as checkIsTemporaryWorkspace, isChannelWorkspace as checkIsChannelWorkspace, getWorkspaceDisplayName as getDisplayName } from '@/renderer/utils/workspace';
 import { Checkbox, Input, Message, Modal, Tooltip, Tree } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
-import { Cloudy, DownSmall, FolderOpen, Magic, Refresh, Search } from '@icon-park/react';
+import { Cloudy, DownSmall, FileText, FolderOpen, Magic, Refresh, Search } from '@icon-park/react';
 import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -19,7 +19,8 @@ import { isElectronDesktop } from '@/renderer/utils/platform';
 import { getLastDirectoryName, isTemporaryWorkspace as checkIsTemporaryWorkspace, isChannelWorkspace as checkIsChannelWorkspace, getWorkspaceDisplayName as getDisplayName } from '@/renderer/utils/workspace';
 import { Checkbox, Input, Message, Modal, Tooltip, Tree } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
-import { AudioFile, Cloudy, DownSmall, FileCode, FileExcel, FileGif, FileJpg, FilePdf, FilePpt, FileText, FileTxt, FileWord, FileZip, FolderOpen, Magic, Refresh, Search, VideoFile } from '@icon-park/react';
+import { Cloudy, DownSmall, FolderOpen, Magic, Refresh, Search } from '@icon-park/react';
+import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
@@ -51,106 +52,7 @@ function isHiddenWorkspaceEntry(name: string): boolean {
 }
 
 function resolveWorkspaceFileIcon(fileName: string): React.ReactNode | null {
-  const extension = fileName.toLowerCase().split('.').pop() ?? '';
-
-  switch (extension) {
-    case 'txt':
-    case 'log':
-    case 'text':
-      return <FileTxt theme='outline' size='16' fill='var(--color-text-3)' />;
-    case 'md':
-    case 'markdown':
-    case 'mdx':
-      return <FileText theme='outline' size='16' fill='var(--color-text-2)' />;
-    case 'doc':
-    case 'docx':
-    case 'wps':
-    case 'rtf':
-    case 'odt':
-      return <FileWord theme='outline' size='16' fill='#3b82f6' />;
-    case 'pdf':
-      return <FilePdf theme='outline' size='16' fill='#ef4444' />;
-    case 'ppt':
-    case 'pptx':
-    case 'key':
-    case 'odp':
-      return <FilePpt theme='outline' size='16' fill='#f97316' />;
-    case 'xls':
-    case 'xlsx':
-    case 'csv':
-    case 'ods':
-      return <FileExcel theme='outline' size='16' fill='#22c55e' />;
-    case 'js':
-    case 'jsx':
-    case 'ts':
-    case 'tsx':
-    case 'mjs':
-    case 'cjs':
-    case 'json':
-    case 'jsonc':
-    case 'yaml':
-    case 'yml':
-    case 'toml':
-    case 'xml':
-    case 'html':
-    case 'htm':
-    case 'css':
-    case 'scss':
-    case 'less':
-    case 'py':
-    case 'java':
-    case 'go':
-    case 'rs':
-    case 'c':
-    case 'cc':
-    case 'cpp':
-    case 'cxx':
-    case 'h':
-    case 'hpp':
-    case 'sh':
-    case 'bash':
-    case 'zsh':
-    case 'sql':
-      return <FileCode theme='outline' size='16' fill='#8b5cf6' />;
-    case 'jpg':
-    case 'jpeg':
-    case 'png':
-    case 'webp':
-    case 'bmp':
-    case 'svg':
-    case 'ico':
-    case 'tif':
-    case 'tiff':
-    case 'avif':
-      return <FileJpg theme='outline' size='16' fill='#06b6d4' />;
-    case 'gif':
-      return <FileGif theme='outline' size='16' fill='#06b6d4' />;
-    case 'zip':
-    case 'rar':
-    case '7z':
-    case 'tar':
-    case 'gz':
-    case 'tgz':
-    case 'bz2':
-    case 'xz':
-      return <FileZip theme='outline' size='16' fill='#f59e0b' />;
-    case 'mp3':
-    case 'wav':
-    case 'flac':
-    case 'aac':
-    case 'm4a':
-    case 'ogg':
-      return <AudioFile theme='outline' size='16' fill='#ec4899' />;
-    case 'mp4':
-    case 'mov':
-    case 'avi':
-    case 'mkv':
-    case 'webm':
-    case 'm4v':
-      return <VideoFile theme='outline' size='16' fill='#6366f1' />;
-    default:
-      return <FileText theme='outline' size='16' fill='var(--color-text-3)' />;
-  }
+  return resolveFileIcon(fileName, { size: 16, theme: 'outline' });
 }
 
 const ChangeWorkspaceIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({ className, ...rest }) => {

--- a/src/renderer/utils/fileIcon.tsx
+++ b/src/renderer/utils/fileIcon.tsx
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AudioFile, FileCode, FileExcel, FileGif, FileJpg, FilePdf, FilePpt, FileText, FileTxt, FileWord, FileZip, VideoFile } from '@icon-park/react';
+import type { Theme } from '@icon-park/react/es/runtime';
+import React from 'react';
+
+export interface FileIconOptions {
+  size?: number | string;
+  theme?: Theme;
+}
+
+/**
+ * 根据文件名后缀返回对应的文件类型图标
+ * Returns an appropriate file type icon based on the file extension.
+ *
+ * Consistent with the workspace file-tree icons so the same visual language
+ * is used everywhere in the app (chat messages, input-box attachments, etc.).
+ */
+export function resolveFileIcon(fileName: string, options: FileIconOptions = {}): React.ReactNode {
+  const { size = 16, theme = 'outline' } = options;
+  const extension = fileName.toLowerCase().split('.').pop() ?? '';
+
+  switch (extension) {
+    case 'txt':
+    case 'log':
+    case 'text':
+      return <FileTxt theme={theme} size={size} fill='var(--color-text-3)' />;
+    case 'md':
+    case 'markdown':
+    case 'mdx':
+      return <FileText theme={theme} size={size} fill='var(--color-text-2)' />;
+    case 'doc':
+    case 'docx':
+    case 'wps':
+    case 'rtf':
+    case 'odt':
+      return <FileWord theme={theme} size={size} fill='#3b82f6' />;
+    case 'pdf':
+      return <FilePdf theme={theme} size={size} fill='#ef4444' />;
+    case 'ppt':
+    case 'pptx':
+    case 'key':
+    case 'odp':
+      return <FilePpt theme={theme} size={size} fill='#f97316' />;
+    case 'xls':
+    case 'xlsx':
+    case 'csv':
+    case 'ods':
+      return <FileExcel theme={theme} size={size} fill='#22c55e' />;
+    case 'js':
+    case 'jsx':
+    case 'ts':
+    case 'tsx':
+    case 'mjs':
+    case 'cjs':
+    case 'json':
+    case 'jsonc':
+    case 'yaml':
+    case 'yml':
+    case 'toml':
+    case 'xml':
+    case 'html':
+    case 'htm':
+    case 'css':
+    case 'scss':
+    case 'less':
+    case 'py':
+    case 'java':
+    case 'go':
+    case 'rs':
+    case 'c':
+    case 'cc':
+    case 'cpp':
+    case 'cxx':
+    case 'h':
+    case 'hpp':
+    case 'sh':
+    case 'bash':
+    case 'zsh':
+    case 'sql':
+    case 'swift':
+    case 'kt':
+    case 'kts':
+    case 'rb':
+    case 'php':
+    case 'lua':
+    case 'r':
+    case 'dart':
+    case 'vue':
+    case 'svelte':
+      return <FileCode theme={theme} size={size} fill='#8b5cf6' />;
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'webp':
+    case 'bmp':
+    case 'svg':
+    case 'ico':
+    case 'tif':
+    case 'tiff':
+    case 'avif':
+      return <FileJpg theme={theme} size={size} fill='#06b6d4' />;
+    case 'gif':
+      return <FileGif theme={theme} size={size} fill='#06b6d4' />;
+    case 'zip':
+    case 'rar':
+    case '7z':
+    case 'tar':
+    case 'gz':
+    case 'tgz':
+    case 'bz2':
+    case 'xz':
+      return <FileZip theme={theme} size={size} fill='#f59e0b' />;
+    case 'mp3':
+    case 'wav':
+    case 'flac':
+    case 'aac':
+    case 'm4a':
+    case 'ogg':
+    case 'wma':
+      return <AudioFile theme={theme} size={size} fill='#ec4899' />;
+    case 'mp4':
+    case 'mov':
+    case 'avi':
+    case 'mkv':
+    case 'webm':
+    case 'm4v':
+    case 'wmv':
+    case 'flv':
+      return <VideoFile theme={theme} size={size} fill='#6366f1' />;
+    default:
+      return <FileText theme={theme} size={size} fill='var(--color-text-3)' />;
+  }
+}


### PR DESCRIPTION
## Summary

- Extract workspace file icon mapping into shared `resolveFileIcon` utility
- Apply file-type-specific icons to chat messages (`MessageFileSend`) and input-box attachments (`FilePreview`)
- Different file extensions now show distinct colored icons (PDF=red, Word=blue, Excel=green, code=purple, etc.)

Closes #596

Generated with [Claude Code](https://claude.ai/code)