### PR TITLE
fix: keep assistant install modal open after successful install

### DIFF
--- a/src/process/providers/LocalConversationProvider.ts
+++ b/src/process/providers/LocalConversationProvider.ts
@@ -165,7 +165,6 @@ export class LocalConversationProvider implements IConversationProvider {
       const all = [...localDbConversations, ...fileOnly];
       all.sort((a, b) => (b.modifyTime || b.createTime || 0) - (a.modifyTime || a.createTime || 0));
 
-      mainLog('LocalProvider', `Listed ${all.length} local conversations (filtered out remote-agent)`);
       return all;
     } catch (error) {
       mainError('LocalProvider', 'Failed to list conversations:', error);

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -1272,7 +1272,7 @@ const AgentModalContent: React.FC = () => {
           await loadAssistants();
           // Refresh agent detection so GuidPage's useGuidAgentSelection picks up the new assistant
           await refreshAgentDetection();
-          setHubDetailVisible(false);
+          // Keep modal open so user can directly click "Go Use" button
         } else {
           Message.error(t('settings.assistant.installFailed', { msg: res.msg || 'Unknown error', defaultValue: `安装失败: ${res.msg || '未知错误'}` }));
         }


### PR DESCRIPTION
## Summary
- Keep modal open after assistant installation completes so user can directly click "Go Use" button without needing to re-select the installed assistant
- Remove verbose log that was flooding the console

## Test plan
- [ ] In personal mode, install a digital assistant
- [ ] Verify the modal stays open after installation completes
- [ ] Verify the button changes from "Install" to "Go Use"
- [ ] Click "Go Use" and verify it navigates to the assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)