### PR TITLE
fix(scode): add date/time query rule to AGENTS.md

### DIFF
--- a/src/process/services/scode/ScodeInstallService.ts
+++ b/src/process/services/scode/ScodeInstallService.ts
@@ -45,6 +45,9 @@ const AGENTS_MD_SAFETY_MARKER = '<!-- SUDOCODE_DELETE_SAFETY_RULES -->';
 /** Marker used to identify the identity-statement section inside AGENTS.md */
 const AGENTS_MD_IDENTITY_MARKER = '<!-- SUDOCODE_IDENTITY_STATEMENT -->';
 
+/** Marker used to identify the date-time-query section inside AGENTS.md */
+const AGENTS_MD_DATE_TIME_MARKER = '<!-- SUDOCODE_DATE_TIME_QUERY -->';
+
 function readLegacyManagedScodeSkillEntries(): Map<string, string> {
   try {
     const raw = fs.readFileSync(SCODE_LEGACY_MANAGED_SKILLS_FILE, 'utf-8');
@@ -494,6 +497,7 @@ function updateMarkerBlock(existingContent: string, marker: string, newBlock: st
   const markers = [
     AGENTS_MD_SAFETY_MARKER,
     AGENTS_MD_IDENTITY_MARKER,
+    AGENTS_MD_DATE_TIME_MARKER,
   ].filter((m) => existingContent.includes(m));
 
   // Find the start of this block (marker line)
@@ -526,9 +530,9 @@ export function ensureAgentsMdRules(): void {
 ${AGENTS_MD_IDENTITY_MARKER}
 ## Identity / 身份
 
-When asked "Who are you?" / "你是谁?", answer: "I am SudoCode, how can I help you?" / "我是SudoCode，有什么可以帮助你的吗？".
+When asked "Who are you?" / "你是谁?", answer: "I am Sudo Code, how can I help you?" / "我是Sudo Code，有什么可以帮助你的吗？".
 Only mention model name when specifically asked about the model.
-当用户问"你是谁"时，回答"我是SudoCode，有什么可以帮助你的吗？"。仅当用户具体询问模型时才提及模型名称。
+当用户问"你是谁"时，回答"我是Sudo Code，有什么可以帮助你的吗？"。仅当用户具体询问模型时才提及模型名称。
 `;
 
   const safetyBlock = `
@@ -543,17 +547,54 @@ Before deleting files/folders, MUST confirm with user:
 4. Cancel if refused / 用户拒绝则取消
 `;
 
+  const dateTimeBlock = `
+${AGENTS_MD_DATE_TIME_MARKER}
+## Date/Time Query / 日期时间查询
+
+When users ask about current date/time (e.g., "What day is today?", "今天几号?", "What time is it?", "现在几点?"), you MUST query the actual system time using shell commands instead of relying on cached knowledge or memory.
+当用户询问当前日期/时间时（如"今天几号?"、"What day is today?"、"现在几点?"、"What time is it?"），必须通过执行系统命令查询实际时间，而不是依赖缓存的知识或记忆。
+
+**CRITICAL: Always execute a shell command to get the real-time date/time.**
+**重要：必须执行shell命令获取实时日期/时间。**
+
+**Commands by OS / 各系统命令:**
+
+- **macOS / Linux**:
+  - Date: \`date "+%Y-%m-%d"\` → e.g., "2026-05-15"
+  - Time: \`date "+%H:%M:%S"\` → e.g., "14:30:25"
+  - Full: \`date\` → e.g., "Thu May 15 14:30:25 CST 2026"
+
+- **Windows (CMD)**:
+  - Date: \`echo %date%\` → e.g., "2026/05/15"
+  - Time: \`echo %time%\` → e.g., "14:30:25.12"
+
+- **Windows (PowerShell)**:
+  - Date: \`powershell -Command "Get-Date -Format 'yyyy-MM-dd'"\`
+  - Time: \`powershell -Command "Get-Date -Format 'HH:mm:ss'"\`
+
+**Workflow / 工作流程:**
+1. Detect user is asking about date/time / 检测用户在询问日期/时间
+2. Execute appropriate command for current OS / 根据当前OS执行相应命令
+3. Return the actual result to user / 将实际结果返回给用户
+
+**Examples / 示例:**
+- User: "今天几号?" → Execute \`date "+%Y-%m-%d"\` (macOS/Linux) or \`echo %date%\` (Windows) → Reply with actual date
+- User: "What day is today?" → Execute \`date\` → Reply with actual date
+- User: "现在几点?" → Execute \`date "+%H:%M:%S"\` → Reply with actual time
+`;
+
   try {
     const fileExists = fs.existsSync(agentsMdPath);
     mainLog(TAG, `AGENTS.md exists: ${fileExists}`);
     if (!fileExists) {
-      // AGENTS.md does not exist — create it with both blocks
-      const content = identityBlock + safetyBlock;
+      // AGENTS.md does not exist — create it with all blocks
+      const content = identityBlock + dateTimeBlock + safetyBlock;
       fs.writeFileSync(agentsMdPath, content, 'utf-8');
-      mainLog(TAG, 'Created AGENTS.md with identity and safety rules');
+      mainLog(TAG, 'Created AGENTS.md with identity, date/time, and safety rules');
     } else {
       const existing = fs.readFileSync(agentsMdPath, 'utf-8');
       let updated = updateMarkerBlock(existing, AGENTS_MD_IDENTITY_MARKER, identityBlock);
+      updated = updateMarkerBlock(updated, AGENTS_MD_DATE_TIME_MARKER, dateTimeBlock);
       updated = updateMarkerBlock(updated, AGENTS_MD_SAFETY_MARKER, safetyBlock);
       if (updated !== existing) {
         fs.writeFileSync(agentsMdPath, updated, 'utf-8');


### PR DESCRIPTION
## Summary
- Add date/time query rule to AGENTS.md to ensure AI uses shell commands to get real-time date/time
- Includes cross-platform commands for macOS/Linux, Windows CMD, and PowerShell
- Bilingual instructions (Chinese/English)

## Problem
Users reported that SudoCode was returning incorrect dates (e.g., answering "5.10" on both May 13 and May 14). This was because the AI was relying on cached knowledge instead of querying the actual system time.

## Solution
Add a new rule block in AGENTS.md that instructs the AI to execute shell commands when users ask about current date/time, ensuring accurate responses.

## Test plan
- [ ] Verify AGENTS.md is created with the new date/time rule block
- [ ] Test asking "今天几号?" and verify AI executes `date` command
- [ ] Test on Windows to verify correct command is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)