### PR TITLE
fix: 钉钉图片多模态分析、健康检查无限重连、相对路径图片显示

### DIFF
--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -234,7 +234,7 @@ export class DingTalkPlugin extends BasePlugin {
     // Guard: if connection is already alive, skip reconnect.
     // Prevents resume() and health check from triggering a double reconnect
     // that would kill the first one's newly established connection.
-    if (this.client && this.client.connected && this.client.registered) {
+    if (this.client && this.client.connected) {
       this.isConnected = true;
       this.reconnectDelay = RECONNECT_INITIAL_DELAY;
       this.startHealthCheck();
@@ -299,18 +299,19 @@ export class DingTalkPlugin extends BasePlugin {
   // ==================== Health Check ====================
 
   /**
-   * Periodically check SDK connection state.
-   * SDK sets client.connected=false / client.registered=false on SYSTEM "disconnect"
-   * without closing the WebSocket, so we poll these flags.
+   * Periodically check SDK connection state via the connected flag.
+   * SDK sets client.connected=false on WebSocket close and on SYSTEM "disconnect"
+   * (which can occur without closing the WebSocket). The keepAlive ping/pong
+   * heartbeat (8s interval) also triggers terminate() on timeout, which sets
+   * connected=false via the close event.
    */
   private startHealthCheck(): void {
     this.stopHealthCheck();
     this.healthCheckTimer = setInterval(() => {
       if (this.shouldReconnect && this.client) {
-        if (!this.client.connected || !this.client.registered) {
+        if (!this.client.connected) {
           mainWarn('DingTalkPlugin', 'Connection lost detected by health check', {
             connected: this.client.connected,
-            registered: this.client.registered,
           });
           this.isConnected = false;
           this.scheduleReconnect();
@@ -337,7 +338,7 @@ export class DingTalkPlugin extends BasePlugin {
     if (!this.shouldReconnect || !this.client) return;
 
     // Check if connection has died
-    if (!this.client.connected || !this.client.registered) {
+    if (!this.client.connected) {
       mainLog('DingTalkPlugin', 'System resume: connection lost, triggering reconnect');
       this.isConnected = false;
       this.reconnectDelay = RECONNECT_INITIAL_DELAY;

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -336,6 +336,7 @@ export function initFsBridge(): void {
       const base64 = await fs.readFile(filePath, { encoding: 'base64' });
       return `data:${mime};base64,${base64}`;
     } catch (error) {
+      mainWarn('fsBridge', 'getImageBase64 failed', { path: filePath, error: String(error) });
       // Return a placeholder data URL instead of throwing
       return 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZGRkIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIGZvbnQtZmFtaWx5PSJBcmlhbCwgc2Fucy1zZXJpZiIgZm9udC1zaXplPSIxNCIgZmlsbD0iIzk5OSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZHk9Ii4zZW0iPkltYWdlIG5vdCBmb3VuZDwvdGV4dD48L3N2Zz4=';
     }

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -776,7 +776,10 @@ This identity statement takes priority over the default identity in USER.md.
         }
 
         if (data.files && data.files.length > 0) {
-          const fileRefs = data.files.map((filePath) => (filePath.includes(' ') ? `@"${filePath}"` : '@' + filePath)).join(' ');
+          const fileRefs = data.files.map((filePath) => {
+            const normalized = filePath.replace(/\\/g, '/');
+            return normalized.includes(' ') ? `@"${normalized}"` : '@' + normalized;
+          }).join(' ');
           contentToSend = fileRefs + ' ' + contentToSend;
         }
 

--- a/src/process/task/acp/AcpAtFileProcessor.ts
+++ b/src/process/task/acp/AcpAtFileProcessor.ts
@@ -65,7 +65,8 @@ export async function processAtFileReferences(content: string, workspace: string
 
   for (const atPath of atPaths) {
     const matchedUploadFile = uploadedFiles?.find((filePath) => {
-      if (atPath === filePath) return true;
+      const normalizedFilePath = filePath.replace(/\\/g, '/');
+      if (atPath === normalizedFilePath) return true;
       const fileName = filePath.split(/[\\/]/).pop() || filePath;
       return atPath === fileName;
     });

--- a/src/renderer/pages/conversation/acp/AcpChat.tsx
+++ b/src/renderer/pages/conversation/acp/AcpChat.tsx
@@ -11,6 +11,7 @@ import MessageList from '@renderer/messages/MessageList';
 import { MessageListProvider, useMessageLstCache } from '@renderer/messages/hooks';
 import HOC from '@renderer/utils/HOC';
 import React, { useEffect, useState } from 'react';
+import LocalImageView from '@renderer/components/LocalImageView';
 import ConversationChatConfirm from '../components/ConversationChatConfirm';
 import SafetyChatConfirm from '../SafetyChatConfirm';
 import AcpSendBox from './AcpSendBox';
@@ -34,9 +35,11 @@ const AcpChat: React.FC<{
   return (
     <ConversationProvider value={{ conversationId: conversation_id, workspace, type: backend === 'remote-agent' ? 'remote-agent' : 'acp' }}>
       <div className='flex-1 flex flex-col px-20px min-h-0'>
-        <FlexFullContainer>
-          <MessageList className='flex-1' aiProcessing={aiProcessing}></MessageList>
-        </FlexFullContainer>
+        <LocalImageView.Provider value={{ root: workspace || '' }}>
+          <FlexFullContainer>
+            <MessageList className='flex-1' aiProcessing={aiProcessing}></MessageList>
+          </FlexFullContainer>
+        </LocalImageView.Provider>
         <SafetyChatConfirm conversation_id={conversation_id}>
           <ConversationChatConfirm conversation_id={conversation_id}>
             <AcpSendBox conversation_id={conversation_id} backend={backend} sessionMode={sessionMode} agentName={agentName} onAiProcessingChange={setAiProcessing}></AcpSendBox>

--- a/src/renderer/pages/conversation/openclaw/OpenClawChat.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawChat.tsx
@@ -10,7 +10,7 @@ import MessageList from '@renderer/messages/MessageList';
 import { MessageListProvider, useMessageLstCache } from '@renderer/messages/hooks';
 import HOC from '@renderer/utils/HOC';
 import React, { createContext, useEffect, useState } from 'react';
-import LocalImageView from '../../../components/LocalImageView';
+import LocalImageView from '@renderer/components/LocalImageView';
 import ConversationChatConfirm from '../components/ConversationChatConfirm';
 import SafetyChatConfirm from '../SafetyChatConfirm';
 import OpenClawSendBox from './OpenClawSendBox';
@@ -24,12 +24,7 @@ const OpenClawChat: React.FC<{
   agentName?: string;
 }> = ({ conversation_id, workspace, agentName }) => {
   useMessageLstCache(conversation_id);
-  const updateLocalImage = LocalImageView.useUpdateLocalImage();
   const [aiProcessing, setAiProcessing] = useState(false);
-
-  useEffect(() => {
-    updateLocalImage({ root: workspace });
-  }, [workspace]);
 
   // Reset aiProcessing when conversation changes
   // 切换会话时重置 aiProcessing 状态
@@ -41,9 +36,11 @@ const OpenClawChat: React.FC<{
     <AIProcessingContext.Provider value={aiProcessing}>
       <ConversationProvider value={{ conversationId: conversation_id, workspace, type: 'openclaw-gateway' }}>
         <div className='flex-1 flex flex-col px-20px min-h-0'>
-          <FlexFullContainer>
-            <MessageList className='flex-1' aiProcessing={aiProcessing} />
-          </FlexFullContainer>
+          <LocalImageView.Provider value={{ root: workspace }}>
+            <FlexFullContainer>
+              <MessageList className='flex-1' aiProcessing={aiProcessing} />
+            </FlexFullContainer>
+          </LocalImageView.Provider>
           <SafetyChatConfirm conversation_id={conversation_id}>
             <ConversationChatConfirm conversation_id={conversation_id}>
               <OpenClawSendBox conversation_id={conversation_id} onAiProcessingChange={setAiProcessing} agentName={agentName} />


### PR DESCRIPTION
## Summary
- 修复 Windows 平台 @ 引用路径反斜杠被 `atCommandParser` 转义剥离，导致图片无法通过多模态视觉分析
- 修复 DingTalk 健康检查依赖 SDK `registered` 标志（始终为 false）导致无限重连循环
- 修复 `LocalImageProvider` 从未渲染导致相对路径图片显示 "Image not found"
- 在 `fsBridge.getImageBase64` catch 块添加错误日志

## Test plan
- [ ] 通过钉钉发送图片，验证 AI 能正确进行多模态视觉分析
- [ ] 验证 DingTalk 连接不再出现无限重连循环，健康检查静默通过
- [ ] 在 scode 对话中生成图片，验证图片正常显示
- [ ] 验证钉钉通道图片不受影响
- [ ] 验证历史会话中图片仍可正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)