### PR TITLE
fix: rename skill installer id and name to sudowork-skill-installer

### DIFF
--- a/skills/_builtin/sudoclaw-skill-installer/SKILL.md
+++ b/skills/_builtin/sudoclaw-skill-installer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sudoclaw-skill-installer
+name: sudowork-skill-installer
 description: >
   🔧 PRIMARY skill installer for Sudowork. Use this skill for ALL skill installation requests.
 

--- a/skills/_builtin/sudoclaw-skill-installer/_sudowork_meta.json
+++ b/skills/_builtin/sudoclaw-skill-installer/_sudowork_meta.json
@@ -1,8 +1,8 @@
 {
-  "id": "skill-installer-sudoclaw",
-  "name": "sudoclaw-skill-installer",
+  "id": "skill-installer-sudowork",
+  "name": "sudowork-skill-installer",
   "display_name": "技能安装助手",
-  "description": "从 SudoClaw skill hub 搜索和安装技能。当用户需要安装新技能时自动触发，提供一键安装体验。",
+  "description": "从 Sudo Hub 搜索和安装技能。当用户需要安装新技能时自动触发，提供一键安装体验。",
   "icon": "",
   "emoji": "⚡",
   "category": "",

--- a/skills/_builtin/sudoclaw-skill-installer/package.json
+++ b/skills/_builtin/sudoclaw-skill-installer/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sudoclaw-skill-installer",
+  "name": "sudowork-skill-installer",
   "version": "1.0.0",
-  "description": "SudoClaw Skill Hub installer CLI",
+  "description": "Sudo Hub Skill installer CLI",
   "bin": {
     "sudoclaw-skill": "./scripts/sudoclaw-skill.mjs"
   },


### PR DESCRIPTION
## Summary
- Change id from "skill-installer-sudoclaw" to "skill-installer-sudowork"
- Change name from "sudoclaw-skill-installer" to "sudowork-skill-installer"
- Update description to reference "Sudo Hub" instead of "SudoClaw skill hub"

## Test plan
- [ ] Verify skill installer still works correctly after rename
- [ ] Check skill metadata displays correctly in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)