### PR TITLE
fix: 首页聊天框 @技能 选择后保留用户已有输入

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -10,7 +10,7 @@ import { openExternalUrl, isElectronDesktop, resolveExtensionAssetUrl } from '@/
 import { useConversationTabs } from '@/renderer/pages/conversation/context/ConversationTabsContext';
 import { ThemeSwitcher } from '@/renderer/components/ThemeSwitcher';
 import { getInstalledSkillDisplay, resolveSkillIcon } from '@/renderer/utils/skillDisplay';
-import { useSkillSelectorController, type SkillSelectorItem } from '@/renderer/hooks/useSkillSelectorController';
+import { useSkillSelectorController, type SkillSelectorItem, stripAtQuery } from '@/renderer/hooks/useSkillSelectorController';
 import SkillSelectorMenu, { type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorMenu';
 import { resolveAssistantName } from '@/renderer/shared/agents/assistantAdapter';
 import { ipcBridge } from '@/common';
@@ -71,6 +71,7 @@ const GuidPage: React.FC = () => {
   // Skill selector state
   const [installedSkills, setInstalledSkills] = useState<any[]>([]);
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [cursorPosition, setCursorPosition] = useState(0);
 
   // Edit drawer state
   const [editDrawerVisible, setEditDrawerVisible] = useState(false);
@@ -210,13 +211,15 @@ const GuidPage: React.FC = () => {
   // Skill selector controller
   const skillSelectorController = useSkillSelectorController({
     input: guidInput.input,
+    cursorPosition,
     skills: skillSelectorItems,
     selectedSkills,
     onSelectSkill: (skillName) => {
       if (!selectedSkills.includes(skillName)) {
         setSelectedSkills([...selectedSkills, skillName]);
       }
-      guidInput.setInput('');
+      // Strip the @query from input when selecting a skill, preserving user's other text
+      guidInput.setInput(stripAtQuery(guidInput.input, cursorPosition));
     },
     onRemoveSkill: (skillName) => {
       setSelectedSkills(selectedSkills.filter((s) => s !== skillName));
@@ -303,6 +306,7 @@ const GuidPage: React.FC = () => {
     guidInput.setDir('');
     agentSelection.resetSelection();
     setSelectedSkills([]);
+    setCursorPosition(0);
     mention.setMentionOpen(false);
     mention.setMentionQuery(null);
     mention.setMentionSelectorVisible(false);
@@ -315,9 +319,11 @@ const GuidPage: React.FC = () => {
 
   // Trigger skill selector via @ button
   const handleTriggerSkillSelector = useCallback(() => {
-    guidInput.setInput('@');
+    const currentInput = guidInput.input;
+    const newInput = currentInput.trim() ? `${currentInput} @` : '@';
+    guidInput.setInput(newInput);
     guidInput.handleTextareaFocus();
-  }, [guidInput.setInput, guidInput.handleTextareaFocus]);
+  }, [guidInput.input, guidInput.setInput, guidInput.handleTextareaFocus]);
 
   // --- Coordinated handlers (depend on multiple hooks) ---
   const handleInputChange = useCallback(
@@ -672,6 +678,10 @@ const GuidPage: React.FC = () => {
               onPaste={guidInput.onPaste}
               onFocus={guidInput.handleTextareaFocus}
               onBlur={guidInput.handleTextareaBlur}
+              onSelect={(e) => {
+                const target = e.currentTarget as HTMLTextAreaElement;
+                setCursorPosition(target.selectionStart);
+              }}
               placeholder={`${mention.selectedAgentLabel}, ${typewriterPlaceholder || t('conversation.welcome.placeholder')}`}
               isInputActive={guidInput.isInputFocused}
               isFileDragging={guidInput.isFileDragging}

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -322,8 +322,17 @@ const GuidPage: React.FC = () => {
     const currentInput = guidInput.input;
     const newInput = currentInput.trim() ? `${currentInput} @` : '@';
     guidInput.setInput(newInput);
-    guidInput.handleTextareaFocus();
-  }, [guidInput.input, guidInput.setInput, guidInput.handleTextareaFocus]);
+    setCursorPosition(newInput.length);
+    // Focus the textarea and move cursor to end so skill selector opens immediately
+    setTimeout(() => {
+      const textarea = guidContainerRef.current?.querySelector('textarea');
+      if (textarea) {
+        textarea.focus();
+        const len = newInput.length;
+        textarea.setSelectionRange(len, len);
+      }
+    }, 0);
+  }, [guidInput.input, guidInput.setInput]);
 
   // --- Coordinated handlers (depend on multiple hooks) ---
   const handleInputChange = useCallback(

--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -24,6 +24,7 @@ type GuidInputCardProps = {
   onPaste: React.ClipboardEventHandler;
   onFocus: () => void;
   onBlur: () => void;
+  onSelect?: (e: React.SyntheticEvent<HTMLTextAreaElement>) => void;
   placeholder: string;
 
   // Styling
@@ -58,7 +59,7 @@ type GuidInputCardProps = {
   actionRow: React.ReactNode;
 };
 
-const GuidInputCard: React.FC<GuidInputCardProps> = ({ input, onInputChange, onKeyDown, onPaste, onFocus, onBlur, placeholder, isInputActive, isFileDragging, activeBorderColor, inactiveBorderColor, activeShadow, dragHandlers, mentionOpen, mentionSelectorBadge, mentionDropdown, skillSelectorOpen, skillSelectorMenu, selectedSkills, onRemoveSkill, getSkillDisplayName, files, onRemoveFile, dir, onClearDir, actionRow }) => {
+const GuidInputCard: React.FC<GuidInputCardProps> = ({ input, onInputChange, onKeyDown, onPaste, onFocus, onBlur, onSelect, placeholder, isInputActive, isFileDragging, activeBorderColor, inactiveBorderColor, activeShadow, dragHandlers, mentionOpen, mentionSelectorBadge, mentionDropdown, skillSelectorOpen, skillSelectorMenu, selectedSkills, onRemoveSkill, getSkillDisplayName, files, onRemoveFile, dir, onClearDir, actionRow }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const { t } = useTranslation();
@@ -160,7 +161,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({ input, onInputChange, onK
           </div>
         </div>
       )}
-      <Input.TextArea autoSize={textareaAutoSize} placeholder={placeholder} className={`text-16px focus:b-none rounded-xl !bg-transparent !b-none !resize-none !p-0 ${styles.lightPlaceholder}`} value={input} onChange={onInputChange} onPaste={onPaste} onFocus={onFocus} onBlur={onBlur} {...compositionHandlers} onKeyDown={handleKeyDown} onContextMenu={handleContextMenu} />
+      <Input.TextArea autoSize={textareaAutoSize} placeholder={placeholder} className={`text-16px focus:b-none rounded-xl !bg-transparent !b-none !resize-none !p-0 ${styles.lightPlaceholder}`} value={input} onChange={onInputChange} onPaste={onPaste} onFocus={onFocus} onBlur={onBlur} onSelect={onSelect} {...compositionHandlers} onKeyDown={handleKeyDown} onContextMenu={handleContextMenu} />
       {mentionOpen && (
         <div className='absolute z-50' style={{ left: 16, top: 44 }}>
           {mentionDropdown}


### PR DESCRIPTION
## Summary

- 修复首页聊天框点击 @技能 会清空输入框全部用户输入的问题
- 使用 stripAtQuery() 只移除 @query 部分，保留用户已有文本（与会话页 sendbox.tsx 行为一致）
- 添加光标位置追踪，确保 stripAtQuery 能正确定位

Closes #618

Generated with [Claude Code](https://claude.ai/code)