### PR TITLE
fix(lark): add support for post message type with images

### DIFF
--- a/src/channels/plugins/lark/LarkAdapter.ts
+++ b/src/channels/plugins/lark/LarkAdapter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IMessageAction, IUnifiedIncomingMessage, IUnifiedMessageContent, IUnifiedOutgoingMessage, IUnifiedUser } from '../../types';
+import type { IMessageAction, IUnifiedAttachment, IUnifiedIncomingMessage, IUnifiedMessageContent, IUnifiedOutgoingMessage, IUnifiedUser } from '../../types';
 
 /**
  * LarkAdapter - Converts between Lark and Unified message formats
@@ -238,6 +238,66 @@ function extractMessageContent(message: LarkMessageEvent['event']['message']): I
           },
         ],
       };
+
+    case 'post': {
+      // Feishu rich text message (post type) can contain multiple elements
+      // including text, images, links, etc.
+      // Extract images and text from the post content
+      const postContent = typeof content === 'object' ? (content as any) : null;
+      if (!postContent) {
+        return { type: 'text', text: '' };
+      }
+
+      const attachments: IUnifiedAttachment[] = [];
+      const textParts: string[] = [];
+
+      // Extract title if present
+      if (postContent.title) {
+        textParts.push(postContent.title);
+      }
+
+      // Process content sections (array of arrays of elements)
+      // content: [[{tag: "text", text: "..."}, {tag: "img", image_key: "..."}], ...]
+      const sections = postContent.content as any[][] | undefined;
+      if (sections && Array.isArray(sections)) {
+        for (const section of sections) {
+          if (!Array.isArray(section)) continue;
+          for (const element of section) {
+            if (!element || typeof element !== 'object') continue;
+
+            if (element.tag === 'text' && element.text) {
+              textParts.push(element.text);
+            } else if (element.tag === 'img' && element.image_key) {
+              attachments.push({
+                type: 'photo',
+                fileId: element.image_key,
+              });
+            } else if (element.tag === 'a' && element.text) {
+              // Links: display as text with URL
+              const href = element.href || '';
+              textParts.push(href ? `[${element.text}](${href})` : element.text);
+            }
+          }
+        }
+      }
+
+      const text = textParts.join('\n').trim();
+
+      // If we have attachments, return as photo/document type
+      if (attachments.length > 0) {
+        return {
+          type: attachments[0].type as 'photo' | 'document',
+          text,
+          attachments,
+        };
+      }
+
+      // No attachments, just text
+      return {
+        type: 'text',
+        text: text || '[post message]',
+      };
+    }
 
     default:
       return {


### PR DESCRIPTION
## Summary
- 飞书发送的图片消息类型是 `post`（富文本），而不是 `image` 类型
- 添加了对 `post` 类型的处理，提取其中的 `img` 标签的 `image_key` 作为图片附件
- 同时提取 `text` 和 `a` 标签的内容作为文本

## Problem
飞书发送图片时，消息类型是 `post`（富文本消息），其结构如下：
```json
{
  "title": "",
  "content": [
    [
      {"tag": "img", "image_key": "img_v3_0211q_xxx"},
      {"tag": "text", "text": "一些文字"}
    ]
  ]
}
```

之前的代码只处理了 `text`, `image`, `file`, `audio` 类型，`post` 类型会进入 `default` 分支被序列化为 JSON 字符串，导致：
1. 图片的 `image_key` 没有被提取
2. 图片没有被下载
3. Agent 收到的是原始 JSON 字符串，无法识别图片

## Solution
在 `LarkAdapter.extractMessageContent` 中添加对 `post` 类型的处理：
- 解析 `post` 消息的 `content` 结构（二维数组）
- 提取所有 `img` 标签的 `image_key` 作为图片附件
- 提取所有 `text` 标签的文本内容
- 提取所有 `a` 标签的链接文本

## Test plan
- [ ] 在飞书中发送图片消息，验证 Agent 能正确识别图片
- [ ] 在飞书中发送包含文字和图片的富文本消息，验证文字和图片都被正确处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)