### PR TITLE
fix(guid): unify assistant source for enterprise remote mode

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -560,11 +560,19 @@ const GuidPage: React.FC = () => {
     return { avatarValue, avatarImage, isImageAvatar };
   }, [selectedAssistantConfig]);
 
-  // Resolve current assistant agent type for dropdown
+  // Resolve current assistant agent type for dropdown.
+  // In enterprise mode, the runtime backend is determined by sessionMode (remote-agent / scode),
+  // not by the assistant metadata's presetAgentType. Display the actual backend so the logo
+  // matches the conversation that will be created (app logo for enterprise users).
+  // 企业模式下真正的后端由 sessionMode 决定（remote-agent / scode），与助手元数据中的 presetAgentType 无关，
+  // 这里按实际后端展示，避免本地元数据里残留的 'claude' 导致 logo 误显示。
   const currentAssistantAgentType = useMemo(() => {
     if (!selectedAssistantConfig) return DEFAULT_PRESET_AGENT_TYPE;
+    if (isEnterprise) {
+      return agentSelection.sessionMode === 'remote' ? 'remote-agent' : 'scode';
+    }
     return normalizePresetAgentType(selectedAssistantConfig.presetAgentType) || DEFAULT_PRESET_AGENT_TYPE;
-  }, [selectedAssistantConfig]);
+  }, [selectedAssistantConfig, isEnterprise, agentSelection.sessionMode]);
 
   // Whether we are in selected assistant mode (preset or user-created custom)
   const isAssistantMode = selectedAssistantConfig !== null;

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -33,12 +33,10 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ customA
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  // Enterprise Remote mode: render cloud assistants from availableAgents
-  // E端 Remote 模式：渲染 availableAgents 中的企业助手（不依赖 customAgents）
-  if (isEnterprise && sessionMode === 'remote' && availableAgents) {
-    const cloudAssistants = availableAgents.filter(
-      (a) => a.isPreset && a.customAgentId
-    );
+  // Enterprise Remote mode: render assistants from customAgents
+  // E端 Remote 模式：助手来自本地 hub/system/custom/tenant 文件夹，id 为 UUID，存放在 customAgents
+  if (isEnterprise && sessionMode === 'remote') {
+    const cloudAssistants = (customAgents || []).filter((a) => a.enabled !== false);
     if (cloudAssistants.length === 0) return null;
 
     return (
@@ -46,11 +44,14 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({ customA
         <div className='flex flex-wrap gap-8px justify-center'>
           {cloudAssistants.map((assistant) => {
             const avatarValue = assistant.avatar?.trim();
-            const isImageAvatar = Boolean(avatarValue && (/\.(svg|png|jpe?g|webp|gif)$/i.test(avatarValue) || /^(https?:|aion-asset:\/\/|file:\/\/|data:)/i.test(avatarValue)));
+            const mappedAvatar = avatarValue ? CUSTOM_AVATAR_IMAGE_MAP[avatarValue] : undefined;
+            const resolvedAvatar = avatarValue ? resolveExtensionAssetUrl(avatarValue) : undefined;
+            const avatarImage = mappedAvatar || resolvedAvatar;
+            const isImageAvatar = Boolean(avatarImage && (/\.(svg|png|jpe?g|webp|gif)$/i.test(avatarImage) || /^(https?:|aion-asset:\/\/|file:\/\/|data:)/i.test(avatarImage)));
             return (
-              <div key={assistant.customAgentId} className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid bg-fill-0 hover:bg-fill-1 select-none' style={{ borderWidth: '1px', borderColor: 'var(--bg-3)' }} onClick={() => onSelectAssistant(`custom:${assistant.customAgentId}`)}>
-                {isImageAvatar ? <img src={avatarValue} alt='' width={16} height={16} style={{ objectFit: 'contain' }} /> : avatarValue ? <span style={{ fontSize: 16, lineHeight: '18px' }}>{avatarValue}</span> : <Robot theme='outline' size={16} />}
-                <span className='text-14px text-2 hover:text-1'>{assistant.name}</span>
+              <div key={assistant.id} className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid bg-fill-0 hover:bg-fill-1 select-none' style={{ borderWidth: '1px', borderColor: 'var(--bg-3)' }} onClick={() => onSelectAssistant(`custom:${assistant.id}`)}>
+                {isImageAvatar ? <img src={avatarImage} alt='' width={16} height={16} style={{ objectFit: 'contain' }} /> : avatarValue ? <span style={{ fontSize: 16, lineHeight: '18px' }}>{avatarValue}</span> : <Robot theme='outline' size={16} />}
+                <span className='text-14px text-2 hover:text-1'>{assistant.nameI18n?.[localeKey] || assistant.name}</span>
               </div>
             );
           })}

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -30,32 +30,6 @@ export function getRendererSessionMode(): 'remote' | 'local' {
 }
 
 /**
- * Moss Server assistant from cloud API
- */
-type MossAssistant = {
-  key: string;
-  name: string;
-  avatar?: string;
-  emoji?: string;
-  description?: string;
-};
-
-/**
- * Map Moss Server assistant to AcpBackendConfig for display in AssistantSelectionArea
- */
-function mapMossAssistantToConfig(assistant: MossAssistant): AcpBackendConfig {
-  return {
-    id: `moss:${assistant.key}`,
-    name: assistant.name,
-    avatar: assistant.emoji || assistant.avatar,
-    description: assistant.description,
-    isPreset: true,
-    enabled: true,
-    presetAgentType: 'remote-agent',
-  };
-}
-
-/**
  * Check if rules contain explicit identity statement like "你是 XX 助手" or "You are XX"
  * Also detects [Identity Override] blocks that we inject
  */
@@ -362,41 +336,26 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   });
 
   useEffect(() => {
+    if (isEnterprise && sessionMode === 'remote') {
+      // Enterprise Remote mode: availableAgents only contains Remote Agent for the top AgentPillBar.
+      // customAgents are loaded from local hub/tenant/custom/system folders by the effect below
+      // (those folders are kept in sync with the remote Moss server, so no extra cloud fetch is needed here).
+      // E端 Remote 模式：availableAgents 只占位 Remote Agent；customAgents 由下方 effect 从本地 hub/tenant/custom/system 加载。
+      const mapped: AvailableAgent[] = [
+        {
+          backend: 'remote-agent' as AcpBackend,
+          name: 'Remote Agent',
+          customAgentId: undefined,
+        },
+      ];
+      setAvailableAgents(mapped);
+      availableAgentsRef.current = mapped;
+      return;
+    }
     if (availableAgentsData && Array.isArray(availableAgentsData)) {
-      if (isEnterprise && sessionMode === 'remote') {
-        // Enterprise Remote mode: Moss assistants go to customAgents, only Remote Agent in availableAgents
-        const enterpriseAgents = availableAgentsData as unknown as MossAssistant[];
-
-        // Convert MossAssistant to AcpBackendConfig for display
-        const localAgents: AcpBackendConfig[] = enterpriseAgents.map(mapMossAssistantToConfig);
-        setCustomAgents(localAgents);
-
-        // availableAgents only contains Remote Agent for top AgentPillBar
-        const mapped: AvailableAgent[] = [
-          {
-            backend: 'remote-agent' as AcpBackend,
-            name: 'Remote Agent',
-            customAgentId: undefined,
-          },
-        ];
-        setAvailableAgents(mapped);
-        availableAgentsRef.current = mapped;
-      } else {
-        // Consumer mode: unchanged
-        setAvailableAgents(availableAgentsData as AvailableAgent[]);
-        availableAgentsRef.current = availableAgentsData as AvailableAgent[];
-      }
-    } else if (isEnterprise && sessionMode === 'remote') {
-      // Enterprise mode: even if API fails, provide a default remote-agent
-      // 企业模式：即使 API 失败，也提供默认的 remote-agent
-      const defaultAgent: AvailableAgent = {
-        backend: 'remote-agent' as AcpBackend,
-        name: 'Remote Agent',
-        customAgentId: undefined,
-      };
-      setAvailableAgents([defaultAgent]);
-      availableAgentsRef.current = [defaultAgent];
-      setCustomAgents([]); // Clear customAgents on loading failure
+      // Consumer mode / Enterprise Local: unchanged
+      setAvailableAgents(availableAgentsData as AvailableAgent[]);
+      availableAgentsRef.current = availableAgentsData as AvailableAgent[];
     }
   }, [availableAgentsData, isEnterprise, sessionMode]);
 
@@ -485,9 +444,9 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
   }, [availableAgents, assistantFromUrl]); // Intentionally NOT including selectedAgentKey/state - use ref instead
 
   // Load custom agents + extension-contributed assistants
-  // E端 Remote 模式下跳过本地助手加载；E端 Local 模式和 C端都加载
+  // 所有模式（E 端 Remote/Local 和 C 端）都从本地 hub/tenant/custom/system 加载助手；
+  // 企业 Remote 模式下，这些目录已从 Moss server 同步，因此无需另走云端接口。
   useEffect(() => {
-    if (isEnterprise && sessionMode === 'remote') return;
     let isActive = true;
     Promise.all([fetchAssistantsAsConfigs(), ipcBridge.extensions.getAssistants.invoke().catch(() => [] as Record<string, unknown>[])])
       .then(([agents, extAssistants]) => {
@@ -904,12 +863,13 @@ This identity statement takes priority over the default identity in USER.md.
 
   const refreshCustomAgents = useCallback(async () => {
     try {
-      if (isEnterprise && sessionMode === 'remote') {
-        await mutate('eeclaw.agents.cloud');
-        return;
+      // Enterprise modes (remote + local) and Consumer mode all read customAgents from local
+      // hub/tenant/custom/system. Only Consumer/Enterprise-Local need ACP availableAgents refresh.
+      // 企业模式（Remote/Local）和 C 端都从本地 hub/tenant/custom/system 重读；仅非企业 Remote 路径需要刷新 ACP availableAgents。
+      if (!(isEnterprise && sessionMode === 'remote')) {
+        await ipcBridge.acpConversation.refreshCustomAgents.invoke();
+        await mutate('acp.agents.available');
       }
-      await ipcBridge.acpConversation.refreshCustomAgents.invoke();
-      await mutate('acp.agents.available');
 
       // Reload customAgents state from assistantHub
       const agents = await fetchAssistantsAsConfigs();
@@ -943,7 +903,9 @@ This identity statement takes priority over the default identity in USER.md.
   useEffect(() => {
     const handler = () => {
       if (isEnterprise && sessionMode === 'remote') {
-        void mutate('eeclaw.agents.cloud');
+        // Enterprise Remote: customAgents come from local hub/tenant/custom/system; re-read them.
+        // 企业 Remote 模式：customAgents 来自本地目录，重新读取即可。
+        void refreshCustomAgents();
         return;
       }
       void ipcBridge.acpConversation.rescanAgents.invoke().then(() => {
@@ -954,7 +916,7 @@ This identity statement takes priority over the default identity in USER.md.
     return () => {
       emitter.off('guid.reset', handler);
     };
-  }, [isEnterprise, sessionMode]);
+  }, [isEnterprise, sessionMode, refreshCustomAgents]);
 
   // Reset agent selection to default state (no assistant selected)
   // In enterprise mode, directly select the first available agent (remote-agent)


### PR DESCRIPTION
## Summary
- Load `customAgents` from local hub/tenant/custom/system folders in enterprise remote mode instead of mapping Moss cloud assistants separately (those folders are already synced from Moss).
- Render assistants in `AssistantSelectionArea` with proper avatar resolution via `CUSTOM_AVATAR_IMAGE_MAP` / extension asset URLs and i18n name.
- Use the actual session backend (`remote-agent` / `scode`) for the assistant dropdown logo so the icon matches the conversation that will be created (avoids stale `claude` metadata showing the wrong logo for enterprise users).

## Test plan
- [ ] Enterprise Remote mode: assistants list renders from local folders with correct avatars and i18n names.
- [ ] Enterprise Local mode: assistant loading still works as before.
- [ ] Consumer mode: no regression in assistant list or selection.
- [ ] Verify the assistant dropdown logo reflects the actual backend (app logo for enterprise remote/scode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)