### PR TITLE
feat(enterprise): add skill/assistant sync for enterprise mode

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1225,6 +1225,14 @@ export interface ISkillHubSkill {
   core_features: string | null;
   created_at: string;
   updated_at: string;
+  /** Enterprise mode: visibility configuration */
+  visible_to?: { department_ids: string[] | null } | null;
+  /** Enterprise mode: download URL */
+  source_url?: string | null;
+  /** Enterprise mode: checksum for verification */
+  checksum?: string | null;
+  /** Enterprise mode: version */
+  version?: string;
 }
 
 export interface ISkillHubVersion {
@@ -1280,6 +1288,16 @@ export interface ISkillHubMeta {
   enabled?: boolean;
   installed_version: string;
   installed_at: string;
+  /** Visibility configuration for enterprise skills (department_ids filter) */
+  visible_to?: { department_ids: string[] | null } | null;
+  /** Whether this skill has been uploaded to Moss Server */
+  uploaded?: boolean;
+  /** Timestamp when uploaded to Moss Server */
+  uploaded_at?: string;
+  /** Publish status for tenant-exclusive skills */
+  publish_status?: 'pending' | 'approved' | 'rejected';
+  /** Timestamp when published as tenant-exclusive */
+  published_at?: string;
 }
 
 /** Info returned for each locally installed skill */
@@ -1355,6 +1373,10 @@ export interface IAssistantHubSkill {
   defaultInitPrompt?: string | null;
   /** Internal: download URL from API (mapped from sourceUrl) */
   _sourceUrl?: string;
+  /** Enterprise mode: visibility configuration */
+  visible_to?: { department_ids: string[] | null } | null;
+  /** Enterprise mode: version */
+  version?: string;
 }
 
 export interface IAssistantHubVersion {
@@ -1782,4 +1804,70 @@ export const eeclaw = {
   tokenRefreshed: bridge.buildEmitter<{ access_token: string; refresh_token: string; expires_at: number }>('eeclaw.token-refreshed'),
   /** Refresh enterprise auth token via main process (single entry point to avoid race conditions) */
   refreshToken: bridge.buildProvider<IBridgeResponse<{ access_token: string; refresh_token?: string; expires_at: number }>, void>('eeclaw.refresh-token'),
+  /** Trigger manual sync of remote skills and assistants to local (for Local mode) */
+  syncFromRemote: bridge.buildProvider<
+    IBridgeResponse<{
+      skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+      assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+    }>,
+    void
+  >('eeclaw.sync-from-remote'),
+  /** Emitted when background sync completes after enterprise login */
+  syncCompleted: bridge.buildEmitter<{
+    skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+    assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+  }>('eeclaw.sync-completed'),
+
+  // === Custom Skill/Assistant Upload ===
+  /** Upload custom skill to Moss Server */
+  uploadCustomSkill: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { skillName: string; displayName: string; description?: string; version?: string; sourcePath?: string }>('eeclaw.upload-custom-skill'),
+  /** Upload custom assistant to Moss Server */
+  uploadCustomAssistant: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { assistantName: string; displayName: string; description?: string; version?: string; enabledSkills?: string[]; memoryMode?: 'session' | 'user'; sourcePath?: string }>('eeclaw.upload-custom-assistant'),
+
+  // === Tenant Skill/Assistant ===
+  /** Fetch tenant-exclusive skills from Moss Server */
+  getTenantSkills: bridge.buildProvider<
+    IBridgeResponse<
+      Array<{
+        id: string;
+        name: string;
+        displayName?: string;
+        description?: string;
+        version?: string;
+        status: 'pending' | 'approved' | 'rejected';
+        author?: string;
+        authorName?: string;
+        approvedAt?: string;
+        installed?: boolean;
+      }>
+    >,
+    void
+  >('eeclaw.get-tenant-skills'),
+  /** Fetch tenant-exclusive assistants from Moss Server */
+  getTenantAssistants: bridge.buildProvider<
+    IBridgeResponse<
+      Array<{
+        id: string;
+        name: string;
+        displayName?: string;
+        description?: string;
+        version?: string;
+        status: 'pending' | 'approved' | 'rejected';
+        author?: string;
+        authorName?: string;
+        enabledSkills?: string[];
+        approvedAt?: string;
+        installed?: boolean;
+      }>
+    >,
+    void
+  >('eeclaw.get-tenant-assistants'),
+  /** Install tenant skill to local */
+  installTenantSkill: bridge.buildProvider<IBridgeResponse<{ name: string }>, { skillId: string }>('eeclaw.install-tenant-skill'),
+  /** Install tenant assistant to local */
+  installTenantAssistant: bridge.buildProvider<IBridgeResponse<{ name: string }>, { assistantId: string }>('eeclaw.install-tenant-assistant'),
+  /** Publish skill as tenant-exclusive */
+  publishTenantSkill: bridge.buildProvider<IBridgeResponse<{ id: string; skillId: string; skillName: string; status: string; message?: string }>, { skillId: string; publishNote?: string }>('eeclaw.publish-tenant-skill'),
+  /** Publish assistant as tenant-exclusive */
+  publishTenantAssistant: bridge.buildProvider<IBridgeResponse<{ id: string; assistantId: string; assistantName: string; status: string; message?: string }>, { assistantId: string; publishNote?: string }>('eeclaw.publish-tenant-assistant'),
 };

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -14,6 +14,7 @@ import type { IMcpServer, IProvider, TChatConversation, TProviderWithModel, ICss
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from './types/preview';
 import type { UpdateCheckRequest, UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult, AutoUpdateStatus } from './updateTypes';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from './utils/protocolDetector';
+import type { SyncAllResult } from '../process/sync/remoteToLocalSync';
 
 // OpenClaw model pricing API response type
 export interface IOpenClawModelsResponse {
@@ -1283,7 +1284,7 @@ export interface ISkillHubMeta {
   core_features: string | null;
   homepage: string | null;
   author_id: string;
-  source_type?: 'hub' | 'upload' | 'custom';
+  source_type?: 'hub' | 'upload' | 'custom' | 'tenant';
   is_builtin?: boolean;
   enabled?: boolean;
   installed_version: string;
@@ -1313,6 +1314,8 @@ export interface IInstalledSkillInfo {
   isAutoInjectedBuiltin?: boolean;
   /** Whether this skill is currently enabled at runtime */
   enabled: boolean;
+  /** Category of the skill (custom, hub, system, tenant) */
+  category?: 'custom' | 'hub' | 'system' | 'tenant';
   /** Rich metadata from _sudowork_meta.json (hub-installed only) */
   meta?: ISkillHubMeta;
 }
@@ -1332,10 +1335,10 @@ export const skillHub = {
   importLocalSkill: bridge.buildProvider<IBridgeResponse<ISkillInstallResult>, { sourcePath: string }>('skill-hub.import-local-skill'),
   /** Get installed skills with rich metadata */
   getInstalledSkills: bridge.buildProvider<IBridgeResponse<IInstalledSkillInfo[]>, void>('skill-hub.get-installed-skills'),
-  /** Enable or disable a custom installed skill */
-  setSkillEnabled: bridge.buildProvider<IBridgeResponse<void>, { skillName: string; enabled: boolean }>('skill-hub.set-skill-enabled'),
-  /** Uninstall a hub-installed skill by directory name (builtin skills are rejected) */
-  uninstallSkill: bridge.buildProvider<IBridgeResponse<void>, { skillName: string }>('skill-hub.uninstall-skill'),
+  /** Enable or disable a custom installed skill. Optionally specify category to disambiguate skills with same name in different directories. */
+  setSkillEnabled: bridge.buildProvider<IBridgeResponse<void>, { skillName: string; enabled: boolean; category?: 'custom' | 'hub' | 'system' | 'tenant' }>('skill-hub.set-skill-enabled'),
+  /** Uninstall a hub-installed skill by directory name (builtin skills are rejected). Optionally specify category to disambiguate skills with same name in different directories. */
+  uninstallSkill: bridge.buildProvider<IBridgeResponse<void>, { skillName: string; category?: 'custom' | 'hub' | 'system' | 'tenant' }>('skill-hub.uninstall-skill'),
   /** Get security audit report for a skill */
   getSkillAuditReport: bridge.buildProvider<IBridgeResponse<import('@/common/skillAuditTypes').SkillAuditReport>, { skillName: string }>('skill-hub.get-skill-audit-report'),
   /** Run security audit for a skill (re-scan) */
@@ -1413,22 +1416,22 @@ export interface IAssistantInstallResult {
 export const assistantHub = {
   /** Get all installed assistants (enabled + disabled) with full metadata */
   getInstalledAssistants: bridge.buildProvider<IBridgeResponse<IAssistantInfo[]>, void>('assistant-hub.get-installed-assistants'),
-  /** Enable an assistant (set meta.enabled = true) */
-  enableAssistant: bridge.buildProvider<IBridgeResponse<void>, { name: string }>('assistant-hub.enable-assistant'),
-  /** Disable an assistant (set meta.enabled = false) */
-  disableAssistant: bridge.buildProvider<IBridgeResponse<void>, { name: string }>('assistant-hub.disable-assistant'),
+  /** Enable an assistant (set meta.enabled = true). Optionally specify category to disambiguate assistants with same name in different directories. */
+  enableAssistant: bridge.buildProvider<IBridgeResponse<void>, { name: string; category?: 'custom' | 'hub' | 'system' | 'tenant' }>('assistant-hub.enable-assistant'),
+  /** Disable an assistant (set meta.enabled = false). Optionally specify category to disambiguate assistants with same name in different directories. */
+  disableAssistant: bridge.buildProvider<IBridgeResponse<void>, { name: string; category?: 'custom' | 'hub' | 'system' | 'tenant' }>('assistant-hub.disable-assistant'),
   /** Merge partial updates into an assistant's _sudowork_meta.json */
-  updateAssistantMeta: bridge.buildProvider<IBridgeResponse<void>, { name: string; updates: Partial<IAssistantMeta> }>('assistant-hub.update-assistant-meta'),
+  updateAssistantMeta: bridge.buildProvider<IBridgeResponse<void>, { name: string; updates: Partial<IAssistantMeta>; category?: 'custom' | 'hub' | 'system' | 'tenant' }>('assistant-hub.update-assistant-meta'),
   /** Read _sudowork_meta.json for a specific assistant */
   getAssistantMeta: bridge.buildProvider<IBridgeResponse<IAssistantMeta | null>, { name: string }>('assistant-hub.get-assistant-meta'),
   /** Create a new custom assistant with metadata and optional rule content */
   createAssistant: bridge.buildProvider<IBridgeResponse<void>, { meta: IAssistantMeta; ruleContent?: string }>('assistant-hub.create-assistant'),
-  /** Uninstall an assistant (delete directory; blocks builtins) */
-  uninstallAssistant: bridge.buildProvider<IBridgeResponse<void>, { name: string }>('assistant-hub.uninstall-assistant'),
+  /** Uninstall an assistant (delete directory; blocks builtins). Optionally specify category to disambiguate assistants with same name in different directories. */
+  uninstallAssistant: bridge.buildProvider<IBridgeResponse<void>, { name: string; category?: 'custom' | 'hub' | 'system' | 'tenant' }>('assistant-hub.uninstall-assistant'),
 
   // === Hub API methods (parallel to skillHub) ===
   /** Fetch assistants list from Assistant Hub API with cursor-based pagination */
-  fetchAssistants: bridge.buildProvider<IBridgeResponse<IAssistantHubListResponse>, { cursor?: string; limit?: number; query?: string; category?: string; tenantId?: string }>('assistant-hub.fetch-assistants'),
+  fetchAssistants: bridge.buildProvider<IBridgeResponse<IAssistantHubListResponse>, { cursor?: string; limit?: number; query?: string; category?: string; tenantId?: string; sourceType?: 'hub' | 'tenant' }>('assistant-hub.fetch-assistants'),
   /** Fetch assistant categories from Assistant Hub API (type=1 for assistants) */
   fetchCategories: bridge.buildProvider<IBridgeResponse<string[]>, void>('assistant-hub.fetch-categories'),
   /** Fetch assistant detail from Assistant Hub API */
@@ -1805,24 +1808,15 @@ export const eeclaw = {
   /** Refresh enterprise auth token via main process (single entry point to avoid race conditions) */
   refreshToken: bridge.buildProvider<IBridgeResponse<{ access_token: string; refresh_token?: string; expires_at: number }>, void>('eeclaw.refresh-token'),
   /** Trigger manual sync of remote skills and assistants to local (for Local mode) */
-  syncFromRemote: bridge.buildProvider<
-    IBridgeResponse<{
-      skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-      assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-    }>,
-    void
-  >('eeclaw.sync-from-remote'),
+  syncFromRemote: bridge.buildProvider<IBridgeResponse<SyncAllResult>, void>('eeclaw.sync-from-remote'),
   /** Emitted when background sync completes after enterprise login */
-  syncCompleted: bridge.buildEmitter<{
-    skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-    assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-  }>('eeclaw.sync-completed'),
+  syncCompleted: bridge.buildEmitter<SyncAllResult>('eeclaw.sync-completed'),
 
   // === Custom Skill/Assistant Upload ===
   /** Upload custom skill to Moss Server */
   uploadCustomSkill: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { skillName: string; displayName: string; description?: string; version?: string; sourcePath?: string }>('eeclaw.upload-custom-skill'),
   /** Upload custom assistant to Moss Server */
-  uploadCustomAssistant: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { assistantName: string; displayName: string; description?: string; version?: string; enabledSkills?: string[]; memoryMode?: 'session' | 'user'; sourcePath?: string }>('eeclaw.upload-custom-assistant'),
+  uploadCustomAssistant: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { assistantName: string; assistantId: string; displayName: string; description?: string; version?: string; enabledSkills?: string[]; memoryMode?: 'session' | 'user'; sourcePath?: string }>('eeclaw.upload-custom-assistant'),
 
   // === Tenant Skill/Assistant ===
   /** Fetch tenant-exclusive skills from Moss Server */

--- a/src/process/AssistantManager.ts
+++ b/src/process/AssistantManager.ts
@@ -2,21 +2,24 @@
  * Assistant Manager - Unified management of assistant preset install, disable, enable, list.
  * Parallel to SkillManager.ts for skills.
  *
- * _sudowork_meta.json is the SSOT. No ConfigStorage involved.
+ * Metadata file: _moss_meta.json (enterprise) or _sudowork_meta.json (personal)
  * Enable/disable = flip meta.enabled field (no directory moves).
  */
 
 import fs from 'fs/promises';
 import path from 'path';
 import { existsSync, mkdirSync } from 'fs';
-import { getAssistantsDir } from './initStorage';
-import { ASSISTANT_SUBDIRS, ASSISTANT_META_FILE } from './constants/assistantStorage';
+import { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir } from './initStorage';
+import { ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE } from './constants/assistantStorage';
 import { mainLog, mainError } from './utils/mainLogger';
 import type { IAssistantMeta } from './constants/assistantStorage';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 
 export type AssistantCategory = 'custom' | 'hub' | 'system';
 
 export interface IAssistantInfo {
+  /** Unique identifier from server */
+  id?: string;
   /** Directory name (used as lookup key) */
   name: string;
   isBuiltin: boolean;
@@ -30,41 +33,54 @@ export interface IAssistantInfo {
  * Assistant Manager class
  */
 export class AssistantManager {
-  private _hubDir?: string;
-  private _systemDir?: string;
-  private _customDir?: string;
-  private _initialized = false;
-
-  /** Lazy init — safe to construct before initStorage has run */
-  private init(): void {
-    if (this._initialized) return;
-    const base = getAssistantsDir();
-    this._hubDir = path.join(base, ASSISTANT_SUBDIRS.hub);
-    this._systemDir = path.join(base, ASSISTANT_SUBDIRS.system);
-    this._customDir = path.join(base, ASSISTANT_SUBDIRS.custom);
-    this.ensureDirs();
-    this._initialized = true;
-  }
-
+  // Use getters for dynamic directory resolution based on current mode
   private get hubDir(): string {
-    this.init();
-    return this._hubDir!;
+    return getHubAssistantsDir();
   }
   private get systemDir(): string {
-    this.init();
-    return this._systemDir!;
+    return getSystemAssistantsDir();
   }
   private get customDir(): string {
-    this.init();
-    return this._customDir!;
+    return getCustomAssistantsDir();
   }
 
   private ensureDirs(): void {
-    for (const dir of [getAssistantsDir(), this._hubDir!, this._systemDir!, this._customDir!]) {
+    for (const dir of [getAssistantsDir(), this.hubDir, this.systemDir, this.customDir]) {
       if (!existsSync(dir)) {
         mkdirSync(dir, { recursive: true });
       }
     }
+  }
+
+  /**
+   * Read assistant metadata file, trying both Moss and Sudowork meta file names
+   * Enterprise mode: _moss_meta.json (primary), _sudowork_meta.json (fallback)
+   * Personal mode: _sudowork_meta.json (primary), _moss_meta.json (fallback)
+   */
+  private async readAssistantMetaFile(assistantDir: string): Promise<{ content: string; fileName: string } | null> {
+    const isEnterprise = isEnterpriseMode();
+    const metaFiles = isEnterprise ? [MOSS_ASSISTANT_META_FILE, ASSISTANT_META_FILE] : [ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE];
+
+    for (const fileName of metaFiles) {
+      const filePath = path.join(assistantDir, fileName);
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        return { content, fileName };
+      } catch {
+        // Try next file
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Write assistant metadata file, using correct file name based on current mode
+   */
+  private async writeAssistantMetaFile(assistantDir: string, meta: IAssistantMeta): Promise<void> {
+    const isEnterprise = isEnterpriseMode();
+    const fileName = isEnterprise ? MOSS_ASSISTANT_META_FILE : ASSISTANT_META_FILE;
+    const filePath = path.join(assistantDir, fileName);
+    await fs.writeFile(filePath, JSON.stringify(meta, null, 2), 'utf-8');
   }
 
   /**
@@ -102,11 +118,12 @@ export class AssistantManager {
   private async readAssistantInfo(assistantDir: string, category: AssistantCategory): Promise<IAssistantInfo | null> {
     const dirName = path.basename(assistantDir);
 
-    try {
-      const raw = await fs.readFile(path.join(assistantDir, ASSISTANT_META_FILE), 'utf-8');
-      const meta = JSON.parse(raw) as IAssistantMeta;
+    const metaResult = await this.readAssistantMetaFile(assistantDir);
+    if (metaResult) {
+      const meta = JSON.parse(metaResult.content) as IAssistantMeta;
 
       return {
+        id: meta.id,
         name: dirName,
         isBuiltin: meta.is_builtin === true,
         isHubInstalled: meta.source_type === 'hub',
@@ -114,9 +131,10 @@ export class AssistantManager {
         category,
         meta,
       };
-    } catch {
+    } else {
       // No valid metadata — treat as custom with defaults
       return {
+        id: dirName,
         name: dirName,
         isBuiltin: false,
         isHubInstalled: false,
@@ -131,9 +149,10 @@ export class AssistantManager {
 
   /**
    * Get all installed assistants (enabled + disabled).
-   * Scans _system/, _hub/, _my-custom-assistant/ directories.
+   * Scans system/, hub/, custom/ directories (enterprise) or _system/, _hub/, _my-custom-assistant/ (personal).
    */
   async getInstalledAssistants(): Promise<IAssistantInfo[]> {
+    this.ensureDirs();
     const assistants: IAssistantInfo[] = [];
 
     for (const baseDir of [this.systemDir, this.hubDir, this.customDir]) {
@@ -179,38 +198,35 @@ export class AssistantManager {
   }
 
   /**
-   * Read _sudowork_meta.json for a specific assistant.
+   * Read metadata file for a specific assistant.
    */
   async getAssistantMeta(name: string): Promise<IAssistantMeta | null> {
     const result = this.findAssistantDir(name);
     if (!result) return null;
 
-    try {
-      const raw = await fs.readFile(path.join(result.dir, ASSISTANT_META_FILE), 'utf-8');
-      return JSON.parse(raw) as IAssistantMeta;
-    } catch {
-      return null;
+    const metaResult = await this.readAssistantMetaFile(result.dir);
+    if (metaResult) {
+      return JSON.parse(metaResult.content) as IAssistantMeta;
     }
+    return null;
   }
 
   /**
-   * Merge partial updates into an assistant's _sudowork_meta.json.
+   * Merge partial updates into an assistant's metadata file.
    */
   async updateAssistantMeta(name: string, updates: Partial<IAssistantMeta>): Promise<{ success: boolean; msg?: string }> {
     try {
       const result = this.findAssistantDir(name);
       if (!result) return { success: false, msg: 'Assistant not found' };
 
-      const metaPath = path.join(result.dir, ASSISTANT_META_FILE);
       let meta: IAssistantMeta = {};
-      try {
-        meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as IAssistantMeta;
-      } catch {
-        // Start fresh if corrupted
+      const metaResult = await this.readAssistantMetaFile(result.dir);
+      if (metaResult) {
+        meta = JSON.parse(metaResult.content) as IAssistantMeta;
       }
 
       const merged = { ...meta, ...updates };
-      await fs.writeFile(metaPath, JSON.stringify(merged, null, 2), 'utf-8');
+      await this.writeAssistantMetaFile(result.dir, merged);
       return { success: true };
     } catch (error) {
       mainError('AssistantManager', 'Failed to update assistant meta:', error);
@@ -249,8 +265,8 @@ export class AssistantManager {
   }
 
   /**
-   * Create a new custom assistant in _my-custom-assistant/{id}/.
-   * Writes _sudowork_meta.json and optionally AGENT.md.
+   * Create a new custom assistant in custom directory.
+   * Writes metadata file and optionally AGENT.md.
    */
   async createAssistant(meta: IAssistantMeta, ruleContent?: string): Promise<{ success: boolean; msg?: string }> {
     try {
@@ -277,7 +293,7 @@ export class AssistantManager {
         ruleFile: ruleFile,
         ...meta,
       };
-      await fs.writeFile(path.join(assistantDir, ASSISTANT_META_FILE), JSON.stringify(fullMeta, null, 2), 'utf-8');
+      await this.writeAssistantMetaFile(assistantDir, fullMeta);
 
       mainLog('AssistantManager', `Created assistant: ${id}`);
       return { success: true };
@@ -296,14 +312,12 @@ export class AssistantManager {
       if (!result) return { success: false, msg: 'Assistant not found' };
 
       // Block uninstalling builtins
-      try {
-        const raw = await fs.readFile(path.join(result.dir, ASSISTANT_META_FILE), 'utf-8');
-        const meta = JSON.parse(raw) as IAssistantMeta;
+      const metaResult = await this.readAssistantMetaFile(result.dir);
+      if (metaResult) {
+        const meta = JSON.parse(metaResult.content) as IAssistantMeta;
         if (meta.is_builtin === true) {
           return { success: false, msg: 'Builtin assistants cannot be uninstalled' };
         }
-      } catch {
-        // No metadata file, allow uninstall
       }
 
       await fs.rm(result.dir, { recursive: true, force: true });

--- a/src/process/AssistantManager.ts
+++ b/src/process/AssistantManager.ts
@@ -11,11 +11,12 @@ import path from 'path';
 import { existsSync, mkdirSync } from 'fs';
 import { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir } from './initStorage';
 import { ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE } from './constants/assistantStorage';
-import { mainLog, mainError } from './utils/mainLogger';
+import { mainLog, mainWarn, mainError } from './utils/mainLogger';
 import type { IAssistantMeta } from './constants/assistantStorage';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { getEnterpriseTenantAssistantsDir } from './constants/enterpriseStorage';
 
-export type AssistantCategory = 'custom' | 'hub' | 'system';
+export type AssistantCategory = 'custom' | 'hub' | 'system' | 'tenant';
 
 export interface IAssistantInfo {
   /** Unique identifier from server */
@@ -43,9 +44,17 @@ export class AssistantManager {
   private get customDir(): string {
     return getCustomAssistantsDir();
   }
+  private get tenantDir(): string {
+    return getEnterpriseTenantAssistantsDir();
+  }
 
   private ensureDirs(): void {
-    for (const dir of [getAssistantsDir(), this.hubDir, this.systemDir, this.customDir]) {
+    const dirs = [getAssistantsDir(), this.hubDir, this.systemDir, this.customDir];
+    // Add tenant dir in enterprise mode
+    if (isEnterpriseMode()) {
+      dirs.push(this.tenantDir);
+    }
+    for (const dir of dirs) {
       if (!existsSync(dir)) {
         mkdirSync(dir, { recursive: true });
       }
@@ -109,6 +118,7 @@ export class AssistantManager {
   private getCategoryFromPath(assistantPath: string): AssistantCategory {
     if (assistantPath.startsWith(this.systemDir)) return 'system';
     if (assistantPath.startsWith(this.hubDir)) return 'hub';
+    if (isEnterpriseMode() && assistantPath.startsWith(this.tenantDir)) return 'tenant';
     return 'custom';
   }
 
@@ -149,13 +159,19 @@ export class AssistantManager {
 
   /**
    * Get all installed assistants (enabled + disabled).
-   * Scans system/, hub/, custom/ directories (enterprise) or _system/, _hub/, _my-custom-assistant/ (personal).
+   * Scans system/, hub/, custom/, tenant/ directories (enterprise) or _system/, _hub/, _my-custom-assistant/ (personal).
    */
   async getInstalledAssistants(): Promise<IAssistantInfo[]> {
     this.ensureDirs();
     const assistants: IAssistantInfo[] = [];
 
-    for (const baseDir of [this.systemDir, this.hubDir, this.customDir]) {
+    const baseDirs = [this.systemDir, this.hubDir, this.customDir];
+    // Add tenant directory in enterprise mode
+    if (isEnterpriseMode()) {
+      baseDirs.push(this.tenantDir);
+    }
+
+    for (const baseDir of baseDirs) {
       const dirs = await this.scanAssistantDirs(baseDir);
       for (const assistantDir of dirs) {
         const category = this.getCategoryFromPath(assistantDir);
@@ -169,14 +185,19 @@ export class AssistantManager {
 
   /**
    * Find an assistant directory by name (or id) across all categories.
-   * Searches: custom → hub → system. Also tries stripping 'builtin-' prefix for system lookup.
+   * Searches: custom → tenant → hub → system. Also tries stripping 'builtin-' prefix for system lookup.
    */
   findAssistantDir(name: string): { dir: string; category: AssistantCategory } | null {
-    const searchDirs = [
-      { dir: this.customDir, category: 'custom' as AssistantCategory },
-      { dir: this.hubDir, category: 'hub' as AssistantCategory },
-      { dir: this.systemDir, category: 'system' as AssistantCategory },
+    const searchDirs: Array<{ dir: string; category: AssistantCategory }> = [
+      { dir: this.customDir, category: 'custom' },
+      { dir: this.hubDir, category: 'hub' },
+      { dir: this.systemDir, category: 'system' },
     ];
+
+    // Add tenant directory in enterprise mode
+    if (isEnterpriseMode()) {
+      searchDirs.splice(1, 0, { dir: this.tenantDir, category: 'tenant' }); // Insert after custom
+    }
 
     for (const { dir, category } of searchDirs) {
       const assistantDir = path.join(dir, name);
@@ -198,6 +219,38 @@ export class AssistantManager {
   }
 
   /**
+   * Find an assistant directory by name and category (precise lookup).
+   * If category is specified, only searches in that category's directory.
+   */
+  findAssistantDirByCategory(name: string, category?: AssistantCategory): { dir: string; category: AssistantCategory } | null {
+    // If category is specified, search only in that directory
+    if (category) {
+      const categoryDirMap: Record<AssistantCategory, string> = {
+        custom: this.customDir,
+        hub: this.hubDir,
+        system: this.systemDir,
+        tenant: this.tenantDir,
+      };
+      const baseDir = categoryDirMap[category];
+      const assistantDir = path.join(baseDir, name);
+      if (existsSync(assistantDir)) {
+        return { dir: assistantDir, category };
+      }
+      // Try stripping 'builtin-' prefix for system dir lookup
+      if (category === 'system' && name.startsWith('builtin-')) {
+        const stripped = name.slice('builtin-'.length);
+        const systemPath = path.join(this.systemDir, stripped);
+        if (existsSync(systemPath)) {
+          return { dir: systemPath, category: 'system' };
+        }
+      }
+      return null;
+    }
+    // No category specified, use default search order
+    return this.findAssistantDir(name);
+  }
+
+  /**
    * Read metadata file for a specific assistant.
    */
   async getAssistantMeta(name: string): Promise<IAssistantMeta | null> {
@@ -214,10 +267,16 @@ export class AssistantManager {
   /**
    * Merge partial updates into an assistant's metadata file.
    */
-  async updateAssistantMeta(name: string, updates: Partial<IAssistantMeta>): Promise<{ success: boolean; msg?: string }> {
+  async updateAssistantMeta(name: string, updates: Partial<IAssistantMeta>, category?: AssistantCategory): Promise<{ success: boolean; msg?: string }> {
     try {
-      const result = this.findAssistantDir(name);
-      if (!result) return { success: false, msg: 'Assistant not found' };
+      mainLog('AssistantManager', `updateAssistantMeta called: name=${name}, category=${category || 'auto'}`);
+      const result = this.findAssistantDirByCategory(name, category);
+      if (!result) {
+        mainWarn('AssistantManager', `Assistant not found: ${name} (category: ${category || 'auto'})`);
+        return { success: false, msg: 'Assistant not found' };
+      }
+
+      mainLog('AssistantManager', `Found assistant at: ${result.dir} (category: ${result.category})`);
 
       let meta: IAssistantMeta = {};
       const metaResult = await this.readAssistantMetaFile(result.dir);
@@ -227,6 +286,7 @@ export class AssistantManager {
 
       const merged = { ...meta, ...updates };
       await this.writeAssistantMetaFile(result.dir, merged);
+      mainLog('AssistantManager', `Successfully updated meta for: ${name}`);
       return { success: true };
     } catch (error) {
       mainError('AssistantManager', 'Failed to update assistant meta:', error);
@@ -237,31 +297,31 @@ export class AssistantManager {
   /**
    * Enable an assistant (set meta.enabled = true).
    */
-  async enableAssistant(name: string): Promise<{ success: boolean; msg?: string }> {
-    mainLog('AssistantManager', `Enabling assistant: ${name}`);
-    return this.updateAssistantMeta(name, { enabled: true });
+  async enableAssistant(name: string, category?: AssistantCategory): Promise<{ success: boolean; msg?: string }> {
+    mainLog('AssistantManager', `Enabling assistant: ${name} (category: ${category || 'auto'})`);
+    return this.updateAssistantMeta(name, { enabled: true }, category);
   }
 
   /**
    * Disable an assistant (set meta.enabled = false).
    */
-  async disableAssistant(name: string): Promise<{ success: boolean; msg?: string }> {
-    mainLog('AssistantManager', `Disabling assistant: ${name}`);
-    return this.updateAssistantMeta(name, { enabled: false });
+  async disableAssistant(name: string, category?: AssistantCategory): Promise<{ success: boolean; msg?: string }> {
+    mainLog('AssistantManager', `Disabling assistant: ${name} (category: ${category || 'auto'})`);
+    return this.updateAssistantMeta(name, { enabled: false }, category);
   }
 
   /**
    * Update enabled skills for an assistant.
    */
-  async setEnabledSkills(name: string, skills: string[]): Promise<{ success: boolean; msg?: string }> {
-    return this.updateAssistantMeta(name, { enabledSkills: skills });
+  async setEnabledSkills(name: string, skills: string[], category?: AssistantCategory): Promise<{ success: boolean; msg?: string }> {
+    return this.updateAssistantMeta(name, { enabledSkills: skills }, category);
   }
 
   /**
    * Update preset agent type for an assistant.
    */
-  async setPresetAgentType(name: string, agentType: string): Promise<{ success: boolean; msg?: string }> {
-    return this.updateAssistantMeta(name, { presetAgentType: agentType });
+  async setPresetAgentType(name: string, agentType: string, category?: AssistantCategory): Promise<{ success: boolean; msg?: string }> {
+    return this.updateAssistantMeta(name, { presetAgentType: agentType }, category);
   }
 
   /**
@@ -283,8 +343,12 @@ export class AssistantManager {
       // If ruleContent provided, write AGENT.md and set ruleFile
       let ruleFile: string | undefined = undefined;
       if (ruleContent) {
+        mainLog('AssistantManager', `Writing AGENT.md for assistant: ${id}, ruleContent length: ${ruleContent.length}`);
         await fs.writeFile(path.join(assistantDir, 'AGENT.md'), ruleContent, 'utf-8');
         ruleFile = 'AGENT.md';
+        mainLog('AssistantManager', `AGENT.md written successfully for: ${id}`);
+      } else {
+        mainLog('AssistantManager', `No ruleContent provided for assistant: ${id}, skipping AGENT.md`);
       }
 
       const fullMeta: IAssistantMeta = {
@@ -295,7 +359,7 @@ export class AssistantManager {
       };
       await this.writeAssistantMetaFile(assistantDir, fullMeta);
 
-      mainLog('AssistantManager', `Created assistant: ${id}`);
+      mainLog('AssistantManager', `Created assistant: ${id} at ${assistantDir}`);
       return { success: true };
     } catch (error) {
       mainError('AssistantManager', 'Failed to create assistant:', error);
@@ -306,9 +370,9 @@ export class AssistantManager {
   /**
    * Uninstall an assistant (delete directory; blocks builtins).
    */
-  async uninstallAssistant(name: string): Promise<{ success: boolean; msg?: string }> {
+  async uninstallAssistant(name: string, category?: AssistantCategory): Promise<{ success: boolean; msg?: string }> {
     try {
-      const result = this.findAssistantDir(name);
+      const result = this.findAssistantDirByCategory(name, category);
       if (!result) return { success: false, msg: 'Assistant not found' };
 
       // Block uninstalling builtins
@@ -321,7 +385,8 @@ export class AssistantManager {
       }
 
       await fs.rm(result.dir, { recursive: true, force: true });
-      mainLog('AssistantManager', `Uninstalled assistant: ${name}`);
+      mainLog('AssistantManager', `Uninstalled assistant: ${name} from ${result.category}`);
+
       return { success: true };
     } catch (error) {
       mainError('AssistantManager', 'Failed to uninstall assistant:', error);

--- a/src/process/SkillManager.ts
+++ b/src/process/SkillManager.ts
@@ -10,6 +10,8 @@ import { app } from 'electron';
 import { getSkillsDir, getSystemSkillsDir, getHubSkillsDir, getCustomSkillsDir } from './initStorage';
 import { toAssetUrl } from '@/extensions/assetProtocol';
 import { mainLog, mainError } from './utils/mainLogger';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { MOSS_SKILL_META_FILE } from './constants/skillStorage';
 
 const UPLOAD_SKILL_DEFAULT_ICON_FILE = 'upload_skill_default.svg';
 
@@ -62,17 +64,23 @@ export interface ISkillInfo {
  * Skill Manager 类
  */
 export class SkillManager {
-  private skillsDir: string;
-  private hubDir: string;
-  private systemDir: string;
-  private customDir: string;
+  // Use getters for dynamic directory resolution based on current mode
+  private get skillsDir(): string {
+    return getSkillsDir();
+  }
+  private get hubDir(): string {
+    return getHubSkillsDir();
+  }
+  private get systemDir(): string {
+    return getSystemSkillsDir();
+  }
+  private get customDir(): string {
+    return getCustomSkillsDir();
+  }
 
   constructor() {
-    this.skillsDir = getSkillsDir();
-    this.hubDir = getHubSkillsDir();
-    this.systemDir = getSystemSkillsDir();
-    this.customDir = getCustomSkillsDir();
-    this.ensureDirs();
+    // Directory paths are now resolved dynamically via getters
+    // ensureDirs() is called on first access if needed
   }
 
   // 确保所有目录存在
@@ -101,6 +109,37 @@ export class SkillManager {
 
     const existing = candidates.find((candidate) => fsExistsSync(candidate));
     return existing || candidates[0];
+  }
+
+  /**
+   * Read skill metadata file, trying both Moss and Sudowork meta file names
+   * Enterprise mode: _moss_meta.json (primary), _sudowork_meta.json (fallback)
+   * Personal mode: _sudowork_meta.json (primary), _moss_meta.json (fallback)
+   */
+  private async readSkillMetaFile(skillDir: string): Promise<{ content: string; fileName: string } | null> {
+    const isEnterprise = isEnterpriseMode();
+    const metaFiles = isEnterprise ? [MOSS_SKILL_META_FILE, SKILL_HUB_META_FILE] : [SKILL_HUB_META_FILE, MOSS_SKILL_META_FILE];
+
+    for (const fileName of metaFiles) {
+      const filePath = path.join(skillDir, fileName);
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        return { content, fileName };
+      } catch {
+        // Try next file
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Write skill metadata file, using correct file name based on current mode
+   */
+  private async writeSkillMetaFile(skillDir: string, meta: ISkillMeta): Promise<void> {
+    const isEnterprise = isEnterpriseMode();
+    const fileName = isEnterprise ? MOSS_SKILL_META_FILE : SKILL_HUB_META_FILE;
+    const filePath = path.join(skillDir, fileName);
+    await fs.writeFile(filePath, JSON.stringify(meta, null, 2), 'utf-8');
   }
 
   // 搜索技能目录（排除 _ 开头的目录）
@@ -197,9 +236,9 @@ export class SkillManager {
     let isHubInstalled = category === 'hub';
     let enabled = true;
 
-    try {
-      const raw = await fs.readFile(path.join(skillDir, SKILL_HUB_META_FILE), 'utf-8');
-      meta = JSON.parse(raw) as ISkillMeta;
+    const metaResult = await this.readSkillMetaFile(skillDir);
+    if (metaResult) {
+      meta = JSON.parse(metaResult.content) as ISkillMeta;
 
       if (!forceBuiltin && meta.is_builtin !== undefined) {
         isBuiltin = meta.is_builtin === true;
@@ -221,7 +260,7 @@ export class SkillManager {
           }
         }
       }
-    } catch {
+    } else {
       // 没有 metadata 文件，默认为自定义
       meta = { source_type: 'upload' };
       isHubInstalled = false;
@@ -253,7 +292,12 @@ export class SkillManager {
 
   // 获取所有已安装的技能列表
   async getInstalledSkills(): Promise<ISkillInfo[]> {
+    this.ensureDirs();
     const skills: ISkillInfo[] = [];
+
+    // Debug: log enterprise mode and directories
+    const isEnterprise = isEnterpriseMode();
+    mainLog('SkillManager', `getInstalledSkills: isEnterpriseMode=${isEnterprise}, hubDir=${this.hubDir}`);
 
     // 1. 扫描所有启用的技能目录
     const enabledDirs = await this.scanAllSkillDirs();
@@ -340,14 +384,12 @@ export class SkillManager {
       }
 
       // 检查是否为内置技能
-      try {
-        const raw = await fs.readFile(path.join(skillDir, SKILL_HUB_META_FILE), 'utf-8');
-        const meta = JSON.parse(raw) as ISkillMeta;
+      const metaResult = await this.readSkillMetaFile(skillDir);
+      if (metaResult) {
+        const meta = JSON.parse(metaResult.content) as ISkillMeta;
         if (meta.is_builtin === true) {
           return { success: false, msg: '内置技能无法禁用' };
         }
-      } catch {
-        // 没有 metadata 文件，允许禁用
       }
 
       // 获取基础目录
@@ -376,16 +418,15 @@ export class SkillManager {
       await fs.rename(skillDir, destDir);
 
       // 修改 meta
-      const metaFilePath = path.join(destDir, SKILL_HUB_META_FILE);
-      try {
-        const raw = await fs.readFile(metaFilePath, 'utf-8');
-        const meta = JSON.parse(raw) as ISkillMeta;
+      const existingMeta = await this.readSkillMetaFile(destDir);
+      if (existingMeta) {
+        const meta = JSON.parse(existingMeta.content) as ISkillMeta;
         meta.enabled = false;
-        await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
-      } catch {
+        await this.writeSkillMetaFile(destDir, meta);
+      } else {
         // 没有 meta 文件，创建一个
-        const newMeta = { enabled: false, source_type: 'upload' };
-        await fs.writeFile(metaFilePath, JSON.stringify(newMeta, null, 2), 'utf-8');
+        const newMeta: ISkillMeta = { enabled: false, source_type: 'upload' };
+        await this.writeSkillMetaFile(destDir, newMeta);
       }
 
       mainLog('SkillManager', `Disabled skill: ${skillName}`);
@@ -431,16 +472,15 @@ export class SkillManager {
       await fs.rename(skillDir, destDir);
 
       // 修改 meta
-      const metaFilePath = path.join(destDir, SKILL_HUB_META_FILE);
-      try {
-        const raw = await fs.readFile(metaFilePath, 'utf-8');
-        const meta = JSON.parse(raw) as ISkillMeta;
+      const existingMeta = await this.readSkillMetaFile(destDir);
+      if (existingMeta) {
+        const meta = JSON.parse(existingMeta.content) as ISkillMeta;
         meta.enabled = true;
-        await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
-      } catch {
+        await this.writeSkillMetaFile(destDir, meta);
+      } else {
         // 没有 meta 文件，创建一个
-        const newMeta = { enabled: true, source_type: 'upload' };
-        await fs.writeFile(metaFilePath, JSON.stringify(newMeta, null, 2), 'utf-8');
+        const newMeta: ISkillMeta = { enabled: true, source_type: 'upload' };
+        await this.writeSkillMetaFile(destDir, newMeta);
       }
 
       mainLog('SkillManager', `Enabled skill: ${skillName}`);
@@ -462,14 +502,12 @@ export class SkillManager {
       const { dir: skillDir, isDisabled } = result;
 
       // 检查是否为内置技能
-      try {
-        const raw = await fs.readFile(path.join(skillDir, SKILL_HUB_META_FILE), 'utf-8');
-        const meta = JSON.parse(raw) as ISkillMeta;
+      const metaResult = await this.readSkillMetaFile(skillDir);
+      if (metaResult) {
+        const meta = JSON.parse(metaResult.content) as ISkillMeta;
         if (meta.is_builtin === true) {
           return { success: false, msg: '内置技能无法卸载' };
         }
-      } catch {
-        // 没有 meta 文件，允许卸载
       }
 
       await fs.rm(skillDir, { recursive: true, force: true });

--- a/src/process/SkillManager.ts
+++ b/src/process/SkillManager.ts
@@ -12,6 +12,7 @@ import { toAssetUrl } from '@/extensions/assetProtocol';
 import { mainLog, mainError } from './utils/mainLogger';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { MOSS_SKILL_META_FILE } from './constants/skillStorage';
+import { getEnterpriseTenantSkillsDir } from './constants/enterpriseStorage';
 
 const UPLOAD_SKILL_DEFAULT_ICON_FILE = 'upload_skill_default.svg';
 
@@ -21,7 +22,7 @@ const VERSION_FILE_NAME = 'version.txt';
 const LEGACY_VERSION_FILE_NAME = 'sudowork-version';
 
 // Skill 分类
-export type SkillCategory = 'custom' | 'hub' | 'system';
+export type SkillCategory = 'custom' | 'hub' | 'system' | 'tenant';
 
 // Skill 状态
 export type SkillStatus = 'enabled' | 'disabled';
@@ -77,6 +78,9 @@ export class SkillManager {
   private get customDir(): string {
     return getCustomSkillsDir();
   }
+  private get tenantDir(): string {
+    return getEnterpriseTenantSkillsDir();
+  }
 
   constructor() {
     // Directory paths are now resolved dynamically via getters
@@ -86,6 +90,10 @@ export class SkillManager {
   // 确保所有目录存在
   private ensureDirs(): void {
     const dirs = [this.skillsDir, this.hubDir, this.systemDir, this.customDir];
+    // Add tenant dir in enterprise mode
+    if (isEnterpriseMode()) {
+      dirs.push(this.tenantDir);
+    }
     for (const dir of dirs) {
       if (!existsSync(dir)) {
         mkdirSync(dir, { recursive: true });
@@ -178,6 +186,12 @@ export class SkillManager {
       dirs.push(...builtinSubDirs);
     }
 
+    // 扫描企业模式下的 tenant 目录
+    if (isEnterpriseMode()) {
+      const tenantSubDirs = await this.scanSkillDirs(this.tenantDir);
+      dirs.push(...tenantSubDirs);
+    }
+
     return dirs;
   }
 
@@ -191,6 +205,11 @@ export class SkillManager {
       { base: this.systemDir, category: 'system' as SkillCategory },
       { base: path.join(this.systemDir, '_builtin'), category: 'system' as SkillCategory },
     ];
+
+    // Add tenant disable directory in enterprise mode
+    if (isEnterpriseMode()) {
+      disableDirs.push({ base: this.tenantDir, category: 'tenant' as SkillCategory });
+    }
 
     for (const { base } of disableDirs) {
       const disableDir = this.getDisableDir(base);
@@ -287,6 +306,9 @@ export class SkillManager {
     if (skillPath.startsWith(this.hubDir)) {
       return 'hub';
     }
+    if (isEnterpriseMode() && skillPath.startsWith(this.tenantDir)) {
+      return 'tenant';
+    }
     return 'custom';
   }
 
@@ -341,6 +363,11 @@ export class SkillManager {
       { dir: path.join(this.systemDir, '_builtin'), category: 'system' as SkillCategory },
     ];
 
+    // Add tenant directory in enterprise mode
+    if (isEnterpriseMode()) {
+      searchDirs.splice(1, 0, { dir: this.tenantDir, category: 'tenant' as SkillCategory }); // Insert after custom
+    }
+
     // Try trimmed name first, then original name (for backward compatibility with dirs created with spaces)
     const namesToTry = [trimmedName, skillName].filter((n, i, arr) => arr.indexOf(n) === i);
 
@@ -369,15 +396,58 @@ export class SkillManager {
     return null;
   }
 
+  // 根据分类查找技能目录（优先按指定分类查找）
+  private async findSkillDirByCategory(skillName: string, category?: SkillCategory, includeDisabled = true): Promise<{ dir: string; category: SkillCategory; isDisabled: boolean } | null> {
+    // Trim skillName to handle cases where metadata had leading/trailing spaces
+    const trimmedName = skillName.trim();
+    const namesToTry = [trimmedName, skillName].filter((n, i, arr) => arr.indexOf(n) === i);
+
+    // 如果指定了分类，优先在该分类目录中查找
+    if (category) {
+      const categoryDirMap: Record<SkillCategory, string> = {
+        custom: this.customDir,
+        hub: this.hubDir,
+        system: this.systemDir,
+        tenant: this.tenantDir,
+      };
+      const baseDir = categoryDirMap[category];
+
+      // 搜索启用目录
+      for (const name of namesToTry) {
+        const skillDir = path.join(baseDir, name);
+        if (existsSync(skillDir)) {
+          return { dir: skillDir, category, isDisabled: false };
+        }
+      }
+
+      // 搜索禁用目录
+      if (includeDisabled) {
+        for (const name of namesToTry) {
+          const disableDir = this.getDisableDir(baseDir);
+          const skillDir = path.join(disableDir, name);
+          if (existsSync(skillDir)) {
+            return { dir: skillDir, category, isDisabled: true };
+          }
+        }
+      }
+
+      // 如果指定了分类但没找到，返回 null（不回退到其他分类）
+      return null;
+    }
+
+    // 未指定分类时，使用默认搜索顺序
+    return this.findSkillDir(skillName, includeDisabled);
+  }
+
   // 禁用技能
-  async disableSkill(skillName: string): Promise<{ success: boolean; msg?: string }> {
+  async disableSkill(skillName: string, category?: SkillCategory): Promise<{ success: boolean; msg?: string }> {
     try {
-      const result = await this.findSkillDir(skillName);
+      const result = await this.findSkillDirByCategory(skillName, category);
       if (!result) {
         return { success: false, msg: 'Skill not found' };
       }
 
-      const { dir: skillDir, category, isDisabled } = result;
+      const { dir: skillDir, category: foundCategory, isDisabled } = result;
 
       if (isDisabled) {
         return { success: false, msg: 'Skill is already disabled' };
@@ -394,12 +464,15 @@ export class SkillManager {
 
       // 获取基础目录
       let baseDir: string;
-      switch (category) {
+      switch (foundCategory) {
         case 'system':
           baseDir = this.systemDir;
           break;
         case 'hub':
           baseDir = this.hubDir;
+          break;
+        case 'tenant':
+          baseDir = this.tenantDir;
           break;
         default:
           baseDir = this.customDir;
@@ -429,7 +502,7 @@ export class SkillManager {
         await this.writeSkillMetaFile(destDir, newMeta);
       }
 
-      mainLog('SkillManager', `Disabled skill: ${skillName}`);
+      mainLog('SkillManager', `Disabled skill: ${skillName} (category: ${foundCategory})`);
       return { success: true };
     } catch (error) {
       mainError('SkillManager', 'Failed to disable skill:', error);
@@ -438,14 +511,14 @@ export class SkillManager {
   }
 
   // 启用技能
-  async enableSkill(skillName: string): Promise<{ success: boolean; msg?: string }> {
+  async enableSkill(skillName: string, category?: SkillCategory): Promise<{ success: boolean; msg?: string }> {
     try {
-      const result = await this.findSkillDir(skillName, true);
+      const result = await this.findSkillDirByCategory(skillName, category, true);
       if (!result) {
         return { success: false, msg: 'Skill not found' };
       }
 
-      const { dir: skillDir, category, isDisabled } = result;
+      const { dir: skillDir, category: foundCategory, isDisabled } = result;
 
       if (!isDisabled) {
         return { success: false, msg: 'Skill is already enabled' };
@@ -453,12 +526,15 @@ export class SkillManager {
 
       // 获取基础目录
       let baseDir: string;
-      switch (category) {
+      switch (foundCategory) {
         case 'system':
           baseDir = this.systemDir;
           break;
         case 'hub':
           baseDir = this.hubDir;
+          break;
+        case 'tenant':
+          baseDir = this.tenantDir;
           break;
         default:
           baseDir = this.customDir;
@@ -483,7 +559,7 @@ export class SkillManager {
         await this.writeSkillMetaFile(destDir, newMeta);
       }
 
-      mainLog('SkillManager', `Enabled skill: ${skillName}`);
+      mainLog('SkillManager', `Enabled skill: ${skillName} (category: ${foundCategory})`);
       return { success: true };
     } catch (error) {
       mainError('SkillManager', 'Failed to enable skill:', error);
@@ -492,9 +568,9 @@ export class SkillManager {
   }
 
   // 卸载技能
-  async uninstallSkill(skillName: string): Promise<{ success: boolean; msg?: string }> {
+  async uninstallSkill(skillName: string, category?: SkillCategory): Promise<{ success: boolean; msg?: string }> {
     try {
-      const result = await this.findSkillDir(skillName, true);
+      const result = await this.findSkillDirByCategory(skillName, category, true);
       if (!result) {
         return { success: false, msg: 'Skill not found' };
       }

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -255,18 +255,18 @@ export function initAssistantHubBridge(): void {
     }
   });
 
-  ipcBridge.assistantHub.enableAssistant.provider(async ({ name }) => {
-    const result = await assistantManager.enableAssistant(name);
+  ipcBridge.assistantHub.enableAssistant.provider(async ({ name, category }) => {
+    const result = await assistantManager.enableAssistant(name, category);
     return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
-  ipcBridge.assistantHub.disableAssistant.provider(async ({ name }) => {
-    const result = await assistantManager.disableAssistant(name);
+  ipcBridge.assistantHub.disableAssistant.provider(async ({ name, category }) => {
+    const result = await assistantManager.disableAssistant(name, category);
     return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
-  ipcBridge.assistantHub.updateAssistantMeta.provider(async ({ name, updates }) => {
-    const result = await assistantManager.updateAssistantMeta(name, updates);
+  ipcBridge.assistantHub.updateAssistantMeta.provider(async ({ name, updates, category }) => {
+    const result = await assistantManager.updateAssistantMeta(name, updates, category);
     return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
@@ -285,7 +285,7 @@ export function initAssistantHubBridge(): void {
     return result.success ? { success: true, data: undefined } : { success: false, msg: result.msg };
   });
 
-  ipcBridge.assistantHub.uninstallAssistant.provider(async ({ name }) => {
+  ipcBridge.assistantHub.uninstallAssistant.provider(async ({ name, category }) => {
     // Delete associated conversations before uninstalling assistant
     const deletedConversationIds: string[] = [];
     try {
@@ -312,7 +312,7 @@ export function initAssistantHubBridge(): void {
       mainWarn('AssistantHub', 'Error deleting associated conversations:', dbError);
     }
 
-    const result = await assistantManager.uninstallAssistant(name);
+    const result = await assistantManager.uninstallAssistant(name, category);
 
     // Emit conversationChanged events to notify renderer to refresh conversation list
     if (deletedConversationIds.length > 0) {
@@ -331,36 +331,55 @@ export function initAssistantHubBridge(): void {
   // === Hub API operations ===
 
   // Fetch assistants list from Hub API with cursor-based pagination
-  ipcBridge.assistantHub.fetchAssistants.provider(async ({ cursor, limit = 20, query = '', category = '', tenantId }) => {
+  ipcBridge.assistantHub.fetchAssistants.provider(async ({ cursor, limit = 20, query = '', category = '', tenantId, sourceType }) => {
     try {
-      // 企业模式：从本地 hub/ 目录加载已同步的助手
-      if (isEnterpriseMode()) {
-        // 企业模式下，助手库展示本地已同步的内容
-        // 专属助手 Tab (tenantId 存在时) 从本地 tenant/ 目录加载
-        const sourceType = tenantId ? 'tenant' : 'hub';
-        const assistantsDir = sourceType === 'tenant' ? path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.tenant) : path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.hub);
+      mainLog('AssistantHub', `fetchAssistants called with tenantId: ${tenantId}, sourceType: ${sourceType}, isEnterpriseMode: ${isEnterpriseMode()}`);
 
-        mainLog('AssistantHub', `Enterprise mode: loading assistants from ${assistantsDir}`);
+      // 企业模式：从本地 hub/ 或 tenant/ 目录加载已同步的助手
+      if (isEnterpriseMode()) {
+        // 企业模式下，根据 sourceType 决定从哪个目录加载
+        // sourceType='tenant' 表示专属助手，从 tenant/ 目录加载
+        // 其他情况从 hub/ 目录加载
+        const dirType = sourceType === 'tenant' ? 'tenant' : 'hub';
+        const assistantsDir = path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS[dirType]);
+
+        mainLog('AssistantHub', `Enterprise mode: dirType=${dirType}, loading assistants from ${assistantsDir}`);
 
         // 读取本地目录中的助手
         const assistants: IAssistantHubSkill[] = [];
 
+        mainLog('AssistantHub', `Directory exists: ${existsSync(assistantsDir)}`);
+
         if (existsSync(assistantsDir)) {
           const entries = await fs.readdir(assistantsDir, { withFileTypes: true });
+          mainLog('AssistantHub', `Found ${entries.length} entries in ${assistantsDir}`);
+
           for (const entry of entries) {
             if (!entry.isDirectory()) continue;
+            // Skip directories starting with _ (like _disable)
+            if (entry.name.startsWith('_')) continue;
 
             const assistantName = entry.name;
             const assistantDir = path.join(assistantsDir, assistantName);
 
-            // 过滤逻辑
-            if (query && !assistantName.toLowerCase().includes(query.toLowerCase())) continue;
-
+            // Read metadata first for search filtering
             const metaResult = await readAssistantMetaFileWithFallback(assistantDir);
             if (metaResult) {
               const meta = JSON.parse(metaResult.content) as AssistantHubMeta;
 
-              // 分类过滤
+              const displayName = meta.nameI18n?.['en-US'] || meta.nameI18n?.['zh-CN'] || assistantName;
+              const description = meta.descriptionI18n?.['en-US'] || meta.descriptionI18n?.['zh-CN'] || '';
+
+              // Search filter: search by name, display_name, and description
+              if (query) {
+                const queryLower = query.toLowerCase();
+                const nameMatch = assistantName.toLowerCase().includes(queryLower);
+                const displayNameMatch = displayName.toLowerCase().includes(queryLower);
+                const descriptionMatch = description.toLowerCase().includes(queryLower);
+                if (!nameMatch && !displayNameMatch && !descriptionMatch) continue;
+              }
+
+              // Category filter
               if (category && category !== 'all') {
                 const assistantCategories = meta.categories || [];
                 if (!assistantCategories.includes(category)) continue;
@@ -369,8 +388,8 @@ export function initAssistantHubBridge(): void {
               assistants.push({
                 id: meta.id || assistantName,
                 name: assistantName,
-                display_name: meta.nameI18n?.['en-US'] || meta.nameI18n?.['zh-CN'] || assistantName,
-                description: meta.descriptionI18n?.['en-US'] || meta.descriptionI18n?.['zh-CN'] || '',
+                display_name: displayName,
+                description: description,
                 avatar: meta.avatar || null,
                 emoji: meta.emoji || null,
                 categories: meta.categories || [],

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -11,6 +11,8 @@ import { skillManager } from '@/process/SkillManager';
 import { getDatabase } from '@/process/database';
 import { DEFAULT_PRESET_AGENT_TYPE, normalizePresetAgentType } from '@/types/acpTypes';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS } from '@/process/constants/enterpriseStorage';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 import path from 'path';
@@ -18,14 +20,48 @@ import https from 'node:https';
 import http from 'node:http';
 import JSZip from 'jszip';
 
+const { existsSync } = fsSync;
+
 // Hub API constants (same service as Skill Hub)
 const ASSISTANT_HUB_BASE_URL = 'https://sudoclawhub.sudoprivacy.com/api/assistants';
 const ASSISTANT_HUB_CURSOR_URL = 'https://sudoclawhub.sudoprivacy.com/api/assistants/cursor';
 const ASSISTANT_CATEGORY_URL = 'https://sudoclawhub.sudoprivacy.com/api/categories';
 const AUTHORIZATION = 'sud0@sudo';
 const ASSISTANT_META_FILE = '_sudowork_meta.json';
+const MOSS_ASSISTANT_META_FILE = '_moss_meta.json';
 
 type AssistantHubMeta = import('@/process/constants/assistantStorage').IAssistantMeta;
+
+/**
+ * Read assistant metadata file, trying both Moss and Sudowork meta file names
+ * Enterprise mode: _moss_meta.json (primary), _sudowork_meta.json (fallback)
+ * Personal mode: _sudowork_meta.json (primary), _moss_meta.json (fallback)
+ */
+async function readAssistantMetaFileWithFallback(assistantDir: string): Promise<{ content: string; fileName: string } | null> {
+  const isEnterprise = isEnterpriseMode();
+  const metaFiles = isEnterprise ? [MOSS_ASSISTANT_META_FILE, ASSISTANT_META_FILE] : [ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE];
+
+  for (const fileName of metaFiles) {
+    const filePath = path.join(assistantDir, fileName);
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return { content, fileName };
+    } catch {
+      // Try next file
+    }
+  }
+  return null;
+}
+
+/**
+ * Write assistant metadata file, using correct file name based on current mode
+ */
+async function writeAssistantMetaFile(assistantDir: string, meta: AssistantHubMeta): Promise<void> {
+  const isEnterprise = isEnterpriseMode();
+  const fileName = isEnterprise ? MOSS_ASSISTANT_META_FILE : ASSISTANT_META_FILE;
+  const filePath = path.join(assistantDir, fileName);
+  await fs.writeFile(filePath, JSON.stringify(meta, null, 2), 'utf-8');
+}
 
 // ==================== Helper Functions ====================
 
@@ -297,6 +333,78 @@ export function initAssistantHubBridge(): void {
   // Fetch assistants list from Hub API with cursor-based pagination
   ipcBridge.assistantHub.fetchAssistants.provider(async ({ cursor, limit = 20, query = '', category = '', tenantId }) => {
     try {
+      // 企业模式：从本地 hub/ 目录加载已同步的助手
+      if (isEnterpriseMode()) {
+        // 企业模式下，助手库展示本地已同步的内容
+        // 专属助手 Tab (tenantId 存在时) 从本地 tenant/ 目录加载
+        const sourceType = tenantId ? 'tenant' : 'hub';
+        const assistantsDir = sourceType === 'tenant' ? path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.tenant) : path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.hub);
+
+        mainLog('AssistantHub', `Enterprise mode: loading assistants from ${assistantsDir}`);
+
+        // 读取本地目录中的助手
+        const assistants: IAssistantHubSkill[] = [];
+
+        if (existsSync(assistantsDir)) {
+          const entries = await fs.readdir(assistantsDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+
+            const assistantName = entry.name;
+            const assistantDir = path.join(assistantsDir, assistantName);
+
+            // 过滤逻辑
+            if (query && !assistantName.toLowerCase().includes(query.toLowerCase())) continue;
+
+            const metaResult = await readAssistantMetaFileWithFallback(assistantDir);
+            if (metaResult) {
+              const meta = JSON.parse(metaResult.content) as AssistantHubMeta;
+
+              // 分类过滤
+              if (category && category !== 'all') {
+                const assistantCategories = meta.categories || [];
+                if (!assistantCategories.includes(category)) continue;
+              }
+
+              assistants.push({
+                id: meta.id || assistantName,
+                name: assistantName,
+                display_name: meta.nameI18n?.['en-US'] || meta.nameI18n?.['zh-CN'] || assistantName,
+                description: meta.descriptionI18n?.['en-US'] || meta.descriptionI18n?.['zh-CN'] || '',
+                avatar: meta.avatar || null,
+                emoji: meta.emoji || null,
+                categories: meta.categories || [],
+                category: (meta.categories || [])[0] || '',
+                preset_agent_type: meta.presetAgentType || null,
+                skills: meta.enabledSkills || meta.defaultEnabledSkills || [],
+                tag: 'hub' as const,
+                homepage: meta.homepage || null,
+                author_id: meta.author_id || '',
+                star_count: 0,
+                applicable_scenarios: meta.applicable_scenarios || null,
+                core_features: meta.core_features || null,
+                created_at: meta.installed_at || new Date().toISOString(),
+                updated_at: meta.installed_at || new Date().toISOString(),
+                defaultInitPrompt: meta.defaultInitPrompt || null,
+                visible_to: meta.visible_to || null,
+                version: meta.installed_version || '1.0.0',
+              });
+            }
+          }
+        }
+
+        // 企业模式不支持分页，返回所有结果
+        return {
+          success: true,
+          data: {
+            assistants,
+            next_cursor: null,
+            has_more: false,
+          },
+        };
+      }
+
+      // 个人模式：从 SudoPrivacy Assistant Hub API 获取数据
       const params = new URLSearchParams();
       if (cursor) params.set('cursor', cursor);
       if (limit) params.set('limit', String(limit));
@@ -357,6 +465,37 @@ export function initAssistantHubBridge(): void {
   // Fetch assistant categories from Hub API (type=1 for assistants)
   ipcBridge.assistantHub.fetchCategories.provider(async () => {
     try {
+      // 企业模式：从本地 hub/ 目录的 meta 文件中提取分类
+      if (isEnterpriseMode()) {
+        const hubAssistantsDir = path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.hub);
+
+        mainLog('AssistantHub', `Enterprise mode: extracting categories from ${hubAssistantsDir}`);
+
+        const categoriesSet = new Set<string>();
+
+        if (existsSync(hubAssistantsDir)) {
+          const entries = await fs.readdir(hubAssistantsDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+
+            const assistantName = entry.name;
+            const assistantDir = path.join(hubAssistantsDir, assistantName);
+
+            const metaResult = await readAssistantMetaFileWithFallback(assistantDir);
+            if (metaResult) {
+              const meta = JSON.parse(metaResult.content) as AssistantHubMeta;
+              const assistantCategories = meta.categories || [];
+              for (const cat of assistantCategories) {
+                if (cat) categoriesSet.add(cat);
+              }
+            }
+          }
+        }
+
+        return { success: true, data: Array.from(categoriesSet) };
+      }
+
+      // 个人模式：从 SudoPrivacy Assistant Hub API 获取分类
       const response = await fetch(`${ASSISTANT_CATEGORY_URL}?type=1`, {
         headers: { Authorization: AUTHORIZATION },
       });
@@ -371,6 +510,53 @@ export function initAssistantHubBridge(): void {
   // Fetch assistant detail from Hub API
   ipcBridge.assistantHub.fetchAssistantDetail.provider(async ({ assistantId }) => {
     try {
+      // 企业模式：从本地 hub/ 目录读取详情
+      if (isEnterpriseMode()) {
+        const hubAssistantsDir = path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.hub);
+        const assistantDir = path.join(hubAssistantsDir, assistantId);
+
+        mainLog('AssistantHub', `Enterprise mode: loading assistant detail from ${assistantDir}`);
+
+        const metaResult = await readAssistantMetaFileWithFallback(assistantDir);
+        if (!metaResult) {
+          return { success: false, msg: `Assistant "${assistantId}" not found in local hub` };
+        }
+
+        const meta = JSON.parse(metaResult.content) as AssistantHubMeta;
+
+        const assistant: IAssistantHubSkill = {
+          id: meta.id || assistantId,
+          name: assistantId,
+          display_name: meta.nameI18n?.['en-US'] || meta.nameI18n?.['zh-CN'] || assistantId,
+          description: meta.descriptionI18n?.['en-US'] || meta.descriptionI18n?.['zh-CN'] || '',
+          avatar: meta.avatar || null,
+          emoji: meta.emoji || null,
+          categories: meta.categories || [],
+          category: (meta.categories || [])[0] || '',
+          preset_agent_type: meta.presetAgentType || null,
+          skills: meta.enabledSkills || meta.skills || [],
+          tag: 'hub' as const,
+          homepage: meta.homepage || null,
+          author_id: meta.author_id || '',
+          star_count: 0,
+          applicable_scenarios: meta.applicable_scenarios || null,
+          core_features: meta.core_features || null,
+          created_at: meta.installed_at || new Date().toISOString(),
+          updated_at: meta.installed_at || new Date().toISOString(),
+          defaultInitPrompt: meta.defaultInitPrompt || null,
+          visible_to: meta.visible_to || null,
+          version: meta.installed_version || '1.0.0',
+        };
+
+        const detail: IAssistantHubDetail = {
+          assistant,
+          versions: [],
+        };
+
+        return { success: true, data: detail };
+      }
+
+      // 个人模式：从 SudoPrivacy Assistant Hub API 获取详情
       const url = `${ASSISTANT_HUB_BASE_URL}/${assistantId}`;
       const response = await fetch(url, {
         headers: { Authorization: AUTHORIZATION },
@@ -580,7 +766,11 @@ export function initAssistantHubBridge(): void {
                 installed_version: latestVersion.version,
                 installed_at: new Date().toISOString(),
               };
-              await fs.writeFile(path.join(skillDir, '_sudowork_meta.json'), JSON.stringify(skillMeta, null, 2), 'utf-8');
+              // Use skillHubBridge's writeSkillMetaFile for consistency
+              const { isEnterpriseMode: checkEnterprise } = await import('@/common/enterpriseDebugConfig');
+              const isEnterprise = await checkEnterprise();
+              const skillMetaFileName = isEnterprise ? '_moss_meta.json' : '_sudowork_meta.json';
+              await fs.writeFile(path.join(skillDir, skillMetaFileName), JSON.stringify(skillMeta, null, 2), 'utf-8');
 
               installedSkillNames.push(skillName);
               installedSkillNamesSet.add(skillName); // Update set for subsequent checks
@@ -596,7 +786,6 @@ export function initAssistantHubBridge(): void {
       }
 
       // Write assistant meta with skill IDs in enabledSkills
-      const metaFilePath = path.join(assistantDir, ASSISTANT_META_FILE);
       const meta: AssistantHubMeta = {
         id: assistantMeta.id,
         name: assistantMeta.name,
@@ -625,7 +814,7 @@ export function initAssistantHubBridge(): void {
         // Rule file for displaying assistant rules
         ruleFile: ruleFile,
       };
-      await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
+      await writeAssistantMetaFile(assistantDir, meta);
 
       return {
         success: true,
@@ -685,16 +874,15 @@ export function registerUploadAssistantToHubBridge() {
       }
 
       // Read assistant meta for additional info
-      const metaFilePath = path.join(assistantDir, ASSISTANT_META_FILE);
+      const metaResult = await readAssistantMetaFileWithFallback(assistantDir);
       let assistantMeta: AssistantHubMeta | null = null;
-      try {
-        const metaContent = await fs.readFile(metaFilePath, 'utf-8');
-        assistantMeta = JSON.parse(metaContent) as AssistantHubMeta;
-      } catch {
+      if (metaResult) {
+        assistantMeta = JSON.parse(metaResult.content) as AssistantHubMeta;
+      } else {
         mainWarn('AssistantHub', `No meta file found for assistant "${name}"`);
       }
 
-      // Create zip file (excluding _sudowork_meta.json)
+      // Create zip file (excluding meta files)
       const zip = new JSZip();
       const files = await fs.readdir(assistantDir, { withFileTypes: true });
 
@@ -703,7 +891,8 @@ export function registerUploadAssistantToHubBridge() {
 
       for (const file of files) {
         if (file.isDirectory()) continue;
-        if (file.name === ASSISTANT_META_FILE) continue; // Exclude meta file
+        // Exclude both meta file variants
+        if (file.name === ASSISTANT_META_FILE || file.name === MOSS_ASSISTANT_META_FILE) continue;
 
         const filePath = path.join(assistantDir, file.name);
         const content = await fs.readFile(filePath);

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -237,8 +237,10 @@ export function initEeclawBridge(): void {
         .then(({ syncAllFromRemote }) => syncAllFromRemote())
         .then((result) => {
           mainLog('eeclawBridge', 'Background sync completed', {
-            skills: result.skills.installed.length,
-            assistants: result.assistants.installed.length,
+            hubSkills: result.skills.hub.installed.length,
+            tenantSkills: result.skills.tenant.installed.length,
+            hubAssistants: result.assistants.hub.installed.length,
+            tenantAssistants: result.assistants.tenant.installed.length,
           });
           // Emit sync completed event to notify renderer
           ipcBridge.eeclaw.syncCompleted.emit(result);
@@ -410,8 +412,8 @@ export function initEeclawBridge(): void {
       return {
         success: false,
         data: {
-          skills: { installed: [], skipped: [], failed: [] },
-          assistants: { installed: [], skipped: [], failed: [] },
+          skills: { hub: { installed: [], skipped: [], failed: [] }, tenant: { installed: [], skipped: [], failed: [] } },
+          assistants: { hub: { installed: [], skipped: [], failed: [] }, tenant: { installed: [], skipped: [], failed: [] } },
         },
         msg: error instanceof Error ? error.message : String(error),
       };

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -399,6 +399,8 @@ export function initEeclawBridge(): void {
     try {
       const { syncIncrementalFromRemote } = await import('@process/sync/remoteToLocalSync');
       const result = await syncIncrementalFromRemote();
+      // Emit sync completed event to notify renderer
+      ipcBridge.eeclaw.syncCompleted.emit(result);
       return {
         success: true,
         data: result,

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -6,7 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import { ProcessConfig } from '@process/initStorage';
-import { mainWarn, mainLog } from '@process/utils/mainLogger';
+import { mainWarn, mainLog, mainError } from '@process/utils/mainLogger';
 import { setCachedAuthToken, setCachedServerUrl, setCachedAppMode } from '@/common/enterpriseDebugConfig';
 import { resetConversationProvider } from '../providers';
 
@@ -160,9 +160,11 @@ export function initEeclawBridge(): void {
     if (mode === 'e') {
       try {
         const { getChannelManager } = await import('@/channels');
-        getChannelManager().initialize().catch((error) => {
-          mainLog('eeclawBridge', 'ChannelManager already initialized or failed: ' + String(error));
-        });
+        getChannelManager()
+          .initialize()
+          .catch((error) => {
+            mainLog('eeclawBridge', 'ChannelManager already initialized or failed: ' + String(error));
+          });
       } catch (error) {
         mainLog('eeclawBridge', 'Failed to import ChannelManager: ' + String(error));
       }
@@ -228,6 +230,22 @@ export function initEeclawBridge(): void {
       resetConversationProvider();
 
       mainLog('eeclawBridge', 'Login successful, cache updated, provider reset');
+
+      // 【新增】后台静默同步，不阻塞登录流程
+      // Background silent sync after enterprise login, non-blocking
+      import('@process/sync/remoteToLocalSync')
+        .then(({ syncAllFromRemote }) => syncAllFromRemote())
+        .then((result) => {
+          mainLog('eeclawBridge', 'Background sync completed', {
+            skills: result.skills.installed.length,
+            assistants: result.assistants.installed.length,
+          });
+          // Emit sync completed event to notify renderer
+          ipcBridge.eeclaw.syncCompleted.emit(result);
+        })
+        .catch((err) => {
+          mainError('eeclawBridge', 'Background sync failed:', err);
+        });
 
       return {
         success: true,
@@ -316,7 +334,7 @@ export function initEeclawBridge(): void {
 
       const data = await response.json();
       // Server returns InstalledAssistantInfo[], map to { key, name, avatar, emoji, description }
-      const assistants: Array<{ key: string; name: string; avatar?: string; emoji?: string; description?: string }> = (Array.isArray(data) ? data : data?.data ?? []).map((a: any) => ({
+      const assistants: Array<{ key: string; name: string; avatar?: string; emoji?: string; description?: string }> = (Array.isArray(data) ? data : (data?.data ?? [])).map((a: any) => ({
         key: a.id || a.name,
         name: a.displayName || a.name,
         avatar: a.avatar || undefined,
@@ -374,5 +392,157 @@ export function initEeclawBridge(): void {
       mainLog('eeclawBridge', 'Logged out, local storage cleared');
     }
     return { success: true, data: {} };
+  });
+
+  // Manual sync trigger (for Local mode or retry)
+  ipcBridge.eeclaw.syncFromRemote.provider(async () => {
+    try {
+      const { syncIncrementalFromRemote } = await import('@process/sync/remoteToLocalSync');
+      const result = await syncIncrementalFromRemote();
+      return {
+        success: true,
+        data: result,
+      };
+    } catch (error) {
+      mainError('eeclawBridge', 'syncFromRemote error:', error);
+      return {
+        success: false,
+        data: {
+          skills: { installed: [], skipped: [], failed: [] },
+          assistants: { installed: [], skipped: [], failed: [] },
+        },
+        msg: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+
+  // === Custom Skill/Assistant Upload ===
+  ipcBridge.eeclaw.uploadCustomSkill.provider(async (params) => {
+    mainLog('eeclawBridge', 'uploadCustomSkill called with params:', params);
+    try {
+      const { uploadCustomSkill } = await import('@process/sync/customUpload');
+      const result = await uploadCustomSkill(params);
+      mainLog('eeclawBridge', 'uploadCustomSkill result:', result);
+      if (result.success) {
+        return { success: true, data: { id: result.id || '', name: result.name, status: result.status || 'active' } };
+      }
+      return { success: false, msg: result.error };
+    } catch (error) {
+      mainError('eeclawBridge', 'uploadCustomSkill error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.eeclaw.uploadCustomAssistant.provider(async (params) => {
+    mainLog('eeclawBridge', 'uploadCustomAssistant called with params:', params);
+    try {
+      const { uploadCustomAssistant } = await import('@process/sync/customUpload');
+      const result = await uploadCustomAssistant(params);
+      mainLog('eeclawBridge', 'uploadCustomAssistant result:', result);
+      if (result.success) {
+        return { success: true, data: { id: result.id || '', name: result.name, status: result.status || 'active' } };
+      }
+      return { success: false, msg: result.error };
+    } catch (error) {
+      mainError('eeclawBridge', 'uploadCustomAssistant error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  // === Tenant Skill/Assistant ===
+  ipcBridge.eeclaw.getTenantSkills.provider(async () => {
+    try {
+      const { fetchTenantSkills } = await import('@process/sync/tenantSync');
+      const skills = await fetchTenantSkills();
+      return { success: true, data: skills };
+    } catch (error) {
+      mainError('eeclawBridge', 'getTenantSkills error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.eeclaw.getTenantAssistants.provider(async () => {
+    try {
+      const { fetchTenantAssistants } = await import('@process/sync/tenantSync');
+      const assistants = await fetchTenantAssistants();
+      return { success: true, data: assistants };
+    } catch (error) {
+      mainError('eeclawBridge', 'getTenantAssistants error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.eeclaw.installTenantSkill.provider(async ({ skillId }) => {
+    try {
+      const { installTenantSkill } = await import('@process/sync/tenantSync');
+      const result = await installTenantSkill(skillId);
+      if (result.success) {
+        return { success: true, data: { name: result.name || '' } };
+      }
+      return { success: false, msg: result.error };
+    } catch (error) {
+      mainError('eeclawBridge', 'installTenantSkill error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.eeclaw.installTenantAssistant.provider(async ({ assistantId }) => {
+    try {
+      const { installTenantAssistant } = await import('@process/sync/tenantSync');
+      const result = await installTenantAssistant(assistantId);
+      if (result.success) {
+        return { success: true, data: { name: result.name || '' } };
+      }
+      return { success: false, msg: result.error };
+    } catch (error) {
+      mainError('eeclawBridge', 'installTenantAssistant error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.eeclaw.publishTenantSkill.provider(async ({ skillId, publishNote }) => {
+    try {
+      const { publishTenantSkill } = await import('@process/sync/tenantSync');
+      const result = await publishTenantSkill(skillId, publishNote);
+      if (result.success) {
+        return {
+          success: true,
+          data: {
+            id: result.id || '',
+            skillId: result.skillId || skillId,
+            skillName: result.skillName || '',
+            status: result.status || 'pending',
+            message: result.message,
+          },
+        };
+      }
+      return { success: false, msg: result.error };
+    } catch (error) {
+      mainError('eeclawBridge', 'publishTenantSkill error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.eeclaw.publishTenantAssistant.provider(async ({ assistantId, publishNote }) => {
+    try {
+      const { publishTenantAssistant } = await import('@process/sync/tenantSync');
+      const result = await publishTenantAssistant(assistantId, publishNote);
+      if (result.success) {
+        return {
+          success: true,
+          data: {
+            id: result.id || '',
+            assistantId: result.assistantId || assistantId,
+            assistantName: result.assistantName || '',
+            status: result.status || 'pending',
+            message: result.message,
+          },
+        };
+      }
+      return { success: false, msg: result.error };
+    } catch (error) {
+      mainError('eeclawBridge', 'publishTenantAssistant error:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
   });
 }

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -13,8 +13,9 @@ import http from 'node:http';
 import { app } from 'electron';
 import JSZip from 'jszip';
 import { ipcBridge } from '../../common';
-import { getSystemDir, getAssistantsDir, getSkillsDir } from '../initStorage';
-import { ASSISTANT_SUBDIRS, ASSISTANT_META_FILE } from '../constants/assistantStorage';
+import { getSystemDir, getAssistantsDir, getSkillsDir, getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir } from '../initStorage';
+import { ASSISTANT_SUBDIRS, ENTERPRISE_ASSISTANT_SUBDIRS, ASSISTANT_META_FILE } from '../constants/assistantStorage';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { readDirectoryRecursive } from '../utils';
 import { scanWorkspaceSkills } from '../utils/scanWorkspaceSkills';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
@@ -118,16 +119,17 @@ async function readBuiltinResource(resourceType: ResourceType, fileName: string)
  * 读取助手资源文件，支持语言回退
  *
  * Directory structure:
- * - Hub: _hub/{name}/{ruleFile} or {ruleFileBase}.{locale}.md
- * - System: _system/{name}/{ruleFile} or {ruleFileBase}.{locale}.md
- * - Custom: _my-custom-assistant/{id}/AGENT.md
+ * Enterprise mode: hub/{name}, system/{name}, custom/{id}
+ * Personal mode: _hub/{name}, _system/{name}, _my-custom-assistant/{id}
  */
 async function readAssistantResource(resourceType: ResourceType, assistantId: string, locale: string, fileNamePattern: (id: string, loc: string) => string): Promise<string> {
   const assistantsDir = getAssistantsDir();
   const locales = [locale, 'en-US', 'zh-CN'].filter((l, i, arr) => arr.indexOf(l) === i);
 
-  // 1. Try new directory structure (hub, system, custom)
-  const subdirs = [ASSISTANT_SUBDIRS.hub, ASSISTANT_SUBDIRS.system, ASSISTANT_SUBDIRS.custom];
+  // 1. Try new directory structure (hub, system, custom) - mode-aware
+  const subdirs = isEnterpriseMode()
+    ? [ENTERPRISE_ASSISTANT_SUBDIRS.hub, ENTERPRISE_ASSISTANT_SUBDIRS.system, ENTERPRISE_ASSISTANT_SUBDIRS.custom]
+    : [ASSISTANT_SUBDIRS.hub, ASSISTANT_SUBDIRS.system, ASSISTANT_SUBDIRS.custom];
   for (const subdir of subdirs) {
     const assistantDir = path.join(assistantsDir, subdir, assistantId);
     try {
@@ -210,8 +212,9 @@ async function readAssistantResource(resourceType: ResourceType, assistantId: st
  * Write assistant resource file to user directory
  * 写入助手资源文件到用户目录
  *
- * New directory structure for custom assistants:
- * - Custom: _my-custom-assistant/{id}/AGENT.md
+ * Directory structure:
+ * Enterprise mode: custom/{id}/AGENT.md
+ * Personal mode: _my-custom-assistant/{id}/AGENT.md
  */
 async function writeAssistantResource(resourceType: ResourceType, assistantId: string, content: string, locale: string, fileNamePattern: (id: string, loc: string) => string): Promise<boolean> {
   try {
@@ -220,7 +223,9 @@ async function writeAssistantResource(resourceType: ResourceType, assistantId: s
     // Check if the assistant directory exists in any of the new subdirs (hub, system, custom).
     // This ensures writes go to the same location that readAssistantResource() reads from,
     // preventing a read/write path mismatch where edits would be silently lost.
-    const subdirs = [ASSISTANT_SUBDIRS.custom, ASSISTANT_SUBDIRS.hub, ASSISTANT_SUBDIRS.system];
+    const subdirs = isEnterpriseMode()
+      ? [ENTERPRISE_ASSISTANT_SUBDIRS.custom, ENTERPRISE_ASSISTANT_SUBDIRS.hub, ENTERPRISE_ASSISTANT_SUBDIRS.system]
+      : [ASSISTANT_SUBDIRS.custom, ASSISTANT_SUBDIRS.hub, ASSISTANT_SUBDIRS.system];
     for (const subdir of subdirs) {
       const assistantDir = path.join(assistantsDir, subdir, assistantId);
       try {

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -5,7 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
-import fsSync from 'fs';
+import fsSync, { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -13,7 +13,7 @@ import https from 'node:https';
 import http from 'node:http';
 import { app } from 'electron';
 import JSZip from 'jszip';
-import { clearSkillsCache, getSkillsDir, getHubSkillsDir, getCustomSkillsDir, getBuiltinSkillsDir, SKILL_SUBDIRS } from '@/process/initStorage';
+import { clearSkillsCache, getSkillsDir, getHubSkillsDir, getCustomSkillsDir, getBuiltinSkillsDir, SKILL_SUBDIRS, ProcessConfig } from '@/process/initStorage';
 import { skillManager, SkillCategory, SkillStatus, ISkillMeta } from '@/process/SkillManager';
 import WorkerManage from '@process/WorkerManage';
 import { serviceManager } from '@process/services/serviceManager';
@@ -22,6 +22,8 @@ import { AcpSkillManager } from '@/process/task/AcpSkillManager';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { buildSkillDisplayName, canonicalizeSkillMarkdownPath, findRootSkillMarkdownFileName, isSkillMarkdownFileName, parseSkillFrontmatter, resolveSkillIconFromFiles } from '@/process/utils/skillPackage';
 import { scanSkillDirectory, readAuditReport } from '@/process/services/safety/SkillAuditScanner';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS } from '@/process/constants/enterpriseStorage';
 
 const SKILL_HUB_BASE_URL = 'https://sudoclawhub.sudoprivacy.com/api/skills';
 const SKILL_HUB_CURSOR_URL = 'https://sudoclawhub.sudoprivacy.com/api/skills/cursor';
@@ -29,9 +31,41 @@ const AUTHORIZATION = 'sud0@sudo';
 const VERSION_FILE_NAME = 'sudowork-version';
 /** Metadata file saved alongside installed hub skills. Prefixed to avoid conflicts with skill content. */
 const SKILL_HUB_META_FILE = '_sudowork_meta.json';
+const MOSS_SKILL_META_FILE = '_moss_meta.json';
 const UPLOAD_SKILL_DEFAULT_ICON_FILE = 'upload_skill_default.svg';
 const MISSING_ROOT_SKILL_MD_MESSAGE = 'The selected directory must contain a root-level SKILL.md file (case-insensitive)';
 type SkillHubMeta = import('@/common/ipcBridge').ISkillHubMeta;
+
+/**
+ * Read skill metadata file, trying both Moss and Sudowork meta file names
+ * Enterprise mode: _moss_meta.json (primary), _sudowork_meta.json (fallback)
+ * Personal mode: _sudowork_meta.json (primary), _moss_meta.json (fallback)
+ */
+async function readSkillMetaFileWithFallback(skillDir: string): Promise<{ content: string; fileName: string } | null> {
+  const isEnterprise = isEnterpriseMode();
+  const metaFiles = isEnterprise ? [MOSS_SKILL_META_FILE, SKILL_HUB_META_FILE] : [SKILL_HUB_META_FILE, MOSS_SKILL_META_FILE];
+
+  for (const fileName of metaFiles) {
+    const filePath = path.join(skillDir, fileName);
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return { content, fileName };
+    } catch {
+      // Try next file
+    }
+  }
+  return null;
+}
+
+/**
+ * Write skill metadata file, using correct file name based on current mode
+ */
+async function writeSkillMetaFile(skillDir: string, meta: SkillHubMeta): Promise<void> {
+  const isEnterprise = isEnterpriseMode();
+  const fileName = isEnterprise ? MOSS_SKILL_META_FILE : SKILL_HUB_META_FILE;
+  const filePath = path.join(skillDir, fileName);
+  await fs.writeFile(filePath, JSON.stringify(meta, null, 2), 'utf-8');
+}
 
 function normalizeInstalledSkillVersion(version: string | undefined | null): string {
   const normalized = (version || '').trim();
@@ -207,14 +241,12 @@ async function resolveInstalledSkillDirAllSubdirs(userSkillsDir: string, skillNa
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         const skillDir = path.join(parentDir, entry.name);
-        try {
-          const raw = await fs.readFile(path.join(skillDir, SKILL_HUB_META_FILE), 'utf-8');
-          const meta = JSON.parse(raw) as import('@/common/ipcBridge').ISkillHubMeta;
+        const metaResult = await readSkillMetaFileWithFallback(skillDir);
+        if (metaResult) {
+          const meta = JSON.parse(metaResult.content) as import('@/common/ipcBridge').ISkillHubMeta;
           if (meta.name === skillName || meta.display_name === skillName) {
             return skillDir;
           }
-        } catch {
-          // Ignore
         }
       }
     } catch {
@@ -380,12 +412,11 @@ async function readSkillManifestFromDirectory(
 }
 
 async function readSkillHubMetaFromDirectory(skillDir: string): Promise<SkillHubMeta | null> {
-  try {
-    const raw = await fs.readFile(path.join(skillDir, SKILL_HUB_META_FILE), 'utf-8');
-    return JSON.parse(raw) as SkillHubMeta;
-  } catch {
-    return null;
+  const metaResult = await readSkillMetaFileWithFallback(skillDir);
+  if (metaResult) {
+    return JSON.parse(metaResult.content) as SkillHubMeta;
   }
+  return null;
 }
 
 async function readInstalledVersionFromDirectory(skillDir: string): Promise<string> {
@@ -452,7 +483,6 @@ async function installImportedSkillFromPreparedDirectory(skillDir: string, impor
 
   await fs.rename(skillDir, customDir);
 
-  const metaFilePath = path.join(customDir, SKILL_HUB_META_FILE);
   const installedAt = new Date().toISOString();
   const meta: SkillHubMeta = {
     id: importedMeta?.id?.trim() || '',
@@ -473,7 +503,7 @@ async function installImportedSkillFromPreparedDirectory(skillDir: string, impor
     installed_version: installedVersion,
     installed_at: installedAt,
   };
-  await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
+  await writeSkillMetaFile(customDir, meta);
 
   // Run security audit synchronously so the report is ready when the frontend opens the audit modal
   try {
@@ -578,6 +608,78 @@ export function initSkillHubBridge(): void {
   ipcBridge.skillHub.fetchSkills.provider(async ({ cursor, limit = 20, query = '', category = '', tenantId }) => {
     try {
       mainLog('SkillHub', 'Fetching skills with params:', { cursor, limit, query, category, tenantId });
+
+      // 企业模式：从本地 hub/ 目录加载已同步的技能
+      if (isEnterpriseMode()) {
+        // 企业模式下，技能库展示本地已同步的内容
+        // 专属技能 Tab (tenantId 存在时) 从本地 tenant/ 目录加载
+        const sourceType = tenantId ? 'tenant' : 'hub';
+        const skillsDir = sourceType === 'tenant' ? path.join(SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS.tenant) : path.join(SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS.hub);
+
+        mainLog('SkillHub', `Enterprise mode: loading skills from ${skillsDir}`);
+
+        // 读取本地目录中的技能
+        const skills: import('@/common/ipcBridge').ISkillHubSkill[] = [];
+
+        if (existsSync(skillsDir)) {
+          const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+
+            const dirName = entry.name;
+            const skillDir = path.join(skillsDir, dirName);
+
+            // 过滤逻辑
+            if (query && !dirName.toLowerCase().includes(query.toLowerCase())) continue;
+
+            const metaResult = await readSkillMetaFileWithFallback(skillDir);
+            if (metaResult) {
+              const meta = JSON.parse(metaResult.content) as SkillHubMeta;
+
+              // 分类过滤
+              if (category && category !== 'all') {
+                const skillCategories = meta.categories || [];
+                if (!skillCategories.includes(category)) continue;
+              }
+
+              // Use meta.name if available (same logic as SkillManager.readSkillInfo)
+              // This ensures consistency between fetchSkills and getInstalledSkills
+              const skillName = meta.name?.trim() || dirName;
+              skills.push({
+                id: meta.id || skillName,
+                name: skillName,
+                display_name: meta.display_name || skillName,
+                description: meta.description || '',
+                icon: meta.icon || '',
+                emoji: meta.emoji || null,
+                category: meta.category || '',
+                categories: meta.categories || [],
+                applicable_scenarios: meta.applicable_scenarios || null,
+                core_features: meta.core_features || null,
+                homepage: meta.homepage || null,
+                author_id: meta.author_id || '',
+                star_count: 0,
+                created_at: meta.installed_at || new Date().toISOString(),
+                updated_at: meta.installed_at || new Date().toISOString(),
+                visible_to: meta.visible_to || null,
+                version: meta.installed_version || '1.0.0',
+              });
+            }
+          }
+        }
+
+        // 企业模式不支持分页，返回所有结果
+        return {
+          success: true,
+          data: {
+            skills,
+            next_cursor: null,
+            has_more: false,
+          },
+        };
+      }
+
+      // 个人模式：从 SudoPrivacy Skill Hub API 获取数据
       const params = new URLSearchParams();
       if (cursor) params.set('cursor', cursor);
       if (limit) params.set('limit', String(limit));
@@ -601,6 +703,34 @@ export function initSkillHubBridge(): void {
   ipcBridge.skillHub.fetchCategories.provider(async () => {
     try {
       mainLog('SkillHub', 'Fetching categories');
+
+      // 企业模式：从本地已安装的技能中提取分类
+      if (isEnterpriseMode()) {
+        const hubSkillsDir = path.join(SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS.hub);
+        const categoriesSet = new Set<string>();
+
+        if (existsSync(hubSkillsDir)) {
+          const entries = await fs.readdir(hubSkillsDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+
+            const skillDir = path.join(hubSkillsDir, entry.name);
+            const metaResult = await readSkillMetaFileWithFallback(skillDir);
+            if (metaResult) {
+              const meta = JSON.parse(metaResult.content) as SkillHubMeta;
+              if (meta.categories) {
+                for (const cat of meta.categories) {
+                  categoriesSet.add(cat);
+                }
+              }
+            }
+          }
+        }
+
+        return { success: true, data: Array.from(categoriesSet) };
+      }
+
+      // 个人模式：从 SudoPrivacy Skill Hub API 获取分类
       const response = await fetch('https://sudoclawhub.sudoprivacy.com/api/categories', {
         headers: { Authorization: AUTHORIZATION },
       });
@@ -617,6 +747,51 @@ export function initSkillHubBridge(): void {
   ipcBridge.skillHub.fetchSkillDetail.provider(async ({ skillId }) => {
     try {
       mainLog('SkillHub', 'Fetching skill detail:', skillId);
+
+      // 企业模式：从本地 hub/ 目录获取详情
+      if (isEnterpriseMode()) {
+        // 先尝试从 hub 目录查找
+        const hubSkillsDir = path.join(SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS.hub);
+
+        if (existsSync(hubSkillsDir)) {
+          const entries = await fs.readdir(hubSkillsDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+
+            const skillDir = path.join(hubSkillsDir, entry.name);
+            const metaResult = await readSkillMetaFileWithFallback(skillDir);
+            if (metaResult) {
+              const meta = JSON.parse(metaResult.content) as SkillHubMeta;
+              // 匹配 id 或 name (use meta.name for name matching)
+              const skillName = meta.name?.trim() || entry.name;
+              if (meta.id === skillId || skillName === skillId || entry.name === skillId) {
+                const detail = {
+                  id: meta.id || entry.name,
+                  name: skillName,
+                  display_name: meta.display_name || skillName,
+                  description: meta.description || '',
+                  icon: meta.icon || '',
+                  emoji: meta.emoji || null,
+                  category: meta.category || '',
+                  categories: meta.categories || [],
+                  applicable_scenarios: meta.applicable_scenarios || null,
+                  core_features: meta.core_features || null,
+                  homepage: meta.homepage || null,
+                  author_id: meta.author_id || '',
+                  version: meta.installed_version || '1.0.0',
+                  visible_to: meta.visible_to || null,
+                };
+                return { success: true, data: detail };
+              }
+            }
+          }
+        }
+
+        // 未找到
+        return { success: false, msg: 'Skill not found in local hub directory' };
+      }
+
+      // 个人模式：从 SudoPrivacy Skill Hub API 获取详情
       const response = await fetch(`${SKILL_HUB_BASE_URL}/${skillId}`, {
         headers: { Authorization: AUTHORIZATION },
       });
@@ -665,10 +840,9 @@ export function initSkillHubBridge(): void {
       await extractSkillZipToDirectory(zipBuffer, skillDir);
 
       // Write hub metadata file so installed skills can be displayed with full info
-      // NOTE: _sudowork_meta.json is the single source of truth for installed version.
+      // NOTE: Metadata file is the single source of truth for installed version.
       // The standalone sudowork-version file is no longer written for new installs.
-      const metaFilePath = path.join(skillDir, SKILL_HUB_META_FILE);
-      const meta = {
+      const meta: SkillHubMeta = {
         id: skillMeta?.id ?? '',
         name: trimmedSkillName,
         display_name: skillMeta?.display_name ?? displayName,
@@ -687,7 +861,7 @@ export function initSkillHubBridge(): void {
         installed_version: version,
         installed_at: new Date().toISOString(),
       };
-      await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
+      await writeSkillMetaFile(skillDir, meta);
 
       mainLog('SkillHub', `Successfully installed skill "${trimmedSkillName}" v${version} to ${skillDir}`);
 

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -625,31 +625,42 @@ export function initSkillHubBridge(): void {
           const entries = await fs.readdir(skillsDir, { withFileTypes: true });
           for (const entry of entries) {
             if (!entry.isDirectory()) continue;
+            // Skip directories starting with _ (like _disable)
+            if (entry.name.startsWith('_')) continue;
 
             const dirName = entry.name;
             const skillDir = path.join(skillsDir, dirName);
 
-            // 过滤逻辑
-            if (query && !dirName.toLowerCase().includes(query.toLowerCase())) continue;
-
+            // Read metadata first for search filtering
             const metaResult = await readSkillMetaFileWithFallback(skillDir);
             if (metaResult) {
               const meta = JSON.parse(metaResult.content) as SkillHubMeta;
 
-              // 分类过滤
+              // Use meta.name if available (same logic as SkillManager.readSkillInfo)
+              const skillName = meta.name?.trim() || dirName;
+              const displayName = meta.display_name || skillName;
+              const description = meta.description || '';
+
+              // Search filter: search by name, display_name, and description
+              if (query) {
+                const queryLower = query.toLowerCase();
+                const nameMatch = skillName.toLowerCase().includes(queryLower);
+                const displayNameMatch = displayName.toLowerCase().includes(queryLower);
+                const descriptionMatch = description.toLowerCase().includes(queryLower);
+                if (!nameMatch && !displayNameMatch && !descriptionMatch) continue;
+              }
+
+              // Category filter
               if (category && category !== 'all') {
                 const skillCategories = meta.categories || [];
                 if (!skillCategories.includes(category)) continue;
               }
 
-              // Use meta.name if available (same logic as SkillManager.readSkillInfo)
-              // This ensures consistency between fetchSkills and getInstalledSkills
-              const skillName = meta.name?.trim() || dirName;
               skills.push({
                 id: meta.id || skillName,
                 name: skillName,
-                display_name: meta.display_name || skillName,
-                description: meta.description || '',
+                display_name: displayName,
+                description: description,
                 icon: meta.icon || '',
                 emoji: meta.emoji || null,
                 category: meta.category || '',
@@ -972,6 +983,8 @@ export function initSkillHubBridge(): void {
         isAutoInjectedBuiltin: skill.isAutoInjectedBuiltin === true,
         isHubInstalled: skill.isHubInstalled,
         enabled: skill.enabled,
+        // 目录分类优先，作为主要分类依据
+        category: skill.category,
         meta: skill.meta
           ? {
               ...skill.meta,
@@ -1001,9 +1014,9 @@ export function initSkillHubBridge(): void {
   });
 
   // Uninstall a skill (using SkillManager)
-  ipcBridge.skillHub.uninstallSkill.provider(async ({ skillName }) => {
+  ipcBridge.skillHub.uninstallSkill.provider(async ({ skillName, category }) => {
     try {
-      const result = await skillManager.uninstallSkill(skillName);
+      const result = await skillManager.uninstallSkill(skillName, category);
       if (result.success) {
         void (async () => {
           try {
@@ -1022,9 +1035,9 @@ export function initSkillHubBridge(): void {
   });
 
   // Enable/disable a skill (using SkillManager)
-  ipcBridge.skillHub.setSkillEnabled.provider(async ({ skillName, enabled }) => {
+  ipcBridge.skillHub.setSkillEnabled.provider(async ({ skillName, enabled, category }) => {
     try {
-      const result = enabled ? await skillManager.enableSkill(skillName) : await skillManager.disableSkill(skillName);
+      const result = enabled ? await skillManager.enableSkill(skillName, category) : await skillManager.disableSkill(skillName, category);
       if (result.success) {
         void (async () => {
           try {

--- a/src/process/constants/assistantStorage.ts
+++ b/src/process/constants/assistantStorage.ts
@@ -84,14 +84,14 @@ export interface IAssistantMeta {
    */
   resourceDir?: string;
   // Storage tracking fields
-  source_type?: 'hub' | 'custom' | 'builtin';
+  source_type?: 'hub' | 'custom' | 'builtin' | 'tenant';
   is_builtin?: boolean;
   enabled?: boolean;
   installed_version?: string;
   installed_at?: string;
   // Hub API fields
-  /** Source tag from Hub API: 'hub' (store), 'custom' (user-created), 'system' (builtin) */
-  tag?: 'hub' | 'custom' | 'system';
+  /** Source tag from Hub API: 'hub' (store), 'custom' (user-created), 'system' (builtin), 'tenant' (enterprise-exclusive) */
+  tag?: 'hub' | 'custom' | 'system' | 'tenant';
   /** Associated skill IDs from Hub API (skills guaranteed to exist in Skill Hub) */
   skills?: string[];
   /** Hub category ID */

--- a/src/process/constants/assistantStorage.ts
+++ b/src/process/constants/assistantStorage.ts
@@ -1,7 +1,10 @@
 /**
  * Assistant subdirectory names for categorized assistant preset storage.
- * All prefixed with `_` to distinguish from legacy flat assistant files.
+ * Personal mode: All prefixed with `_` to distinguish from legacy flat assistant files.
+ * Enterprise mode: No prefix (hub/custom/tenant/system).
  */
+
+/** Personal mode subdirectory names (prefixed with `_`) */
 export const ASSISTANT_SUBDIRS = {
   /** Hub-installed assistant presets (source_type: 'hub') */
   hub: '_hub',
@@ -11,8 +14,23 @@ export const ASSISTANT_SUBDIRS = {
   custom: '_my-custom-assistant',
 } as const;
 
-/** Metadata file name for assistant presets */
+/** Enterprise mode subdirectory names (no prefix) */
+export const ENTERPRISE_ASSISTANT_SUBDIRS = {
+  /** Hub-installed assistants (synced from Moss Server) */
+  hub: 'hub',
+  /** User-created custom assistants */
+  custom: 'custom',
+  /** Enterprise tenant-exclusive assistants (approved by admin) */
+  tenant: 'tenant',
+  /** System/builtin assistants */
+  system: 'system',
+} as const;
+
+/** Metadata file name for assistant presets (personal mode) */
 export const ASSISTANT_META_FILE = '_sudowork_meta.json';
+
+/** Metadata file name for assistant presets (enterprise mode - matches Moss Server) */
+export const MOSS_ASSISTANT_META_FILE = '_moss_meta.json';
 
 /**
  * Assistant preset metadata stored in _sudowork_meta.json.
@@ -90,4 +108,14 @@ export interface IAssistantMeta {
   core_features?: string | null;
   /** Default initial prompt to pre-fill input when selecting this assistant */
   defaultInitPrompt?: string | null;
+  /** Visibility configuration for enterprise assistants (department_ids filter) */
+  visible_to?: { department_ids: string[] | null } | null;
+  /** Whether this assistant has been uploaded to Moss Server */
+  uploaded?: boolean;
+  /** Timestamp when uploaded to Moss Server */
+  uploaded_at?: string;
+  /** Publish status for tenant-exclusive assistants */
+  publish_status?: 'pending' | 'approved' | 'rejected';
+  /** Timestamp when published as tenant-exclusive */
+  published_at?: string;
 }

--- a/src/process/constants/enterpriseStorage.ts
+++ b/src/process/constants/enterpriseStorage.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Enterprise Mode Directory Management
+ *
+ * 企业模式目录管理模块，提供企业模式下的技能和助手目录路径计算。
+ * 企业模式使用不带 `_` 前缀的子目录结构（hub/custom/tenant/system）。
+ */
+
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { ENTERPRISE_SKILL_SUBDIRS, SKILL_SUBDIRS, SKILL_HUB_META_FILE, MOSS_SKILL_META_FILE } from './skillStorage';
+import { ENTERPRISE_ASSISTANT_SUBDIRS, ASSISTANT_SUBDIRS, ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE } from './assistantStorage';
+
+// Re-export for use in bridge files
+export { ENTERPRISE_SKILL_SUBDIRS, ENTERPRISE_ASSISTANT_SUBDIRS };
+
+/** Nexus root directory (~/.nexus) */
+export const NEXUS_DIR = path.join(os.homedir(), '.nexus');
+
+/** Skills root directory */
+export const SKILLS_ROOT_DIR = path.join(NEXUS_DIR, 'skills');
+
+/** Assistants root directory */
+export const ASSISTANTS_ROOT_DIR = path.join(NEXUS_DIR, 'assistants');
+
+/** Source type for skills/assistants */
+export type SourceType = 'hub' | 'custom' | 'tenant' | 'system';
+
+/**
+ * Get skill metadata file name based on current mode
+ * Enterprise mode: _moss_meta.json (matches Moss Server)
+ * Personal mode: _sudowork_meta.json
+ */
+export function getSkillMetaFileName(): string {
+  if (isEnterpriseMode()) {
+    return MOSS_SKILL_META_FILE;
+  }
+  return SKILL_HUB_META_FILE;
+}
+
+/**
+ * Get assistant metadata file name based on current mode
+ * Enterprise mode: _moss_meta.json (matches Moss Server)
+ * Personal mode: _sudowork_meta.json
+ */
+export function getAssistantMetaFileName(): string {
+  if (isEnterpriseMode()) {
+    return MOSS_ASSISTANT_META_FILE;
+  }
+  return ASSISTANT_META_FILE;
+}
+
+/**
+ * Get skill subdirectory name based on current mode
+ * 根据当前模式获取技能子目录名称
+ */
+export function getSkillSubdirName(sourceType: SourceType): string {
+  if (isEnterpriseMode()) {
+    return ENTERPRISE_SKILL_SUBDIRS[sourceType];
+  }
+  // Personal mode: map 'tenant' to 'custom' since tenant doesn't exist in personal mode
+  if (sourceType === 'tenant') {
+    return SKILL_SUBDIRS.custom;
+  }
+  return SKILL_SUBDIRS[sourceType];
+}
+
+/**
+ * Get assistant subdirectory name based on current mode
+ * 根据当前模式获取助手子目录名称
+ */
+export function getAssistantSubdirName(sourceType: SourceType): string {
+  if (isEnterpriseMode()) {
+    return ENTERPRISE_ASSISTANT_SUBDIRS[sourceType];
+  }
+  // Personal mode: map 'tenant' to 'custom' since tenant doesn't exist in personal mode
+  if (sourceType === 'tenant') {
+    return ASSISTANT_SUBDIRS.custom;
+  }
+  return ASSISTANT_SUBDIRS[sourceType];
+}
+
+/**
+ * Get skill install directory path
+ * 获取技能安装目录路径
+ *
+ * @param skillName - Skill name (directory name)
+ * @param sourceType - Source type (hub/custom/tenant/system)
+ * @returns Full path to skill directory
+ */
+export function getSkillInstallDir(skillName: string, sourceType: SourceType): string {
+  const subdirName = getSkillSubdirName(sourceType);
+  return path.join(SKILLS_ROOT_DIR, subdirName, skillName);
+}
+
+/**
+ * Get assistant install directory path
+ * 获取助手安装目录路径
+ *
+ * @param assistantName - Assistant name (directory name)
+ * @param sourceType - Source type (hub/custom/tenant/system)
+ * @returns Full path to assistant directory
+ */
+export function getAssistantInstallDir(assistantName: string, sourceType: SourceType): string {
+  const subdirName = getAssistantSubdirName(sourceType);
+  return path.join(ASSISTANTS_ROOT_DIR, subdirName, assistantName);
+}
+
+/**
+ * Get hub skills directory path
+ * 获取 Hub 安装技能目录路径
+ */
+export function getEnterpriseHubSkillsDir(): string {
+  return path.join(SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS.hub);
+}
+
+/**
+ * Get custom skills directory path
+ * 获取自定义技能目录路径
+ */
+export function getEnterpriseCustomSkillsDir(): string {
+  return path.join(SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS.custom);
+}
+
+/**
+ * Get tenant skills directory path
+ * 获取企业专属技能目录路径
+ */
+export function getEnterpriseTenantSkillsDir(): string {
+  return path.join(SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS.tenant);
+}
+
+/**
+ * Get hub assistants directory path
+ * 获取 Hub 安装助手目录路径
+ */
+export function getEnterpriseHubAssistantsDir(): string {
+  return path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.hub);
+}
+
+/**
+ * Get custom assistants directory path
+ * 获取自定义助手目录路径
+ */
+export function getEnterpriseCustomAssistantsDir(): string {
+  return path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.custom);
+}
+
+/**
+ * Get tenant assistants directory path
+ * 获取企业专属助手目录路径
+ */
+export function getEnterpriseTenantAssistantsDir(): string {
+  return path.join(ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS.tenant);
+}
+
+/**
+ * Initialize enterprise mode directory structure
+ * 初始化企业模式目录结构
+ *
+ * Creates hub/custom/tenant/system subdirectories under skills/ and assistants/
+ */
+export function initEnterpriseDirs(): void {
+  if (!isEnterpriseMode()) {
+    return;
+  }
+
+  // Ensure root directories exist
+  if (!existsSync(SKILLS_ROOT_DIR)) {
+    mkdirSync(SKILLS_ROOT_DIR, { recursive: true });
+  }
+  if (!existsSync(ASSISTANTS_ROOT_DIR)) {
+    mkdirSync(ASSISTANTS_ROOT_DIR, { recursive: true });
+  }
+
+  // Create enterprise mode subdirectories
+  const skillSubdirs = Object.values(ENTERPRISE_SKILL_SUBDIRS);
+  const assistantSubdirs = Object.values(ENTERPRISE_ASSISTANT_SUBDIRS);
+
+  for (const subdir of skillSubdirs) {
+    const dirPath = path.join(SKILLS_ROOT_DIR, subdir);
+    if (!existsSync(dirPath)) {
+      mkdirSync(dirPath, { recursive: true });
+    }
+  }
+
+  for (const subdir of assistantSubdirs) {
+    const dirPath = path.join(ASSISTANTS_ROOT_DIR, subdir);
+    if (!existsSync(dirPath)) {
+      mkdirSync(dirPath, { recursive: true });
+    }
+  }
+}
+
+/**
+ * Check if enterprise directories are initialized
+ * 检查企业模式目录是否已初始化
+ */
+export function areEnterpriseDirsInitialized(): boolean {
+  if (!isEnterpriseMode()) {
+    return true; // Not enterprise mode, no need to check
+  }
+
+  const requiredDirs = [getEnterpriseHubSkillsDir(), getEnterpriseCustomSkillsDir(), getEnterpriseTenantSkillsDir(), getEnterpriseHubAssistantsDir(), getEnterpriseCustomAssistantsDir(), getEnterpriseTenantAssistantsDir()];
+
+  return requiredDirs.every((dir) => existsSync(dir));
+}
+
+/**
+ * Get all skill directories by source type
+ * 获取指定源类型的所有技能目录
+ *
+ * @param sourceType - Source type to filter
+ * @returns Array of skill directory paths
+ */
+export async function getSkillDirsBySourceType(sourceType: SourceType): Promise<string[]> {
+  const parentDir = getSkillInstallDir('', sourceType).replace(/\/$/, '');
+
+  if (!existsSync(parentDir)) {
+    return [];
+  }
+
+  const entries = await fs.readdir(parentDir, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => path.join(parentDir, entry.name));
+}
+
+/**
+ * Get all assistant directories by source type
+ * 获取指定源类型的所有助手目录
+ *
+ * @param sourceType - Source type to filter
+ * @returns Array of assistant directory paths
+ */
+export async function getAssistantDirsBySourceType(sourceType: SourceType): Promise<string[]> {
+  const parentDir = getAssistantInstallDir('', sourceType).replace(/\/$/, '');
+
+  if (!existsSync(parentDir)) {
+    return [];
+  }
+
+  const entries = await fs.readdir(parentDir, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => path.join(parentDir, entry.name));
+}

--- a/src/process/constants/skillStorage.ts
+++ b/src/process/constants/skillStorage.ts
@@ -1,7 +1,10 @@
 /**
  * Skill subdirectory names for categorized skill storage.
- * All prefixed with `_` to distinguish from legacy flat skill directories.
+ * Personal mode: All prefixed with `_` to distinguish from legacy flat skill directories.
+ * Enterprise mode: No prefix (hub/custom/tenant/system).
  */
+
+/** Personal mode subdirectory names (prefixed with `_`) */
 export const SKILL_SUBDIRS = {
   /** Hub-installed skills (source_type: 'hub') */
   hub: '_hub',
@@ -12,3 +15,21 @@ export const SKILL_SUBDIRS = {
   /** Legacy builtin directory (pre-migration) */
   legacyBuiltin: '_builtin',
 } as const;
+
+/** Enterprise mode subdirectory names (no prefix) */
+export const ENTERPRISE_SKILL_SUBDIRS = {
+  /** Hub-installed skills (synced from Moss Server) */
+  hub: 'hub',
+  /** User-created custom skills */
+  custom: 'custom',
+  /** Enterprise tenant-exclusive skills (approved by admin) */
+  tenant: 'tenant',
+  /** System/builtin skills */
+  system: 'system',
+} as const;
+
+/** Metadata file name for skills (personal mode) */
+export const SKILL_HUB_META_FILE = '_sudowork_meta.json';
+
+/** Metadata file name for skills (enterprise mode - matches Moss Server) */
+export const MOSS_SKILL_META_FILE = '_moss_meta.json';

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -17,7 +17,9 @@ import { copyDirectoryRecursively, ensureDirectory, getConfigPath, getDataPath, 
 import { getDatabase } from './database/export';
 import type { AcpBackendConfig } from '@/types/acpTypes';
 import { perfLog, mainLog, mainWarn, mainError } from './utils/mainLogger';
-import { SKILL_SUBDIRS } from './constants/skillStorage';
+import { SKILL_SUBDIRS, ENTERPRISE_SKILL_SUBDIRS } from './constants/skillStorage';
+import { ASSISTANT_SUBDIRS, ENTERPRISE_ASSISTANT_SUBDIRS } from './constants/assistantStorage';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 // Platform and architecture types (moved from deleted updateConfig)
 type PlatformType = 'win32' | 'darwin' | 'linux';
 type ArchitectureType = 'x64' | 'arm64' | 'ia32' | 'arm';
@@ -279,27 +281,36 @@ const getAssistantsDir = () => {
 };
 
 /**
- * 获取 Hub 安装助手目录路径 (_hub 子目录)
+ * 获取 Hub 安装助手目录路径
  * Get hub-installed assistants directory path
+ * Enterprise mode: assistants/hub
+ * Personal mode: assistants/_hub
  */
 const getHubAssistantsDir = () => {
-  return path.join(getAssistantsDir(), '_hub');
+  const subdirs = isEnterpriseMode() ? ENTERPRISE_ASSISTANT_SUBDIRS : ASSISTANT_SUBDIRS;
+  return path.join(getAssistantsDir(), subdirs.hub);
 };
 
 /**
- * 获取系统/内置助手目录路径 (_system 子目录)
+ * 获取系统/内置助手目录路径
  * Get system/builtin assistants directory path
+ * Enterprise mode: assistants/system
+ * Personal mode: assistants/_system
  */
 const getSystemAssistantsDir = () => {
-  return path.join(getAssistantsDir(), '_system');
+  const subdirs = isEnterpriseMode() ? ENTERPRISE_ASSISTANT_SUBDIRS : ASSISTANT_SUBDIRS;
+  return path.join(getAssistantsDir(), subdirs.system);
 };
 
 /**
- * 获取自定义助手目录路径 (_my-custom-assistant 子目录)
+ * 获取自定义助手目录路径
  * Get custom assistants directory path
+ * Enterprise mode: assistants/custom
+ * Personal mode: assistants/_my-custom-assistant
  */
 const getCustomAssistantsDir = () => {
-  return path.join(getAssistantsDir(), '_my-custom-assistant');
+  const subdirs = isEnterpriseMode() ? ENTERPRISE_ASSISTANT_SUBDIRS : ASSISTANT_SUBDIRS;
+  return path.join(getAssistantsDir(), subdirs.custom);
 };
 
 /**
@@ -311,16 +322,19 @@ const getSkillsDir = () => {
 };
 
 /**
- * 获取系统技能根目录路径（_system 子目录）
- * Get system skills root directory path (_system subdirectory)
+ * 获取系统技能根目录路径
+ * Get system skills root directory path
+ * Enterprise mode: skills/system
+ * Personal mode: skills/_system
  */
 const getSystemSkillsDir = () => {
-  return path.join(getSkillsDir(), SKILL_SUBDIRS.system);
+  const subdirs = isEnterpriseMode() ? ENTERPRISE_SKILL_SUBDIRS : SKILL_SUBDIRS;
+  return path.join(getSkillsDir(), subdirs.system);
 };
 
 /**
- * 获取内置技能目录路径（_system/_builtin 子目录）
- * Get builtin skills directory path (_system/_builtin subdirectory)
+ * 获取内置技能目录路径
+ * Get builtin skills directory path
  * Skills in this directory are automatically injected for ALL agents and scenarios
  */
 const getBuiltinSkillsDir = () => {
@@ -330,17 +344,23 @@ const getBuiltinSkillsDir = () => {
 /**
  * 获取 Hub 安装技能目录路径
  * Get hub-installed skills directory path
+ * Enterprise mode: skills/hub
+ * Personal mode: skills/_hub
  */
 const getHubSkillsDir = () => {
-  return path.join(getSkillsDir(), SKILL_SUBDIRS.hub);
+  const subdirs = isEnterpriseMode() ? ENTERPRISE_SKILL_SUBDIRS : SKILL_SUBDIRS;
+  return path.join(getSkillsDir(), subdirs.hub);
 };
 
 /**
  * 获取自定义上传技能目录路径
  * Get custom uploaded skills directory path
+ * Enterprise mode: skills/custom
+ * Personal mode: skills/_my-custom-skill
  */
 const getCustomSkillsDir = () => {
-  return path.join(getSkillsDir(), SKILL_SUBDIRS.custom);
+  const subdirs = isEnterpriseMode() ? ENTERPRISE_SKILL_SUBDIRS : SKILL_SUBDIRS;
+  return path.join(getSkillsDir(), subdirs.custom);
 };
 
 /**
@@ -1084,13 +1104,7 @@ const initStorage = async () => {
   const channelAgentMigrationDone = await configFile.get(CHANNEL_AGENT_MIGRATION_KEY).catch(() => false);
   if (!channelAgentMigrationDone) {
     try {
-      const CHANNEL_AGENT_KEYS = [
-        'assistant.telegram.agent',
-        'assistant.lark.agent',
-        'assistant.dingtalk.agent',
-        'assistant.wechat.agent',
-        'assistant.wecom.agent',
-      ] as const;
+      const CHANNEL_AGENT_KEYS = ['assistant.telegram.agent', 'assistant.lark.agent', 'assistant.dingtalk.agent', 'assistant.wechat.agent', 'assistant.wecom.agent'] as const;
       for (const key of CHANNEL_AGENT_KEYS) {
         const saved = await configFile.get(key).catch(() => undefined);
         if (saved && typeof saved === 'object' && (saved as any).backend === 'openclaw-gateway') {
@@ -1145,30 +1159,48 @@ export { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCusto
  */
 const skillsContentCache = new Map<string, string>();
 const SKILL_HUB_META_FILE = '_sudowork_meta.json';
+const MOSS_SKILL_META_FILE = '_moss_meta.json';
+
+/**
+ * Read skill metadata file, trying both Moss and Sudowork meta file names
+ * Enterprise mode: _moss_meta.json (primary), _sudowork_meta.json (fallback)
+ * Personal mode: _sudowork_meta.json (primary), _moss_meta.json (fallback)
+ */
+async function readSkillMetaFileWithFallback(skillDir: string): Promise<{ enabled?: boolean } | null> {
+  const isEnterprise = isEnterpriseMode();
+  const metaFiles = isEnterprise ? [MOSS_SKILL_META_FILE, SKILL_HUB_META_FILE] : [SKILL_HUB_META_FILE, MOSS_SKILL_META_FILE];
+
+  for (const fileName of metaFiles) {
+    const filePath = path.join(skillDir, fileName);
+    try {
+      const raw = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(raw) as { enabled?: boolean };
+    } catch {
+      // Try next file
+    }
+  }
+  return null;
+}
 
 export async function isUserSkillEnabled(skillName: string): Promise<boolean> {
   // Search in all subdirectories for the skill metadata
   const subdirs = [SKILL_SUBDIRS.custom, SKILL_SUBDIRS.hub, SKILL_SUBDIRS.system];
   for (const subdir of subdirs) {
-    const skillMetaPath = path.join(getSkillsDir(), subdir, skillName, SKILL_HUB_META_FILE);
-    try {
-      const raw = await fs.readFile(skillMetaPath, 'utf-8');
-      const meta = JSON.parse(raw) as { enabled?: boolean };
+    const skillDir = path.join(getSkillsDir(), subdir, skillName);
+    const meta = await readSkillMetaFileWithFallback(skillDir);
+    if (meta) {
       return meta.enabled !== false;
-    } catch {
-      // Not found in this subdir, continue
     }
   }
 
   // Fallback: check legacy flat path for backward compatibility
-  const legacyMetaPath = path.join(getSkillsDir(), skillName, SKILL_HUB_META_FILE);
-  try {
-    const raw = await fs.readFile(legacyMetaPath, 'utf-8');
-    const meta = JSON.parse(raw) as { enabled?: boolean };
+  const legacySkillDir = path.join(getSkillsDir(), skillName);
+  const meta = await readSkillMetaFileWithFallback(legacySkillDir);
+  if (meta) {
     return meta.enabled !== false;
-  } catch {
-    return true;
   }
+
+  return true;
 }
 
 /**

--- a/src/process/sync/customUpload.ts
+++ b/src/process/sync/customUpload.ts
@@ -1,0 +1,437 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Custom Skill/Assistant Upload Module
+ *
+ * 自定义技能/助手创建与上传模块
+ *
+ * 功能：
+ * 1. 本地创建自定义技能/助手（保存到 custom/ 目录）
+ * 2. 打包为 zip 文件
+ * 3. 上传到 Moss Server
+ * 4. 更新本地元数据标记为已上传
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { existsSync, mkdirSync } from 'fs';
+import JSZip from 'jszip';
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { isEnterpriseMode, getEnterpriseConfig } from '@/common/enterpriseDebugConfig';
+import { getSkillInstallDir, getAssistantInstallDir, initEnterpriseDirs, getEnterpriseCustomSkillsDir, getEnterpriseCustomAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName, SourceType } from '@/process/constants/enterpriseStorage';
+import type { IAssistantMeta } from '@/process/constants/assistantStorage';
+import type { ISkillHubMeta } from '@/common/ipcBridge';
+
+// ============ 类型定义 ============
+
+export interface CustomSkillUploadParams {
+  skillName: string;
+  displayName: string;
+  description?: string;
+  version?: string;
+  /** Local skill directory path (if already exists) */
+  sourcePath?: string;
+}
+
+export interface CustomSkillUploadResult {
+  success: boolean;
+  id?: string;
+  name: string;
+  status?: string;
+  error?: string;
+}
+
+export interface CustomAssistantUploadParams {
+  assistantName: string;
+  displayName: string;
+  description?: string;
+  version?: string;
+  enabledSkills?: string[];
+  memoryMode?: 'session' | 'user';
+  /** Local assistant directory path (if already exists) */
+  sourcePath?: string;
+}
+
+export interface CustomAssistantUploadResult {
+  success: boolean;
+  id?: string;
+  name: string;
+  status?: string;
+  error?: string;
+}
+
+// ============ 工具函数 ============
+
+/**
+ * Get Moss Server URL and token
+ */
+function getMossConfig(): { serverUrl: string; token: string } {
+  const config = getEnterpriseConfig();
+  return {
+    serverUrl: config.mossServerUrl,
+    token: config.authToken,
+  };
+}
+
+/**
+ * Create zip file from directory
+ */
+async function createZipFromDirectory(sourceDir: string): Promise<Buffer> {
+  const zip = new JSZip();
+
+  async function addDirectoryToZip(dirPath: string, zipPath: string = ''): Promise<void> {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      const zipEntryPath = zipPath ? `${zipPath}/${entry.name}` : entry.name;
+
+      if (entry.isDirectory()) {
+        await addDirectoryToZip(fullPath, zipEntryPath);
+      } else if (entry.isFile()) {
+        const content = await fs.readFile(fullPath);
+        zip.file(zipEntryPath, content);
+      }
+    }
+  }
+
+  await addDirectoryToZip(sourceDir);
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+/**
+ * Upload file to Moss Server via JSON body with base64 encoded file
+ * Moss Server expects JSON body with file as base64 string
+ */
+async function uploadFile(url: string, token: string, params: Record<string, string | string[] | undefined>, zipBuffer: Buffer): Promise<Response> {
+  // Convert zip buffer to base64
+  const fileBase64 = zipBuffer.toString('base64');
+
+  // Build JSON body matching Moss Server's expected format
+  const body: Record<string, unknown> = {
+    file: fileBase64,
+    name: params.name || '',
+    displayName: params.displayName || params.name || '',
+    description: params.description || '',
+    version: params.version || '1.0.0',
+  };
+
+  // Add optional fields for assistants
+  if (params.enabledSkills) {
+    body.enabledSkills = params.enabledSkills;
+  }
+  if (params.memoryMode) {
+    body.memoryMode = params.memoryMode;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  return response;
+}
+
+// ============ 自定义技能上传 ============
+
+/**
+ * Create local custom skill directory
+ */
+export async function createLocalCustomSkill(params: CustomSkillUploadParams): Promise<string> {
+  // Initialize enterprise directories if needed
+  if (isEnterpriseMode()) {
+    initEnterpriseDirs();
+  }
+
+  const skillDir = getSkillInstallDir(params.skillName, 'custom');
+  await fs.mkdir(skillDir, { recursive: true });
+
+  // Create SKILL.md if not exists
+  const skillMdPath = path.join(skillDir, 'SKILL.md');
+  if (!existsSync(skillMdPath)) {
+    const skillMdContent = `---
+name: ${params.skillName}
+display_name: ${params.displayName}
+version: ${params.version || '1.0.0'}
+description: ${params.description || ''}
+---
+
+# ${params.displayName}
+
+${params.description || 'Custom skill created by user.'}
+`;
+    await fs.writeFile(skillMdPath, skillMdContent, 'utf-8');
+  }
+
+  // Create metadata
+  const meta: ISkillHubMeta = {
+    id: '',
+    name: params.skillName,
+    display_name: params.displayName,
+    description: params.description || '',
+    icon: '',
+    emoji: null,
+    category: '',
+    categories: [],
+    applicable_scenarios: null,
+    core_features: null,
+    homepage: null,
+    author_id: '',
+    source_type: 'custom',
+    is_builtin: false,
+    enabled: true,
+    installed_version: params.version || '1.0.0',
+    installed_at: new Date().toISOString(),
+  };
+
+  const metaFileName = getSkillMetaFileName();
+  const metaPath = path.join(skillDir, metaFileName);
+  await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+
+  mainLog('CustomUpload', `Created local custom skill: ${params.skillName} at ${skillDir}`);
+  return skillDir;
+}
+
+/**
+ * Upload custom skill to Moss Server
+ */
+export async function uploadCustomSkill(params: CustomSkillUploadParams): Promise<CustomSkillUploadResult> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    return {
+      success: false,
+      name: params.skillName,
+      error: 'Moss Server not configured or not authenticated',
+    };
+  }
+
+  try {
+    // Determine source directory
+    let skillDir: string;
+    if (params.sourcePath) {
+      skillDir = params.sourcePath;
+    } else {
+      skillDir = getSkillInstallDir(params.skillName, 'custom');
+    }
+
+    // Check if directory exists
+    if (!existsSync(skillDir)) {
+      return {
+        success: false,
+        name: params.skillName,
+        error: `Skill directory not found: ${skillDir}`,
+      };
+    }
+
+    // Create zip
+    mainLog('CustomUpload', `Creating zip for skill: ${params.skillName}`);
+    const zipBuffer = await createZipFromDirectory(skillDir);
+
+    // Upload to Moss Server
+    const uploadUrl = `${serverUrl}/api/v1/skills/custom`;
+    mainLog('CustomUpload', `Uploading skill to: ${uploadUrl}`);
+
+    const response = await uploadFile(
+      uploadUrl,
+      token,
+      {
+        name: params.skillName,
+        displayName: params.displayName,
+        description: params.description,
+        version: params.version,
+      },
+      zipBuffer
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        success: false,
+        name: params.skillName,
+        error: `Upload failed: HTTP ${response.status} - ${errorText}`,
+      };
+    }
+
+    const result = await response.json();
+    mainLog('CustomUpload', `Skill upload successful: ${JSON.stringify(result)}`);
+
+    // Update local metadata with server ID
+    const metaFileName = getSkillMetaFileName();
+    const metaPath = path.join(skillDir, metaFileName);
+    if (existsSync(metaPath)) {
+      const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as ISkillHubMeta;
+      meta.id = result.id || '';
+      meta.uploaded = true;
+      meta.uploaded_at = new Date().toISOString();
+      await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+    }
+
+    return {
+      success: true,
+      id: result.id,
+      name: params.skillName,
+      status: result.status || 'active',
+    };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    mainError('CustomUpload', `Failed to upload skill ${params.skillName}:`, error);
+    return {
+      success: false,
+      name: params.skillName,
+      error: errorMsg,
+    };
+  }
+}
+
+// ============ 自定义助手上传 ============
+
+/**
+ * Create local custom assistant directory
+ */
+export async function createLocalCustomAssistant(params: CustomAssistantUploadParams): Promise<string> {
+  // Initialize enterprise directories if needed
+  if (isEnterpriseMode()) {
+    initEnterpriseDirs();
+  }
+
+  const assistantDir = getAssistantInstallDir(params.assistantName, 'custom');
+  await fs.mkdir(assistantDir, { recursive: true });
+
+  // Create AGENT.md if not exists
+  const agentMdPath = path.join(assistantDir, 'AGENT.md');
+  if (!existsSync(agentMdPath)) {
+    const agentMdContent = `# ${params.displayName}
+
+${params.description || 'Custom assistant created by user.'}
+`;
+    await fs.writeFile(agentMdPath, agentMdContent, 'utf-8');
+  }
+
+  // Create metadata
+  const meta: IAssistantMeta = {
+    id: '',
+    name: params.assistantName,
+    nameI18n: { 'en-US': params.displayName },
+    descriptionI18n: { 'en-US': params.description || '' },
+    presetAgentType: 'claude',
+    defaultEnabledSkills: params.enabledSkills || [],
+    enabledSkills: params.enabledSkills || [],
+    source_type: 'custom',
+    tag: 'custom',
+    is_builtin: false,
+    enabled: true,
+    installed_version: params.version || '1.0.0',
+    installed_at: new Date().toISOString(),
+  };
+
+  const metaFileName = getAssistantMetaFileName();
+  const metaPath = path.join(assistantDir, metaFileName);
+  await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+
+  mainLog('CustomUpload', `Created local custom assistant: ${params.assistantName} at ${assistantDir}`);
+  return assistantDir;
+}
+
+/**
+ * Upload custom assistant to Moss Server
+ */
+export async function uploadCustomAssistant(params: CustomAssistantUploadParams): Promise<CustomAssistantUploadResult> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    return {
+      success: false,
+      name: params.assistantName,
+      error: 'Moss Server not configured or not authenticated',
+    };
+  }
+
+  try {
+    // Determine source directory
+    let assistantDir: string;
+    if (params.sourcePath) {
+      assistantDir = params.sourcePath;
+    } else {
+      assistantDir = getAssistantInstallDir(params.assistantName, 'custom');
+    }
+
+    // Check if directory exists
+    if (!existsSync(assistantDir)) {
+      return {
+        success: false,
+        name: params.assistantName,
+        error: `Assistant directory not found: ${assistantDir}`,
+      };
+    }
+
+    // Create zip
+    mainLog('CustomUpload', `Creating zip for assistant: ${params.assistantName}`);
+    const zipBuffer = await createZipFromDirectory(assistantDir);
+
+    // Upload to Moss Server
+    const uploadUrl = `${serverUrl}/api/v1/agents/custom`;
+    mainLog('CustomUpload', `Uploading assistant to: ${uploadUrl}`);
+
+    const response = await uploadFile(
+      uploadUrl,
+      token,
+      {
+        name: params.assistantName,
+        displayName: params.displayName,
+        description: params.description,
+        version: params.version,
+        enabledSkills: params.enabledSkills ? JSON.stringify(params.enabledSkills) : undefined,
+        memoryMode: params.memoryMode,
+      },
+      zipBuffer
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        success: false,
+        name: params.assistantName,
+        error: `Upload failed: HTTP ${response.status} - ${errorText}`,
+      };
+    }
+
+    const result = await response.json();
+    mainLog('CustomUpload', `Assistant upload successful: ${JSON.stringify(result)}`);
+
+    // Update local metadata with server ID
+    const metaFileName = getAssistantMetaFileName();
+    const metaPath = path.join(assistantDir, metaFileName);
+    if (existsSync(metaPath)) {
+      const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as IAssistantMeta;
+      meta.id = result.id || '';
+      meta.uploaded = true;
+      meta.uploaded_at = new Date().toISOString();
+      await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+    }
+
+    return {
+      success: true,
+      id: result.id,
+      name: params.assistantName,
+      status: result.status || 'active',
+    };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    mainError('CustomUpload', `Failed to upload assistant ${params.assistantName}:`, error);
+    return {
+      success: false,
+      name: params.assistantName,
+      error: errorMsg,
+    };
+  }
+}

--- a/src/process/sync/customUpload.ts
+++ b/src/process/sync/customUpload.ts
@@ -47,7 +47,10 @@ export interface CustomSkillUploadResult {
 }
 
 export interface CustomAssistantUploadParams {
+  /** Assistant name (display name, e.g., "微信公众号运营助手") */
   assistantName: string;
+  /** Assistant ID (UUID, e.g., "fb11954c-a848-41a2-967f-e1ef5e711fe6") */
+  assistantId: string;
   displayName: string;
   description?: string;
   version?: string;
@@ -120,6 +123,11 @@ async function uploadFile(url: string, token: string, params: Record<string, str
     description: params.description || '',
     version: params.version || '1.0.0',
   };
+
+  // Add id (UUID) if provided
+  if (params.id) {
+    body.id = params.id;
+  }
 
   // Add optional fields for assistants
   if (params.enabledSkills) {
@@ -320,7 +328,7 @@ ${params.description || 'Custom assistant created by user.'}
   // Create metadata
   const meta: IAssistantMeta = {
     id: '',
-    name: params.assistantName,
+    name: params.displayName, // Use actual user-input name
     nameI18n: { 'en-US': params.displayName },
     descriptionI18n: { 'en-US': params.description || '' },
     presetAgentType: 'claude',
@@ -357,13 +365,16 @@ export async function uploadCustomAssistant(params: CustomAssistantUploadParams)
   }
 
   try {
-    // Determine source directory
+    // Determine source directory - use assistantId (UUID) as directory name
     let assistantDir: string;
     if (params.sourcePath) {
       assistantDir = params.sourcePath;
     } else {
-      assistantDir = getAssistantInstallDir(params.assistantName, 'custom');
+      // Local directory is named by assistantId (UUID)
+      assistantDir = getAssistantInstallDir(params.assistantId, 'custom');
     }
+
+    mainLog('CustomUpload', `[Upload Assistant] assistantName: ${params.assistantName}, assistantId: ${params.assistantId}, sourceDir: ${assistantDir}`);
 
     // Check if directory exists
     if (!existsSync(assistantDir)) {
@@ -386,7 +397,8 @@ export async function uploadCustomAssistant(params: CustomAssistantUploadParams)
       uploadUrl,
       token,
       {
-        name: params.assistantName,
+        name: params.assistantName, // User-visible name
+        id: params.assistantId, // UUID for server reference
         displayName: params.displayName,
         description: params.description,
         version: params.version,
@@ -407,16 +419,24 @@ export async function uploadCustomAssistant(params: CustomAssistantUploadParams)
 
     const result = await response.json();
     mainLog('CustomUpload', `Assistant upload successful: ${JSON.stringify(result)}`);
+    mainLog('CustomUpload', `[Upload Assistant] Server returned id: ${result.id}, local assistantName: ${params.assistantName}`);
 
-    // Update local metadata with server ID
+    // Update local metadata with server ID, preserving existing fields like ruleFile
     const metaFileName = getAssistantMetaFileName();
     const metaPath = path.join(assistantDir, metaFileName);
+    mainLog('CustomUpload', `[Upload Assistant] Updating metadata at: ${metaPath}`);
     if (existsSync(metaPath)) {
       const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as IAssistantMeta;
+      const oldId = meta.id;
       meta.id = result.id || '';
       meta.uploaded = true;
       meta.uploaded_at = new Date().toISOString();
+      // Preserve ruleFile field if it exists
+      // Note: ruleFile should already be set if AGENT.md was created during assistant creation
       await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+      mainLog('CustomUpload', `[Upload Assistant] Updated metadata: oldId=${oldId} -> newId=${meta.id}`);
+    } else {
+      mainWarn('CustomUpload', `[Upload Assistant] Metadata file not found at ${metaPath}`);
     }
 
     return {

--- a/src/process/sync/index.ts
+++ b/src/process/sync/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Enterprise Sync Module Index
+ *
+ * 企业同步模块索引，导出所有同步相关功能
+ */
+
+// Remote → Local Sync
+export { syncRemoteSkillsToLocal, syncRemoteAssistantsToLocal, syncAllFromRemote, syncIncrementalFromRemote, downloadFileWithAuth, type SyncResult, type RemoteSkillInfo, type RemoteAssistantInfo } from './remoteToLocalSync';
+
+// Custom Upload
+export { createLocalCustomSkill, uploadCustomSkill, createLocalCustomAssistant, uploadCustomAssistant, type CustomSkillUploadParams, type CustomSkillUploadResult, type CustomAssistantUploadParams, type CustomAssistantUploadResult } from './customUpload';
+
+// Tenant Sync
+export { fetchTenantSkills, installTenantSkill, publishTenantSkill, fetchTenantAssistants, installTenantAssistant, publishTenantAssistant, type TenantSkillInfo, type TenantAssistantInfo, type PublishResult } from './tenantSync';

--- a/src/process/sync/remoteToLocalSync.ts
+++ b/src/process/sync/remoteToLocalSync.ts
@@ -21,6 +21,7 @@ import { ProcessConfig, getHubSkillsDir, getHubAssistantsDir } from '@process/in
 import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
 import { getValidToken } from '@process/bridge/eeclawBridge';
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
 import path from 'path';
 import https from 'node:https';
 import http from 'node:http';
@@ -28,7 +29,7 @@ import JSZip from 'jszip';
 import { skillManager } from '@process/SkillManager';
 import { assistantManager } from '@process/AssistantManager';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
-import { initEnterpriseDirs, getEnterpriseHubSkillsDir, getEnterpriseHubAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName } from '@/process/constants/enterpriseStorage';
+import { initEnterpriseDirs, getEnterpriseHubSkillsDir, getEnterpriseHubAssistantsDir, getEnterpriseTenantSkillsDir, getEnterpriseTenantAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName } from '@/process/constants/enterpriseStorage';
 import { SKILL_HUB_META_FILE } from '@/process/constants/skillStorage';
 import type { IAssistantMeta } from '@/process/constants/assistantStorage';
 import { ASSISTANT_META_FILE } from '@/process/constants/assistantStorage';
@@ -40,6 +41,11 @@ export type SyncResult = {
   installed: string[];
   skipped: string[];
   failed: Array<{ id: string; name: string; error: string }>;
+};
+
+export type SyncAllResult = {
+  skills: { hub: SyncResult; tenant: SyncResult };
+  assistants: { hub: SyncResult; tenant: SyncResult };
 };
 
 export type RemoteSkillInfo = {
@@ -847,6 +853,9 @@ async function getLocalInstalledAssistants(): Promise<Set<string>> {
 /**
  * 同步远程 skills 到本地
  * 优先使用新版 API（通过 ID 下载），失败时回退到旧版 API
+ *
+ * 注意：只同步 isHubInstalled: true 的技能（从技能库安装的）
+ * 自定义技能和专属技能由各自的同步逻辑处理
  */
 export async function syncRemoteSkillsToLocal(): Promise<SyncResult> {
   const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
@@ -862,13 +871,18 @@ export async function syncRemoteSkillsToLocal(): Promise<SyncResult> {
   const remoteSkills = await getRemoteSkillsInstalled(serverUrl, token);
   mainLog('remoteToLocalSync', `Remote skills: ${remoteSkills.length}`);
 
+  // 1.5 只同步从技能库安装的技能（isHubInstalled: true）
+  // 自定义技能和专属技能由各自的同步逻辑处理
+  const hubSkills = remoteSkills.filter((s) => s.isHubInstalled === true);
+  mainLog('remoteToLocalSync', `Hub skills (isHubInstalled=true): ${hubSkills.length}`);
+
   // 2. 获取本地已安装列表（按 ID 判断）
   const localSkillIds = await getLocalInstalledSkillIds();
   mainLog('remoteToLocalSync', `Local skills (by ID): ${localSkillIds.size}`);
 
   // 3. 计算差异（按 ID）
-  const toInstall = remoteSkills.filter((s) => s.id && !localSkillIds.has(s.id));
-  const alreadyInstalled = remoteSkills.filter((s) => s.id && localSkillIds.has(s.id));
+  const toInstall = hubSkills.filter((s) => s.id && !localSkillIds.has(s.id));
+  const alreadyInstalled = hubSkills.filter((s) => s.id && localSkillIds.has(s.id));
   mainLog('remoteToLocalSync', `Skills to install: ${toInstall.length}`);
 
   const result: SyncResult = {
@@ -908,6 +922,9 @@ export async function syncRemoteSkillsToLocal(): Promise<SyncResult> {
 /**
  * 同步远程 assistants 到本地
  * 优先使用新版 API（通过 ID 下载），失败时回退到旧版 API
+ *
+ * 注意：只同步 isHubInstalled: true 的助手（从助手库安装的）
+ * 自定义助手和专属助手由各自的同步逻辑处理
  */
 export async function syncRemoteAssistantsToLocal(): Promise<SyncResult> {
   const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
@@ -923,13 +940,18 @@ export async function syncRemoteAssistantsToLocal(): Promise<SyncResult> {
   const remoteAssistants = await getRemoteAssistantsInstalled(serverUrl, token);
   mainLog('remoteToLocalSync', `Remote assistants: ${remoteAssistants.length}`);
 
+  // 1.5 只同步从助手库安装的助手（isHubInstalled: true）
+  // 自定义助手和专属助手由各自的同步逻辑处理
+  const hubAssistants = remoteAssistants.filter((a) => a.isHubInstalled === true);
+  mainLog('remoteToLocalSync', `Hub assistants (isHubInstalled=true): ${hubAssistants.length}`);
+
   // 2. 获取本地已安装列表（按 ID 判断）
   const localAssistantIds = await getLocalInstalledAssistantIds();
   mainLog('remoteToLocalSync', `Local assistants (by ID): ${localAssistantIds.size}`);
 
   // 3. 计算差异（按 ID）
-  const toInstall = remoteAssistants.filter((a) => a.id && !localAssistantIds.has(a.id));
-  const alreadyInstalled = remoteAssistants.filter((a) => a.id && localAssistantIds.has(a.id));
+  const toInstall = hubAssistants.filter((a) => a.id && !localAssistantIds.has(a.id));
+  const alreadyInstalled = hubAssistants.filter((a) => a.id && localAssistantIds.has(a.id));
   mainLog('remoteToLocalSync', `Assistants to install: ${toInstall.length}`);
 
   const result: SyncResult = {
@@ -969,31 +991,42 @@ export async function syncRemoteAssistantsToLocal(): Promise<SyncResult> {
 /**
  * 全量同步（登录成功后调用）
  *
- * 并行同步 skills 和 assistants
+ * 并行同步 hub skills/assistants 和 tenant skills/assistants
  */
-export async function syncAllFromRemote(): Promise<{
-  skills: SyncResult;
-  assistants: SyncResult;
-}> {
+export async function syncAllFromRemote(): Promise<SyncAllResult> {
   mainLog('remoteToLocalSync', 'Starting full sync from remote...');
 
-  const [skills, assistants] = await Promise.all([
+  // 并行同步 hub 和 tenant
+  const [hubSkills, hubAssistants, tenantSkills, tenantAssistants] = await Promise.all([
     syncRemoteSkillsToLocal().catch((error) => {
-      mainError('remoteToLocalSync', 'Skill sync failed:', error);
+      mainError('remoteToLocalSync', 'Hub skill sync failed:', error);
       return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
     }),
     syncRemoteAssistantsToLocal().catch((error) => {
-      mainError('remoteToLocalSync', 'Assistant sync failed:', error);
+      mainError('remoteToLocalSync', 'Hub assistant sync failed:', error);
+      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+    }),
+    syncTenantSkillsToLocal().catch((error) => {
+      mainError('remoteToLocalSync', 'Tenant skill sync failed:', error);
+      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+    }),
+    syncTenantAssistantsToLocal().catch((error) => {
+      mainError('remoteToLocalSync', 'Tenant assistant sync failed:', error);
       return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
     }),
   ]);
 
   mainLog('remoteToLocalSync', 'Full sync completed', {
-    skills: skills.installed.length,
-    assistants: assistants.installed.length,
+    hubSkills: hubSkills.installed.length,
+    hubAssistants: hubAssistants.installed.length,
+    tenantSkills: tenantSkills.installed.length,
+    tenantAssistants: tenantAssistants.installed.length,
   });
 
-  return { skills, assistants };
+  return {
+    skills: { hub: hubSkills, tenant: tenantSkills },
+    assistants: { hub: hubAssistants, tenant: tenantAssistants },
+  };
 }
 
 /**
@@ -1001,11 +1034,226 @@ export async function syncAllFromRemote(): Promise<{
  *
  * 仅同步差异部分，比全量同步更快
  */
-export async function syncIncrementalFromRemote(): Promise<{
-  skills: SyncResult;
-  assistants: SyncResult;
-}> {
+export async function syncIncrementalFromRemote(): Promise<SyncAllResult> {
   // 增量同步逻辑与全量同步相同，只是调用时机不同
   // 差异计算已在 syncRemoteSkillsToLocal/syncRemoteAssistantsToLocal 中实现
   return syncAllFromRemote();
+}
+
+// ============ Tenant 同步逻辑 ============
+
+/**
+ * 同步专属技能到本地 tenant 目录
+ */
+async function syncTenantSkillsToLocal(): Promise<SyncResult> {
+  const { fetchTenantSkills, installTenantSkill } = await import('./tenantSync');
+
+  mainLog('remoteToLocalSync', 'Starting tenant skill sync...');
+
+  // 1. 获取远程专属技能列表（只获取已审核通过的）
+  const remoteSkills = await fetchTenantSkills();
+  const approvedSkills = remoteSkills.filter((s) => s.status === 'approved');
+  mainLog('remoteToLocalSync', `Remote tenant skills (approved): ${approvedSkills.length}`);
+
+  // 2. 获取本地已安装的专属技能 ID（包括 _disable 目录）
+  const localSkillIds = await getLocalTenantSkillIds();
+  mainLog('remoteToLocalSync', `Local tenant skills (by ID): ${localSkillIds.size}`);
+
+  // 3. 计算差异
+  const toInstall = approvedSkills.filter((s) => s.id && !localSkillIds.has(s.id));
+  const alreadyInstalled = approvedSkills.filter((s) => s.id && localSkillIds.has(s.id));
+  mainLog('remoteToLocalSync', `Tenant skills to install: ${toInstall.length}, already installed: ${alreadyInstalled.length}`);
+
+  const result: SyncResult = {
+    installed: [],
+    skipped: alreadyInstalled.map((s) => s.name),
+    failed: [],
+  };
+
+  // 4. 逐个安装
+  for (const skill of toInstall) {
+    try {
+      const installResult = await installTenantSkill(skill.id);
+      if (installResult.success) {
+        result.installed.push(skill.name);
+      } else {
+        result.failed.push({
+          id: skill.id,
+          name: skill.name,
+          error: installResult.error || 'Unknown error',
+        });
+      }
+    } catch (error) {
+      mainError('remoteToLocalSync', `Failed to install tenant skill ${skill.name}:`, error);
+      result.failed.push({
+        id: skill.id,
+        name: skill.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  mainLog('remoteToLocalSync', `Tenant skill sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+
+  return result;
+}
+
+/**
+ * 同步专属助手到本地 tenant 目录
+ */
+async function syncTenantAssistantsToLocal(): Promise<SyncResult> {
+  const { fetchTenantAssistants, installTenantAssistant } = await import('./tenantSync');
+
+  mainLog('remoteToLocalSync', 'Starting tenant assistant sync...');
+
+  // 1. 获取远程专属助手列表（只获取已审核通过的）
+  const remoteAssistants = await fetchTenantAssistants();
+  const approvedAssistants = remoteAssistants.filter((a) => a.status === 'approved');
+  mainLog('remoteToLocalSync', `Remote tenant assistants (approved): ${approvedAssistants.length}`);
+
+  // 2. 获取本地已安装的专属助手 ID（包括 _disable 目录）
+  const localAssistantIds = await getLocalTenantAssistantIds();
+  mainLog('remoteToLocalSync', `Local tenant assistants (by ID): ${localAssistantIds.size}`);
+
+  // 3. 计算差异
+  const toInstall = approvedAssistants.filter((a) => a.id && !localAssistantIds.has(a.id));
+  const alreadyInstalled = approvedAssistants.filter((a) => a.id && localAssistantIds.has(a.id));
+  mainLog('remoteToLocalSync', `Tenant assistants to install: ${toInstall.length}, already installed: ${alreadyInstalled.length}`);
+
+  const result: SyncResult = {
+    installed: [],
+    skipped: alreadyInstalled.map((a) => a.name),
+    failed: [],
+  };
+
+  // 4. 逐个安装
+  for (const assistant of toInstall) {
+    try {
+      const installResult = await installTenantAssistant(assistant.id);
+      if (installResult.success) {
+        result.installed.push(assistant.name);
+      } else {
+        result.failed.push({
+          id: assistant.id,
+          name: assistant.name,
+          error: installResult.error || 'Unknown error',
+        });
+      }
+    } catch (error) {
+      mainError('remoteToLocalSync', `Failed to install tenant assistant ${assistant.name}:`, error);
+      result.failed.push({
+        id: assistant.id,
+        name: assistant.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  mainLog('remoteToLocalSync', `Tenant assistant sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+
+  return result;
+}
+
+/**
+ * 获取本地已安装的专属技能 ID 集合（包括 _disable 目录）
+ */
+async function getLocalTenantSkillIds(): Promise<Set<string>> {
+  const ids = new Set<string>();
+
+  if (!isEnterpriseMode()) {
+    return ids;
+  }
+
+  try {
+    const tenantDir = getEnterpriseTenantSkillsDir();
+    if (!existsSync(tenantDir)) {
+      return ids;
+    }
+
+    // 扫描 tenant/ 和 tenant/_disable/ 目录
+    const dirsToScan = [tenantDir];
+    const disableDir = path.join(tenantDir, '_disable');
+    if (existsSync(disableDir)) {
+      dirsToScan.push(disableDir);
+    }
+
+    for (const dir of dirsToScan) {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name.startsWith('_')) continue;
+
+        const skillDir = path.join(dir, entry.name);
+        const metaFileName = getSkillMetaFileName();
+        const metaPath = path.join(skillDir, metaFileName);
+
+        if (existsSync(metaPath)) {
+          try {
+            const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as ISkillHubMeta;
+            if (meta.id) {
+              ids.add(meta.id);
+            }
+          } catch {
+            // Ignore invalid meta
+          }
+        }
+      }
+    }
+  } catch (error) {
+    mainWarn('remoteToLocalSync', 'Failed to get local tenant skill IDs:', error);
+  }
+
+  return ids;
+}
+
+/**
+ * 获取本地已安装的专属助手 ID 集合（包括 _disable 目录）
+ */
+async function getLocalTenantAssistantIds(): Promise<Set<string>> {
+  const ids = new Set<string>();
+
+  if (!isEnterpriseMode()) {
+    return ids;
+  }
+
+  try {
+    const tenantDir = getEnterpriseTenantAssistantsDir();
+    if (!existsSync(tenantDir)) {
+      return ids;
+    }
+
+    // 扫描 tenant/ 和 tenant/_disable/ 目录
+    const dirsToScan = [tenantDir];
+    const disableDir = path.join(tenantDir, '_disable');
+    if (existsSync(disableDir)) {
+      dirsToScan.push(disableDir);
+    }
+
+    for (const dir of dirsToScan) {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name.startsWith('_')) continue;
+
+        const assistantDir = path.join(dir, entry.name);
+        const metaFileName = getAssistantMetaFileName();
+        const metaPath = path.join(assistantDir, metaFileName);
+
+        if (existsSync(metaPath)) {
+          try {
+            const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as IAssistantMeta;
+            if (meta.id) {
+              ids.add(meta.id);
+            }
+          } catch {
+            // Ignore invalid meta
+          }
+        }
+      }
+    }
+  } catch (error) {
+    mainWarn('remoteToLocalSync', 'Failed to get local tenant assistant IDs:', error);
+  }
+
+  return ids;
 }

--- a/src/process/sync/remoteToLocalSync.ts
+++ b/src/process/sync/remoteToLocalSync.ts
@@ -1,0 +1,1011 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Remote → Local 同步模块
+ *
+ * 企业登录后，将服务端已安装的 skill 和 assistant 同步到本地
+ *
+ * 同步流程：
+ * 1. 获取远程已安装列表（/api/v1/skills/installed, /api/v1/agents/installed）
+ * 2. 计算本地与远程差异
+ * 3. 下载技能/助手包（/api/v1/skills/installed/{id}/download）
+ * 4. 解压安装到本地 hub/ 目录
+ * 5. 写入 _sudowork_meta.json 元数据
+ */
+
+import { ProcessConfig, getHubSkillsDir, getHubAssistantsDir } from '@process/initStorage';
+import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
+import { getValidToken } from '@process/bridge/eeclawBridge';
+import fs from 'fs/promises';
+import path from 'path';
+import https from 'node:https';
+import http from 'node:http';
+import JSZip from 'jszip';
+import { skillManager } from '@process/SkillManager';
+import { assistantManager } from '@process/AssistantManager';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { initEnterpriseDirs, getEnterpriseHubSkillsDir, getEnterpriseHubAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName } from '@/process/constants/enterpriseStorage';
+import { SKILL_HUB_META_FILE } from '@/process/constants/skillStorage';
+import type { IAssistantMeta } from '@/process/constants/assistantStorage';
+import { ASSISTANT_META_FILE } from '@/process/constants/assistantStorage';
+import type { ISkillHubMeta } from '@/common/ipcBridge';
+
+// ============ 类型定义 ============
+
+export type SyncResult = {
+  installed: string[];
+  skipped: string[];
+  failed: Array<{ id: string; name: string; error: string }>;
+};
+
+export type RemoteSkillInfo = {
+  id: string;
+  name: string;
+  displayName: string;
+  version: string;
+  source: string;
+  isHubInstalled: boolean;
+  visibleTo: { department_ids: string[] | null } | null;
+};
+
+export type RemoteAssistantInfo = {
+  id: string;
+  name: string;
+  displayName: string;
+  version: string;
+  source: string;
+  isHubInstalled: boolean;
+  visibleTo: { department_ids: string[] | null } | null;
+  enabledSkills: string[];
+};
+
+export type SkillInstallDetail = {
+  name: string;
+  sourceUrl: string;
+  checksum: string;
+  version: string;
+  meta: Record<string, unknown>;
+};
+
+export type AssistantInstallDetail = {
+  name: string;
+  sourceUrl: string;
+  checksum: string;
+  version: string;
+  meta: Record<string, unknown>;
+};
+
+// ============ Mock 开关 ============
+
+const USE_MOCK = process.env.MOSS_SYNC_MOCK === 'true';
+
+// ============ API 调用 ============
+
+async function fetchRemote<T>(urlPath: string, serverUrl: string, token: string): Promise<T> {
+  const response = await fetch(`${serverUrl}${urlPath}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    signal: AbortSignal.timeout(30000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+async function getRemoteSkillsInstalledMock(): Promise<RemoteSkillInfo[]> {
+  return [
+    {
+      id: 'skill-001',
+      name: 'code-review',
+      displayName: 'Code Review',
+      version: '1.2.0',
+      source: '/mock/path',
+      isHubInstalled: true,
+      visibleTo: { department_ids: ['dept-001'] },
+    },
+    {
+      id: 'skill-002',
+      name: 'test-gen',
+      displayName: 'Test Generator',
+      version: '1.0.0',
+      source: '/mock/path',
+      isHubInstalled: true,
+      visibleTo: null,
+    },
+  ];
+}
+
+async function getRemoteSkillsInstalled(serverUrl: string, token: string): Promise<RemoteSkillInfo[]> {
+  if (USE_MOCK) {
+    return getRemoteSkillsInstalledMock();
+  }
+
+  const data = await fetchRemote<RemoteSkillInfo[] | { data: RemoteSkillInfo[] }>('/api/v1/skills/installed', serverUrl, token);
+  return Array.isArray(data) ? data : (data.data ?? []);
+}
+
+async function getRemoteAssistantsInstalledMock(): Promise<RemoteAssistantInfo[]> {
+  return [
+    {
+      id: 'agent-001',
+      name: 'code-assistant',
+      displayName: 'Code Assistant',
+      version: '2.0.0',
+      source: '/mock/path',
+      isHubInstalled: true,
+      visibleTo: null,
+      enabledSkills: ['skill-001', 'skill-002'],
+    },
+  ];
+}
+
+async function getRemoteAssistantsInstalled(serverUrl: string, token: string): Promise<RemoteAssistantInfo[]> {
+  if (USE_MOCK) {
+    return getRemoteAssistantsInstalledMock();
+  }
+
+  const data = await fetchRemote<RemoteAssistantInfo[] | { data: RemoteAssistantInfo[] }>('/api/v1/agents/installed', serverUrl, token);
+  return Array.isArray(data) ? data : (data.data ?? []);
+}
+
+async function getSkillInstallDetailMock(name: string): Promise<SkillInstallDetail> {
+  return {
+    name,
+    sourceUrl: `https://mock-skill-hub.internal/skills/${name}/package.zip`,
+    checksum: 'mock-checksum',
+    version: '1.0.0',
+    meta: {
+      id: `skill-${name}`,
+      display_name: name,
+      description: `Mock skill ${name}`,
+      visible_to: { department_ids: ['dept-001'] },
+    },
+  };
+}
+
+async function getSkillInstallDetail(name: string, serverUrl: string, token: string): Promise<SkillInstallDetail> {
+  if (USE_MOCK) {
+    return getSkillInstallDetailMock(name);
+  }
+
+  return fetchRemote<SkillInstallDetail>(`/api/v1/skills/installed-detail?name=${encodeURIComponent(name)}`, serverUrl, token);
+}
+
+async function getAssistantInstallDetailMock(name: string): Promise<AssistantInstallDetail> {
+  return {
+    name,
+    sourceUrl: `https://mock-assistant-hub.internal/assistants/${name}/package.zip`,
+    checksum: 'mock-checksum',
+    version: '1.0.0',
+    meta: {
+      id: `agent-${name}`,
+      display_name: name,
+      description: `Mock assistant ${name}`,
+      visible_to: null,
+      enabledSkills: [],
+    },
+  };
+}
+
+async function getAssistantInstallDetail(name: string, serverUrl: string, token: string): Promise<AssistantInstallDetail> {
+  if (USE_MOCK) {
+    return getAssistantInstallDetailMock(name);
+  }
+
+  return fetchRemote<AssistantInstallDetail>(`/api/v1/agents/installed-detail?name=${encodeURIComponent(name)}`, serverUrl, token);
+}
+
+// ============ 新版 API（通过 ID 下载）============
+
+/**
+ * Download skill package by ID from Moss Server
+ * 新版 API：通过 ID 直接下载技能包
+ *
+ * @param skillId - Skill UUID
+ * @param serverUrl - Moss Server URL
+ * @param token - Auth token
+ * @returns Zip buffer
+ */
+async function downloadSkillById(skillId: string, serverUrl: string, token: string, onProgress?: (percent: number) => void): Promise<Buffer> {
+  const downloadUrl = `${serverUrl}/api/v1/skills/installed/${skillId}/download`;
+  mainLog('remoteToLocalSync', `Downloading skill by ID: ${skillId} from ${downloadUrl}`);
+
+  return downloadFileWithAuth(downloadUrl, token, onProgress);
+}
+
+/**
+ * Download assistant package by ID from Moss Server
+ * 新版 API：通过 ID 直接下载助手包
+ *
+ * @param assistantId - Assistant UUID
+ * @param serverUrl - Moss Server URL
+ * @param token - Auth token
+ * @returns Zip buffer
+ */
+async function downloadAssistantById(assistantId: string, serverUrl: string, token: string, onProgress?: (percent: number) => void): Promise<Buffer> {
+  const downloadUrl = `${serverUrl}/api/v1/agents/installed/${assistantId}/download`;
+  mainLog('remoteToLocalSync', `Downloading assistant by ID: ${assistantId} from ${downloadUrl}`);
+
+  return downloadFileWithAuth(downloadUrl, token, onProgress);
+}
+
+/**
+ * Download file with Bearer token authentication
+ * Exported for use by tenantSync module
+ */
+export async function downloadFileWithAuth(url: string, token: string, onProgress?: (percent: number) => void): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(url);
+    const client = parsedUrl.protocol === 'https:' ? https : http;
+
+    const request = client.get(
+      url,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'Sudowork-EnterpriseSync/1.0',
+        },
+      },
+      (response) => {
+        // Handle redirects
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          const redirectUrl = response.headers.location;
+          if (redirectUrl) {
+            downloadFileWithAuth(redirectUrl, token, onProgress).then(resolve).catch(reject);
+            return;
+          }
+        }
+
+        if (response.statusCode && response.statusCode >= 400) {
+          reject(new Error(`HTTP ${response.statusCode}`));
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        const totalSize = parseInt(response.headers['content-length'] || '0', 10);
+        let downloadedSize = 0;
+
+        response.on('data', (chunk: Buffer) => {
+          chunks.push(chunk);
+          downloadedSize += chunk.length;
+          if (totalSize > 0 && onProgress) {
+            onProgress(Math.round((downloadedSize / totalSize) * 100));
+          }
+        });
+
+        response.on('end', () => {
+          resolve(Buffer.concat(chunks));
+        });
+
+        response.on('error', reject);
+      }
+    );
+
+    request.setTimeout(120000, () => {
+      request.destroy(new Error('Download timeout'));
+    });
+
+    request.on('error', reject);
+  });
+}
+
+// ============ 文件下载 ============
+
+/**
+ * Download file from URL with progress callback
+ */
+async function downloadFile(url: string, onProgress?: (percent: number) => void): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(url);
+    const client = parsedUrl.protocol === 'https:' ? https : http;
+
+    const request = client.get(
+      url,
+      {
+        headers: {
+          'User-Agent': 'Sudowork-RemoteSync/1.0',
+        },
+      },
+      (response) => {
+        // Handle redirects
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          const redirectUrl = response.headers.location;
+          if (redirectUrl) {
+            downloadFile(redirectUrl, onProgress).then(resolve).catch(reject);
+            return;
+          }
+        }
+
+        if (response.statusCode && response.statusCode >= 400) {
+          reject(new Error(`HTTP ${response.statusCode}`));
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        const totalSize = parseInt(response.headers['content-length'] || '0', 10);
+        let downloadedSize = 0;
+
+        response.on('data', (chunk: Buffer) => {
+          chunks.push(chunk);
+          downloadedSize += chunk.length;
+          if (totalSize > 0 && onProgress) {
+            onProgress(Math.round((downloadedSize / totalSize) * 100));
+          }
+        });
+
+        response.on('end', () => {
+          resolve(Buffer.concat(chunks));
+        });
+
+        response.on('error', reject);
+      }
+    );
+
+    request.setTimeout(60000, () => {
+      request.destroy(new Error('Download timeout'));
+    });
+
+    request.on('error', reject);
+  });
+}
+
+/**
+ * Verify checksum (SHA256)
+ */
+async function verifyChecksum(buffer: Buffer, expectedChecksum: string): Promise<boolean> {
+  const crypto = await import('crypto');
+  const actualChecksum = crypto.createHash('sha256').update(buffer).digest('hex');
+  return actualChecksum === expectedChecksum;
+}
+
+// ============ Zip 处理 ============
+
+function normalizeZipEntryPath(entryPath: string): string {
+  return path.posix.normalize(entryPath.replaceAll('\\', '/').replace(/^\.\/+/, ''));
+}
+
+function isUnsafeZipEntryPath(entryPath: string): boolean {
+  if (!entryPath || entryPath === '.') return false;
+  if (/^[a-zA-Z]:[\\/]/.test(entryPath)) return true;
+  if (entryPath.startsWith('/') || entryPath.startsWith('\\')) return true;
+  const normalized = normalizeZipEntryPath(entryPath);
+  return normalized === '..' || normalized.startsWith('../');
+}
+
+function resolveZipLayout(zip: JSZip): { stripPrefix: string } {
+  const fileEntries = Object.values(zip.files)
+    .filter((entry) => !entry.dir)
+    .map((entry) => normalizeZipEntryPath(entry.name))
+    .filter(Boolean);
+
+  for (const entryPath of fileEntries) {
+    if (isUnsafeZipEntryPath(entryPath)) {
+      throw new Error(`Unsafe zip entry path: ${entryPath}`);
+    }
+  }
+
+  // Check if all files are under a single top-level directory
+  const topLevelParts = fileEntries.map((entryPath) => entryPath.split('/')[0]);
+  const uniqueTopLevel = Array.from(new Set(topLevelParts));
+
+  // If there's a single top-level directory and all files have path separator, strip it
+  if (uniqueTopLevel.length === 1 && fileEntries.every((e) => e.includes('/'))) {
+    return { stripPrefix: `${uniqueTopLevel[0]}/` };
+  }
+
+  return { stripPrefix: '' };
+}
+
+async function extractZipToDirectory(zipBuffer: Buffer, targetDir: string): Promise<void> {
+  const zip = await JSZip.loadAsync(zipBuffer);
+  const { stripPrefix } = resolveZipLayout(zip);
+
+  await fs.mkdir(targetDir, { recursive: true });
+
+  for (const zipEntry of Object.values(zip.files)) {
+    if (zipEntry.dir) continue;
+    if (isUnsafeZipEntryPath(zipEntry.name)) {
+      throw new Error(`Unsafe zip entry path: ${zipEntry.name}`);
+    }
+
+    const normalizedPath = normalizeZipEntryPath(zipEntry.name);
+    let targetPath = normalizedPath;
+
+    if (stripPrefix) {
+      if (!normalizedPath.startsWith(stripPrefix)) continue;
+      targetPath = normalizedPath.slice(stripPrefix.length);
+    }
+
+    if (!targetPath) continue;
+
+    const fullPath = path.join(targetDir, targetPath);
+    const fullDir = path.dirname(fullPath);
+    await fs.mkdir(fullDir, { recursive: true });
+
+    const content = await zipEntry.async('nodebuffer');
+    await fs.writeFile(fullPath, content);
+  }
+}
+
+// ============ 本地安装 ============
+
+/**
+ * Get the appropriate hub skills directory based on current mode
+ */
+async function getHubSkillsDirForMode(): Promise<string> {
+  if (isEnterpriseMode()) {
+    return getEnterpriseHubSkillsDir();
+  }
+  return getHubSkillsDir();
+}
+
+/**
+ * Get the appropriate hub assistants directory based on current mode
+ */
+async function getHubAssistantsDirForMode(): Promise<string> {
+  if (isEnterpriseMode()) {
+    return getEnterpriseHubAssistantsDir();
+  }
+  return getHubAssistantsDir();
+}
+
+/**
+ * 下载并安装 skill 到本地
+ */
+async function installSkillToLocal(detail: SkillInstallDetail): Promise<void> {
+  // Trim skill name to avoid leading/trailing spaces in directory names
+  const skillName = detail.name.trim();
+  mainLog('remoteToLocalSync', `Installing skill: ${skillName} v${detail.version}`);
+
+  // Download zip file
+  const zipBuffer = await downloadFile(detail.sourceUrl, (percent) => {
+    mainLog('remoteToLocalSync', `Download progress for ${skillName}: ${percent}%`);
+  });
+
+  // Verify checksum if provided
+  if (detail.checksum) {
+    const isValid = await verifyChecksum(zipBuffer, detail.checksum);
+    if (!isValid) {
+      mainWarn('remoteToLocalSync', `Checksum verification failed for skill ${skillName}, but continuing anyway`);
+    }
+  }
+
+  // Initialize enterprise directories if needed
+  if (isEnterpriseMode()) {
+    initEnterpriseDirs();
+  }
+
+  // Get hub skills directory (mode-aware)
+  const hubSkillsDir = await getHubSkillsDirForMode();
+  await fs.mkdir(hubSkillsDir, { recursive: true });
+
+  const skillDir = path.join(hubSkillsDir, skillName);
+
+  // Remove existing if present
+  try {
+    await fs.access(skillDir);
+    await fs.rm(skillDir, { recursive: true, force: true });
+  } catch {
+    // Directory doesn't exist
+  }
+
+  // Extract zip contents
+  await extractZipToDirectory(zipBuffer, skillDir);
+
+  // Use mode-aware metadata file name
+  const metaFileName = getSkillMetaFileName();
+  const metaFilePath = path.join(skillDir, metaFileName);
+  const meta = {
+    id: detail.meta.id || skillName,
+    name: skillName,
+    display_name: detail.meta.display_name || skillName,
+    description: detail.meta.description || '',
+    icon: detail.meta.icon || '',
+    emoji: detail.meta.emoji ?? null,
+    category: detail.meta.category || '',
+    categories: detail.meta.categories || [],
+    applicable_scenarios: detail.meta.applicable_scenarios ?? null,
+    core_features: detail.meta.core_features ?? null,
+    homepage: detail.meta.homepage ?? null,
+    author_id: detail.meta.author_id || '',
+    source_type: 'hub',
+    is_builtin: false,
+    enabled: true,
+    installed_version: detail.version,
+    installed_at: new Date().toISOString(),
+    // Include visible_to for permission filtering
+    visible_to: detail.meta.visible_to ?? null,
+  };
+  await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
+
+  mainLog('remoteToLocalSync', `Successfully installed skill: ${skillName} v${detail.version}`);
+}
+
+/**
+ * 下载并安装 assistant 到本地
+ */
+async function installAssistantToLocal(detail: AssistantInstallDetail): Promise<void> {
+  // Trim assistant name to avoid leading/trailing spaces in directory names
+  const assistantName = detail.name.trim();
+  mainLog('remoteToLocalSync', `Installing assistant: ${assistantName} v${detail.version}`);
+
+  // Download zip file
+  const zipBuffer = await downloadFile(detail.sourceUrl, (percent) => {
+    mainLog('remoteToLocalSync', `Download progress for ${assistantName}: ${percent}%`);
+  });
+
+  // Verify checksum if provided
+  if (detail.checksum) {
+    const isValid = await verifyChecksum(zipBuffer, detail.checksum);
+    if (!isValid) {
+      mainWarn('remoteToLocalSync', `Checksum verification failed for assistant ${assistantName}, but continuing anyway`);
+    }
+  }
+
+  // Initialize enterprise directories if needed
+  if (isEnterpriseMode()) {
+    initEnterpriseDirs();
+  }
+
+  // Get hub assistants directory (mode-aware)
+  const hubAssistantsDir = await getHubAssistantsDirForMode();
+  await fs.mkdir(hubAssistantsDir, { recursive: true });
+
+  const assistantDir = path.join(hubAssistantsDir, assistantName);
+
+  // Remove existing if present
+  try {
+    await fs.access(assistantDir);
+    await fs.rm(assistantDir, { recursive: true, force: true });
+  } catch {
+    // Directory doesn't exist
+  }
+
+  // Extract zip contents
+  await extractZipToDirectory(zipBuffer, assistantDir);
+
+  // Scan for .md files and select ruleFile
+  let ruleFile: string | undefined;
+  try {
+    const files = await fs.readdir(assistantDir);
+    const mdFiles = files.filter((f) => f.endsWith('.md'));
+    if (mdFiles.length > 0) {
+      // Priority: {assistantName}.md > any .md file
+      ruleFile = mdFiles.find((f) => f === `${assistantName}.md`) || mdFiles[0];
+    }
+  } catch {
+    // Ignore
+  }
+
+  // Use mode-aware metadata file name
+  const metaFileName = getAssistantMetaFileName();
+  const metaFilePath = path.join(assistantDir, metaFileName);
+  const meta = {
+    id: detail.meta.id || assistantName,
+    name: assistantName,
+    nameI18n: { 'zh-CN': detail.meta.display_name || assistantName },
+    descriptionI18n: detail.meta.description ? { 'zh-CN': detail.meta.description } : undefined,
+    avatar: detail.meta.avatar || detail.meta.emoji || undefined,
+    emoji: detail.meta.emoji,
+    presetAgentType: detail.meta.presetAgentType || 'claude',
+    source_type: 'hub',
+    tag: 'hub',
+    skills: detail.meta.enabledSkills || [],
+    category_id: detail.meta.category || '',
+    categories: detail.meta.categories || [],
+    author_id: detail.meta.author_id || '',
+    homepage: detail.meta.homepage ?? null,
+    applicable_scenarios: detail.meta.applicable_scenarios ?? null,
+    core_features: detail.meta.core_features ?? null,
+    is_builtin: false,
+    enabled: true,
+    defaultInitPrompt: detail.meta.defaultInitPrompt || null,
+    installed_version: detail.version,
+    installed_at: new Date().toISOString(),
+    enabledSkills: detail.meta.enabledSkills || [],
+    ruleFile: ruleFile,
+    // Include visible_to for permission filtering
+    visible_to: detail.meta.visible_to ?? null,
+  };
+  await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
+
+  mainLog('remoteToLocalSync', `Successfully installed assistant: ${assistantName} v${detail.version}`);
+}
+
+// ============ 新版安装函数（通过 ID 下载）============
+
+/**
+ * 通过 ID 直接下载并安装技能
+ * 新版 API：使用 /api/v1/skills/installed/{id}/download
+ */
+async function installSkillById(skill: RemoteSkillInfo, serverUrl: string, token: string): Promise<void> {
+  // Trim skill name to avoid leading/trailing spaces in directory names
+  const skillName = skill.name.trim();
+  mainLog('remoteToLocalSync', `Installing skill by ID: ${skillName} (${skill.id})`);
+
+  // Download skill package by ID
+  const zipBuffer = await downloadSkillById(skill.id, serverUrl, token, (percent) => {
+    if (percent % 20 === 0) {
+      mainLog('remoteToLocalSync', `Download progress for ${skillName}: ${percent}%`);
+    }
+  });
+
+  // Initialize enterprise directories if needed
+  if (isEnterpriseMode()) {
+    initEnterpriseDirs();
+  }
+
+  // Get hub skills directory (mode-aware)
+  const hubSkillsDir = await getHubSkillsDirForMode();
+  await fs.mkdir(hubSkillsDir, { recursive: true });
+
+  const skillDir = path.join(hubSkillsDir, skillName);
+
+  // Remove existing if present
+  try {
+    await fs.access(skillDir);
+    await fs.rm(skillDir, { recursive: true, force: true });
+  } catch {
+    // Directory doesn't exist
+  }
+
+  // Extract zip contents
+  await extractZipToDirectory(zipBuffer, skillDir);
+
+  // Read existing meta from zip (if exists) and merge with remote info
+  const metaFileName = getSkillMetaFileName();
+  const metaFilePath = path.join(skillDir, metaFileName);
+
+  let existingMeta: ISkillHubMeta | null = null;
+  try {
+    const metaContent = await fs.readFile(metaFilePath, 'utf-8');
+    existingMeta = JSON.parse(metaContent) as ISkillHubMeta;
+  } catch {
+    // Meta file doesn't exist in zip, will create new one
+  }
+
+  // Merge existing meta with remote info (remote info takes precedence for certain fields)
+  const meta: ISkillHubMeta = {
+    // Start with existing meta or defaults
+    id: existingMeta?.id || skill.id,
+    name: existingMeta?.name || skillName,
+    display_name: existingMeta?.display_name || skill.displayName || skillName,
+    description: existingMeta?.description || '',
+    icon: existingMeta?.icon || '',
+    emoji: existingMeta?.emoji || null,
+    category: existingMeta?.category || '',
+    categories: existingMeta?.categories || [],
+    applicable_scenarios: existingMeta?.applicable_scenarios || null,
+    core_features: existingMeta?.core_features || null,
+    homepage: existingMeta?.homepage || null,
+    author_id: existingMeta?.author_id || '',
+    source_type: 'hub',
+    is_builtin: false,
+    enabled: true,
+    installed_version: skill.version || existingMeta?.installed_version || '1.0.0',
+    installed_at: new Date().toISOString(),
+    visible_to: skill.visibleTo ?? existingMeta?.visible_to ?? null,
+  };
+
+  await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
+
+  mainLog('remoteToLocalSync', `Successfully installed skill by ID: ${skillName}`);
+}
+
+/**
+ * 通过 ID 直接下载并安装助手
+ * 新版 API：使用 /api/v1/agents/installed/{id}/download
+ */
+async function installAssistantById(assistant: RemoteAssistantInfo, serverUrl: string, token: string): Promise<void> {
+  // Trim assistant name to avoid leading/trailing spaces in directory names
+  const assistantName = assistant.name.trim();
+  mainLog('remoteToLocalSync', `Installing assistant by ID: ${assistantName} (${assistant.id})`);
+
+  // Download assistant package by ID
+  const zipBuffer = await downloadAssistantById(assistant.id, serverUrl, token, (percent) => {
+    if (percent % 20 === 0) {
+      mainLog('remoteToLocalSync', `Download progress for ${assistantName}: ${percent}%`);
+    }
+  });
+
+  // Initialize enterprise directories if needed
+  if (isEnterpriseMode()) {
+    initEnterpriseDirs();
+  }
+
+  // Get hub assistants directory (mode-aware)
+  const hubAssistantsDir = await getHubAssistantsDirForMode();
+  await fs.mkdir(hubAssistantsDir, { recursive: true });
+
+  const assistantDir = path.join(hubAssistantsDir, assistantName);
+
+  // Remove existing if present
+  try {
+    await fs.access(assistantDir);
+    await fs.rm(assistantDir, { recursive: true, force: true });
+  } catch {
+    // Directory doesn't exist
+  }
+
+  // Extract zip contents
+  await extractZipToDirectory(zipBuffer, assistantDir);
+
+  // Scan for .md files and select ruleFile
+  let ruleFile: string | undefined;
+  try {
+    const files = await fs.readdir(assistantDir);
+    const mdFiles = files.filter((f) => f.endsWith('.md'));
+    if (mdFiles.length > 0) {
+      ruleFile = mdFiles.find((f) => f === `${assistantName}.md`) || mdFiles[0];
+    }
+  } catch {
+    // Ignore
+  }
+
+  // Read existing meta from zip (if exists) and merge with remote info
+  const metaFileName = getAssistantMetaFileName();
+  const metaFilePath = path.join(assistantDir, metaFileName);
+
+  let existingMeta: IAssistantMeta | null = null;
+  try {
+    const metaContent = await fs.readFile(metaFilePath, 'utf-8');
+    existingMeta = JSON.parse(metaContent) as IAssistantMeta;
+  } catch {
+    // Meta file doesn't exist in zip, will create new one
+  }
+
+  // Merge existing meta with remote info
+  const meta: IAssistantMeta = {
+    // Start with existing meta or defaults
+    id: existingMeta?.id || assistant.id,
+    name: existingMeta?.name || assistantName,
+    nameI18n: existingMeta?.nameI18n || { 'en-US': assistant.displayName || assistantName },
+    descriptionI18n: existingMeta?.descriptionI18n || {},
+    avatar: existingMeta?.avatar || undefined,
+    emoji: existingMeta?.emoji || undefined,
+    presetAgentType: existingMeta?.presetAgentType || 'claude',
+    source_type: 'hub',
+    tag: 'hub',
+    skills: existingMeta?.skills || assistant.enabledSkills || [],
+    category_id: existingMeta?.category_id || '',
+    categories: existingMeta?.categories || [],
+    author_id: existingMeta?.author_id || '',
+    homepage: existingMeta?.homepage || null,
+    applicable_scenarios: existingMeta?.applicable_scenarios || null,
+    core_features: existingMeta?.core_features || null,
+    is_builtin: false,
+    enabled: true,
+    defaultInitPrompt: existingMeta?.defaultInitPrompt || null,
+    installed_version: assistant.version || existingMeta?.installed_version || '1.0.0',
+    installed_at: new Date().toISOString(),
+    enabledSkills: existingMeta?.enabledSkills || assistant.enabledSkills || [],
+    defaultEnabledSkills: existingMeta?.defaultEnabledSkills || assistant.enabledSkills || [],
+    ruleFile: ruleFile || existingMeta?.ruleFile,
+    visible_to: assistant.visibleTo ?? existingMeta?.visible_to ?? null,
+  };
+  await fs.writeFile(metaFilePath, JSON.stringify(meta, null, 2), 'utf-8');
+
+  mainLog('remoteToLocalSync', `Successfully installed assistant by ID: ${assistantName}`);
+}
+
+// ============ 本地已安装查询 ============
+
+/**
+ * 获取本地已安装技能 ID 集合
+ * 用于增量同步时判断是否需要下载
+ */
+async function getLocalInstalledSkillIds(): Promise<Set<string>> {
+  const skills = await skillManager.getInstalledSkills();
+  const ids = new Set<string>();
+  for (const skill of skills) {
+    if (skill.meta?.id) {
+      ids.add(skill.meta.id);
+    }
+  }
+  return ids;
+}
+
+async function getLocalInstalledSkills(): Promise<Set<string>> {
+  const skills = await skillManager.getInstalledSkills();
+  return new Set(skills.map((s) => s.name));
+}
+
+/**
+ * 获取本地已安装助手 ID 集合
+ * 用于增量同步时判断是否需要下载
+ */
+async function getLocalInstalledAssistantIds(): Promise<Set<string>> {
+  const assistants = await assistantManager.getInstalledAssistants();
+  const ids = new Set<string>();
+  for (const assistant of assistants) {
+    // Check meta.id first, then fall back to name for backwards compatibility
+    if (assistant.meta?.id) {
+      ids.add(assistant.meta.id);
+    } else if (assistant.id) {
+      ids.add(assistant.id);
+    }
+  }
+  return ids;
+}
+
+async function getLocalInstalledAssistants(): Promise<Set<string>> {
+  const assistants = await assistantManager.getInstalledAssistants();
+  return new Set(assistants.map((a) => a.name));
+}
+
+// ============ 核心同步逻辑 ============
+
+/**
+ * 同步远程 skills 到本地
+ * 优先使用新版 API（通过 ID 下载），失败时回退到旧版 API
+ */
+export async function syncRemoteSkillsToLocal(): Promise<SyncResult> {
+  const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
+  if (!serverUrl) {
+    throw new Error('Server URL not configured');
+  }
+
+  const token = await getValidToken();
+
+  mainLog('remoteToLocalSync', 'Starting skill sync...');
+
+  // 1. 获取远程已安装列表
+  const remoteSkills = await getRemoteSkillsInstalled(serverUrl, token);
+  mainLog('remoteToLocalSync', `Remote skills: ${remoteSkills.length}`);
+
+  // 2. 获取本地已安装列表（按 ID 判断）
+  const localSkillIds = await getLocalInstalledSkillIds();
+  mainLog('remoteToLocalSync', `Local skills (by ID): ${localSkillIds.size}`);
+
+  // 3. 计算差异（按 ID）
+  const toInstall = remoteSkills.filter((s) => s.id && !localSkillIds.has(s.id));
+  const alreadyInstalled = remoteSkills.filter((s) => s.id && localSkillIds.has(s.id));
+  mainLog('remoteToLocalSync', `Skills to install: ${toInstall.length}`);
+
+  const result: SyncResult = {
+    installed: [],
+    skipped: alreadyInstalled.map((s) => s.name),
+    failed: [],
+  };
+
+  // 4. 逐个安装（优先使用新版 API）
+  for (const skill of toInstall) {
+    try {
+      if (skill.id) {
+        // 新版 API：通过 ID 直接下载
+        await installSkillById(skill, serverUrl, token);
+      } else {
+        // 回退到旧版 API：通过名称获取详情后下载
+        mainWarn('remoteToLocalSync', `Skill ${skill.name} has no ID, falling back to legacy API`);
+        const detail = await getSkillInstallDetail(skill.name, serverUrl, token);
+        await installSkillToLocal(detail);
+      }
+      result.installed.push(skill.name);
+    } catch (error) {
+      mainError('remoteToLocalSync', `Failed to install skill ${skill.name}:`, error);
+      result.failed.push({
+        id: skill.id || '',
+        name: skill.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  mainLog('remoteToLocalSync', `Skill sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+
+  return result;
+}
+
+/**
+ * 同步远程 assistants 到本地
+ * 优先使用新版 API（通过 ID 下载），失败时回退到旧版 API
+ */
+export async function syncRemoteAssistantsToLocal(): Promise<SyncResult> {
+  const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
+  if (!serverUrl) {
+    throw new Error('Server URL not configured');
+  }
+
+  const token = await getValidToken();
+
+  mainLog('remoteToLocalSync', 'Starting assistant sync...');
+
+  // 1. 获取远程已安装列表
+  const remoteAssistants = await getRemoteAssistantsInstalled(serverUrl, token);
+  mainLog('remoteToLocalSync', `Remote assistants: ${remoteAssistants.length}`);
+
+  // 2. 获取本地已安装列表（按 ID 判断）
+  const localAssistantIds = await getLocalInstalledAssistantIds();
+  mainLog('remoteToLocalSync', `Local assistants (by ID): ${localAssistantIds.size}`);
+
+  // 3. 计算差异（按 ID）
+  const toInstall = remoteAssistants.filter((a) => a.id && !localAssistantIds.has(a.id));
+  const alreadyInstalled = remoteAssistants.filter((a) => a.id && localAssistantIds.has(a.id));
+  mainLog('remoteToLocalSync', `Assistants to install: ${toInstall.length}`);
+
+  const result: SyncResult = {
+    installed: [],
+    skipped: alreadyInstalled.map((a) => a.name),
+    failed: [],
+  };
+
+  // 4. 逐个安装（优先使用新版 API）
+  for (const assistant of toInstall) {
+    try {
+      if (assistant.id) {
+        // 新版 API：通过 ID 直接下载
+        await installAssistantById(assistant, serverUrl, token);
+      } else {
+        // 回退到旧版 API：通过名称获取详情后下载
+        mainWarn('remoteToLocalSync', `Assistant ${assistant.name} has no ID, falling back to legacy API`);
+        const detail = await getAssistantInstallDetail(assistant.name, serverUrl, token);
+        await installAssistantToLocal(detail);
+      }
+      result.installed.push(assistant.name);
+    } catch (error) {
+      mainError('remoteToLocalSync', `Failed to install assistant ${assistant.name}:`, error);
+      result.failed.push({
+        id: assistant.id || '',
+        name: assistant.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  mainLog('remoteToLocalSync', `Assistant sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+
+  return result;
+}
+
+/**
+ * 全量同步（登录成功后调用）
+ *
+ * 并行同步 skills 和 assistants
+ */
+export async function syncAllFromRemote(): Promise<{
+  skills: SyncResult;
+  assistants: SyncResult;
+}> {
+  mainLog('remoteToLocalSync', 'Starting full sync from remote...');
+
+  const [skills, assistants] = await Promise.all([
+    syncRemoteSkillsToLocal().catch((error) => {
+      mainError('remoteToLocalSync', 'Skill sync failed:', error);
+      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+    }),
+    syncRemoteAssistantsToLocal().catch((error) => {
+      mainError('remoteToLocalSync', 'Assistant sync failed:', error);
+      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+    }),
+  ]);
+
+  mainLog('remoteToLocalSync', 'Full sync completed', {
+    skills: skills.installed.length,
+    assistants: assistants.installed.length,
+  });
+
+  return { skills, assistants };
+}
+
+/**
+ * 增量同步（切换到 Local 模式时调用）
+ *
+ * 仅同步差异部分，比全量同步更快
+ */
+export async function syncIncrementalFromRemote(): Promise<{
+  skills: SyncResult;
+  assistants: SyncResult;
+}> {
+  // 增量同步逻辑与全量同步相同，只是调用时机不同
+  // 差异计算已在 syncRemoteSkillsToLocal/syncRemoteAssistantsToLocal 中实现
+  return syncAllFromRemote();
+}

--- a/src/process/sync/tenantSync.ts
+++ b/src/process/sync/tenantSync.ts
@@ -47,6 +47,8 @@ export interface TenantSkillInfo {
 export interface TenantAssistantInfo {
   id: string;
   name: string;
+  /** API may return display_name or displayName */
+  display_name?: string;
   displayName?: string;
   description?: string;
   version?: string;
@@ -230,26 +232,35 @@ export async function publishTenantSkill(skillId: string, publishNote?: string):
     return { success: false, error: 'Moss Server not configured or not authenticated' };
   }
 
+  const url = `${serverUrl}/api/v1/skills/tenant/publish`;
+  const requestBody = {
+    skillId,
+    publishNote: publishNote || '',
+  };
+
+  mainLog('TenantSync', `[Publish Skill] Request URL: ${url}`);
+  mainLog('TenantSync', `[Publish Skill] Request body: ${JSON.stringify(requestBody)}`);
+
   try {
-    const response = await fetch(`${serverUrl}/api/v1/skills/tenant/publish`, {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        skillId,
-        publishNote: publishNote || '',
-      }),
+      body: JSON.stringify(requestBody),
     });
+
+    mainLog('TenantSync', `[Publish Skill] Response status: ${response.status}`);
 
     if (!response.ok) {
       const errorText = await response.text();
+      mainError('TenantSync', `[Publish Skill] Error response: ${errorText}`);
       return { success: false, error: `Publish failed: HTTP ${response.status} - ${errorText}` };
     }
 
     const result = await response.json();
-    mainLog('TenantSync', `Skill publish request submitted: ${JSON.stringify(result)}`);
+    mainLog('TenantSync', `[Publish Skill] Success response: ${JSON.stringify(result)}`);
 
     return {
       success: true,
@@ -295,6 +306,8 @@ export async function fetchTenantAssistants(): Promise<TenantAssistantInfo[]> {
 
 /**
  * Install tenant assistant to local
+ * Moss Server already sets correct metadata (id=UUID, source_type=tenant) during approval.
+ * Sudowork just needs to download and extract to tenant directory.
  */
 export async function installTenantAssistant(assistantId: string): Promise<{ success: boolean; name?: string; error?: string }> {
   const { serverUrl, token } = getMossConfig();
@@ -329,47 +342,71 @@ export async function installTenantAssistant(assistantId: string): Promise<{ suc
       }
     });
 
-    // Extract to tenant directory
-    const tenantDir = getEnterpriseTenantAssistantsDir();
-    await fs.mkdir(tenantDir, { recursive: true });
+    // Extract to temp directory first to read original metadata
+    const tempDir = path.join(path.dirname(getEnterpriseTenantAssistantsDir()), '.temp-tenant-' + Date.now());
+    await fs.mkdir(tempDir, { recursive: true });
 
-    const assistantDir = path.join(tenantDir, assistant.name);
+    try {
+      await extractZipToDirectory(zipBuffer, tempDir);
 
-    // Remove existing if present
-    if (existsSync(assistantDir)) {
-      await fs.rm(assistantDir, { recursive: true, force: true });
+      // Find the assistant directory (might be nested)
+      let extractedDir = tempDir;
+      const entries = await fs.readdir(tempDir, { withFileTypes: true });
+      if (entries.length === 1 && entries[0].isDirectory()) {
+        extractedDir = path.join(tempDir, entries[0].name);
+      }
+
+      // Read original metadata to get the UUID (Moss Server sets correct id=UUID)
+      const originalMeta = await readAssistantMetaFromDir(extractedDir);
+      const assistantUuid = originalMeta?.id || path.basename(extractedDir);
+
+      // Move to tenant directory with UUID as directory name
+      const tenantDir = getEnterpriseTenantAssistantsDir();
+      await fs.mkdir(tenantDir, { recursive: true });
+
+      const assistantDir = path.join(tenantDir, assistantUuid);
+
+      // Remove existing if present
+      if (existsSync(assistantDir)) {
+        await fs.rm(assistantDir, { recursive: true, force: true });
+      }
+
+      // Move extracted directory to final location (preserves original metadata from Moss)
+      await fs.rename(extractedDir, assistantDir);
+
+      mainLog('TenantSync', `Successfully installed tenant assistant: ${assistantUuid}`);
+      return { success: true, name: assistantUuid };
+    } finally {
+      // Cleanup temp directory
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
     }
-
-    await extractZipToDirectory(zipBuffer, assistantDir);
-
-    // Write metadata
-    const meta: IAssistantMeta = {
-      id: assistant.id,
-      name: assistant.name,
-      nameI18n: { 'en-US': assistant.displayName || assistant.name },
-      descriptionI18n: { 'en-US': assistant.description || '' },
-      presetAgentType: 'claude',
-      defaultEnabledSkills: assistant.enabledSkills || [],
-      enabledSkills: assistant.enabledSkills || [],
-      source_type: 'hub',
-      tag: 'hub',
-      is_builtin: false,
-      enabled: true,
-      installed_version: assistant.version || '1.0.0',
-      installed_at: new Date().toISOString(),
-    };
-
-    const metaFileName = getAssistantMetaFileName();
-    const metaPath = path.join(assistantDir, metaFileName);
-    await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
-
-    mainLog('TenantSync', `Successfully installed tenant assistant: ${assistant.name}`);
-    return { success: true, name: assistant.name };
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     mainError('TenantSync', `Failed to install tenant assistant ${assistantId}:`, error);
     return { success: false, error: errorMsg };
   }
+}
+
+/**
+ * Read assistant metadata from a directory
+ */
+async function readAssistantMetaFromDir(assistantDir: string): Promise<IAssistantMeta | null> {
+  const metaFiles = ['_moss_meta.json', '_sudowork_meta.json'];
+
+  for (const fileName of metaFiles) {
+    const filePath = path.join(assistantDir, fileName);
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(content) as IAssistantMeta;
+    } catch {
+      // Try next file
+    }
+  }
+  return null;
 }
 
 /**
@@ -382,26 +419,35 @@ export async function publishTenantAssistant(assistantId: string, publishNote?: 
     return { success: false, error: 'Moss Server not configured or not authenticated' };
   }
 
+  const url = `${serverUrl}/api/v1/agents/tenant/publish`;
+  const requestBody = {
+    assistantId,
+    publishNote: publishNote || '',
+  };
+
+  mainLog('TenantSync', `[Publish Assistant] Request URL: ${url}`);
+  mainLog('TenantSync', `[Publish Assistant] Request body: ${JSON.stringify(requestBody)}`);
+
   try {
-    const response = await fetch(`${serverUrl}/api/v1/agents/tenant/publish`, {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        assistantId,
-        publishNote: publishNote || '',
-      }),
+      body: JSON.stringify(requestBody),
     });
+
+    mainLog('TenantSync', `[Publish Assistant] Response status: ${response.status}`);
 
     if (!response.ok) {
       const errorText = await response.text();
+      mainError('TenantSync', `[Publish Assistant] Error response: ${errorText}`);
       return { success: false, error: `Publish failed: HTTP ${response.status} - ${errorText}` };
     }
 
     const result = await response.json();
-    mainLog('TenantSync', `Assistant publish request submitted: ${JSON.stringify(result)}`);
+    mainLog('TenantSync', `[Publish Assistant] Success response: ${JSON.stringify(result)}`);
 
     return {
       success: true,

--- a/src/process/sync/tenantSync.ts
+++ b/src/process/sync/tenantSync.ts
@@ -1,0 +1,419 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tenant Skill/Assistant Module
+ *
+ * 企业专属技能/助手模块
+ *
+ * 功能：
+ * 1. 获取专属技能/助手列表（GET /api/v1/skills/tenant, /api/v1/agents/tenant）
+ * 2. 下载并安装专属内容（GET /api/v1/skills/tenant/{id}/download）
+ * 3. 发布专属申请（POST /api/v1/skills/tenant/publish）
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { existsSync, mkdirSync } from 'fs';
+import JSZip from 'jszip';
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { getEnterpriseConfig } from '@/common/enterpriseDebugConfig';
+import { initEnterpriseDirs, getEnterpriseTenantSkillsDir, getEnterpriseTenantAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName } from '@/process/constants/enterpriseStorage';
+import type { ISkillHubMeta } from '@/common/ipcBridge';
+import type { IAssistantMeta } from '@/process/constants/assistantStorage';
+import { downloadFileWithAuth } from './remoteToLocalSync';
+
+// ============ 类型定义 ============
+
+/** Tenant skill info from Moss Server */
+export interface TenantSkillInfo {
+  id: string;
+  name: string;
+  displayName?: string;
+  description?: string;
+  version?: string;
+  status: 'pending' | 'approved' | 'rejected';
+  author?: string;
+  authorName?: string;
+  approvedAt?: string;
+  submittedAt?: string;
+  installed?: boolean;
+}
+
+/** Tenant assistant info from Moss Server */
+export interface TenantAssistantInfo {
+  id: string;
+  name: string;
+  displayName?: string;
+  description?: string;
+  version?: string;
+  status: 'pending' | 'approved' | 'rejected';
+  author?: string;
+  authorName?: string;
+  enabledSkills?: string[];
+  memoryMode?: 'session' | 'user';
+  approvedAt?: string;
+  submittedAt?: string;
+  installed?: boolean;
+}
+
+/** Publish request result */
+export interface PublishResult {
+  success: boolean;
+  id?: string;
+  skillId?: string;
+  assistantId?: string;
+  skillName?: string;
+  assistantName?: string;
+  status?: string;
+  message?: string;
+  error?: string;
+}
+
+// ============ 工具函数 ============
+
+function getMossConfig(): { serverUrl: string; token: string } {
+  const config = getEnterpriseConfig();
+  return {
+    serverUrl: config.mossServerUrl,
+    token: config.authToken,
+  };
+}
+
+async function extractZipToDirectory(zipBuffer: Buffer, targetDir: string): Promise<void> {
+  const zip = await JSZip.loadAsync(zipBuffer);
+
+  await fs.mkdir(targetDir, { recursive: true });
+
+  for (const [entryPath, zipEntry] of Object.entries(zip.files)) {
+    if (zipEntry.dir) continue;
+
+    // Normalize path
+    const normalizedPath = entryPath.replace(/^\/+/, '').replace(/\\/g, '/');
+    if (normalizedPath.startsWith('..') || normalizedPath.includes('/..')) {
+      mainWarn('TenantSync', `Skipping unsafe path: ${entryPath}`);
+      continue;
+    }
+
+    const fullPath = path.join(targetDir, normalizedPath);
+    const fullDir = path.dirname(fullPath);
+
+    if (!existsSync(fullDir)) {
+      mkdirSync(fullDir, { recursive: true });
+    }
+
+    const content = await zipEntry.async('nodebuffer');
+    await fs.writeFile(fullPath, content);
+  }
+}
+
+// ============ 专属技能 API ============
+
+/**
+ * Fetch tenant skills list from Moss Server
+ */
+export async function fetchTenantSkills(): Promise<TenantSkillInfo[]> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    throw new Error('Moss Server not configured or not authenticated');
+  }
+
+  const response = await fetch(`${serverUrl}/api/v1/skills/tenant`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tenant skills: HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  return Array.isArray(data) ? data : data.data || [];
+}
+
+/**
+ * Install tenant skill to local
+ */
+export async function installTenantSkill(skillId: string): Promise<{ success: boolean; name?: string; error?: string }> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    return { success: false, error: 'Moss Server not configured or not authenticated' };
+  }
+
+  try {
+    // Initialize enterprise directories
+    initEnterpriseDirs();
+
+    // Get skill info first
+    const skills = await fetchTenantSkills();
+    const skill = skills.find((s) => s.id === skillId);
+
+    if (!skill) {
+      return { success: false, error: `Tenant skill not found: ${skillId}` };
+    }
+
+    if (skill.status !== 'approved') {
+      return { success: false, error: `Skill is not approved: ${skill.status}` };
+    }
+
+    // Download skill package
+    const downloadUrl = `${serverUrl}/api/v1/skills/tenant/${skillId}/download`;
+    mainLog('TenantSync', `Downloading tenant skill: ${skill.name} from ${downloadUrl}`);
+
+    const zipBuffer = await downloadFileWithAuth(downloadUrl, token, (percent) => {
+      if (percent % 20 === 0) {
+        mainLog('TenantSync', `Download progress for ${skill.name}: ${percent}%`);
+      }
+    });
+
+    // Extract to tenant directory
+    const tenantDir = getEnterpriseTenantSkillsDir();
+    await fs.mkdir(tenantDir, { recursive: true });
+
+    const skillDir = path.join(tenantDir, skill.name);
+
+    // Remove existing if present
+    if (existsSync(skillDir)) {
+      await fs.rm(skillDir, { recursive: true, force: true });
+    }
+
+    await extractZipToDirectory(zipBuffer, skillDir);
+
+    // Write metadata
+    const meta: ISkillHubMeta = {
+      id: skill.id,
+      name: skill.name,
+      display_name: skill.displayName || skill.name,
+      description: skill.description || '',
+      icon: '',
+      emoji: null,
+      category: '',
+      categories: [],
+      applicable_scenarios: null,
+      core_features: null,
+      homepage: null,
+      author_id: skill.author || '',
+      source_type: 'hub', // Tenant skills are also hub-type
+      is_builtin: false,
+      enabled: true,
+      installed_version: skill.version || '1.0.0',
+      installed_at: new Date().toISOString(),
+    };
+
+    const metaFileName = getSkillMetaFileName();
+    const metaPath = path.join(skillDir, metaFileName);
+    await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+
+    mainLog('TenantSync', `Successfully installed tenant skill: ${skill.name}`);
+    return { success: true, name: skill.name };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    mainError('TenantSync', `Failed to install tenant skill ${skillId}:`, error);
+    return { success: false, error: errorMsg };
+  }
+}
+
+/**
+ * Publish skill as tenant-exclusive
+ */
+export async function publishTenantSkill(skillId: string, publishNote?: string): Promise<PublishResult> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    return { success: false, error: 'Moss Server not configured or not authenticated' };
+  }
+
+  try {
+    const response = await fetch(`${serverUrl}/api/v1/skills/tenant/publish`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        skillId,
+        publishNote: publishNote || '',
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return { success: false, error: `Publish failed: HTTP ${response.status} - ${errorText}` };
+    }
+
+    const result = await response.json();
+    mainLog('TenantSync', `Skill publish request submitted: ${JSON.stringify(result)}`);
+
+    return {
+      success: true,
+      id: result.id,
+      skillId: result.skillId || skillId,
+      skillName: result.skillName,
+      status: result.status || 'pending',
+      message: result.message,
+    };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    mainError('TenantSync', `Failed to publish skill ${skillId}:`, error);
+    return { success: false, error: errorMsg };
+  }
+}
+
+// ============ 专属助手 API ============
+
+/**
+ * Fetch tenant assistants list from Moss Server
+ */
+export async function fetchTenantAssistants(): Promise<TenantAssistantInfo[]> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    throw new Error('Moss Server not configured or not authenticated');
+  }
+
+  const response = await fetch(`${serverUrl}/api/v1/agents/tenant`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tenant assistants: HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  return Array.isArray(data) ? data : data.data || [];
+}
+
+/**
+ * Install tenant assistant to local
+ */
+export async function installTenantAssistant(assistantId: string): Promise<{ success: boolean; name?: string; error?: string }> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    return { success: false, error: 'Moss Server not configured or not authenticated' };
+  }
+
+  try {
+    // Initialize enterprise directories
+    initEnterpriseDirs();
+
+    // Get assistant info first
+    const assistants = await fetchTenantAssistants();
+    const assistant = assistants.find((a) => a.id === assistantId);
+
+    if (!assistant) {
+      return { success: false, error: `Tenant assistant not found: ${assistantId}` };
+    }
+
+    if (assistant.status !== 'approved') {
+      return { success: false, error: `Assistant is not approved: ${assistant.status}` };
+    }
+
+    // Download assistant package
+    const downloadUrl = `${serverUrl}/api/v1/agents/tenant/${assistantId}/download`;
+    mainLog('TenantSync', `Downloading tenant assistant: ${assistant.name} from ${downloadUrl}`);
+
+    const zipBuffer = await downloadFileWithAuth(downloadUrl, token, (percent) => {
+      if (percent % 20 === 0) {
+        mainLog('TenantSync', `Download progress for ${assistant.name}: ${percent}%`);
+      }
+    });
+
+    // Extract to tenant directory
+    const tenantDir = getEnterpriseTenantAssistantsDir();
+    await fs.mkdir(tenantDir, { recursive: true });
+
+    const assistantDir = path.join(tenantDir, assistant.name);
+
+    // Remove existing if present
+    if (existsSync(assistantDir)) {
+      await fs.rm(assistantDir, { recursive: true, force: true });
+    }
+
+    await extractZipToDirectory(zipBuffer, assistantDir);
+
+    // Write metadata
+    const meta: IAssistantMeta = {
+      id: assistant.id,
+      name: assistant.name,
+      nameI18n: { 'en-US': assistant.displayName || assistant.name },
+      descriptionI18n: { 'en-US': assistant.description || '' },
+      presetAgentType: 'claude',
+      defaultEnabledSkills: assistant.enabledSkills || [],
+      enabledSkills: assistant.enabledSkills || [],
+      source_type: 'hub',
+      tag: 'hub',
+      is_builtin: false,
+      enabled: true,
+      installed_version: assistant.version || '1.0.0',
+      installed_at: new Date().toISOString(),
+    };
+
+    const metaFileName = getAssistantMetaFileName();
+    const metaPath = path.join(assistantDir, metaFileName);
+    await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+
+    mainLog('TenantSync', `Successfully installed tenant assistant: ${assistant.name}`);
+    return { success: true, name: assistant.name };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    mainError('TenantSync', `Failed to install tenant assistant ${assistantId}:`, error);
+    return { success: false, error: errorMsg };
+  }
+}
+
+/**
+ * Publish assistant as tenant-exclusive
+ */
+export async function publishTenantAssistant(assistantId: string, publishNote?: string): Promise<PublishResult> {
+  const { serverUrl, token } = getMossConfig();
+
+  if (!serverUrl || !token) {
+    return { success: false, error: 'Moss Server not configured or not authenticated' };
+  }
+
+  try {
+    const response = await fetch(`${serverUrl}/api/v1/agents/tenant/publish`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        assistantId,
+        publishNote: publishNote || '',
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return { success: false, error: `Publish failed: HTTP ${response.status} - ${errorText}` };
+    }
+
+    const result = await response.json();
+    mainLog('TenantSync', `Assistant publish request submitted: ${JSON.stringify(result)}`);
+
+    return {
+      success: true,
+      id: result.id,
+      assistantId: result.assistantId || assistantId,
+      assistantName: result.assistantName,
+      status: result.status || 'pending',
+      message: result.message,
+    };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    mainError('TenantSync', `Failed to publish assistant ${assistantId}:`, error);
+    return { success: false, error: errorMsg };
+  }
+}

--- a/src/process/utils/assistantResources.ts
+++ b/src/process/utils/assistantResources.ts
@@ -14,7 +14,8 @@ import fs from 'fs/promises';
 import path from 'path';
 import { app } from 'electron';
 import { getAssistantsDir } from '../initStorage';
-import { ASSISTANT_SUBDIRS } from '../constants/assistantStorage';
+import { ASSISTANT_SUBDIRS, ENTERPRISE_ASSISTANT_SUBDIRS } from '../constants/assistantStorage';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { mainWarn } from '@process/utils/mainLogger';
 
 type ResourceType = 'rules' | 'skills';
@@ -78,24 +79,28 @@ export async function readBuiltinResource(resourceType: ResourceType, fileName: 
  * Read assistant resource file with directory-based priority search.
  *
  * Search order:
- * 1. Custom: _my-custom-assistant/{id}/AGENT.md (or SKILLS.md)
- * 2. Hub: _hub/{id}/AGENT.md
- * 3. System: _system/{strippedId}/AGENT.md (strips `builtin-` prefix)
- * 4. Legacy flat files: {assistantsDir}/{id}.{locale}.md (backward compat)
- * 5. Bundled fallback: builtin resource directory
+ * Enterprise mode: custom/{id} > hub/{id} > system/{strippedId}
+ * Personal mode: _my-custom-assistant/{id} > _hub/{id} > _system/{strippedId}
  */
 export async function readAssistantResource(resourceType: ResourceType, assistantId: string, locale: string, fileNamePattern: (id: string, loc: string) => string): Promise<string> {
   const fileName = resourceTypeToFile(resourceType);
 
-  // 1. Try directory-based paths with priority: custom > hub > system
-  const dirCandidates: string[] = [path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.custom, assistantId, fileName), path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.hub, assistantId, fileName)];
+  // 1. Try directory-based paths with priority: custom > hub > system - mode-aware
+  const subdirs = isEnterpriseMode()
+    ? { custom: ENTERPRISE_ASSISTANT_SUBDIRS.custom, hub: ENTERPRISE_ASSISTANT_SUBDIRS.hub, system: ENTERPRISE_ASSISTANT_SUBDIRS.system }
+    : { custom: ASSISTANT_SUBDIRS.custom, hub: ASSISTANT_SUBDIRS.hub, system: ASSISTANT_SUBDIRS.system };
+
+  const dirCandidates: string[] = [
+    path.join(getAssistantsDir(), subdirs.custom, assistantId, fileName),
+    path.join(getAssistantsDir(), subdirs.hub, assistantId, fileName),
+  ];
 
   // For builtin assistants (id starts with "builtin-"), strip prefix for system dir lookup
   const strippedId = assistantId.startsWith('builtin-') ? assistantId.slice('builtin-'.length) : assistantId;
-  dirCandidates.push(path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.system, strippedId, fileName));
+  dirCandidates.push(path.join(getAssistantsDir(), subdirs.system, strippedId, fileName));
   // Also try with the full id in system/
   if (strippedId !== assistantId) {
-    dirCandidates.push(path.join(getAssistantsDir(), ASSISTANT_SUBDIRS.system, assistantId, fileName));
+    dirCandidates.push(path.join(getAssistantsDir(), subdirs.system, assistantId, fileName));
   }
 
   for (const candidate of dirCandidates) {

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -6,7 +6,7 @@
 
 import { ipcBridge, skillHub, assistantHub } from '@/common';
 import { eeclaw } from '@/common/ipcBridge';
-import type { IInstalledSkillInfo, IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill } from '@/common/ipcBridge';
+import type { IInstalledSkillInfo, IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill, TProviderWithModel } from '@/common/ipcBridge';
 import { toBackendConfig, resolveAssistantName } from '@/renderer/shared/agents/assistantAdapter';
 import type { AssistantCategory } from '@/process/AssistantManager';
 import { resolveLocaleKey, uuid } from '@/common/utils';
@@ -19,7 +19,7 @@ import { getInstalledSkillDisplay, normalizeSkillVersion } from '@/renderer/util
 import { isElectronDesktop, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { DEFAULT_PRESET_AGENT_TYPE, normalizePresetAgentType, type AcpBackendConfig } from '@/types/acpTypes';
 import { Avatar, Button, Checkbox, Collapse, Drawer, Input, Message, Modal, Popconfirm, Progress, Select, Spin, Switch, Tag, Tooltip, Typography } from '@arco-design/web-react';
-import { Close, Copy, Delete, Edit, Lightning, PreviewOpen, Plus, Robot, Shield, Search, Install, Upload, Share, UploadOne } from '@icon-park/react';
+import { Close, Copy, Delete, Edit, Lightning, PreviewOpen, Plus, Robot, Shield, Search, Install, Upload, Share, UploadOne, Check } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +28,7 @@ import useSWR, { mutate } from 'swr';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsViewMode } from '../settingsViewContext';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
+import { emitter } from '@/renderer/utils/emitter';
 
 // ==================== Types ====================
 
@@ -94,10 +95,12 @@ const InstalledAssistantCard: React.FC<{
   onClick: () => void;
   /** Enterprise mode: publish button element */
   enterprisePublishButton?: React.ReactNode;
-}> = ({ assistant, isExtension, localeKey, avatarImageMap, onToggleEnabled, onDelete, onDuplicate, onUpload, onClick, enterprisePublishButton }) => {
+  /** Enterprise mode: whether to hide delete button (only custom assistants can be deleted) */
+  hideDelete?: boolean;
+}> = ({ assistant, isExtension, localeKey, avatarImageMap, onToggleEnabled, onDelete, onDuplicate, onUpload, onClick, enterprisePublishButton, hideDelete }) => {
   const { t } = useTranslation();
   const isCustom = !assistant.isBuiltin && !isExtension && !assistant._isHubInstalled;
-  const isReadonly = assistant.isBuiltin || isExtension || assistant._isHubInstalled;
+  const isReadonly = assistant.isBuiltin || isExtension || assistant._isHubInstalled || hideDelete;
   const isEnabled = isExtension ? true : assistant.enabled !== false;
 
   const resolvedAvatar = assistant.avatar?.trim();
@@ -142,7 +145,7 @@ const InstalledAssistantCard: React.FC<{
             {displayName.length > 15 ? `${displayName.slice(0, 15)}...` : displayName}
           </span>
         </div>
-        <div className='mt-3px min-h-30px'>{description ? <div className='text-11px text-t-secondary line-clamp-2 leading-15px'>{description}</div> : <div className='text-11px text-t-tertiary italic line-clamp-2 leading-15px'>{assistant.id}</div>}</div>
+        <div className='mt-3px min-h-30px'>{description ? <div className='text-11px text-t-secondary line-clamp-2 leading-15px'>{description}</div> : null}</div>
         {assistant.enabledSkills && assistant.enabledSkills.length > 0 && (
           <div className='mt-4px flex items-center gap-4px'>
             <Lightning size='12' className='text-primary flex-shrink-0' />
@@ -184,12 +187,8 @@ const InstalledAssistantCard: React.FC<{
           <Copy size='13' />
           <span className='max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all duration-180 group-hover:max-w-40px group-hover:opacity-100'>{t('settings.assistant.duplicate', { defaultValue: '复制' })}</span>
         </button>
-        {/* Shield (builtin/extension) or Delete (custom) */}
-        {assistant.isBuiltin || isExtension ? (
-          <div className='w-24px h-24px flex items-center justify-center text-primary' title='内置助手'>
-            <Shield size='15' />
-          </div>
-        ) : (
+        {/* Delete button - only for custom assistants that are not readonly */}
+        {!isReadonly && (
           <Popconfirm title={t('settings.deleteAssistantConfirmTitle', { defaultValue: '删除该助手会一并删除已关联会话。如需保留，请导出会话进行备份。是否确认删除？' })} onOk={onDelete} okText={t('common.delete', { defaultValue: '删除' })} cancelText={t('common.cancel', { defaultValue: '取消' })} okButtonProps={{ status: 'danger' }}>
             <button type='button' className='group h-24px px-8px rd-full border-none bg-fill-2 text-t-secondary text-11px font-medium flex items-center justify-center gap-4px cursor-pointer transition-colors hover:bg-fill-3 hover:text-danger'>
               <Delete size='13' />
@@ -279,6 +278,81 @@ const HubAssistantCard: React.FC<{
             <span className='max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all duration-180 group-hover:max-w-40px group-hover:opacity-100'>{t('settings.assistant.install', { defaultValue: '安装' })}</span>
           </button>
         ) : null}
+      </div>
+    </div>
+  );
+};
+
+// ==================== TenantAssistantCard (for exclusive tab in enterprise mode) ====================
+
+const TenantAssistantCard: React.FC<{
+  assistant: {
+    id: string;
+    name: string;
+    displayName?: string;
+    description?: string;
+    version?: string;
+    status: string;
+    author?: string;
+    authorName?: string;
+    enabledSkills?: string[];
+    approvedAt?: string;
+    installed?: boolean;
+  };
+  isInstalled: boolean;
+  installing: boolean;
+  installProgress: number;
+  onDuplicate: (e: React.MouseEvent) => void;
+  onClick: () => void;
+}> = ({ assistant, isInstalled, installing, installProgress, onDuplicate, onClick }) => {
+  const { t } = useTranslation();
+
+  const displayName = assistant.displayName || assistant.name;
+
+  // Tenant assistants are synced from server and always considered installed
+  // Show "已安装" badge and duplicate button (same as hub installed assistants)
+
+  return (
+    <div className='group bg-fill-1 rd-12px cursor-pointer hover:bg-fill-2 transition-colors border border-line p-12px flex items-start gap-12px relative overflow-hidden' onClick={onClick}>
+      {/* Icon */}
+      <div className='w-48px flex-shrink-0 flex flex-col items-center'>
+        <div className='w-48px h-48px rd-8px overflow-hidden bg-fill-2'>
+          <div className='w-full h-full flex items-center justify-center bg-primary-light'>
+            <Robot theme='filled' size='22' className='text-primary' />
+          </div>
+        </div>
+        {/* Tenant assistants are always installed after sync */}
+        <span className='mt-6px px-5px py-0px bg-primary-light text-primary text-10px rd-3px whitespace-nowrap leading-18px'>{t('settings.assistant.installed', { defaultValue: '已安装' })}</span>
+      </div>
+
+      {/* Content */}
+      <div className='flex-1 min-w-0'>
+        <div className='flex items-center gap-6px pr-100px min-w-0'>
+          <span className='flex-1 min-w-0 font-medium text-13px text-t-primary truncate'>{displayName}</span>
+        </div>
+        <div className='text-11px text-t-secondary mt-3px line-clamp-2 leading-relaxed'>{assistant.description || ''}</div>
+        {assistant.enabledSkills && assistant.enabledSkills.length > 0 && (
+          <div className='mt-4px flex items-center gap-4px'>
+            <Lightning size='12' className='text-primary flex-shrink-0' />
+            <span className='text-10px text-t-tertiary'>{t('settings.assistant.relatedSkills', { count: assistant.enabledSkills.length, defaultValue: `${assistant.enabledSkills.length} 个关联技能` })}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Actions - top right */}
+      <div className='absolute top-10px right-10px flex items-center' onClick={(e) => e.stopPropagation()}>
+        {/* Installing progress */}
+        {installing ? (
+          <div className='w-52px'>
+            <Progress percent={installProgress} size='mini' />
+          </div>
+        ) : (
+          /* Duplicate button - tenant assistants are always installed, show duplicate like hub */
+          <button type='button' className='h-24px px-8px rd-full border-none bg-fill-2 text-t-secondary text-11px font-medium flex items-center justify-center gap-4px cursor-pointer transition-colors hover:bg-fill-3 hover:text-t-primary' onClick={onDuplicate}>
+            <Copy size='13' />
+            <span className='max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all duration-180 group-hover:max-w-40px group-hover:opacity-100'>{t('settings.assistant.duplicate', { defaultValue: '复制' })}</span>
+          </button>
+        )}
       </div>
     </div>
   );
@@ -643,6 +717,14 @@ const AgentModalContent: React.FC = () => {
   const [duplicateConfirmVisible, setDuplicateConfirmVisible] = useState(false);
   const [duplicateAssistant, setDuplicateAssistant] = useState<IAssistantHubSkill | null>(null);
   const [duplicateInstalledAssistant, setDuplicateInstalledAssistant] = useState<AssistantListItem | null>(null);
+  // Duplicate tenant assistant state (for enterprise mode)
+  const [duplicateTenantAssistant, setDuplicateTenantAssistant] = useState<{
+    id: string;
+    name: string;
+    displayName?: string;
+    description?: string;
+    enabledSkills?: string[];
+  } | null>(null);
   // Upload assistant state
   const [uploadConfirmVisible, setUploadConfirmVisible] = useState(false);
   const [uploadAssistant, setUploadAssistant] = useState<AssistantListItem | null>(null);
@@ -654,6 +736,9 @@ const AgentModalContent: React.FC = () => {
   // Upload/Publish state for enterprise mode
   const [uploadingAssistantName, setUploadingAssistantName] = useState<string | null>(null);
   const [publishingAssistantName, setPublishingAssistantName] = useState<string | null>(null);
+
+  // Track if sync has been triggered for current tab session (avoid loop)
+  const syncTriggeredRef = useRef(false);
 
   // Tenant assistants state for exclusive tab in enterprise mode
   const [tenantAssistants, setTenantAssistants] = useState<
@@ -834,17 +919,13 @@ const AgentModalContent: React.FC = () => {
 
         const category = selectedHubCategoryRef.current === 'all' ? '' : selectedHubCategoryRef.current;
         const query = hubSearchQueryRef.current.trim();
-        const tenantId = currentAssistantTenantId;
-
-        if (activeTab === 'exclusive' && !tenantId) {
-          setHubAssistantList([]);
-          setHubNextCursor(null);
-          setHubHasMore(false);
-          return;
-        }
+        // Enterprise mode: use sourceType to specify directory (hub or tenant)
+        // Personal mode: use tenantId for tenant assistants
+        const sourceType = isEnterprise && activeTab === 'exclusive' ? 'tenant' : undefined;
+        const tenantId = isEnterprise ? undefined : currentAssistantTenantId;
 
         if (isElectronDesktop()) {
-          const res = await assistantHub.fetchAssistants.invoke({ cursor, limit: 40, query, category, tenantId });
+          const res = await assistantHub.fetchAssistants.invoke({ cursor, limit: 40, query, category, tenantId, sourceType });
           if (res.success && res.data) {
             const newAssistants = res.data.assistants || [];
             if (append) {
@@ -935,8 +1016,22 @@ const AgentModalContent: React.FC = () => {
   useEffect(() => {
     if (!isEnterprise || !isElectronDesktop()) return;
 
-    const handleSyncCompleted = (data: { skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } }) => {
-      setSyncStatus({ syncing: false, skills: data.skills, assistants: data.assistants });
+    const handleSyncCompleted = (data: {
+      skills: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } };
+      assistants: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } };
+    }) => {
+      // Merge hub and tenant results for display
+      const mergedSkills = {
+        installed: [...data.skills.hub.installed, ...data.skills.tenant.installed],
+        skipped: [...data.skills.hub.skipped, ...data.skills.tenant.skipped],
+        failed: [...data.skills.hub.failed, ...data.skills.tenant.failed],
+      };
+      const mergedAssistants = {
+        installed: [...data.assistants.hub.installed, ...data.assistants.tenant.installed],
+        skipped: [...data.assistants.hub.skipped, ...data.assistants.tenant.skipped],
+        failed: [...data.assistants.hub.failed, ...data.assistants.tenant.failed],
+      };
+      setSyncStatus({ syncing: false, skills: mergedSkills, assistants: mergedAssistants });
       // Refresh installed list after sync
       void fetchInstalledAssistantNames();
     };
@@ -946,21 +1041,35 @@ const AgentModalContent: React.FC = () => {
   }, [isEnterprise, fetchInstalledAssistantNames]);
 
   // Trigger sync when switching to store tab in enterprise mode
-  // Only trigger if not already syncing (avoid duplicate requests)
+  // Only trigger once per tab session, not on every syncStatus change
   useEffect(() => {
-    if (!isEnterprise || activeTab !== 'store' || !isElectronDesktop()) return;
+    if (!isEnterprise || activeTab !== 'store' || !isElectronDesktop()) {
+      // Reset ref when leaving store tab
+      syncTriggeredRef.current = false;
+      return;
+    }
 
-    // Skip if already syncing to avoid duplicate requests
-    if (syncStatus.syncing) return;
+    // Skip if already triggered for this tab session
+    if (syncTriggeredRef.current) return;
 
-    // Reset sync status and trigger sync
+    // Mark as triggered and start sync
+    syncTriggeredRef.current = true;
     setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
 
-    eeclaw.syncFromRemote.invoke().catch((err) => {
-      console.error('Failed to trigger sync:', err);
-      setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
-    });
-  }, [isEnterprise, activeTab, syncStatus.syncing]);
+    eeclaw.syncFromRemote.invoke()
+      .then((res) => {
+        if (!res.success) {
+          // Sync failed, reset status (syncCompleted event won't be emitted)
+          console.error('Sync failed:', res.msg);
+          setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+        }
+        // If success, syncCompleted event will be emitted and handled separately
+      })
+      .catch((err) => {
+        console.error('Failed to trigger sync:', err);
+        setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+      });
+  }, [isEnterprise, activeTab]);
 
   // Fetch tenant assistants when switching to exclusive tab in enterprise mode
   useEffect(() => {
@@ -1023,12 +1132,17 @@ const AgentModalContent: React.FC = () => {
 
   const refreshAgentDetection = useCallback(async () => {
     try {
-      await ipcBridge.acpConversation.refreshCustomAgents.invoke();
-      await mutate('acp.agents.available');
+      if (isEnterprise) {
+        // Enterprise mode: refresh local assistants from hub/tenant/custom/system directories
+        await mutate('assistantHub.installed');
+      } else {
+        await ipcBridge.acpConversation.refreshCustomAgents.invoke();
+        await mutate('acp.agents.available');
+      }
     } catch {
       // ignore
     }
-  }, []);
+  }, [isEnterprise]);
 
   const loadAssistantContext = useCallback(
     async (assistantId: string): Promise<string> => {
@@ -1173,19 +1287,23 @@ const AgentModalContent: React.FC = () => {
     [hubAssistantList, fetchInstalledAssistantNames, loadAssistants, refreshAgentDetection, t]
   );
 
-  // Go use installed assistant (navigate to guid page)
+  // Go use installed assistant (navigate to guid page with assistant pre-selected)
   const handleGoUseHubAssistant = useCallback(async () => {
     if (!hubDetailAssistant) return;
     setHubDetailVisible(false);
-    // Refresh agent detection before navigating so GuidPage's customAgents are up-to-date
+
+    // Use display_name for URL parameter to match customAgents.name in useGuidAgentSelection
+    // hubDetailAssistant.name is the identifier (UUID), display_name is the user-facing name
+    const assistantName = hubDetailAssistant.display_name || hubDetailAssistant.name;
     await refreshAgentDetection();
-    void navigate(`/guid?assistant=${encodeURIComponent(hubDetailAssistant.name)}`);
+    void navigate(`/guid?assistant=${encodeURIComponent(assistantName)}`);
   }, [hubDetailAssistant, navigate, refreshAgentDetection]);
 
   // Open duplicate confirm modal for hub assistant
   const handleOpenDuplicateModal = useCallback((assistant: IAssistantHubSkill) => {
     setDuplicateAssistant(assistant);
     setDuplicateInstalledAssistant(null);
+    setDuplicateTenantAssistant(null);
     setDuplicateConfirmVisible(true);
   }, []);
 
@@ -1193,107 +1311,23 @@ const AgentModalContent: React.FC = () => {
   const handleOpenDuplicateModalFromInstalled = useCallback((assistant: AssistantListItem) => {
     setDuplicateAssistant(null);
     setDuplicateInstalledAssistant(assistant);
+    setDuplicateTenantAssistant(null);
     setDuplicateConfirmVisible(true);
   }, []);
 
-  // Duplicate assistant to custom list
-  const handleDuplicateConfirm = useCallback(async () => {
-    if (!duplicateAssistant && !duplicateInstalledAssistant) return;
-    if (!isElectronDesktop()) {
-      agentMessage.warning(t('settings.assistant.desktopOnly', { defaultValue: '助手复制仅在桌面端可用' }));
-      return;
-    }
-
-    try {
-      // Handle hub assistant duplication
-      if (duplicateAssistant) {
-        const baseName = duplicateAssistant.display_name || duplicateAssistant.name;
-        const customName = t('settings.assistant.duplicatedName', { name: baseName, defaultValue: `自定义-${baseName}` });
-        const customId = uuid(36); // Generate UUID for assistant ID
-
-        // Read the assistant rule content if already installed
-        let ruleContent: string | undefined = undefined;
-        if (hubInstalledAssistantNames.has(duplicateAssistant.name)) {
-          try {
-            const content = await ipcBridge.fs.readAssistantRule.invoke({
-              assistantId: duplicateAssistant.name,
-              locale: localeKey,
-            });
-            if (content && content.trim()) {
-              ruleContent = content;
-            }
-          } catch {
-            // No rule content available
-          }
-        }
-
-        // Create new custom assistant
-        await ipcBridge.assistantHub.createAssistant.invoke({
-          meta: {
-            id: customId,
-            nameI18n: { 'zh-CN': customName },
-            descriptionI18n: duplicateAssistant.description ? { 'zh-CN': duplicateAssistant.description } : undefined,
-            avatar: duplicateAssistant.avatar || duplicateAssistant.emoji,
-            presetAgentType: DEFAULT_PRESET_AGENT_TYPE,
-            enabled: true,
-            source_type: 'custom',
-            enabledSkills: duplicateAssistant.skills || [],
-            defaultInitPrompt: duplicateAssistant.defaultInitPrompt,
-          },
-          ruleContent: ruleContent,
-        });
-
-        agentMessage.success(t('settings.assistant.duplicateSuccess', { name: customName, defaultValue: `已复制到自定义列表: ${customName}` }));
-      }
-
-      // Handle installed assistant duplication
-      if (duplicateInstalledAssistant) {
-        const baseName = duplicateInstalledAssistant.nameI18n?.[localeKey] || duplicateInstalledAssistant.name;
-        const customName = t('settings.assistant.duplicatedName', { name: baseName, defaultValue: `自定义-${baseName}` });
-        const customId = uuid(36); // Generate UUID for assistant ID
-
-        // Read the assistant rule content
-        let ruleContent: string | undefined = undefined;
-        try {
-          const content = await ipcBridge.fs.readAssistantRule.invoke({
-            assistantId: duplicateInstalledAssistant.id,
-            locale: localeKey,
-          });
-          if (content && content.trim()) {
-            ruleContent = content;
-          }
-        } catch {
-          // No rule content available
-        }
-
-        // Create new custom assistant
-        await ipcBridge.assistantHub.createAssistant.invoke({
-          meta: {
-            id: customId,
-            nameI18n: { 'zh-CN': customName },
-            descriptionI18n: duplicateInstalledAssistant.descriptionI18n || (duplicateInstalledAssistant.description ? { 'zh-CN': duplicateInstalledAssistant.description } : undefined),
-            avatar: duplicateInstalledAssistant.avatar,
-            presetAgentType: DEFAULT_PRESET_AGENT_TYPE,
-            enabled: true,
-            source_type: 'custom',
-            enabledSkills: duplicateInstalledAssistant.enabledSkills || [],
-            defaultInitPrompt: duplicateInstalledAssistant.defaultInitPrompt,
-          },
-          ruleContent: ruleContent,
-        });
-
-        agentMessage.success(t('settings.assistant.duplicateSuccess', { name: customName, defaultValue: `已复制到自定义列表: ${customName}` }));
-      }
-
-      await loadAssistants();
-      setDuplicateConfirmVisible(false);
-      setDuplicateAssistant(null);
-      setDuplicateInstalledAssistant(null);
-    } catch (err) {
-      console.error('Failed to duplicate assistant:', err);
-      agentMessage.error(t('settings.assistant.duplicateFailed', { defaultValue: '复制失败' }));
-    }
-  }, [duplicateAssistant, duplicateInstalledAssistant, hubInstalledAssistantNames, localeKey, loadAssistants, t]);
+  // Open duplicate confirm modal for tenant assistant (enterprise mode)
+  const handleOpenDuplicateModalFromTenant = useCallback((assistant: {
+    id: string;
+    name: string;
+    displayName?: string;
+    description?: string;
+    enabledSkills?: string[];
+  }) => {
+    setDuplicateAssistant(null);
+    setDuplicateInstalledAssistant(null);
+    setDuplicateTenantAssistant(assistant);
+    setDuplicateConfirmVisible(true);
+  }, []);
 
   // Open upload confirm modal for custom assistant
   const handleUploadAssistant = useCallback(
@@ -1365,15 +1399,18 @@ const AgentModalContent: React.FC = () => {
         return { success: false, msg: 'Not desktop' };
       }
 
-      const assistantName = assistant.id;
-      const displayName = assistant.nameI18n?.[localeKey] || assistant.name;
+      // Use assistant name (display name) as assistantName, not UUID
+      const assistantName = assistant.nameI18n?.[localeKey] || assistant.name;
+      const displayName = assistantName;
       const description = assistant.descriptionI18n?.[localeKey] || assistant.description || '';
+      const assistantId = assistant.id; // UUID for server reference
 
       setUploadingAssistantName(assistantName);
       try {
-        console.log('[handleUploadCustomAssistant] Calling eeclaw.uploadCustomAssistant.invoke with:', { assistantName, displayName, description });
+        console.log('[handleUploadCustomAssistant] Calling eeclaw.uploadCustomAssistant.invoke with:', { assistantName, assistantId, displayName, description });
         const res = await eeclaw.uploadCustomAssistant.invoke({
           assistantName,
+          assistantId,
           displayName,
           description,
           enabledSkills: assistant.enabledSkills,
@@ -1441,6 +1478,191 @@ const AgentModalContent: React.FC = () => {
     [loadAssistants, t]
   );
 
+  // ---- Duplicate assistant to custom list ----
+  const handleDuplicateConfirm = useCallback(async () => {
+    if (!duplicateAssistant && !duplicateInstalledAssistant && !duplicateTenantAssistant) return;
+    if (!isElectronDesktop()) {
+      agentMessage.warning(t('settings.assistant.desktopOnly', { defaultValue: '助手复制仅在桌面端可用' }));
+      return;
+    }
+
+    try {
+      // Handle hub assistant duplication
+      if (duplicateAssistant) {
+        const baseName = duplicateAssistant.display_name || duplicateAssistant.name;
+        const customName = t('settings.assistant.duplicatedName', { name: baseName, defaultValue: `自定义-${baseName}` });
+        const customId = uuid(36); // Generate UUID for assistant ID
+
+        // Read the assistant rule content if already installed
+        let ruleContent: string | undefined = undefined;
+        if (hubInstalledAssistantNames.has(duplicateAssistant.name)) {
+          try {
+            const content = await ipcBridge.fs.readAssistantRule.invoke({
+              assistantId: duplicateAssistant.name,
+              locale: localeKey,
+            });
+            if (content && content.trim()) {
+              ruleContent = content;
+            }
+          } catch {
+            // No rule content available
+          }
+        }
+
+        // Create new custom assistant
+        await ipcBridge.assistantHub.createAssistant.invoke({
+          meta: {
+            id: customId,
+            nameI18n: { 'zh-CN': customName },
+            descriptionI18n: duplicateAssistant.description ? { 'zh-CN': duplicateAssistant.description } : undefined,
+            avatar: duplicateAssistant.avatar || duplicateAssistant.emoji,
+            presetAgentType: DEFAULT_PRESET_AGENT_TYPE,
+            enabled: true,
+            source_type: 'custom',
+            enabledSkills: duplicateAssistant.skills || [],
+            defaultInitPrompt: duplicateAssistant.defaultInitPrompt,
+          },
+          ruleContent: ruleContent,
+        });
+
+        // Enterprise mode: upload to Moss Server
+        if (isEnterprise) {
+          const result = await ipcBridge.assistantHub.getInstalledAssistants.invoke();
+          if (result.success && result.data) {
+            const newAssistantInfo = result.data.find((a) => a.meta?.id === customId || a.name === customId);
+            if (newAssistantInfo) {
+              const newAssistant: AssistantListItem = {
+                ...toBackendConfig(newAssistantInfo),
+                _category: newAssistantInfo.category,
+                _isHubInstalled: newAssistantInfo.isHubInstalled,
+              };
+              await handleUploadCustomAssistant(newAssistant);
+            }
+          }
+        }
+
+        agentMessage.success(t('settings.assistant.duplicateSuccess', { name: customName, defaultValue: `已复制到自定义列表: ${customName}` }));
+      }
+
+      // Handle installed assistant duplication
+      if (duplicateInstalledAssistant) {
+        const baseName = duplicateInstalledAssistant.nameI18n?.[localeKey] || duplicateInstalledAssistant.name;
+        const customName = t('settings.assistant.duplicatedName', { name: baseName, defaultValue: `自定义-${baseName}` });
+        const customId = uuid(36); // Generate UUID for assistant ID
+
+        // Read the assistant rule content
+        let ruleContent: string | undefined = undefined;
+        try {
+          const content = await ipcBridge.fs.readAssistantRule.invoke({
+            assistantId: duplicateInstalledAssistant.id,
+            locale: localeKey,
+          });
+          if (content && content.trim()) {
+            ruleContent = content;
+          }
+        } catch {
+          // No rule content available
+        }
+
+        // Create new custom assistant
+        await ipcBridge.assistantHub.createAssistant.invoke({
+          meta: {
+            id: customId,
+            nameI18n: { 'zh-CN': customName },
+            descriptionI18n: duplicateInstalledAssistant.descriptionI18n || (duplicateInstalledAssistant.description ? { 'zh-CN': duplicateInstalledAssistant.description } : undefined),
+            avatar: duplicateInstalledAssistant.avatar,
+            presetAgentType: DEFAULT_PRESET_AGENT_TYPE,
+            enabled: true,
+            source_type: 'custom',
+            enabledSkills: duplicateInstalledAssistant.enabledSkills || [],
+            defaultInitPrompt: duplicateInstalledAssistant.defaultInitPrompt,
+          },
+          ruleContent: ruleContent,
+        });
+
+        // Enterprise mode: upload to Moss Server
+        if (isEnterprise) {
+          const result = await ipcBridge.assistantHub.getInstalledAssistants.invoke();
+          if (result.success && result.data) {
+            const newAssistantInfo = result.data.find((a) => a.meta?.id === customId || a.name === customId);
+            if (newAssistantInfo) {
+              const newAssistant: AssistantListItem = {
+                ...toBackendConfig(newAssistantInfo),
+                _category: newAssistantInfo.category,
+                _isHubInstalled: newAssistantInfo.isHubInstalled,
+              };
+              await handleUploadCustomAssistant(newAssistant);
+            }
+          }
+        }
+
+        agentMessage.success(t('settings.assistant.duplicateSuccess', { name: customName, defaultValue: `已复制到自定义列表: ${customName}` }));
+      }
+
+      // Handle tenant assistant duplication (enterprise mode)
+      if (duplicateTenantAssistant) {
+        const baseName = duplicateTenantAssistant.displayName || duplicateTenantAssistant.name;
+        const customName = t('settings.assistant.duplicatedName', { name: baseName, defaultValue: `自定义-${baseName}` });
+        const customId = uuid(36); // Generate UUID for assistant ID
+
+        // Read the assistant rule content (tenant assistants are synced to local tenant/ directory)
+        let ruleContent: string | undefined = undefined;
+        try {
+          const content = await ipcBridge.fs.readAssistantRule.invoke({
+            assistantId: duplicateTenantAssistant.name,
+            locale: localeKey,
+          });
+          if (content && content.trim()) {
+            ruleContent = content;
+          }
+        } catch {
+          // No rule content available
+        }
+
+        // Create new custom assistant
+        await ipcBridge.assistantHub.createAssistant.invoke({
+          meta: {
+            id: customId,
+            nameI18n: { 'zh-CN': customName },
+            descriptionI18n: duplicateTenantAssistant.description ? { 'zh-CN': duplicateTenantAssistant.description } : undefined,
+            presetAgentType: DEFAULT_PRESET_AGENT_TYPE,
+            enabled: true,
+            source_type: 'custom',
+            enabledSkills: duplicateTenantAssistant.enabledSkills || [],
+          },
+          ruleContent: ruleContent,
+        });
+
+        // Enterprise mode: upload to Moss Server
+        if (isEnterprise) {
+          const result = await ipcBridge.assistantHub.getInstalledAssistants.invoke();
+          if (result.success && result.data) {
+            const newAssistantInfo = result.data.find((a) => a.meta?.id === customId || a.name === customId);
+            if (newAssistantInfo) {
+              const newAssistant: AssistantListItem = {
+                ...toBackendConfig(newAssistantInfo),
+                _category: newAssistantInfo.category,
+                _isHubInstalled: newAssistantInfo.isHubInstalled,
+              };
+              await handleUploadCustomAssistant(newAssistant);
+            }
+          }
+        }
+
+        agentMessage.success(t('settings.assistant.duplicateSuccess', { name: customName, defaultValue: `已复制到自定义列表: ${customName}` }));
+      }
+
+      await loadAssistants();
+      setDuplicateConfirmVisible(false);
+      setDuplicateAssistant(null);
+      setDuplicateInstalledAssistant(null);
+      setDuplicateTenantAssistant(null);
+    } catch (err) {
+      console.error('Failed to duplicate assistant:', err);
+      agentMessage.error(t('settings.assistant.duplicateFailed', { defaultValue: '复制失败' }));
+    }
+  }, [duplicateAssistant, duplicateInstalledAssistant, duplicateTenantAssistant, hubInstalledAssistantNames, localeKey, loadAssistants, t, isEnterprise, handleUploadCustomAssistant]);
+
   // ---- Enterprise mode: Install tenant assistant ----
   const handleInstallTenantAssistant = useCallback(
     async (assistantId: string, assistantName: string) => {
@@ -1486,10 +1708,24 @@ const AgentModalContent: React.FC = () => {
   // Only custom assistants can be edited; hub-installed, builtin, and extension assistants are readonly
   const isReadonlyAssistant = Boolean(activeAssistant && (isExtensionAssistant(activeAssistant) || activeAssistant._isHubInstalled || activeAssistant.isBuiltin));
 
-  // Categorize assistants into 3 groups by metadata (mirrors skill pattern: source_type / isBuiltin)
-  const hubAssistants = assistants.filter((a) => !a.isBuiltin && a._isHubInstalled);
-  const builtinAssistants = assistants.filter((a) => a.isBuiltin || isExtensionAssistant(a));
-  const customAssistants = assistants.filter((a) => !a.isBuiltin && !a._isHubInstalled && !isExtensionAssistant(a));
+  // ===== 分类逻辑：以目录分类（_category）为主，其他字段仅作兼容兜底 =====
+  // Tenant assistants: 目录分类为 tenant
+  const localTenantAssistants = assistants.filter((a) => a._category === 'tenant');
+  // Filter tenant assistants by search query
+  const filteredTenantAssistants = hubSearchQuery.trim()
+    ? localTenantAssistants.filter((a) => {
+        const displayName = a.nameI18n?.[localeKey] || a.name;
+        const description = a.descriptionI18n?.[localeKey] || a.description || '';
+        const query = hubSearchQuery.trim().toLowerCase();
+        return displayName.toLowerCase().includes(query) || description.toLowerCase().includes(query);
+      })
+    : localTenantAssistants;
+  // Hub assistants: 目录分类为 hub（_isHubInstalled 仅作兼容兜底）
+  const hubAssistants = assistants.filter((a) => a._category === 'hub' || (!a._category && !a.isBuiltin && a._isHubInstalled));
+  // Builtin assistants: 目录分类为 system 或 isBuiltin 为 true
+  const builtinAssistants = assistants.filter((a) => a._category === 'system' || a.isBuiltin || isExtensionAssistant(a));
+  // Custom assistants: 目录分类为 custom（其他字段仅作兼容兜底）
+  const customAssistants = assistants.filter((a) => a._category === 'custom' || (!a._category && !a.isBuiltin && !a._isHubInstalled && !isExtensionAssistant(a)));
 
   // Avatar helpers
   const isEmoji = useCallback((str: string) => {
@@ -1671,7 +1907,9 @@ const AgentModalContent: React.FC = () => {
     if (!activeAssistant) return;
     try {
       const lookupName = resolveAssistantName(activeAssistant.id);
-      await ipcBridge.assistantHub.uninstallAssistant.invoke({ name: lookupName });
+      // Pass category for precise assistant location
+      const assistantCategory = activeAssistant._category as 'custom' | 'hub' | 'system' | 'tenant' | undefined;
+      await ipcBridge.assistantHub.uninstallAssistant.invoke({ name: lookupName, category: assistantCategory });
       await loadAssistants();
       setDeleteConfirmVisible(false);
       setEditVisible(false);
@@ -1686,7 +1924,9 @@ const AgentModalContent: React.FC = () => {
   const handleDeleteFromCard = async (assistant: AssistantListItem) => {
     try {
       const lookupName = resolveAssistantName(assistant.id);
-      await ipcBridge.assistantHub.uninstallAssistant.invoke({ name: lookupName });
+      // Pass category for precise assistant location
+      const assistantCategory = assistant._category as 'custom' | 'hub' | 'system' | 'tenant' | undefined;
+      await ipcBridge.assistantHub.uninstallAssistant.invoke({ name: lookupName, category: assistantCategory });
       await loadAssistants();
       agentMessage.success(t('common.success', { defaultValue: 'Success' }));
       await refreshAgentDetection();
@@ -1703,10 +1943,12 @@ const AgentModalContent: React.FC = () => {
     }
     try {
       const lookupName = resolveAssistantName(assistant.id);
+      // Pass category for precise assistant location
+      const assistantCategory = assistant._category as 'custom' | 'hub' | 'system' | 'tenant' | undefined;
       if (enabled) {
-        await ipcBridge.assistantHub.enableAssistant.invoke({ name: lookupName });
+        await ipcBridge.assistantHub.enableAssistant.invoke({ name: lookupName, category: assistantCategory });
       } else {
-        await ipcBridge.assistantHub.disableAssistant.invoke({ name: lookupName });
+        await ipcBridge.assistantHub.disableAssistant.invoke({ name: lookupName, category: assistantCategory });
       }
       await loadAssistants();
       await refreshAgentDetection();
@@ -1720,10 +1962,10 @@ const AgentModalContent: React.FC = () => {
 
   const editAvatarImage = resolveAvatarImageSrc(editAvatar);
 
-  const renderAssistantGrid = (list: AssistantListItem[]) => (
+  const renderAssistantGrid = (list: AssistantListItem[], hideDelete = false) => (
     <div className='grid gap-8px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
       {list.map((assistant) => (
-        <InstalledAssistantCard key={assistant.id} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onUpload={!assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined} onClick={() => void handleEdit(assistant)} />
+        <InstalledAssistantCard key={assistant.id} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onUpload={!assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined} onClick={() => void handleEdit(assistant)} hideDelete={hideDelete} />
       ))}
     </div>
   );
@@ -1795,14 +2037,10 @@ const AgentModalContent: React.FC = () => {
             <span className='text-11px text-primary'>{t('settings.assistant.syncing', { defaultValue: '同步中...' })}</span>
           </div>
         )}
-        {isEnterprise && activeTab === 'store' && !syncStatus.syncing && (syncStatus.assistants.installed.length > 0 || syncStatus.assistants.failed.length > 0) && (
-          <div className='flex items-center gap-6px px-10px py-4px bg-fill-2 rd-6px flex-shrink-0'>
-            <span className='text-11px text-t-secondary'>
-              {t('settings.assistant.syncCompletedShort', {
-                installed: syncStatus.assistants.installed.length,
-                defaultValue: `已同步 ${syncStatus.assistants.installed.length} 个助手`,
-              })}
-            </span>
+        {isEnterprise && activeTab === 'store' && !syncStatus.syncing && (syncStatus.assistants.installed.length > 0 || syncStatus.assistants.skipped.length > 0 || syncStatus.assistants.failed.length > 0) && (
+          <div className='flex items-center gap-6px px-10px py-4px bg-success-light rd-6px flex-shrink-0'>
+            <Check size={12} className='text-success' />
+            <span className='text-11px text-success'>{t('settings.assistant.syncCompleted', { defaultValue: '已同步' })}</span>
           </div>
         )}
 
@@ -1839,66 +2077,43 @@ const AgentModalContent: React.FC = () => {
 
           {/* Assistant grid */}
           <AionScrollArea className='flex-1 min-h-0' disableOverflow={isPageMode} onScroll={handleHubScroll}>
-            {/* Enterprise mode: show tenant assistants from Moss Server */}
+            {/* Enterprise mode: show tenant assistants from local tenant/ directory */}
             {activeTab === 'exclusive' && isEnterprise ? (
-              tenantAssistantsLoading ? (
+              hubLoading ? (
                 <div className='flex justify-center items-center py-48px'>
                   <Spin size={28} />
                 </div>
-              ) : tenantAssistants.length === 0 ? (
+              ) : hubAssistantList.length === 0 ? (
                 <div className='flex flex-col items-center justify-center py-48px text-t-secondary gap-8px'>
                   <Shield size='32' className='text-t-tertiary' />
                   <span className='text-13px'>{t('settings.assistant.noTenantAssistants', { defaultValue: '暂无专属助手' })}</span>
                 </div>
               ) : (
                 <div className='grid gap-8px pb-16px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
-                  {tenantAssistants
-                    .filter((a) => a.status === 'approved')
-                    .map((assistant) => {
-                      const isInstalling = installingTenantAssistantId === assistant.id;
-                      const isInstalled = assistant.installed === true;
-                      return (
-                        <div
-                          key={assistant.id}
-                          className='bg-base rd-12px border border-line p-12px flex items-start gap-12px cursor-pointer hover:border-primary transition-colors'
-                          onClick={() => {
-                            if (!isInstalled && !isInstalling) {
-                              void handleInstallTenantAssistant(assistant.id, assistant.name);
-                            }
-                          }}
-                        >
-                          <div className='w-48px h-48px flex-shrink-0 rd-8px bg-fill-2 flex items-center justify-center'>
-                            <Robot size='24' className='text-t-tertiary' />
-                          </div>
-                          <div className='flex-1 min-w-0 flex flex-col gap-4px'>
-                            <div className='text-13px font-medium text-t-primary truncate'>{assistant.displayName || assistant.name}</div>
-                            <div className='text-11px text-t-secondary line-clamp-2'>{assistant.description || ''}</div>
-                            <div className='flex items-center gap-4px mt-4px'>
-                              {assistant.authorName && <span className='text-10px text-t-tertiary'>{assistant.authorName}</span>}
-                              {assistant.version && <span className='text-10px text-t-tertiary'>v{assistant.version}</span>}
-                            </div>
-                          </div>
-                          {/* Install/Installed indicator */}
-                          <div className='flex-shrink-0'>
-                            {isInstalled ? (
-                              <span className='px-6px py-2px bg-success text-white text-10px rd-4px'>{t('common.installed', { defaultValue: '已安装' })}</span>
-                            ) : isInstalling ? (
-                              <Spin size={16} />
-                            ) : (
-                              <button
-                                className='px-6px py-2px bg-primary text-white text-10px rd-4px cursor-pointer border-none hover:opacity-80'
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  void handleInstallTenantAssistant(assistant.id, assistant.name);
-                                }}
-                              >
-                                {t('common.install', { defaultValue: '安装' })}
-                              </button>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
+                  {hubAssistantList.map((assistant) => {
+                    return (
+                      <HubAssistantCard
+                        key={assistant.id}
+                        assistant={assistant}
+                        isInstalled={true}
+                        installing={false}
+                        installProgress={installProgress}
+                        onInstall={(e) => {
+                          e.stopPropagation();
+                          setHubDetailAssistant(assistant);
+                          setHubDetailVisible(true);
+                        }}
+                        onDuplicate={(e) => {
+                          e.stopPropagation();
+                          handleOpenDuplicateModal(assistant);
+                        }}
+                        onClick={() => {
+                          setHubDetailAssistant(assistant);
+                          setHubDetailVisible(true);
+                        }}
+                      />
+                    );
+                  })}
                 </div>
               )
             ) : activeTab === 'exclusive' && !enterpriseCode ? (
@@ -1992,13 +2207,24 @@ const AgentModalContent: React.FC = () => {
                 {customAssistants.length > 0 ? isEnterprise ? renderCustomAssistantGridWithEnterpriseActions(customAssistants) : renderAssistantGrid(customAssistants) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomAssistants', { defaultValue: '暂无自定义助手' })}</div>}
               </section>
 
+              {/* Tenant assistants section - enterprise mode only */}
+              {isEnterprise && (
+                <section>
+                  <div className='flex items-center justify-between gap-8px mb-10px'>
+                    <div className='text-13px font-medium text-t-primary'>{t('settings.tenantAssistants', { defaultValue: '专属助手' })}</div>
+                    <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{filteredTenantAssistants.length}</span>
+                  </div>
+                  {filteredTenantAssistants.length > 0 ? renderAssistantGrid(filteredTenantAssistants, true) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noTenantAssistants', { defaultValue: '暂无专属助手' })}</div>}
+                </section>
+              )}
+
               {/* Hub/store assistants section */}
               <section>
                 <div className='flex items-center justify-between gap-8px mb-10px'>
                   <div className='text-13px font-medium text-t-primary'>{t('settings.hubAssistants', { defaultValue: '商店助手' })}</div>
                   <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{hubAssistants.length}</span>
                 </div>
-                {hubAssistants.length > 0 ? renderAssistantGrid(hubAssistants) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>}
+                {hubAssistants.length > 0 ? renderAssistantGrid(hubAssistants, isEnterprise) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>}
               </section>
 
               {/* Builtin assistants section */}

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge, skillHub, assistantHub } from '@/common';
+import { eeclaw } from '@/common/ipcBridge';
 import type { IInstalledSkillInfo, IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill } from '@/common/ipcBridge';
 import { toBackendConfig, resolveAssistantName } from '@/renderer/shared/agents/assistantAdapter';
 import type { AssistantCategory } from '@/process/AssistantManager';
@@ -17,8 +18,8 @@ import { getSelectableAssistantSkills, isAutoInjectedBuiltinSkill, sanitizeAssis
 import { getInstalledSkillDisplay, normalizeSkillVersion } from '@/renderer/utils/skillDisplay';
 import { isElectronDesktop, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { DEFAULT_PRESET_AGENT_TYPE, normalizePresetAgentType, type AcpBackendConfig } from '@/types/acpTypes';
-import { Avatar, Button, Checkbox, Collapse, Drawer, Input, Message, Modal, Popconfirm, Progress, Select, Spin, Switch, Tag, Typography } from '@arco-design/web-react';
-import { Close, Copy, Delete, Edit, Lightning, PreviewOpen, Plus, Robot, Shield, Search, Install, Upload } from '@icon-park/react';
+import { Avatar, Button, Checkbox, Collapse, Drawer, Input, Message, Modal, Popconfirm, Progress, Select, Spin, Switch, Tag, Tooltip, Typography } from '@arco-design/web-react';
+import { Close, Copy, Delete, Edit, Lightning, PreviewOpen, Plus, Robot, Shield, Search, Install, Upload, Share, UploadOne } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +27,7 @@ import { useAuth } from '@/renderer/context/AuthContext';
 import useSWR, { mutate } from 'swr';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsViewMode } from '../settingsViewContext';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 
 // ==================== Types ====================
 
@@ -90,7 +92,9 @@ const InstalledAssistantCard: React.FC<{
   onDuplicate: () => void;
   onUpload?: () => void;
   onClick: () => void;
-}> = ({ assistant, isExtension, localeKey, avatarImageMap, onToggleEnabled, onDelete, onDuplicate, onUpload, onClick }) => {
+  /** Enterprise mode: publish button element */
+  enterprisePublishButton?: React.ReactNode;
+}> = ({ assistant, isExtension, localeKey, avatarImageMap, onToggleEnabled, onDelete, onDuplicate, onUpload, onClick, enterprisePublishButton }) => {
   const { t } = useTranslation();
   const isCustom = !assistant.isBuiltin && !isExtension && !assistant._isHubInstalled;
   const isReadonly = assistant.isBuiltin || isExtension || assistant._isHubInstalled;
@@ -116,8 +120,8 @@ const InstalledAssistantCard: React.FC<{
 
   return (
     <div className={classNames('bg-fill-1 rd-12px border border-line p-12px flex items-start gap-12px relative overflow-hidden transition-colors cursor-pointer hover:bg-fill-2', !isEnabled && 'opacity-65')} onClick={onClick}>
-      {/* Avatar + toggle */}
-      <div className='w-48px flex-shrink-0 flex flex-col items-center'>
+      {/* Avatar */}
+      <div className='w-48px flex-shrink-0'>
         <div className='w-48px h-48px rd-8px overflow-hidden bg-fill-2'>
           {avatarImage ? (
             <img src={avatarImage} alt={displayName} className='w-full h-full object-cover' />
@@ -129,20 +133,10 @@ const InstalledAssistantCard: React.FC<{
             </div>
           )}
         </div>
-        {isCustom && (
-          <div
-            className='mt-6px w-full flex justify-center'
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-          >
-            <Switch size='small' checked={isEnabled} onChange={(checked) => onToggleEnabled(checked)} className={isEnabled ? '!bg-primary !border-primary' : ''} />
-          </div>
-        )}
       </div>
 
       {/* Content */}
-      <div className='flex-1 min-w-0 pr-58px'>
+      <div className='flex-1 min-w-0'>
         <div className='h-20px flex items-center'>
           <span className='font-medium text-13px text-t-primary truncate' title={displayName.length > 15 ? displayName : undefined}>
             {displayName.length > 15 ? `${displayName.slice(0, 15)}...` : displayName}
@@ -153,6 +147,20 @@ const InstalledAssistantCard: React.FC<{
           <div className='mt-4px flex items-center gap-4px'>
             <Lightning size='12' className='text-primary flex-shrink-0' />
             <span className='text-10px text-t-tertiary'>{t('settings.assistant.relatedSkills', { count: assistant.enabledSkills.length, defaultValue: `${assistant.enabledSkills.length} 个关联技能` })}</span>
+          </div>
+        )}
+        {/* Toggle + Enterprise publish button row - at the bottom */}
+        {isCustom && (
+          <div className='mt-8px flex items-center justify-between'>
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <Switch size='small' checked={isEnabled} onChange={(checked) => onToggleEnabled(checked)} className={isEnabled ? '!bg-primary !border-primary' : ''} />
+            </div>
+            {/* Enterprise publish button - at the rightmost, same row as toggle */}
+            {enterprisePublishButton}
           </div>
         )}
       </div>
@@ -296,6 +304,9 @@ const AssistantDetailModal: React.FC<{
   const [relatedSkillTags, setRelatedSkillTags] = useState<Map<string, string>>(new Map());
   const [loadingSkills, setLoadingSkills] = useState(false);
 
+  // Use useAppMode hook for renderer process (enterpriseDebugConfig.isEnterpriseMode only works in main process)
+  const { isEnterprise } = useAppMode();
+
   // Check if assistant has a valid download URL
   const hasDownloadUrl = Boolean(assistant?._sourceUrl);
 
@@ -335,10 +346,13 @@ const AssistantDetailModal: React.FC<{
     const fetchData = async () => {
       try {
         if (isElectronDesktop()) {
-          // Fetch assistant detail
-          const res = await assistantHub.fetchAssistantDetail.invoke({ assistantId: assistant.id });
-          if (res.success && res.data) {
-            setDetail(res.data);
+          // In enterprise mode, skip SkillHub API calls - only use local data
+          if (!isEnterprise) {
+            // Fetch assistant detail from Hub (personal mode only)
+            const res = await assistantHub.fetchAssistantDetail.invoke({ assistantId: assistant.id });
+            if (res.success && res.data) {
+              setDetail(res.data);
+            }
           }
 
           // Fetch related skill details by IDs
@@ -379,9 +393,9 @@ const AssistantDetailModal: React.FC<{
               }
             }
 
-            // Fetch remaining skills from Hub API
+            // Fetch remaining skills from Hub API (personal mode only)
             let hubSkills: ISkillHubSkill[] = [];
-            if (notFoundSkillIds.length > 0) {
+            if (notFoundSkillIds.length > 0 && !isEnterprise) {
               const skillsRes = await assistantHub.fetchSkillDetailsByIds.invoke({ skillIds: notFoundSkillIds });
               if (skillsRes.success && skillsRes.data) {
                 hubSkills = skillsRes.data;
@@ -418,7 +432,7 @@ const AssistantDetailModal: React.FC<{
       }
     };
     void fetchData();
-  }, [visible, assistant, localSkillByIdMap]);
+  }, [visible, assistant, localSkillByIdMap, isEnterprise]);
 
   if (!assistant) return null;
 
@@ -609,6 +623,7 @@ const AgentModalContent: React.FC = () => {
 
   // Hub state (for store/exclusive tabs)
   const { user } = useAuth();
+  const enterpriseCode = user?.enterprise_code?.trim();
   const navigate = useNavigate();
   const [hubAssistantList, setHubAssistantList] = useState<IAssistantHubSkill[]>([]);
   const [hubCategories, setHubCategories] = useState<string[]>([]);
@@ -632,7 +647,39 @@ const AgentModalContent: React.FC = () => {
   const [uploadConfirmVisible, setUploadConfirmVisible] = useState(false);
   const [uploadAssistant, setUploadAssistant] = useState<AssistantListItem | null>(null);
   const [uploading, setUploading] = useState(false);
-  const enterpriseCode = user?.enterprise_code?.trim();
+
+  // Enterprise mode detection - use useAppMode hook for renderer process
+  const { isEnterprise } = useAppMode();
+
+  // Upload/Publish state for enterprise mode
+  const [uploadingAssistantName, setUploadingAssistantName] = useState<string | null>(null);
+  const [publishingAssistantName, setPublishingAssistantName] = useState<string | null>(null);
+
+  // Tenant assistants state for exclusive tab in enterprise mode
+  const [tenantAssistants, setTenantAssistants] = useState<
+    Array<{
+      id: string;
+      name: string;
+      displayName?: string;
+      description?: string;
+      version?: string;
+      status: 'pending' | 'approved' | 'rejected';
+      author?: string;
+      authorName?: string;
+      enabledSkills?: string[];
+      approvedAt?: string;
+      installed?: boolean;
+    }>
+  >([]);
+  const [tenantAssistantsLoading, setTenantAssistantsLoading] = useState(false);
+  const [installingTenantAssistantId, setInstallingTenantAssistantId] = useState<string | null>(null);
+
+  // Sync status state
+  const [syncStatus, setSyncStatus] = useState<{
+    syncing: boolean;
+    skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+    assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+  }>({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
 
   const avatarImageMap = React.useMemo<Record<string, string>>(
     () => ({
@@ -883,6 +930,58 @@ const AgentModalContent: React.FC = () => {
     }, 300);
     return () => clearTimeout(timer);
   }, [activeTab, hubSearchQuery, fetchHubAssistants]);
+
+  // Listen for sync completed event (enterprise mode)
+  useEffect(() => {
+    if (!isEnterprise || !isElectronDesktop()) return;
+
+    const handleSyncCompleted = (data: { skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } }) => {
+      setSyncStatus({ syncing: false, skills: data.skills, assistants: data.assistants });
+      // Refresh installed list after sync
+      void fetchInstalledAssistantNames();
+    };
+
+    const unsubscribe = eeclaw.syncCompleted.on(handleSyncCompleted);
+    return () => unsubscribe();
+  }, [isEnterprise, fetchInstalledAssistantNames]);
+
+  // Trigger sync when switching to store tab in enterprise mode
+  // Only trigger if not already syncing (avoid duplicate requests)
+  useEffect(() => {
+    if (!isEnterprise || activeTab !== 'store' || !isElectronDesktop()) return;
+
+    // Skip if already syncing to avoid duplicate requests
+    if (syncStatus.syncing) return;
+
+    // Reset sync status and trigger sync
+    setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+
+    eeclaw.syncFromRemote.invoke().catch((err) => {
+      console.error('Failed to trigger sync:', err);
+      setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+    });
+  }, [isEnterprise, activeTab, syncStatus.syncing]);
+
+  // Fetch tenant assistants when switching to exclusive tab in enterprise mode
+  useEffect(() => {
+    if (!isEnterprise || activeTab !== 'exclusive' || !isElectronDesktop()) return;
+
+    const fetchTenantAssistants = async () => {
+      setTenantAssistantsLoading(true);
+      try {
+        const res = await eeclaw.getTenantAssistants.invoke();
+        if (res.success && res.data) {
+          setTenantAssistants(res.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch tenant assistants:', err);
+      } finally {
+        setTenantAssistantsLoading(false);
+      }
+    };
+
+    void fetchTenantAssistants();
+  }, [isEnterprise, activeTab]);
 
   // IntersectionObserver for infinite scroll
   const findScrollParent = useCallback((el: HTMLElement | null): HTMLElement | null => {
@@ -1257,6 +1356,132 @@ const AgentModalContent: React.FC = () => {
     }
   }, [uploadAssistant, localeKey, enterpriseCode, t]);
 
+  // ---- Enterprise mode: Upload custom assistant to Moss Server ----
+  const handleUploadCustomAssistant = useCallback(
+    async (assistant: AssistantListItem): Promise<{ success: boolean; msg?: string }> => {
+      console.log('[handleUploadCustomAssistant] Starting upload for assistant:', assistant.id);
+      if (!isElectronDesktop()) {
+        console.log('[handleUploadCustomAssistant] Not desktop, returning');
+        return { success: false, msg: 'Not desktop' };
+      }
+
+      const assistantName = assistant.id;
+      const displayName = assistant.nameI18n?.[localeKey] || assistant.name;
+      const description = assistant.descriptionI18n?.[localeKey] || assistant.description || '';
+
+      setUploadingAssistantName(assistantName);
+      try {
+        console.log('[handleUploadCustomAssistant] Calling eeclaw.uploadCustomAssistant.invoke with:', { assistantName, displayName, description });
+        const res = await eeclaw.uploadCustomAssistant.invoke({
+          assistantName,
+          displayName,
+          description,
+          enabledSkills: assistant.enabledSkills,
+        });
+        console.log('[handleUploadCustomAssistant] Upload response:', res);
+        if (res.success && res.data) {
+          agentMessage.success(
+            t('settings.assistant.uploadSuccess', {
+              name: displayName,
+              defaultValue: `助手 "${displayName}" 已上传到服务器`,
+            })
+          );
+          // Refresh installed list
+          void loadAssistants();
+          return { success: true };
+        } else {
+          return { success: false, msg: res.msg || 'Unknown error' };
+        }
+      } catch (err) {
+        console.error('Failed to upload custom assistant:', err);
+        return { success: false, msg: String(err) };
+      } finally {
+        setUploadingAssistantName(null);
+      }
+    },
+    [localeKey, loadAssistants, t]
+  );
+
+  // ---- Enterprise mode: Publish assistant as tenant-exclusive ----
+  const handlePublishTenantAssistant = useCallback(
+    async (assistantId: string, assistantName: string) => {
+      if (!isElectronDesktop()) return;
+
+      setPublishingAssistantName(assistantName);
+      try {
+        const res = await eeclaw.publishTenantAssistant.invoke({ assistantId });
+        if (res.success && res.data) {
+          agentMessage.success(
+            t('settings.assistant.publishSuccess', {
+              name: assistantName,
+              defaultValue: `助手 "${assistantName}" 已提交发布申请，等待管理员审批`,
+            })
+          );
+          void loadAssistants();
+        } else {
+          agentMessage.error(
+            t('settings.assistant.publishFailed', {
+              msg: res.msg || 'Unknown error',
+              defaultValue: `发布失败: ${res.msg || '未知错误'}`,
+            })
+          );
+        }
+      } catch (err) {
+        console.error('Failed to publish tenant assistant:', err);
+        agentMessage.error(
+          t('settings.assistant.publishFailed', {
+            msg: String(err),
+            defaultValue: `发布失败: ${String(err)}`,
+          })
+        );
+      } finally {
+        setPublishingAssistantName(null);
+      }
+    },
+    [loadAssistants, t]
+  );
+
+  // ---- Enterprise mode: Install tenant assistant ----
+  const handleInstallTenantAssistant = useCallback(
+    async (assistantId: string, assistantName: string) => {
+      if (!isElectronDesktop()) return;
+
+      setInstallingTenantAssistantId(assistantId);
+      try {
+        const res = await eeclaw.installTenantAssistant.invoke({ assistantId });
+        if (res.success && res.data) {
+          agentMessage.success(
+            t('settings.assistant.installTenantSuccess', {
+              name: assistantName,
+              defaultValue: `专属助手 "${assistantName}" 已安装`,
+            })
+          );
+          // Update tenant assistants list to mark as installed
+          setTenantAssistants((prev) => prev.map((a) => (a.id === assistantId ? { ...a, installed: true } : a)));
+          void loadAssistants();
+        } else {
+          agentMessage.error(
+            t('settings.assistant.installTenantFailed', {
+              msg: res.msg || 'Unknown error',
+              defaultValue: `安装失败: ${res.msg || '未知错误'}`,
+            })
+          );
+        }
+      } catch (err) {
+        console.error('Failed to install tenant assistant:', err);
+        agentMessage.error(
+          t('settings.assistant.installTenantFailed', {
+            msg: String(err),
+            defaultValue: `安装失败: ${String(err)}`,
+          })
+        );
+      } finally {
+        setInstallingTenantAssistantId(null);
+      }
+    },
+    [loadAssistants, t]
+  );
+
   const activeAssistant = assistants.find((assistant) => assistant.id === activeAssistantId) || null;
   // Only custom assistants can be edited; hub-installed, builtin, and extension assistants are readonly
   const isReadonlyAssistant = Boolean(activeAssistant && (isExtensionAssistant(activeAssistant) || activeAssistant._isHubInstalled || activeAssistant.isBuiltin));
@@ -1361,7 +1586,38 @@ const AgentModalContent: React.FC = () => {
         });
         setActiveAssistantId(newId);
         await loadAssistants();
-        agentMessage.success(t('common.createSuccess', { defaultValue: 'Created successfully' }));
+
+        // Enterprise mode: sync upload to Moss Server after create
+        console.log('[AgentModalContent] isEnterprise:', isEnterprise);
+        if (isEnterprise) {
+          console.log('[AgentModalContent] Enterprise mode: starting sync upload to Moss Server');
+          const result = await ipcBridge.assistantHub.getInstalledAssistants.invoke();
+          if (result.success && result.data) {
+            const newAssistantInfo = result.data.find((a) => a.meta?.id === newId || a.name === newId);
+            console.log('[AgentModalContent] newAssistantInfo:', newAssistantInfo);
+            if (newAssistantInfo) {
+              const newAssistant: AssistantListItem = {
+                ...toBackendConfig(newAssistantInfo),
+                _category: newAssistantInfo.category,
+                _isHubInstalled: newAssistantInfo.isHubInstalled,
+              };
+              console.log('[AgentModalContent] Calling handleUploadCustomAssistant');
+              const uploadRes = await handleUploadCustomAssistant(newAssistant);
+              console.log('[AgentModalContent] uploadRes:', uploadRes);
+              if (uploadRes.success) {
+                agentMessage.success(t('common.createSuccess', { defaultValue: 'Created successfully' }));
+              } else {
+                agentMessage.error(t('settings.assistant.uploadFailed', { msg: uploadRes.msg, defaultValue: `上传失败: ${uploadRes.msg}` }));
+              }
+            } else {
+              agentMessage.success(t('common.createSuccess', { defaultValue: 'Created successfully' }));
+            }
+          } else {
+            agentMessage.success(t('common.createSuccess', { defaultValue: 'Created successfully' }));
+          }
+        } else {
+          agentMessage.success(t('common.createSuccess', { defaultValue: 'Created successfully' }));
+        }
       } else {
         if (!activeAssistant) return;
         const lookupName = resolveAssistantName(activeAssistant.id);
@@ -1472,6 +1728,44 @@ const AgentModalContent: React.FC = () => {
     </div>
   );
 
+  // Render custom assistants with enterprise action buttons (publish only, auto-upload on create)
+  const renderCustomAssistantGridWithEnterpriseActions = (list: AssistantListItem[]) => (
+    <div className='grid gap-8px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
+      {list.map((assistant) => {
+        const assistantId = assistant.id;
+        const isPublishing = publishingAssistantName === assistantId;
+        const publishStatus = (assistant as any).publish_status;
+
+        // Enterprise publish button element - placed below delete button
+        const enterprisePublishButton =
+          isEnterprise && !publishStatus ? (
+            <Tooltip content={t('settings.assistant.publishAsTenant', { defaultValue: '发布为专属助手' })}>
+              <button
+                className='w-20px h-20px rd-4px flex items-center justify-center bg-fill-2 hover:bg-primary hover:text-white transition-colors cursor-pointer border-none'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void handlePublishTenantAssistant(assistantId, assistant.name);
+                }}
+                disabled={isPublishing}
+              >
+                {isPublishing ? <Spin size={12} /> : <Share size={12} />}
+              </button>
+            </Tooltip>
+          ) : isEnterprise && publishStatus === 'pending' ? (
+            <Tooltip content={t('settings.assistant.publishPending', { defaultValue: '发布审批中' })}>
+              <span className='w-20px h-20px rd-4px flex items-center justify-center bg-warning text-white text-10px'>⏳</span>
+            </Tooltip>
+          ) : isEnterprise && publishStatus === 'approved' ? (
+            <Tooltip content={t('settings.assistant.publishApproved', { defaultValue: '已发布为专属助手' })}>
+              <span className='w-20px h-20px rd-4px flex items-center justify-center bg-success text-white text-10px'>✓</span>
+            </Tooltip>
+          ) : undefined;
+
+        return <InstalledAssistantCard key={assistantId} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onClick={() => void handleEdit(assistant)} enterprisePublishButton={enterprisePublishButton} />;
+      })}
+    </div>
+  );
+
   // ==================== Main render ====================
 
   return (
@@ -1493,6 +1787,24 @@ const AgentModalContent: React.FC = () => {
             {assistants.length > 0 && <span className='ml-5px px-5px py-0px bg-primary text-white text-10px rd-full leading-16px'>{assistants.length}</span>}
           </button>
         </div>
+
+        {/* Sync status indicator for enterprise mode - compact inline style */}
+        {isEnterprise && activeTab === 'store' && syncStatus.syncing && (
+          <div className='flex items-center gap-6px px-10px py-4px bg-primary-light-1 rd-6px flex-shrink-0'>
+            <Spin size={12} />
+            <span className='text-11px text-primary'>{t('settings.assistant.syncing', { defaultValue: '同步中...' })}</span>
+          </div>
+        )}
+        {isEnterprise && activeTab === 'store' && !syncStatus.syncing && (syncStatus.assistants.installed.length > 0 || syncStatus.assistants.failed.length > 0) && (
+          <div className='flex items-center gap-6px px-10px py-4px bg-fill-2 rd-6px flex-shrink-0'>
+            <span className='text-11px text-t-secondary'>
+              {t('settings.assistant.syncCompletedShort', {
+                installed: syncStatus.assistants.installed.length,
+                defaultValue: `已同步 ${syncStatus.assistants.installed.length} 个助手`,
+              })}
+            </span>
+          </div>
+        )}
 
         {/* Search - for store/exclusive tabs */}
         <div className={classNames('flex-1 min-w-0 transition-opacity duration-150', activeTab === 'installed' ? 'opacity-0 pointer-events-none' : '')}>
@@ -1527,7 +1839,69 @@ const AgentModalContent: React.FC = () => {
 
           {/* Assistant grid */}
           <AionScrollArea className='flex-1 min-h-0' disableOverflow={isPageMode} onScroll={handleHubScroll}>
-            {activeTab === 'exclusive' && !enterpriseCode ? (
+            {/* Enterprise mode: show tenant assistants from Moss Server */}
+            {activeTab === 'exclusive' && isEnterprise ? (
+              tenantAssistantsLoading ? (
+                <div className='flex justify-center items-center py-48px'>
+                  <Spin size={28} />
+                </div>
+              ) : tenantAssistants.length === 0 ? (
+                <div className='flex flex-col items-center justify-center py-48px text-t-secondary gap-8px'>
+                  <Shield size='32' className='text-t-tertiary' />
+                  <span className='text-13px'>{t('settings.assistant.noTenantAssistants', { defaultValue: '暂无专属助手' })}</span>
+                </div>
+              ) : (
+                <div className='grid gap-8px pb-16px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
+                  {tenantAssistants
+                    .filter((a) => a.status === 'approved')
+                    .map((assistant) => {
+                      const isInstalling = installingTenantAssistantId === assistant.id;
+                      const isInstalled = assistant.installed === true;
+                      return (
+                        <div
+                          key={assistant.id}
+                          className='bg-base rd-12px border border-line p-12px flex items-start gap-12px cursor-pointer hover:border-primary transition-colors'
+                          onClick={() => {
+                            if (!isInstalled && !isInstalling) {
+                              void handleInstallTenantAssistant(assistant.id, assistant.name);
+                            }
+                          }}
+                        >
+                          <div className='w-48px h-48px flex-shrink-0 rd-8px bg-fill-2 flex items-center justify-center'>
+                            <Robot size='24' className='text-t-tertiary' />
+                          </div>
+                          <div className='flex-1 min-w-0 flex flex-col gap-4px'>
+                            <div className='text-13px font-medium text-t-primary truncate'>{assistant.displayName || assistant.name}</div>
+                            <div className='text-11px text-t-secondary line-clamp-2'>{assistant.description || ''}</div>
+                            <div className='flex items-center gap-4px mt-4px'>
+                              {assistant.authorName && <span className='text-10px text-t-tertiary'>{assistant.authorName}</span>}
+                              {assistant.version && <span className='text-10px text-t-tertiary'>v{assistant.version}</span>}
+                            </div>
+                          </div>
+                          {/* Install/Installed indicator */}
+                          <div className='flex-shrink-0'>
+                            {isInstalled ? (
+                              <span className='px-6px py-2px bg-success text-white text-10px rd-4px'>{t('common.installed', { defaultValue: '已安装' })}</span>
+                            ) : isInstalling ? (
+                              <Spin size={16} />
+                            ) : (
+                              <button
+                                className='px-6px py-2px bg-primary text-white text-10px rd-4px cursor-pointer border-none hover:opacity-80'
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  void handleInstallTenantAssistant(assistant.id, assistant.name);
+                                }}
+                              >
+                                {t('common.install', { defaultValue: '安装' })}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                </div>
+              )
+            ) : activeTab === 'exclusive' && !enterpriseCode ? (
               <div className='flex flex-col items-center justify-center py-48px text-t-secondary gap-8px'>
                 <Shield size='32' className='text-t-tertiary' />
                 <span className='text-13px'>{t('settings.assistant.noEnterpriseCode', { defaultValue: '当前账号没有企业编码，无法加载专属助手。' })}</span>
@@ -1615,7 +1989,7 @@ const AgentModalContent: React.FC = () => {
                   <div className='text-13px font-medium text-t-primary'>{t('settings.customAssistants', { defaultValue: '自定义助手' })}</div>
                   <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{customAssistants.length}</span>
                 </div>
-                {customAssistants.length > 0 ? renderAssistantGrid(customAssistants) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomAssistants', { defaultValue: '暂无自定义助手' })}</div>}
+                {customAssistants.length > 0 ? isEnterprise ? renderCustomAssistantGridWithEnterpriseActions(customAssistants) : renderAssistantGrid(customAssistants) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomAssistants', { defaultValue: '暂无自定义助手' })}</div>}
               </section>
 
               {/* Hub/store assistants section */}

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -6,20 +6,21 @@
 
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { ipcBridge } from '@/common';
+import { eeclaw, skillHub } from '@/common/ipcBridge';
 import { resolveSkillIcon, getInstalledSkillDisplay, normalizeSkillVersion } from '@/renderer/utils/skillDisplay';
 import { useSettingsViewMode } from '../settingsViewContext';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, Spin, Message, Input, Progress, Modal, Popconfirm, Switch } from '@arco-design/web-react';
-import { Download, Search, Delete, Close, Shield, Lightning, UploadOne, Install } from '@icon-park/react';
+import { Button, Spin, Message, Input, Progress, Modal, Popconfirm, Switch, Tooltip } from '@arco-design/web-react';
+import { Download, Search, Delete, Close, Shield, Lightning, UploadOne, Install, Share, Plus } from '@icon-park/react';
 import classNames from 'classnames';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import { emitter } from '@/renderer/utils/emitter';
-import { skillHub } from '@/common/ipcBridge';
 import type { ISkillHubSkill, ISkillHubDetail, ISkillHubListResponse, IInstalledSkillInfo, ISkillHubMeta } from '@/common/ipcBridge';
 import { useAuth } from '@/renderer/context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { SkillAuditSummary, SkillAuditDetailModal, SkillAuditReportModal } from './SkillAuditReport';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 
 // ==================== Helpers ====================
 
@@ -221,7 +222,9 @@ const InstalledSkillCard: React.FC<{
   hasUpdate?: boolean;
   onUpdate?: () => void;
   updating?: boolean;
-}> = ({ skill, onUninstall, uninstalling, onToggleEnabled, togglingEnabled, onClick, hasUpdate, onUpdate, updating }) => {
+  /** Enterprise mode: publish button element */
+  enterprisePublishButton?: React.ReactNode;
+}> = ({ skill, onUninstall, uninstalling, onToggleEnabled, togglingEnabled, onClick, hasUpdate, onUpdate, updating, enterprisePublishButton }) => {
   const { displayName, description, icon, emoji } = getInstalledSkillDisplay(skill);
   const displayVersion = normalizeSkillVersion(skill.version);
   const canUninstall = !skill.isBuiltin;
@@ -232,8 +235,8 @@ const InstalledSkillCard: React.FC<{
 
   return (
     <div className={classNames('bg-fill-1 rd-12px border border-line p-12px flex items-start gap-12px relative overflow-hidden transition-colors', !isEnabled && 'opacity-65', hasDetail ? 'cursor-pointer hover:bg-fill-2' : 'hover:bg-fill-2')} onClick={hasDetail ? onClick : undefined}>
-      {/* Icon + toggle */}
-      <div className='w-48px flex-shrink-0 flex flex-col items-center'>
+      {/* Icon */}
+      <div className='w-48px flex-shrink-0'>
         <div className='w-48px h-48px rd-8px overflow-hidden bg-fill-2'>
           {icon ? (
             <img src={icon} alt={displayName} className='w-full h-full object-cover' />
@@ -245,20 +248,10 @@ const InstalledSkillCard: React.FC<{
             </div>
           )}
         </div>
-        {canToggleEnabled && (
-          <div
-            className='mt-6px w-full flex justify-center'
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-          >
-            <Switch size='small' checked={isEnabled} loading={togglingEnabled} onChange={(checked) => onToggleEnabled?.(checked)} className={isEnabled ? '!bg-primary !border-primary' : ''} />
-          </div>
-        )}
       </div>
 
       {/* Content */}
-      <div className='flex-1 min-w-0 pr-28px'>
+      <div className='flex-1 min-w-0'>
         <div className='h-20px flex items-center'>
           <span className='font-medium text-13px text-t-primary truncate'>{displayName}</span>
         </div>
@@ -277,9 +270,23 @@ const InstalledSkillCard: React.FC<{
           )}
         </div>
         <div className='mt-3px min-h-30px'>{description ? <div className='text-11px text-t-secondary line-clamp-2 leading-15px'>{description}</div> : <div className='text-11px text-t-tertiary italic line-clamp-2 leading-15px'>{skill.name}</div>}</div>
+        {/* Toggle + Enterprise publish button row - at the bottom */}
+        {canToggleEnabled && (
+          <div className='mt-8px flex items-center justify-between'>
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <Switch size='small' checked={isEnabled} loading={togglingEnabled} onChange={(checked) => onToggleEnabled?.(checked)} className={isEnabled ? '!bg-primary !border-primary' : ''} />
+            </div>
+            {/* Enterprise publish button - at the rightmost, same row as toggle */}
+            {enterprisePublishButton}
+          </div>
+        )}
       </div>
 
-      {/* Uninstall / builtin indicator — stop propagation so card click doesn't fire */}
+      {/* Uninstall / builtin indicator - top right */}
       <div className='absolute top-10px right-10px' onClick={(e) => e.stopPropagation()}>
         {skill.isBuiltin ? (
           <div className='w-22px h-22px flex items-center justify-center text-primary' title='内置技能'>
@@ -347,9 +354,20 @@ const SkillDetailModal: React.FC<{
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
 
+  // Use useAppMode hook for renderer process (enterpriseDebugConfig.isEnterpriseMode only works in main process)
+  const { isEnterprise } = useAppMode();
+
   useEffect(() => {
+    console.log('[SkillDetailModal] useEffect triggered', { visible: !!skill, skillId: skill?.id, isEnterprise, skipApiFetch });
+
     // If data is pre-loaded from local meta, no need to call the API
     if (skipApiFetch) {
+      setDetail(null);
+      setLoading(false);
+      return;
+    }
+    // In enterprise mode, skip SkillHub API calls
+    if (isEnterprise) {
       setDetail(null);
       setLoading(false);
       return;
@@ -378,7 +396,7 @@ const SkillDetailModal: React.FC<{
     if (!visible) {
       setDetail(null);
     }
-  }, [detail, visible, skill, skipApiFetch]);
+  }, [detail, visible, skill, skipApiFetch, isEnterprise]);
 
   if (!skill) return null;
 
@@ -595,6 +613,38 @@ const SkillModalContent: React.FC = () => {
   const enterpriseCode = user?.enterprise_code?.trim();
   const currentTenantId = resolveSkillTenantId(activeTab, enterpriseCode);
 
+  // Enterprise mode detection - use useAppMode hook for renderer process
+  const { isEnterprise } = useAppMode();
+
+  // Upload/Publish state for enterprise mode
+  const [uploadingSkillName, setUploadingSkillName] = useState<string | null>(null);
+  const [publishingSkillName, setPublishingSkillName] = useState<string | null>(null);
+
+  // Tenant skills state for exclusive tab in enterprise mode
+  const [tenantSkills, setTenantSkills] = useState<
+    Array<{
+      id: string;
+      name: string;
+      displayName?: string;
+      description?: string;
+      version?: string;
+      status: 'pending' | 'approved' | 'rejected';
+      author?: string;
+      authorName?: string;
+      approvedAt?: string;
+      installed?: boolean;
+    }>
+  >([]);
+  const [tenantSkillsLoading, setTenantSkillsLoading] = useState(false);
+  const [installingTenantSkillId, setInstallingTenantSkillId] = useState<string | null>(null);
+
+  // Sync status state
+  const [syncStatus, setSyncStatus] = useState<{
+    syncing: boolean;
+    skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+    assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
+  }>({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+
   // ---- Fetch installed skills ----
   const fetchInstalledSkills = useCallback(async () => {
     if (!isElectronDesktop()) {
@@ -643,6 +693,41 @@ const SkillModalContent: React.FC = () => {
     }
   }, []);
 
+  // ---- Enterprise mode: Upload custom skill to Moss Server ----
+  const handleUploadCustomSkill = useCallback(
+    async (skill: IInstalledSkillInfo): Promise<{ success: boolean; msg?: string }> => {
+      if (!isElectronDesktop()) return { success: false, msg: 'Not desktop' };
+
+      const skillName = skill.name;
+      const displayName = skill.meta?.display_name || skillName;
+      const description = skill.meta?.description || '';
+
+      setUploadingSkillName(skillName);
+      try {
+        const res = await eeclaw.uploadCustomSkill.invoke({ skillName, displayName, description });
+        if (res.success && res.data) {
+          Message.success(
+            t('settings.skill.uploadSuccess', {
+              name: skillName,
+              defaultValue: `技能 "${skillName}" 已上传到服务器`,
+            })
+          );
+          // Update local meta to mark as uploaded
+          await fetchInstalledList();
+          return { success: true };
+        } else {
+          return { success: false, msg: res.msg || 'Unknown error' };
+        }
+      } catch (err) {
+        console.error('Failed to upload custom skill:', err);
+        return { success: false, msg: String(err) };
+      } finally {
+        setUploadingSkillName(null);
+      }
+    },
+    [fetchInstalledList, t]
+  );
+
   const handleImportLocalSkill = useCallback(
     async (source?: LocalSkillImportSource) => {
       if (!isElectronDesktop()) return;
@@ -669,6 +754,25 @@ const SkillModalContent: React.FC = () => {
           // Open standalone audit report modal (just the audit summary, not the full detail page)
           setAuditReportSkillName(importedSkillName);
           setAuditReportVisible(true);
+
+          // Enterprise mode: sync upload to Moss Server after import
+          if (isEnterprise) {
+            const installedRes = await skillHub.getInstalledSkills.invoke();
+            if (installedRes.success && installedRes.data) {
+              const newSkill = installedRes.data.find((s) => s.name === importedSkillName);
+              if (newSkill) {
+                const uploadRes = await handleUploadCustomSkill(newSkill);
+                if (!uploadRes.success) {
+                  Message.error(
+                    t('settings.skill.uploadFailed', {
+                      msg: uploadRes.msg,
+                      defaultValue: `上传失败: ${uploadRes.msg}`,
+                    })
+                  );
+                }
+              }
+            }
+          }
         } else {
           Message.error(
             t('settings.skill.importFailed', {
@@ -687,15 +791,104 @@ const SkillModalContent: React.FC = () => {
         );
       }
     },
-    [fetchInstalledSkills, fetchInstalledList, t]
+    [fetchInstalledSkills, fetchInstalledList, t, isEnterprise, handleUploadCustomSkill]
   );
 
   const onImportButtonClick = useCallback(() => {
     setImportSourceVisible(true);
   }, []);
 
+  // ---- Enterprise mode: Publish skill as tenant-exclusive ----
+  const handlePublishTenantSkill = useCallback(
+    async (skillId: string, skillName: string) => {
+      if (!isElectronDesktop()) return;
+
+      setPublishingSkillName(skillName);
+      try {
+        const res = await eeclaw.publishTenantSkill.invoke({ skillId });
+        if (res.success && res.data) {
+          Message.success(
+            t('settings.skill.publishSuccess', {
+              name: skillName,
+              defaultValue: `技能 "${skillName}" 已提交发布申请，等待管理员审批`,
+            })
+          );
+          await fetchInstalledList();
+        } else {
+          Message.error(
+            t('settings.skill.publishFailed', {
+              msg: res.msg || 'Unknown error',
+              defaultValue: `发布失败: ${res.msg || '未知错误'}`,
+            })
+          );
+        }
+      } catch (err) {
+        console.error('Failed to publish tenant skill:', err);
+        Message.error(
+          t('settings.skill.publishFailed', {
+            msg: String(err),
+            defaultValue: `发布失败: ${String(err)}`,
+          })
+        );
+      } finally {
+        setPublishingSkillName(null);
+      }
+    },
+    [fetchInstalledList, t]
+  );
+
+  // ---- Enterprise mode: Install tenant skill ----
+  const handleInstallTenantSkill = useCallback(
+    async (skillId: string, skillName: string) => {
+      if (!isElectronDesktop()) return;
+
+      setInstallingTenantSkillId(skillId);
+      try {
+        const res = await eeclaw.installTenantSkill.invoke({ skillId });
+        if (res.success && res.data) {
+          Message.success(
+            t('settings.skill.installTenantSuccess', {
+              name: skillName,
+              defaultValue: `专属技能 "${skillName}" 已安装`,
+            })
+          );
+          // Update tenant skills list to mark as installed
+          setTenantSkills((prev) => prev.map((s) => (s.id === skillId ? { ...s, installed: true } : s)));
+          await fetchInstalledList();
+          emitter.emit('skills.changed');
+        } else {
+          Message.error(
+            t('settings.skill.installTenantFailed', {
+              msg: res.msg || 'Unknown error',
+              defaultValue: `安装失败: ${res.msg || '未知错误'}`,
+            })
+          );
+        }
+      } catch (err) {
+        console.error('Failed to install tenant skill:', err);
+        Message.error(
+          t('settings.skill.installTenantFailed', {
+            msg: String(err),
+            defaultValue: `安装失败: ${String(err)}`,
+          })
+        );
+      } finally {
+        setInstallingTenantSkillId(null);
+      }
+    },
+    [fetchInstalledList, t]
+  );
+
   // ---- Fetch latest versions ----
+  // Only used in personal mode to check for skill updates
+  // Enterprise mode doesn't need this - versions are managed by Moss Server
   const fetchLatestVersions = useCallback(async (skillList: ISkillHubSkill[], existingMap?: Map<string, SkillLatestVersion>) => {
+    // Skip in enterprise mode
+    console.log('[SkillModalContent] fetchLatestVersions called, isEnterprise:', isEnterprise);
+    if (isEnterprise) {
+      return existingMap || new Map<string, SkillLatestVersion>();
+    }
+
     const versionMap = existingMap ? new Map(existingMap) : new Map<string, SkillLatestVersion>();
     const toFetch = skillList.filter((s) => !versionMap.has(s.id));
     if (toFetch.length === 0) {
@@ -907,6 +1100,58 @@ const SkillModalContent: React.FC = () => {
     void fetchInstalledList();
   }, [fetchInstalledList]);
 
+  // Listen for sync completed event (enterprise mode)
+  useEffect(() => {
+    if (!isEnterprise || !isElectronDesktop()) return;
+
+    const handleSyncCompleted = (data: { skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } }) => {
+      setSyncStatus({ syncing: false, skills: data.skills, assistants: data.assistants });
+      // Refresh installed list after sync
+      void fetchInstalledList();
+    };
+
+    const unsubscribe = eeclaw.syncCompleted.on(handleSyncCompleted);
+    return () => unsubscribe();
+  }, [isEnterprise, fetchInstalledList]);
+
+  // Trigger sync when switching to store tab in enterprise mode
+  // Only trigger if not already syncing (avoid duplicate requests)
+  useEffect(() => {
+    if (!isEnterprise || activeTab !== 'store' || !isElectronDesktop()) return;
+
+    // Skip if already syncing to avoid duplicate requests
+    if (syncStatus.syncing) return;
+
+    // Reset sync status and trigger sync
+    setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+
+    eeclaw.syncFromRemote.invoke().catch((err) => {
+      console.error('Failed to trigger sync:', err);
+      setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+    });
+  }, [isEnterprise, activeTab, syncStatus.syncing]);
+
+  // Fetch tenant skills when switching to exclusive tab in enterprise mode
+  useEffect(() => {
+    if (!isEnterprise || activeTab !== 'exclusive' || !isElectronDesktop()) return;
+
+    const fetchTenantSkills = async () => {
+      setTenantSkillsLoading(true);
+      try {
+        const res = await eeclaw.getTenantSkills.invoke();
+        if (res.success && res.data) {
+          setTenantSkills(res.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch tenant skills:', err);
+      } finally {
+        setTenantSkillsLoading(false);
+      }
+    };
+
+    void fetchTenantSkills();
+  }, [isEnterprise, activeTab]);
+
   // Load installed list when switching to installed tab
   useEffect(() => {
     if (activeTab === 'installed') {
@@ -915,7 +1160,9 @@ const SkillModalContent: React.FC = () => {
   }, [activeTab, fetchInstalledList]);
 
   // Fetch latest hub versions for installed hub skills so we can detect updates
+  // Only in personal mode (not enterprise) - enterprise mode doesn't interact with SkillHub
   useEffect(() => {
+    if (isEnterprise) return; // Skip in enterprise mode
     if (installedList.length === 0) return;
     const hubInstalled = installedList.filter((s) => s.isHubInstalled && s.meta?.id);
     if (hubInstalled.length === 0) return;
@@ -929,7 +1176,7 @@ const SkillModalContent: React.FC = () => {
         }) as ISkillHubSkill
     );
     void fetchLatestVersions(syntheticSkills, latestVersionsRef.current);
-  }, [installedList, fetchLatestVersions]);
+  }, [isEnterprise, installedList, fetchLatestVersions]);
 
   // ---- Install handler ----
   const handleInstall = useCallback(
@@ -1217,6 +1464,63 @@ const SkillModalContent: React.FC = () => {
     </div>
   );
 
+  // Render custom skills with enterprise action buttons (publish only, auto-upload on create)
+  const renderCustomSkillGridWithEnterpriseActions = (skillList: IInstalledSkillInfo[]) => (
+    <div className='grid gap-8px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
+      {skillList.map((skill) => {
+        const skillHubId = skill.meta?.id;
+        const isPublishing = publishingSkillName === skill.name;
+        const publishStatus = skill.meta?.publish_status;
+
+        // Enterprise publish button element - placed below delete button
+        const enterprisePublishButton =
+          isEnterprise && !publishStatus ? (
+            <Tooltip content={t('settings.skill.publishAsTenant', { defaultValue: '发布为专属技能' })}>
+              <button
+                className='w-20px h-20px rd-4px flex items-center justify-center bg-fill-2 hover:bg-primary hover:text-white transition-colors cursor-pointer border-none'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (skillHubId) void handlePublishTenantSkill(skillHubId, skill.name);
+                }}
+                disabled={isPublishing || !skillHubId}
+              >
+                {isPublishing ? <Spin size={12} /> : <Share size={12} />}
+              </button>
+            </Tooltip>
+          ) : isEnterprise && publishStatus === 'pending' ? (
+            <Tooltip content={t('settings.skill.publishPending', { defaultValue: '发布审批中' })}>
+              <span className='w-20px h-20px rd-4px flex items-center justify-center bg-warning text-white text-10px'>⏳</span>
+            </Tooltip>
+          ) : isEnterprise && publishStatus === 'approved' ? (
+            <Tooltip content={t('settings.skill.publishApproved', { defaultValue: '已发布为专属技能' })}>
+              <span className='w-20px h-20px rd-4px flex items-center justify-center bg-success text-white text-10px'>✓</span>
+            </Tooltip>
+          ) : undefined;
+
+        return (
+          <InstalledSkillCard
+            key={skill.name}
+            skill={skill}
+            onUninstall={() => void handleUninstall(skill.name)}
+            uninstalling={uninstallingSkillName === skill.name}
+            onToggleEnabled={(enabled) => void handleToggleSkillEnabled(skill.name, enabled)}
+            togglingEnabled={togglingSkillName === skill.name}
+            hasUpdate={false}
+            onClick={
+              skill.meta
+                ? () => {
+                    setInstalledDetailInfo(skill);
+                    setInstalledDetailVisible(true);
+                  }
+                : undefined
+            }
+            enterprisePublishButton={enterprisePublishButton}
+          />
+        );
+      })}
+    </div>
+  );
+
   return (
     <div ref={containerRef} className='flex flex-col h-full w-full'>
       {/* Header: tabs + search + create button */}
@@ -1235,17 +1539,33 @@ const SkillModalContent: React.FC = () => {
           </button>
         </div>
 
+        {/* Sync status indicator for enterprise mode - compact inline style */}
+        {isEnterprise && activeTab === 'store' && syncStatus.syncing && (
+          <div className='flex items-center gap-6px px-10px py-4px bg-primary-light-1 rd-6px flex-shrink-0'>
+            <Spin size={12} />
+            <span className='text-11px text-primary'>{t('settings.skill.syncing', { defaultValue: '同步中...' })}</span>
+          </div>
+        )}
+        {isEnterprise && activeTab === 'store' && !syncStatus.syncing && (syncStatus.skills.installed.length > 0 || syncStatus.skills.failed.length > 0) && (
+          <div className='flex items-center gap-6px px-10px py-4px bg-fill-2 rd-6px flex-shrink-0'>
+            <span className='text-11px text-t-secondary'>
+              {t('settings.skill.syncCompletedShort', {
+                installed: syncStatus.skills.installed.length,
+                defaultValue: `已同步 ${syncStatus.skills.installed.length} 个技能`,
+              })}
+            </span>
+          </div>
+        )}
+
         {/* Search - always rendered to preserve layout, hidden on installed tab */}
         <div className={classNames('flex-1 min-w-0 transition-opacity duration-150', activeTab === 'installed' ? 'opacity-0 pointer-events-none' : '')}>
           <Input placeholder={t('settings.skill.searchPlaceholder', { defaultValue: '搜索...' })} value={searchQuery} onChange={setSearchQuery} prefix={<Search size='14' className='text-t-tertiary' />} size='small' className='skill-hub-input' />
         </div>
         {activeTab === 'installed' && isElectronDesktop() && (
           <button type='button' className='group h-34px px-4 py-0 border border-solid rd-999px flex items-center gap-8px flex-shrink-0 cursor-pointer transition-all outline-none bg-[color-mix(in_srgb,var(--color-fill-2)_84%,transparent)] border-[color-mix(in_srgb,var(--color-border-2)_70%,transparent)] hover:bg-[color-mix(in_srgb,var(--color-primary-light-1)_58%,transparent)] hover:border-[color-mix(in_srgb,var(--color-primary)_36%,transparent)]' onClick={onImportButtonClick}>
-            <span className='w-22px h-22px rd-full flex items-center justify-center bg-[color-mix(in_srgb,var(--color-primary)_14%,transparent)] text-[var(--color-primary)] transition-transform group-hover:scale-105'>
-              <UploadOne size='13' />
-            </span>
+            <span className='w-22px h-22px rd-full flex items-center justify-center bg-[color-mix(in_srgb,var(--color-primary)_14%,transparent)] text-[var(--color-primary)] transition-transform group-hover:scale-105'>{isEnterprise ? <Plus size='13' /> : <UploadOne size='13' />}</span>
             <span className='flex items-baseline gap-5px leading-none'>
-              <span className='text-12px font-medium text-t-primary'>{t('common.upload', { defaultValue: '上传' })}</span>
+              <span className='text-12px font-medium text-t-primary'>{isEnterprise ? t('common.create', { defaultValue: '创建' }) : t('common.upload', { defaultValue: '上传' })}</span>
               <span className='text-11px text-t-secondary'>{t('settings.customSkills', { defaultValue: 'Custom Skills' })}</span>
             </span>
           </button>
@@ -1266,7 +1586,69 @@ const SkillModalContent: React.FC = () => {
 
           {/* Skill grid */}
           <AionScrollArea className='flex-1 min-h-0' disableOverflow={isPageMode} onScroll={handleScroll}>
-            {activeTab === 'exclusive' && !enterpriseCode ? (
+            {/* Enterprise mode: show tenant skills from Moss Server */}
+            {activeTab === 'exclusive' && isEnterprise ? (
+              tenantSkillsLoading ? (
+                <div className='flex justify-center items-center py-48px'>
+                  <Spin size={28} />
+                </div>
+              ) : tenantSkills.length === 0 ? (
+                <div className='flex flex-col items-center justify-center py-48px text-t-secondary gap-8px'>
+                  <Shield size='32' className='text-t-tertiary' />
+                  <span className='text-13px'>{t('settings.skill.noTenantSkills', { defaultValue: '暂无专属技能' })}</span>
+                </div>
+              ) : (
+                <div className='grid gap-8px pb-16px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
+                  {tenantSkills
+                    .filter((s) => s.status === 'approved')
+                    .map((skill) => {
+                      const isInstalling = installingTenantSkillId === skill.id;
+                      const isInstalled = skill.installed === true;
+                      return (
+                        <div
+                          key={skill.id}
+                          className='bg-base rd-12px border border-line p-12px flex items-start gap-12px cursor-pointer hover:border-primary transition-colors'
+                          onClick={() => {
+                            if (!isInstalled && !isInstalling) {
+                              void handleInstallTenantSkill(skill.id, skill.name);
+                            }
+                          }}
+                        >
+                          <div className='w-48px h-48px flex-shrink-0 rd-8px bg-fill-2 flex items-center justify-center'>
+                            <Lightning size='24' className='text-t-tertiary' />
+                          </div>
+                          <div className='flex-1 min-w-0 flex flex-col gap-4px'>
+                            <div className='text-13px font-medium text-t-primary truncate'>{skill.displayName || skill.name}</div>
+                            <div className='text-11px text-t-secondary line-clamp-2'>{skill.description || ''}</div>
+                            <div className='flex items-center gap-4px mt-4px'>
+                              {skill.authorName && <span className='text-10px text-t-tertiary'>{skill.authorName}</span>}
+                              {skill.version && <span className='text-10px text-t-tertiary'>v{skill.version}</span>}
+                            </div>
+                          </div>
+                          {/* Install/Installed indicator */}
+                          <div className='flex-shrink-0'>
+                            {isInstalled ? (
+                              <span className='px-6px py-2px bg-success text-white text-10px rd-4px'>{t('common.installed', { defaultValue: '已安装' })}</span>
+                            ) : isInstalling ? (
+                              <Spin size={16} />
+                            ) : (
+                              <button
+                                className='px-6px py-2px bg-primary text-white text-10px rd-4px cursor-pointer border-none hover:opacity-80'
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  void handleInstallTenantSkill(skill.id, skill.name);
+                                }}
+                              >
+                                {t('common.install', { defaultValue: '安装' })}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                </div>
+              )
+            ) : activeTab === 'exclusive' && !enterpriseCode ? (
               <div className='flex flex-col items-center justify-center py-48px text-t-secondary gap-8px'>
                 <Shield size='32' className='text-t-tertiary' />
                 <span className='text-13px'>{t('settings.skill.noEnterpriseCode', { defaultValue: '当前账号没有企业编码，无法加载专属技能。' })}</span>
@@ -1361,7 +1743,7 @@ const SkillModalContent: React.FC = () => {
                     <div className='text-13px font-medium text-t-primary'>{t('settings.customSkills')}</div>
                     <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{customInstalledSkills.length}</span>
                   </div>
-                  {customInstalledSkills.length > 0 ? renderInstalledSkillGrid(customInstalledSkills) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomSkills')}</div>}
+                  {customInstalledSkills.length > 0 ? isEnterprise ? renderCustomSkillGridWithEnterpriseActions(customInstalledSkills) : renderInstalledSkillGrid(customInstalledSkills) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomSkills')}</div>}
                 </section>
 
                 <section>

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -11,7 +11,7 @@ import { resolveSkillIcon, getInstalledSkillDisplay, normalizeSkillVersion } fro
 import { useSettingsViewMode } from '../settingsViewContext';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Spin, Message, Input, Progress, Modal, Popconfirm, Switch, Tooltip } from '@arco-design/web-react';
-import { Download, Search, Delete, Close, Shield, Lightning, UploadOne, Install, Share, Plus } from '@icon-park/react';
+import { Download, Search, Delete, Close, Shield, Lightning, UploadOne, Install, Share, Plus, Check } from '@icon-park/react';
 import classNames from 'classnames';
 import { isElectronDesktop } from '@/renderer/utils/platform';
 import { emitter } from '@/renderer/utils/emitter';
@@ -224,10 +224,12 @@ const InstalledSkillCard: React.FC<{
   updating?: boolean;
   /** Enterprise mode: publish button element */
   enterprisePublishButton?: React.ReactNode;
-}> = ({ skill, onUninstall, uninstalling, onToggleEnabled, togglingEnabled, onClick, hasUpdate, onUpdate, updating, enterprisePublishButton }) => {
+  /** Enterprise mode: whether to hide uninstall button (only custom skills can be uninstalled) */
+  hideUninstall?: boolean;
+}> = ({ skill, onUninstall, uninstalling, onToggleEnabled, togglingEnabled, onClick, hasUpdate, onUpdate, updating, enterprisePublishButton, hideUninstall }) => {
   const { displayName, description, icon, emoji } = getInstalledSkillDisplay(skill);
   const displayVersion = normalizeSkillVersion(skill.version);
-  const canUninstall = !skill.isBuiltin;
+  const canUninstall = !skill.isBuiltin && !hideUninstall;
   const canToggleEnabled = !!skill.meta && !skill.isBuiltin;
   const hasDetail = !!skill.meta;
   const isEnabled = skill.enabled;
@@ -619,6 +621,9 @@ const SkillModalContent: React.FC = () => {
   // Upload/Publish state for enterprise mode
   const [uploadingSkillName, setUploadingSkillName] = useState<string | null>(null);
   const [publishingSkillName, setPublishingSkillName] = useState<string | null>(null);
+
+  // Track if sync has been triggered for current tab session (avoid loop)
+  const syncTriggeredRef = useRef(false);
 
   // Tenant skills state for exclusive tab in enterprise mode
   const [tenantSkills, setTenantSkills] = useState<
@@ -1104,8 +1109,22 @@ const SkillModalContent: React.FC = () => {
   useEffect(() => {
     if (!isEnterprise || !isElectronDesktop()) return;
 
-    const handleSyncCompleted = (data: { skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } }) => {
-      setSyncStatus({ syncing: false, skills: data.skills, assistants: data.assistants });
+    const handleSyncCompleted = (data: {
+      skills: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } };
+      assistants: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } };
+    }) => {
+      // Merge hub and tenant results for display
+      const mergedSkills = {
+        installed: [...data.skills.hub.installed, ...data.skills.tenant.installed],
+        skipped: [...data.skills.hub.skipped, ...data.skills.tenant.skipped],
+        failed: [...data.skills.hub.failed, ...data.skills.tenant.failed],
+      };
+      const mergedAssistants = {
+        installed: [...data.assistants.hub.installed, ...data.assistants.tenant.installed],
+        skipped: [...data.assistants.hub.skipped, ...data.assistants.tenant.skipped],
+        failed: [...data.assistants.hub.failed, ...data.assistants.tenant.failed],
+      };
+      setSyncStatus({ syncing: false, skills: mergedSkills, assistants: mergedAssistants });
       // Refresh installed list after sync
       void fetchInstalledList();
     };
@@ -1115,21 +1134,35 @@ const SkillModalContent: React.FC = () => {
   }, [isEnterprise, fetchInstalledList]);
 
   // Trigger sync when switching to store tab in enterprise mode
-  // Only trigger if not already syncing (avoid duplicate requests)
+  // Only trigger once per tab session, not on every syncStatus change
   useEffect(() => {
-    if (!isEnterprise || activeTab !== 'store' || !isElectronDesktop()) return;
+    if (!isEnterprise || activeTab !== 'store' || !isElectronDesktop()) {
+      // Reset ref when leaving store tab
+      syncTriggeredRef.current = false;
+      return;
+    }
 
-    // Skip if already syncing to avoid duplicate requests
-    if (syncStatus.syncing) return;
+    // Skip if already triggered for this tab session
+    if (syncTriggeredRef.current) return;
 
-    // Reset sync status and trigger sync
+    // Mark as triggered and start sync
+    syncTriggeredRef.current = true;
     setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
 
-    eeclaw.syncFromRemote.invoke().catch((err) => {
-      console.error('Failed to trigger sync:', err);
-      setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
-    });
-  }, [isEnterprise, activeTab, syncStatus.syncing]);
+    eeclaw.syncFromRemote.invoke()
+      .then((res) => {
+        if (!res.success) {
+          // Sync failed, reset status (syncCompleted event won't be emitted)
+          console.error('Sync failed:', res.msg);
+          setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+        }
+        // If success, syncCompleted event will be emitted and handled separately
+      })
+      .catch((err) => {
+        console.error('Failed to trigger sync:', err);
+        setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+      });
+  }, [isEnterprise, activeTab]);
 
   // Fetch tenant skills when switching to exclusive tab in enterprise mode
   useEffect(() => {
@@ -1282,11 +1315,11 @@ const SkillModalContent: React.FC = () => {
 
   // ---- Uninstall handler ----
   const handleUninstall = useCallback(
-    async (skillName: string) => {
+    async (skillName: string, category?: 'custom' | 'hub' | 'system' | 'tenant') => {
       if (!isElectronDesktop()) return;
       setUninstallingSkillName(skillName);
       try {
-        const res = await skillHub.uninstallSkill.invoke({ skillName });
+        const res = await skillHub.uninstallSkill.invoke({ skillName, category });
         if (res.success) {
           Message.success(`已卸载技能：${skillName}`);
           await fetchInstalledSkills();
@@ -1372,11 +1405,11 @@ const SkillModalContent: React.FC = () => {
   );
 
   const handleToggleSkillEnabled = useCallback(
-    async (skillName: string, enabled: boolean) => {
+    async (skillName: string, enabled: boolean, category?: 'custom' | 'hub' | 'system' | 'tenant') => {
       if (!isElectronDesktop()) return;
       setTogglingSkillName(skillName);
       try {
-        const res = await skillHub.setSkillEnabled.invoke({ skillName, enabled });
+        const res = await skillHub.setSkillEnabled.invoke({ skillName, enabled, category });
         if (res.success) {
           Message.success(enabled ? t('settings.skill.enableSuccess', { name: skillName, defaultValue: `已启用技能：${skillName}` }) : t('settings.skill.disableSuccess', { name: skillName, defaultValue: `已禁用技能：${skillName}` }));
           await fetchInstalledList();
@@ -1428,28 +1461,49 @@ const SkillModalContent: React.FC = () => {
   const detailIsHubInstalled = detailSkill ? (findInstalledHubSkillInfo(detailSkill)?.isHubInstalled ?? false) : false;
   const detailLatestVersion = detailSkill ? latestVersions.get(detailSkill.id) : undefined;
   const detailHasVersion = !!detailLatestVersion;
-  const customInstalledSkills = installedList.filter((skill) => !skill.isBuiltin && skill.meta?.source_type === 'upload');
-  const hubInstalledSkills = installedList.filter((skill) => !skill.isBuiltin && (!skill.meta?.source_type || skill.meta?.source_type === 'hub'));
-  const builtinInstalledSkills = installedList.filter((skill) => skill.isBuiltin);
 
-  const renderInstalledSkillGrid = (skillList: IInstalledSkillInfo[]) => (
+  // ===== 分类逻辑：以目录分类（category）为主，source_type 仅作兼容兜底 =====
+  // Tenant skills: 目录分类为 tenant
+  const localTenantSkills = installedList.filter((skill) => skill.category === 'tenant');
+  // Filter tenant skills by search query
+  const filteredTenantSkills = searchQuery.trim()
+    ? localTenantSkills.filter((skill) => {
+        const displayName = skill.meta?.display_name || skill.meta?.name || skill.name;
+        const description = skill.meta?.description || '';
+        const query = searchQuery.trim().toLowerCase();
+        const matches = displayName.toLowerCase().includes(query) || description.toLowerCase().includes(query);
+        console.log('[Tenant Skill Filter]', { name: skill.name, displayName, description, query, matches });
+        return matches;
+      })
+    : localTenantSkills;
+  // Hub skills: 目录分类为 hub（source_type 仅作兼容兜底）
+  const hubInstalledSkills = installedList.filter((skill) => skill.category === 'hub' || (!skill.category && !skill.isBuiltin && (skill.meta?.source_type === 'hub' || skill.isHubInstalled)));
+  // Custom skills: 目录分类为 custom（source_type 仅作兼容兜底）
+  const customInstalledSkills = installedList.filter((skill) => skill.category === 'custom' || (!skill.category && !skill.isBuiltin && skill.meta?.source_type === 'upload'));
+  // Builtin skills: 目录分类为 system 或 isBuiltin 为 true
+  const builtinInstalledSkills = installedList.filter((skill) => skill.category === 'system' || skill.isBuiltin);
+
+  const renderInstalledSkillGrid = (skillList: IInstalledSkillInfo[], hideUninstall = false) => (
     <div className='grid gap-8px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
       {skillList.map((skill) => {
         const skillHubId = skill.meta?.id;
         const latestVer = skillHubId ? latestVersions.get(skillHubId) : undefined;
         const installedVer = normalizeSkillVersion(skill.version);
         const skillHasUpdate = skill.isHubInstalled && !!latestVer && (!installedVer || latestVer.version !== installedVer);
+        // Pass category to handlers for precise skill location
+        const skillCategory = skill.category as 'custom' | 'hub' | 'system' | 'tenant' | undefined;
         return (
           <InstalledSkillCard
             key={skill.name}
             skill={skill}
-            onUninstall={() => void handleUninstall(skill.name)}
+            onUninstall={() => void handleUninstall(skill.name, skillCategory)}
             uninstalling={uninstallingSkillName === skill.name}
-            onToggleEnabled={(enabled) => void handleToggleSkillEnabled(skill.name, enabled)}
+            onToggleEnabled={(enabled) => void handleToggleSkillEnabled(skill.name, enabled, skillCategory)}
             togglingEnabled={togglingSkillName === skill.name}
             hasUpdate={skillHasUpdate}
             onUpdate={() => skillHubId && void handleUpdate(skillHubId, skill.name, skill.meta)}
             updating={updatingSkillId === skillHubId}
+            hideUninstall={hideUninstall}
             onClick={
               skill.meta
                 ? () => {
@@ -1471,6 +1525,8 @@ const SkillModalContent: React.FC = () => {
         const skillHubId = skill.meta?.id;
         const isPublishing = publishingSkillName === skill.name;
         const publishStatus = skill.meta?.publish_status;
+        // Custom skills have category 'custom'
+        const skillCategory = skill.category as 'custom' | undefined;
 
         // Enterprise publish button element - placed below delete button
         const enterprisePublishButton =
@@ -1501,9 +1557,9 @@ const SkillModalContent: React.FC = () => {
           <InstalledSkillCard
             key={skill.name}
             skill={skill}
-            onUninstall={() => void handleUninstall(skill.name)}
+            onUninstall={() => void handleUninstall(skill.name, skillCategory)}
             uninstalling={uninstallingSkillName === skill.name}
-            onToggleEnabled={(enabled) => void handleToggleSkillEnabled(skill.name, enabled)}
+            onToggleEnabled={(enabled) => void handleToggleSkillEnabled(skill.name, enabled, skillCategory)}
             togglingEnabled={togglingSkillName === skill.name}
             hasUpdate={false}
             onClick={
@@ -1547,13 +1603,9 @@ const SkillModalContent: React.FC = () => {
           </div>
         )}
         {isEnterprise && activeTab === 'store' && !syncStatus.syncing && (syncStatus.skills.installed.length > 0 || syncStatus.skills.failed.length > 0) && (
-          <div className='flex items-center gap-6px px-10px py-4px bg-fill-2 rd-6px flex-shrink-0'>
-            <span className='text-11px text-t-secondary'>
-              {t('settings.skill.syncCompletedShort', {
-                installed: syncStatus.skills.installed.length,
-                defaultValue: `已同步 ${syncStatus.skills.installed.length} 个技能`,
-              })}
-            </span>
+          <div className='flex items-center gap-6px px-10px py-4px bg-success-light rd-6px flex-shrink-0'>
+            <Check size={12} className='text-success' />
+            <span className='text-11px text-success'>{t('settings.skill.syncCompleted', { defaultValue: '已同步' })}</span>
           </div>
         )}
 
@@ -1586,66 +1638,39 @@ const SkillModalContent: React.FC = () => {
 
           {/* Skill grid */}
           <AionScrollArea className='flex-1 min-h-0' disableOverflow={isPageMode} onScroll={handleScroll}>
-            {/* Enterprise mode: show tenant skills from Moss Server */}
+            {/* Enterprise mode: show tenant skills from local tenant/ directory */}
             {activeTab === 'exclusive' && isEnterprise ? (
-              tenantSkillsLoading ? (
-                <div className='flex justify-center items-center py-48px'>
-                  <Spin size={28} />
-                </div>
-              ) : tenantSkills.length === 0 ? (
+              filteredTenantSkills.length === 0 ? (
                 <div className='flex flex-col items-center justify-center py-48px text-t-secondary gap-8px'>
                   <Shield size='32' className='text-t-tertiary' />
                   <span className='text-13px'>{t('settings.skill.noTenantSkills', { defaultValue: '暂无专属技能' })}</span>
                 </div>
               ) : (
                 <div className='grid gap-8px pb-16px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
-                  {tenantSkills
-                    .filter((s) => s.status === 'approved')
-                    .map((skill) => {
-                      const isInstalling = installingTenantSkillId === skill.id;
-                      const isInstalled = skill.installed === true;
-                      return (
-                        <div
-                          key={skill.id}
-                          className='bg-base rd-12px border border-line p-12px flex items-start gap-12px cursor-pointer hover:border-primary transition-colors'
-                          onClick={() => {
-                            if (!isInstalled && !isInstalling) {
-                              void handleInstallTenantSkill(skill.id, skill.name);
-                            }
-                          }}
-                        >
-                          <div className='w-48px h-48px flex-shrink-0 rd-8px bg-fill-2 flex items-center justify-center'>
-                            <Lightning size='24' className='text-t-tertiary' />
-                          </div>
-                          <div className='flex-1 min-w-0 flex flex-col gap-4px'>
-                            <div className='text-13px font-medium text-t-primary truncate'>{skill.displayName || skill.name}</div>
-                            <div className='text-11px text-t-secondary line-clamp-2'>{skill.description || ''}</div>
-                            <div className='flex items-center gap-4px mt-4px'>
-                              {skill.authorName && <span className='text-10px text-t-tertiary'>{skill.authorName}</span>}
-                              {skill.version && <span className='text-10px text-t-tertiary'>v{skill.version}</span>}
-                            </div>
-                          </div>
-                          {/* Install/Installed indicator */}
-                          <div className='flex-shrink-0'>
-                            {isInstalled ? (
-                              <span className='px-6px py-2px bg-success text-white text-10px rd-4px'>{t('common.installed', { defaultValue: '已安装' })}</span>
-                            ) : isInstalling ? (
-                              <Spin size={16} />
-                            ) : (
-                              <button
-                                className='px-6px py-2px bg-primary text-white text-10px rd-4px cursor-pointer border-none hover:opacity-80'
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  void handleInstallTenantSkill(skill.id, skill.name);
-                                }}
-                              >
-                                {t('common.install', { defaultValue: '安装' })}
-                              </button>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
+                  {filteredTenantSkills.map((skill) => {
+                    const skillHubId = skill.meta?.id;
+                    // Tenant skills have category 'tenant'
+                    return (
+                      <InstalledSkillCard
+                        key={skill.name}
+                        skill={skill}
+                        onUninstall={() => void handleUninstall(skill.name, 'tenant')}
+                        uninstalling={uninstallingSkillName === skill.name}
+                        onToggleEnabled={(enabled) => void handleToggleSkillEnabled(skill.name, enabled, 'tenant')}
+                        togglingEnabled={togglingSkillName === skill.name}
+                        hasUpdate={false}
+                        hideUninstall={true}
+                        onClick={
+                          skill.meta
+                            ? () => {
+                                setInstalledDetailInfo(skill);
+                                setInstalledDetailVisible(true);
+                              }
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
                 </div>
               )
             ) : activeTab === 'exclusive' && !enterpriseCode ? (
@@ -1746,12 +1771,23 @@ const SkillModalContent: React.FC = () => {
                   {customInstalledSkills.length > 0 ? isEnterprise ? renderCustomSkillGridWithEnterpriseActions(customInstalledSkills) : renderInstalledSkillGrid(customInstalledSkills) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noCustomSkills')}</div>}
                 </section>
 
+                {/* Tenant skills section - enterprise mode only */}
+                {isEnterprise && (
+                  <section>
+                    <div className='flex items-center justify-between gap-8px mb-10px'>
+                      <div className='text-13px font-medium text-t-primary'>{t('settings.tenantSkills', { defaultValue: '专属技能' })}</div>
+                      <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{localTenantSkills.length}</span>
+                    </div>
+                    {localTenantSkills.length > 0 ? renderInstalledSkillGrid(localTenantSkills, true) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noTenantSkills', { defaultValue: '暂无专属技能' })}</div>}
+                  </section>
+                )}
+
                 <section>
                   <div className='flex items-center justify-between gap-8px mb-10px'>
                     <div className='text-13px font-medium text-t-primary'>{t('settings.hubSkills', { defaultValue: 'Hub Skills' })}</div>
                     <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{hubInstalledSkills.length}</span>
                   </div>
-                  {hubInstalledSkills.length > 0 ? renderInstalledSkillGrid(hubInstalledSkills) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubSkills', { defaultValue: 'No hub-installed skills' })}</div>}
+                  {hubInstalledSkills.length > 0 ? renderInstalledSkillGrid(hubInstalledSkills, isEnterprise) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubSkills', { defaultValue: 'No hub-installed skills' })}</div>}
                 </section>
 
                 <section>

--- a/src/renderer/pages/guid/components/AssistantEditDrawer.tsx
+++ b/src/renderer/pages/guid/components/AssistantEditDrawer.tsx
@@ -27,6 +27,7 @@ import { Close, Lightning, Robot, Shield } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { mutate } from 'swr';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 
 type AssistantEditDrawerProps = {
   visible: boolean;
@@ -59,6 +60,7 @@ const AGENT_OPTIONS = [
 
 const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assistantId, localeKey, onClose, onSaved }) => {
   const { t } = useTranslation();
+  const { isEnterprise } = useAppMode();
   const textareaWrapperRef = useRef<HTMLDivElement>(null);
 
   // Edit state
@@ -123,9 +125,24 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
         const res = await ipcBridge.assistantHub.getInstalledAssistants.invoke();
         if (!res.success || !res.data) return;
 
-        // Find the assistant by id (directory name)
-        const foundInfo = res.data.find((a) => a.name === assistantId || a.meta.id === assistantId);
-        if (cancelled || !foundInfo) return;
+        // Find the assistant by id (directory name), meta.id (UUID), or display name
+        // assistantId can be: directory name (UUID), builtin-xxx, or display name
+        const foundInfo = res.data.find((a) => {
+          // Match by directory name (a.name)
+          if (a.name === assistantId) return true;
+          // Match by meta.id (UUID from server)
+          if (a.meta?.id === assistantId) return true;
+          // Match by display name (nameI18n or meta.name)
+          const displayName = a.meta?.nameI18n?.['zh-CN'] || a.meta?.nameI18n?.['en-US'] || a.meta?.name;
+          if (displayName === assistantId) return true;
+          // Match by builtin prefix (builtin-xxx)
+          if (a.isBuiltin && `builtin-${a.name}` === assistantId) return true;
+          return false;
+        });
+        if (cancelled || !foundInfo) {
+          console.warn('[AssistantEditDrawer] Assistant not found:', assistantId, 'Available:', res.data.map(a => ({ name: a.name, metaId: a.meta?.id, displayName: a.meta?.nameI18n?.['zh-CN'] || a.meta?.name })));
+          return;
+        }
 
         // Convert to config format, preserving isHubInstalled flag
         const found: AssistantConfigWithMeta = {
@@ -237,7 +254,7 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
       const lookupName = resolveAssistantName(assistant.id);
 
       // For custom assistants, save all fields (presetAgentType stays locked to Sudo Code)
-      await ipcBridge.assistantHub.updateAssistantMeta.invoke({
+      const updateResult = await ipcBridge.assistantHub.updateAssistantMeta.invoke({
         name: lookupName,
         updates: {
           nameI18n: { 'zh-CN': editName },
@@ -248,6 +265,11 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
         },
       });
 
+      if (!updateResult.success) {
+        Message.error(t('settings.assistant.saveFailed', { msg: updateResult.msg || 'Unknown error', defaultValue: `保存失败: ${updateResult.msg || '未知错误'}` }));
+        return;
+      }
+
       // Save rules file if changed
       if (editContext.trim()) {
         await ipcBridge.fs.writeAssistantRule.invoke({
@@ -257,10 +279,15 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
         });
       }
 
-      // Refresh agent detection
-      await ipcBridge.acpConversation.refreshCustomAgents.invoke();
-      await mutate('acp.agents.available');
-      await mutate('assistantHub.installed');
+      // Refresh agent detection - use different refresh logic based on mode
+      if (isEnterprise) {
+        // Enterprise mode: refresh local assistants from hub/tenant/custom/system directories
+        await mutate('assistantHub.installed');
+      } else {
+        // Personal mode: refresh ACP agents
+        await ipcBridge.acpConversation.refreshCustomAgents.invoke();
+        await mutate('acp.agents.available');
+      }
 
       Message.success(t('common.saveSuccess', { defaultValue: 'Saved successfully' }));
       onSaved();
@@ -269,7 +296,7 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
       console.error('Failed to save assistant:', error);
       Message.error(t('common.failed', { defaultValue: 'Failed' }));
     }
-  }, [assistant, isReadonly, editName, editDescription, editAvatar, editAgent, editContext, selectedSkills, localeKey, onSaved, onClose, t]);
+  }, [assistant, isReadonly, isEnterprise, editName, editDescription, editAvatar, editAgent, editContext, selectedSkills, localeKey, onSaved, onClose, t]);
 
   const editAvatarImage = resolveAvatarImage(editAvatar);
 

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -12,38 +12,13 @@ import type { IProvider } from '@/common/storage';
 import { ConfigStorage } from '@/common/storage';
 import { DEFAULT_PRESET_AGENT_TYPE, resolvePresetAgentBackend } from '@/types/acpTypes';
 import type { AcpBackend, AcpBackendConfig, AcpModelInfo, AvailableAgent, EffectiveAgentInfo, PresetAgentType } from '../types';
-import { fetchAssistantsAsConfigs } from '@/renderer/shared/agents/assistantAdapter';
+import { fetchAssistantsAsConfigs, toBackendConfig } from '@/renderer/shared/agents/assistantAdapter';
 import { getAgentModes } from '@/renderer/constants/agentModes';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import { emitter } from '@/renderer/utils/emitter';
-
-/**
- * Moss Server assistant from cloud API
- */
-type MossAssistant = {
-  key: string;
-  name: string;
-  avatar?: string;
-  emoji?: string;
-  description?: string;
-};
-
-/**
- * Map Moss Server assistant to AcpBackendConfig for display in AssistantSelectionArea
- */
-function mapMossAssistantToConfig(assistant: MossAssistant): AcpBackendConfig {
-  return {
-    id: `moss:${assistant.key}`,
-    name: assistant.name,
-    avatar: assistant.emoji || assistant.avatar,
-    description: assistant.description,
-    isPreset: true,
-    enabled: true,
-    presetAgentType: 'remote-agent',
-  };
-}
+import type { IAssistantInfo } from '@/process/AssistantManager';
 
 /**
  * Check if rules contain explicit identity statement like "你是 XX 助手" or "You are XX"
@@ -237,7 +212,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   /**
    * Find agent by key.
    * Supports both "custom:uuid" format and plain backend type.
-   * For enterprise mode, also checks customAgents for Moss assistants.
+   * For enterprise mode, also checks customAgents for local assistants.
    */
   const findAgentByKey = (key: string): AvailableAgent | undefined => {
     if (key.startsWith('custom:')) {
@@ -247,33 +222,15 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       const foundInAvailable = availableAgents?.find((a) => a.customAgentId === customAgentId);
       if (foundInAvailable) return foundInAvailable;
 
-      // For enterprise mode, check customAgents (Moss assistants)
-      if (isEnterprise) {
-        const mossAssistant = customAgents.find((a) => a.id === customAgentId);
-        if (mossAssistant) {
-          // Extract original Moss key from id (remove 'moss:' prefix)
-          // Moss Server expects the original key, not 'moss:{key}'
-          const mossKey = mossAssistant.id.startsWith('moss:') ? mossAssistant.id.slice(5) : mossAssistant.id;
-          return {
-            backend: 'remote-agent' as AcpBackend,
-            name: mossAssistant.name,
-            customAgentId: mossKey, // Use original Moss key for Moss Server
-            isPreset: true,
-            avatar: mossAssistant.avatar,
-            context: mossAssistant.description,
-          };
-        }
-      }
-
-      // Fallback: check customAgents for non-enterprise
+      // Check customAgents (local assistants from hub/tenant/custom/system directories)
       const assistant = customAgents.find((a) => a.id === customAgentId);
       if (assistant) {
         return {
           backend: 'custom' as AcpBackend,
           name: assistant.name,
           customAgentId: assistant.id,
-          isPreset: true,
-          context: '',
+          isPreset: assistant.isPreset,
+          context: assistant.description || '',
           avatar: assistant.avatar,
         };
       }
@@ -291,10 +248,13 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   }, [customAgents]);
 
   // --- SWR: Fetch available agents ---
-  const swrKey = isEnterprise ? 'eeclaw.agents.cloud' : 'acp.agents.available';
+  // Enterprise mode: load from local directories (hub/tenant/custom/system) like "My Assistants" page
+  // Consumer mode: load from ACP detection
+  const swrKey = isEnterprise ? 'assistantHub.installed' : 'acp.agents.available';
   const { data: availableAgentsData } = useSWR(swrKey, async () => {
     if (isEnterprise) {
-      const result = await ipcBridge.eeclaw.getCloudAssistants.invoke();
+      // Load assistants from local directories (hub/tenant/custom/system)
+      const result = await ipcBridge.assistantHub.getInstalledAssistants.invoke();
       return result.data ?? [];
     }
     const result = await ipcBridge.acpConversation.getAvailableAgents.invoke();
@@ -304,12 +264,12 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   useEffect(() => {
     if (availableAgentsData && Array.isArray(availableAgentsData)) {
       if (isEnterprise) {
-        // Enterprise mode: Moss assistants go to customAgents, only Remote Agent in availableAgents
-        const enterpriseAgents = availableAgentsData as unknown as MossAssistant[];
+        // Enterprise mode: Load assistants from local directories (hub/tenant/custom/system)
+        const assistantInfos = availableAgentsData as IAssistantInfo[];
 
-        // Map Moss assistants to customAgents for bottom display
-        const mossCustomAgents: AcpBackendConfig[] = enterpriseAgents.map(mapMossAssistantToConfig);
-        setCustomAgents(mossCustomAgents);
+        // Convert IAssistantInfo to AcpBackendConfig for display
+        const localAgents: AcpBackendConfig[] = assistantInfos.map(toBackendConfig);
+        setCustomAgents(localAgents);
 
         // availableAgents only contains Remote Agent for top AgentPillBar
         const mapped: AvailableAgent[] = [
@@ -327,8 +287,8 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
         availableAgentsRef.current = availableAgentsData as AvailableAgent[];
       }
     } else if (isEnterprise) {
-      // Enterprise mode: even if API fails, provide a default remote-agent
-      // 企业模式：即使 API 失败，也提供默认的 remote-agent
+      // Enterprise mode: even if loading fails, provide a default remote-agent
+      // 企业模式：即使加载失败，也提供默认的 remote-agent
       const defaultAgent: AvailableAgent = {
         backend: 'remote-agent' as AcpBackend,
         name: 'Remote Agent',
@@ -336,7 +296,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       };
       setAvailableAgents([defaultAgent]);
       availableAgentsRef.current = [defaultAgent];
-      setCustomAgents([]); // Clear customAgents on API failure
+      setCustomAgents([]); // Clear customAgents on loading failure
     }
   }, [availableAgentsData, isEnterprise]);
 
@@ -347,10 +307,10 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
       // 'remote-agent' is always valid
       if (currentKey === 'remote-agent') return;
 
-      // Check if current selection is a valid Moss assistant
-      const isValidMossAssistant = customAgents.some((a) => `custom:${a.id}` === currentKey);
+      // Check if current selection is a valid local assistant
+      const isValidAssistant = customAgents.some((a) => `custom:${a.id}` === currentKey);
 
-      if (!isValidMossAssistant) {
+      if (!isValidAssistant) {
         _setSelectedAgentKey('remote-agent');
         selectedAgentKeyRef.current = 'remote-agent';
       }
@@ -844,7 +804,8 @@ This identity statement takes priority over the default identity in USER.md.
   const refreshCustomAgents = useCallback(async () => {
     try {
       if (isEnterprise) {
-        await mutate('eeclaw.agents.cloud');
+        // Enterprise mode: refresh local assistants from hub/tenant/custom/system directories
+        await mutate('assistantHub.installed');
         return;
       }
       await ipcBridge.acpConversation.refreshCustomAgents.invoke();
@@ -882,7 +843,8 @@ This identity statement takes priority over the default identity in USER.md.
   useEffect(() => {
     const handler = () => {
       if (isEnterprise) {
-        void mutate('eeclaw.agents.cloud');
+        // Enterprise mode: refresh local assistants from hub/tenant/custom/system directories
+        void mutate('assistantHub.installed');
         return;
       }
       void ipcBridge.acpConversation.rescanAgents.invoke().then(() => {
@@ -910,9 +872,9 @@ This identity statement takes priority over the default identity in USER.md.
       console.error('Failed to clear saved agent:', error);
     });
 
-    // Enterprise mode: re-fetch Moss assistants from server
+    // Enterprise mode: refresh local assistants from hub/tenant/custom/system directories
     if (isEnterprise) {
-      void mutate('eeclaw.agents.cloud');
+      void mutate('assistantHub.installed');
       return;
     }
 

--- a/src/renderer/shared/agents/assistantAdapter.ts
+++ b/src/renderer/shared/agents/assistantAdapter.ts
@@ -17,14 +17,14 @@ import type { AcpBackendConfig } from '@/types/acpTypes';
 
 /** Convert a single IAssistantInfo to AcpBackendConfig for renderer consumption. */
 export function toBackendConfig(info: IAssistantInfo): AcpBackendConfig {
-  const meta = info.meta;
+  const meta = info.meta || {};
   // Always use directory name (info.name) as id for consistent lookup
   const id = info.isBuiltin ? `builtin-${info.name}` : info.name;
   // isPreset = builtin or hub-installed (NOT user-created custom assistants)
   const isPreset = info.isBuiltin || info.isHubInstalled;
   return {
     id,
-    name: meta.nameI18n?.['zh-CN'] || meta.nameI18n?.['en-US'] || meta.id || info.name,
+    name: meta.nameI18n?.['zh-CN'] || meta.nameI18n?.['en-US'] || meta.name || meta.id || info.name,
     nameI18n: meta.nameI18n,
     descriptionI18n: meta.descriptionI18n,
     avatar: meta.avatar,


### PR DESCRIPTION
## Summary
- Add skill/assistant sync functionality for enterprise mode
- Implement remote to local sync with tenant-specific storage
- Add custom upload support for enterprise resources
- Emit syncCompleted event after manual sync
- Improve UI consistency in AgentModalContent and SkillModalContent

## Test plan
- [ ] Test skill sync from enterprise hub
- [ ] Test assistant sync from enterprise hub
- [ ] Verify manual sync triggers correctly
- [ ] Check UI displays sync status properly
- [ ] Verify tenant isolation for sync data

🤖 Generated with [Claude Code](https://claude.com/claude-code)