### PR TITLE
fix(remote-agent): pass enabledSkills to Moss Server for skill sync

### DIFF
--- a/src/agent/remote/MossWsConnection.ts
+++ b/src/agent/remote/MossWsConnection.ts
@@ -40,6 +40,8 @@ export interface MossWsConnectionConfig {
   wsUrl?: string;
   /** Resume mode: existing session ID */
   sessionId?: string;
+  /** Enabled skill names (optional, for non-assistant sessions) */
+  enabledSkills?: string[];
 }
 
 export interface MossWsCallbacks {
@@ -178,6 +180,8 @@ export class MossWsConnection {
       cwd: this.config.cwd,
       dangerously_skip_permissions: this.config.dangerouslySkipPermissions ?? false,
       assistant_name: this.config.assistantName,
+      // 新增: 发送启用的 skill 列表（仅当显式指定时）
+      enabled_skills: this.config.enabledSkills,
     };
 
     if (this.config.runtimeType) {

--- a/src/process/WorkerManage.ts
+++ b/src/process/WorkerManage.ts
@@ -99,6 +99,10 @@ const buildConversation = (conversation: TChatConversation, options?: BuildConve
         // Lazy creation: pass mossSessionPending flag
         // 延迟创建：传递 mossSessionPending 标志
         mossSessionPending,
+        // Enabled skills: passed for non-assistant sessions
+        // When assistant is specified, Moss Server will use assistant's config
+        // 启用的技能：用于非助手会话；当指定助手时，Moss Server 会使用助手配置
+        enabledSkills: conversation.extra?.enabledSkills,
       });
 
       if (!options?.skipCache) {

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -44,6 +44,8 @@ export interface RemoteAgentData {
   sessionId?: string;
   /** Whether Moss session is pending creation */
   mossSessionPending?: boolean;
+  /** Enabled skill names (optional, for non-assistant sessions) */
+  enabledSkills?: string[];
 }
 
 /**
@@ -111,9 +113,11 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
           // No wsUrl - will create new session
           wsUrl: undefined,
           sessionId: undefined,
+          // 新增: 传递启用的 skill 列表
+          enabledSkills: this.options.enabledSkills,
         };
 
-        mainLog('RemoteAgent', `MossWsConnection config: cwd=${config.cwd}, assistant=${config.assistantName || 'default'}`);
+        mainLog('RemoteAgent', `MossWsConnection config: cwd=${config.cwd}, assistant=${config.assistantName || 'default'}, enabledSkills=${config.enabledSkills?.length || 0}`);
 
         const callbacks: MossWsCallbacks = {
           onMessage: (msg) => this.handleStreamMessage(msg),
@@ -154,9 +158,11 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
           // Resume mode: use existing wsUrl and sessionId
           wsUrl: this.options.wsUrl,
           sessionId: this.options.sessionId || this.conversation_id,
+          // 新增: 传递启用的 skill 列表（resume 模式也支持）
+          enabledSkills: this.options.enabledSkills,
         };
 
-        mainLog('RemoteAgent', `MossWsConnection config: resume=${!!config.wsUrl}, sessionId=${config.sessionId}`);
+        mainLog('RemoteAgent', `MossWsConnection config: resume=${!!config.wsUrl}, sessionId=${config.sessionId}, enabledSkills=${config.enabledSkills?.length || 0}`);
 
         const callbacks: MossWsCallbacks = {
           onMessage: (msg) => this.handleStreamMessage(msg),


### PR DESCRIPTION
## Summary
- Add `enabledSkills` field to `MossWsConnectionConfig` and `RemoteAgentData` interfaces
- Pass `enabledSkills` from `conversation.extra` to `RemoteAgent` in `WorkerManage`
- Send `enabled_skills` in session creation request to Moss Server
- Moss Server handles priority: assistant config > client passed > all available

## Problem
Enterprise mode (RemoteAgent) was not passing skill information to Moss Server, causing:
1. Non-assistant sessions had no skills synced
2. Skill sync relied on undefined behavior

## Solution
- Client passes `enabledSkills` to Moss Server during session creation
- Moss Server handles the priority logic (see companion PR in moss repo)
- Personal mode (AcpAgent) is unaffected - uses existing `resolveLatestConversationEnabledSkills()` flow

## Test Plan
- [ ] Create enterprise mode session without assistant - verify skills are synced
- [ ] Create enterprise mode session with assistant - verify assistant's skills are used
- [ ] Create personal mode session - verify existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)