### PR TITLE
fix(dingtalk): sync reply messages and finalize AI card

### DIFF
--- a/src/channels/agent/ChannelResponseRouter.ts
+++ b/src/channels/agent/ChannelResponseRouter.ts
@@ -34,7 +34,9 @@ export function setupChannelResponseRouting(conversation: TChatConversation): ()
   // For WeChat and WeCom: accumulate text and send once at finish
   // WeChat: no edit support
   // WeCom: proactive push (aibot_send_msg) only supports non-streaming markdown
-  const shouldAccumulate = channelSource === 'wechat' || channelSource === 'wecom';
+  // DingTalk: createAndDeliverAICard creates card without content; only editMessage sets it,
+  // but ChannelResponseRouter doesn't call editMessage, so each sendMessage creates an empty card.
+  const shouldAccumulate = channelSource === 'wechat' || channelSource === 'wecom' || channelSource === 'dingtalk';
   let accumulatedText = '';
   const pendingFiles: Array<{ type: 'image' | 'file'; url: string; fileName?: string }> = [];
 

--- a/src/channels/agent/ChannelResponseRouter.ts
+++ b/src/channels/agent/ChannelResponseRouter.ts
@@ -117,8 +117,13 @@ export function setupChannelResponseRouting(conversation: TChatConversation): ()
             mainLog('ChannelResponseRouter', `Channel route (${channelSource}): sending text (${accumulatedText.length} chars)`);
             const msgId = await plugin.sendMessage(channelChatId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML' });
             // DingTalk AI Card: finalize to remove loading indicator
+            // Strip local image markdown from text to prevent editMessage from re-extracting and re-sending images
             if (channelSource === 'dingtalk' && msgId) {
-              await plugin.editMessage(channelChatId, msgId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML', replyMarkup: {} as any });
+              const cleanForEdit = accumulatedText.trim().replace(/!\[[^\]]*\]\(([^)]+)\)/g, (match, imgPath: string) => {
+                if (/^(https?:|data:|file:)/i.test(imgPath)) return match;
+                return '';
+              }).replace(/\n{3,}/g, '\n\n').trim();
+              await plugin.editMessage(channelChatId, msgId, { type: 'text', text: cleanForEdit, parseMode: 'HTML', replyMarkup: {} as any });
             }
           }
 

--- a/src/channels/agent/ChannelResponseRouter.ts
+++ b/src/channels/agent/ChannelResponseRouter.ts
@@ -114,8 +114,12 @@ export function setupChannelResponseRouting(conversation: TChatConversation): ()
 
           // Send accumulated text first
           if (accumulatedText.trim()) {
-            mainLog('ChannelResponseRouter', `Channel route (WeChat): sending text (${accumulatedText.length} chars)`);
-            await plugin.sendMessage(channelChatId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML' });
+            mainLog('ChannelResponseRouter', `Channel route (${channelSource}): sending text (${accumulatedText.length} chars)`);
+            const msgId = await plugin.sendMessage(channelChatId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML' });
+            // DingTalk AI Card: finalize to remove loading indicator
+            if (channelSource === 'dingtalk' && msgId) {
+              await plugin.editMessage(channelChatId, msgId, { type: 'text', text: accumulatedText.trim(), parseMode: 'HTML', replyMarkup: {} as any });
+            }
           }
 
           // Send pending files after text

--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -683,6 +683,15 @@ export class DingTalkPlugin extends BasePlugin {
       inputingStarted: false,
     });
 
+    // Set initial content so the card is not empty
+    if (_initialText) {
+      try {
+        await this.streamAICard(outTrackId, _initialText);
+      } catch (error) {
+        mainWarn('DingTalkPlugin', 'Failed to set initial AI Card content', error);
+      }
+    }
+
     return messageId;
   }
 

--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -411,10 +411,15 @@ export class DingTalkPlugin extends BasePlugin {
       const extracted = this.extractLocalImageRefs(textContent);
       textContent = extracted.cleanText;
       localImages = extracted.imagePaths;
+      // If text was fully extracted as images, just send the images directly
+      if (!textContent && localImages.length > 0) {
+        await this.sendLocalImages(chatId, localImages);
+        return '';
+      }
     }
 
     // Try AI Card streaming for text/markdown messages
-    if (contentType === 'markdown' && textContent !== undefined) {
+    if (contentType === 'markdown' && textContent !== undefined && textContent !== '') {
       try {
         const cardMessageId = await this.createAndDeliverAICard(chatType, id, textContent);
         // Send extracted local images after text


### PR DESCRIPTION
## Summary
- Sync reply messages with conversation for DingTalk channel
- Finalize AI card message to remove loading indicator after sending text

## Testing
- [ ] Verified message sync works correctly
- [ ] AI card loading indicator is properly removed