### PR TITLE
feat(nexus): E-side credentials management via Moss secret client

### DIFF
--- a/src/common/enterpriseDebugConfig.ts
+++ b/src/common/enterpriseDebugConfig.ts
@@ -36,6 +36,7 @@ import { isEnterpriseMode as eeclawIsEnterpriseMode } from './eeclawMode';
 let cachedAppMode: 'c' | 'e' | null = null;
 let cachedServerUrl: string = '';
 let cachedAuthToken: string = '';
+let cachedUserId: string = '';
 // Cache for guid session mode (remote/local), updated by refreshEnterpriseCache and setSessionMode IPC
 // guid session 模式缓存（remote/local），由 refreshEnterpriseCache 和 setSessionMode IPC 更新
 let cachedSessionMode: 'remote' | 'local' = 'remote';
@@ -67,6 +68,10 @@ export async function refreshEnterpriseCache(): Promise<void> {
     cachedAuthToken = authStorage?.access_token || '';
     cachedServerUrl = config.getSync('eeclaw.serverUrl') || '';
     cachedSessionMode = config.getSync('guid.sessionMode') || 'remote';
+    const userInfo = config.getSync('eeclaw.userInfo');
+    if (userInfo?.id) {
+      cachedUserId = userInfo.id;
+    }
   } catch {
     // Keep existing cache values on error
   }
@@ -179,6 +184,22 @@ export async function getMossServerUrlAsync(): Promise<string> {
   } catch {
     return '';
   }
+}
+
+/**
+ * Get cached user ID (synchronous, uses cached value)
+ * 获取缓存的用户 ID（同步，使用缓存值）
+ */
+export function getUserId(): string {
+  return cachedUserId;
+}
+
+/**
+ * Set cached user ID
+ * 设置缓存的用户 ID
+ */
+export function setCachedUserId(id: string): void {
+  cachedUserId = id;
 }
 
 /**

--- a/src/common/nexus/moss-secret-client-factory.ts
+++ b/src/common/nexus/moss-secret-client-factory.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MossSecretClient } from './moss-secret-client'
+import { getAuthToken, getMossServerUrl, getUserId } from '../enterpriseDebugConfig'
+
+let mossClientInstance: MossSecretClient | null = null
+let lastToken: string = ''
+
+export function getMossSecretClient(): MossSecretClient {
+  const currentToken = getAuthToken()
+  if (!mossClientInstance || lastToken !== currentToken) {
+    mossClientInstance = new MossSecretClient(
+      getMossServerUrl(),
+      currentToken,
+      getUserId(),
+    )
+    lastToken = currentToken
+  }
+  return mossClientInstance
+}

--- a/src/common/nexus/moss-secret-client.ts
+++ b/src/common/nexus/moss-secret-client.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface MossSecretEntry {
+  id: string
+  namespace: string
+  key: string
+  description: string | null
+  enabled: boolean
+  current_version: number
+  deleted_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+interface MossResponse<T> {
+  success: boolean
+  data?: T
+  error?: { code: string; message: string }
+}
+
+export class MossSecretClient {
+  private readonly baseUrl: string
+  private readonly headers: Record<string, string>
+
+  constructor(mossServerUrl: string, authToken: string, _userId: string) {
+    this.baseUrl = mossServerUrl.replace(/\/+$/, '')
+    this.headers = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${authToken}`,
+    }
+  }
+
+  private url(namespace: string, key: string, action?: string): string {
+    const ns = encodeURIComponent(namespace)
+    const k = encodeURIComponent(key)
+    const base = `${this.baseUrl}/api/v1/me/secrets/${ns}/${k}`
+    return action ? `${base}/${action}` : base
+  }
+
+  private async request<T>(url: string, options: RequestInit): Promise<T> {
+    const res = await fetch(url, { ...options, headers: { ...this.headers, ...options.headers }, signal: AbortSignal.timeout(10000) })
+    if (res.status === 404) {
+      return null as T
+    }
+    const body = await res.json() as MossResponse<T>
+    if (!body.success) {
+      const msg = body.error?.message || body.error?.code || `HTTP ${res.status}`
+      throw new Error(`Moss API error: ${msg}`)
+    }
+    return body.data as T
+  }
+
+  async getSecret(namespace: string, key: string): Promise<string | null> {
+    const data = await this.request<{ value: string } | null>(this.url(namespace, key), { method: 'GET' })
+    return data?.value ?? null
+  }
+
+  async putSecret(namespace: string, key: string, value: string): Promise<void> {
+    await this.request<void>(this.url(namespace, key), {
+      method: 'PUT',
+      body: JSON.stringify({ value }),
+    })
+  }
+
+  async deleteSecret(namespace: string, key: string): Promise<void> {
+    const res = await fetch(this.url(namespace, key), {
+      method: 'DELETE',
+      headers: this.headers,
+      signal: AbortSignal.timeout(10000),
+    })
+    if (!res.ok && res.status !== 404) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`Moss DELETE ${namespace}/${key} failed: ${res.status} ${text}`)
+    }
+  }
+
+  async enableSecret(namespace: string, key: string): Promise<void> {
+    await this.request<void>(this.url(namespace, key, 'enable'), { method: 'POST' })
+  }
+
+  async disableSecret(namespace: string, key: string): Promise<void> {
+    await this.request<void>(this.url(namespace, key, 'disable'), { method: 'POST' })
+  }
+
+  async listSecrets(): Promise<MossSecretEntry[]> {
+    const res = await fetch(`${this.baseUrl}/api/v1/me/secrets`, {
+      headers: this.headers,
+      signal: AbortSignal.timeout(10000),
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`Moss LIST failed: ${res.status} ${text}`)
+    }
+    const body = await res.json() as MossResponse<MossSecretEntry[]>
+    return body.data ?? []
+  }
+}

--- a/src/common/nexus/namespace.ts
+++ b/src/common/nexus/namespace.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Build a secret namespace from pinyin and optional userId.
+ * C端: buildNamespace('openai') → "service:openai"
+ * B端: buildNamespace('openai', 'u_123') → "user:u_123:openai"
+ */
+export function buildNamespace(pinyin: string, userId?: string): string {
+  if (userId) {
+    return `user:${userId}:${pinyin}`
+  }
+  return `service:${pinyin}`
+}

--- a/src/process/services/authProxy/index.ts
+++ b/src/process/services/authProxy/index.ts
@@ -10,6 +10,7 @@
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { AuthProxyServer } from './AuthProxyServer';
 import { refreshRules, getRules } from './configItemsLoader';
+import { isEnterpriseMode } from '@common/enterpriseDebugConfig';
 
 // ============================================================================
 // Module state
@@ -28,6 +29,11 @@ let serverPort: number | null = null;
  * Returns the port the server is listening on.
  */
 export async function startAuthProxy(): Promise<number> {
+  if (isEnterpriseMode()) {
+    mainLog('AuthProxy', 'Enterprise mode - skipping local Auth Proxy (handled by Moss Server)');
+    return 0;
+  }
+
   if (server) {
     return server.getPort()!;
   }

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -255,7 +255,9 @@ export class ServiceManager {
           try {
             const { startAuthProxy } = await import('@process/services/authProxy');
             const port = await startAuthProxy();
-            mainLog('ServiceManager', `Auth Proxy started on port ${port}`);
+            if (port > 0) {
+              mainLog('ServiceManager', `Auth Proxy started on port ${port}`);
+            }
           } catch (err) {
             mainWarn('ServiceManager', 'Auth Proxy start failed (non-critical):', err);
           }

--- a/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/WebuiModalContent.tsx
@@ -724,16 +724,14 @@ const WebuiModalContent: React.FC = () => {
             </span>
           }
         />
-        {!isEnterprise && (
-          <Tabs.TabPane
-            key='secrets'
-            title={
-              <span data-webui-tab='secrets' className={`inline-flex items-center gap-6px transition-colors ${activeTab === 'secrets' ? 'text-t-primary font-600' : 'text-t-secondary'}`}>
-                <span className='text-14px'>{t('settings.secrets', '秘钥管理')}</span>
-              </span>
-            }
-          />
-        )}
+        <Tabs.TabPane
+          key='secrets'
+          title={
+            <span data-webui-tab='secrets' className={`inline-flex items-center gap-6px transition-colors ${activeTab === 'secrets' ? 'text-t-primary font-600' : 'text-t-secondary'}`}>
+              <span className='text-14px'>{isEnterprise ? t('settings.secrets.enterprise', '我的凭据') : t('settings.secrets', '秘钥管理')}</span>
+            </span>
+          }
+        />
       </Tabs>
 
       {/* {activeTab === 'webui' ? (

--- a/src/renderer/components/SettingsModal/contents/secrets/EnterpriseSecretSection.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/EnterpriseSecretSection.tsx
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Collapse, Input, Tooltip } from '@arco-design/web-react';
+import configItemDefaultIcon from '@/renderer/assets/config-item-default.svg';
+import { ConfigStorage } from '@/common/storage';
+import { useAuth } from '@/renderer/context/AuthContext';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import PreferenceRow from './PreferenceRow';
+import type { TenantConfigItem } from './types';
+
+function resolveIconUrl(iconUrl: string | null): string {
+  if (!iconUrl) return configItemDefaultIcon;
+  if (iconUrl.startsWith('data:') || iconUrl.startsWith('http://') || iconUrl.startsWith('https://')) {
+    return iconUrl;
+  }
+  return configItemDefaultIcon;
+}
+
+const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string }> = ({ iconUrl, name }) => {
+  const [useDefault, setUseDefault] = React.useState(false);
+
+  React.useEffect(() => { setUseDefault(false); }, [iconUrl]);
+
+  const src = useDefault ? configItemDefaultIcon : resolveIconUrl(iconUrl ?? null);
+  return <img src={src} alt={name} className='w-14px h-14px object-contain shrink-0' onError={() => setUseDefault(true)} />;
+};
+
+const LOCKED_TIP = '企业凭据禁止操作';
+
+export const EnterpriseSecretSection: React.FC = () => {
+  const { t } = useTranslation();
+  const { ensureValidToken, user } = useAuth();
+  const [items, setItems] = useState<TenantConfigItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadItems = useCallback(async () => {
+    if (!user?.id) return;
+    try {
+      const token = await ensureValidToken();
+      const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+      const headers = { Authorization: `Bearer ${token}` };
+
+      // 1. Get authorized system config IDs
+      const authRes = await fetch(`${serverUrl}/api/v1/me/authorized-system-configs`, { headers });
+      const authData = await authRes.json();
+      if (!authData.success) return;
+      const authorizedIds = new Set((authData.data as Array<{ id: number }>).map(i => i.id));
+      if (authorizedIds.size === 0) return;
+
+      // 2. Get full config items with entries, filter to authorized system items
+      const itemsRes = await fetch(`${serverUrl}/api/v1/config/items`, { headers });
+      const itemsData = await itemsRes.json();
+      if (!itemsData.success) return;
+
+      const systemItems: TenantConfigItem[] = itemsData.data
+        .filter((item: TenantConfigItem) => item.scope === 'system' && authorizedIds.has(item.id))
+        .map((item: TenantConfigItem) => item);
+
+      setItems(systemItems);
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, [ensureValidToken, user?.id]);
+
+  useEffect(() => {
+    void loadItems();
+  }, [loadItems]);
+
+  if (loading || items.length === 0) return null;
+
+  return (
+    <div className='space-y-12px'>
+      <div className='flex items-center gap-8px mb-4px'>
+        <span className='text-13px font-500 text-t-secondary'>{t('settings.secrets.enterprise.title', '企业凭据')}</span>
+      </div>
+      {items.map(item => (
+        <Collapse
+          key={item.id}
+          defaultActiveKey={[]}
+          className='[&_div.arco-collapse-item-header-title]:flex-1'
+        >
+          <Collapse.Item
+            header={
+              <div className='flex items-center justify-between group'>
+                <div className='flex items-center gap-8px flex-1 min-w-0'>
+                  <ConfigItemIcon iconUrl={item.icon_url} name={item.name} />
+                  <span className='text-14px text-t-primary'>{item.name}</span>
+                </div>
+              </div>
+            }
+            name={`enterprise-${item.id}`}
+            className='[&_div.arco-collapse-item-content-box]:py-3'
+          >
+            <div className='flex flex-col gap-24px'>
+              <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+                {item.entries.map((entry) => (
+                  <PreferenceRow key={entry.id} label={entry.name} description={entry.config_desc || undefined} required={entry.required === 1}>
+                    <Tooltip content={LOCKED_TIP}>
+                      <Input.Password
+                        value='••••••••'
+                        style={{ width: 240 }}
+                        disabled
+                      />
+                    </Tooltip>
+                  </PreferenceRow>
+                ))}
+              </div>
+            </div>
+          </Collapse.Item>
+        </Collapse>
+      ))}
+    </div>
+  );
+};

--- a/src/renderer/components/SettingsModal/contents/secrets/SecretModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/SecretModalContent.tsx
@@ -11,7 +11,9 @@ import { useTranslation } from 'react-i18next';
 import { useSettingsViewMode } from '../../settingsViewContext';
 import itemRefreshIcon from '@/renderer/assets/item-refresh.svg';
 import TenantConfigSection from './TenantConfigSection';
+import { EnterpriseSecretSection } from './EnterpriseSecretSection';
 import { ZentaoChannelItem } from '../ZentaoConfigForm';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 
 /**
  * Secret Management Content Component
@@ -20,10 +22,13 @@ const SecretModalContent: React.FC = () => {
   const { t } = useTranslation();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
+  const { isEnterprise } = useAppMode();
 
   const [refreshCounter, setRefreshCounter] = useState(0);
 
-  const guideText = t('settings.secrets.description', '管理各服务的秘钥凭证，秘钥安全存储在本地 Nexus 密钥库中。');
+  const guideText = isEnterprise
+    ? t('settings.secrets.description.enterprise', '管理您的凭据，凭据安全存储在服务端。')
+    : t('settings.secrets.description', '管理各服务的秘钥凭证，秘钥安全存储在本地 Nexus 密钥库中。');
   const setupSteps = [t('settings.secrets.step1', '选择服务并填写秘钥信息。'), t('settings.secrets.step2', '点击保存完成配置。')];
 
   const handleRefresh = useCallback(() => {
@@ -53,8 +58,11 @@ const SecretModalContent: React.FC = () => {
         </div>
 
         <div className='space-y-12px mt-12px'>
-          {/* 禅道 */}
-          <ZentaoChannelItem />
+          {/* 企业凭据只读区域 */}
+          {isEnterprise && <EnterpriseSecretSection />}
+
+          {/* 禅道（仅C端） */}
+          {!isEnterprise && <ZentaoChannelItem />}
 
           {/* 租户配置项 */}
           <TenantConfigSection refreshTrigger={refreshCounter} />

--- a/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
@@ -87,13 +87,6 @@ const TenantConfigItemGroup: React.FC<TenantConfigItemGroupProps> = ({
   const handleToggle = useCallback(
     async (checked: boolean) => {
       if (!checked) {
-        setLocalValues((prev) => {
-          const cleared: TenantConfigValues = {};
-          for (const entry of configItem.entries) {
-            cleared[entry.config_key] = '';
-          }
-          return cleared;
-        });
         void onToggleEnabled(checked);
       } else {
         const hasNewValues = configItem.entries.some((entry) => {

--- a/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
@@ -12,6 +12,14 @@ import { useTranslation } from 'react-i18next';
 import PreferenceRow from './PreferenceRow';
 import type { TenantConfigItem, TenantConfigValues } from './types';
 
+function resolveIconUrl(iconUrl: string | null): string {
+  if (!iconUrl) return configItemDefaultIcon;
+  if (iconUrl.startsWith('data:') || iconUrl.startsWith('http://') || iconUrl.startsWith('https://')) {
+    return iconUrl;
+  }
+  return `${SUDOWORK_SERVER_BASE_URL}${iconUrl}`;
+}
+
 const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string }> = ({ iconUrl, name }) => {
   const [useDefault, setUseDefault] = useState(false);
 
@@ -19,7 +27,7 @@ const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string }> = ({ iconUrl,
     setUseDefault(false);
   }, [iconUrl]);
 
-  const src = useDefault || !iconUrl ? configItemDefaultIcon : `${SUDOWORK_SERVER_BASE_URL}${iconUrl}`;
+  const src = useDefault ? configItemDefaultIcon : resolveIconUrl(iconUrl ?? null);
 
   return <img src={src} alt={name} className='w-14px h-14px object-contain shrink-0' onError={() => setUseDefault(true)} />;
 };
@@ -77,10 +85,49 @@ const TenantConfigItemGroup: React.FC<TenantConfigItemGroupProps> = ({
   }, [localValues, onSave, enabled, onToggleEnabled, t, configItem.entries, configItem.name]);
 
   const handleToggle = useCallback(
-    (checked: boolean) => {
-      void onToggleEnabled(checked);
+    async (checked: boolean) => {
+      if (!checked) {
+        setLocalValues((prev) => {
+          const cleared: TenantConfigValues = {};
+          for (const entry of configItem.entries) {
+            cleared[entry.config_key] = '';
+          }
+          return cleared;
+        });
+        void onToggleEnabled(checked);
+      } else {
+        const hasNewValues = configItem.entries.some((entry) => {
+          const local = localValues[entry.config_key]?.trim() ?? '';
+          const external = externalValues[entry.config_key]?.trim() ?? '';
+          return local !== '' && local !== external;
+        });
+        if (hasNewValues) {
+          const emptyRequired = configItem.entries.find(
+            (e) => e.required === 1 && !localValues[e.config_key]?.trim(),
+          );
+          if (emptyRequired) {
+            Message.warning(
+              t('settings.secrets.tenantFieldRequiredSpecific', '请填写：{{configItemName}} - {{entryName}}', {
+                configItemName: configItem.name,
+                entryName: emptyRequired.name,
+              }),
+            );
+            return;
+          }
+          const success = await onSave(localValues);
+          if (success) {
+            Message.success(t('settings.secrets.tenantSaveSuccess', '配置保存成功'));
+            onToggleEnabled(true);
+          } else {
+            Message.error(t('settings.secrets.tenantSaveFailed', '配置保存失败'));
+          }
+        } else {
+          setLocalValues(externalValues);
+          void onToggleEnabled(checked);
+        }
+      }
     },
-    [onToggleEnabled],
+    [localValues, externalValues, onSave, onToggleEnabled, t, configItem.entries, configItem.name],
   );
 
   return (

--- a/src/renderer/components/SettingsModal/contents/secrets/TenantConfigSection.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/TenantConfigSection.tsx
@@ -39,7 +39,9 @@ const TenantConfigSection: React.FC<TenantConfigSectionProps> = ({ refreshTrigge
   }
 
   if (configItems.length === 0) {
-    return null;
+    return (
+      <div className='text-13px text-t-tertiary py-16px'>{t('settings.secrets.emptyHint', '暂无凭据配置项')}</div>
+    );
   }
 
   return (

--- a/src/renderer/components/SettingsModal/contents/secrets/types.ts
+++ b/src/renderer/components/SettingsModal/contents/secrets/types.ts
@@ -25,6 +25,7 @@ export interface TenantConfigItem {
   icon: string | null;
   icon_url: string;
   pinyin: string | null;
+  scope?: string;
 }
 
 /**

--- a/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
+++ b/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
@@ -15,7 +15,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { TenantConfigEntry, TenantConfigItem, TenantConfigValues } from './types';
 
 const TENANT_ENABLED_STORAGE_KEY = 'settings.tenant.enabled';
-const MASKED_VALUE = '••••••••';
 
 interface UseTenantConfigItemsReturn {
   configItems: TenantConfigItem[];
@@ -144,16 +143,7 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
     }
 
     if (mountedRef.current) {
-      // Mask all loaded values — plain text should never appear in frontend state
-      const maskedMap: Record<number, TenantConfigValues> = {};
-      for (const [id, vals] of Object.entries(newValuesMap)) {
-        const masked: TenantConfigValues = {};
-        for (const [k, v] of Object.entries(vals)) {
-          masked[k] = v ? MASKED_VALUE : '';
-        }
-        maskedMap[Number(id)] = masked;
-      }
-      setValuesMap(maskedMap);
+      setValuesMap(newValuesMap);
     }
   }, [isEnterprise, user?.id]);
 
@@ -321,13 +311,6 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
             }),
           );
           const allSuccess = results.every(r => r.success);
-          if (allSuccess) {
-            const masked: TenantConfigValues = {};
-            for (const entry of entries) {
-              masked[entry.config_key] = values[entry.config_key]?.trim() ? MASKED_VALUE : '';
-            }
-            setValuesMap(prev => ({ ...prev, [configItemId]: masked }));
-          }
           return allSuccess;
         }
 
@@ -370,13 +353,6 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
           }),
         );
         const allSuccess = results.every(r => r.success);
-        if (allSuccess) {
-          const masked: TenantConfigValues = {};
-          for (const entry of entries) {
-            masked[entry.config_key] = values[entry.config_key]?.trim() ? MASKED_VALUE : '';
-          }
-          setValuesMap(prev => ({ ...prev, [configItemId]: masked }));
-        }
         return allSuccess;
       } catch (err) {
         console.error('[TenantConfig] Failed to save config item:', err);

--- a/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
+++ b/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
@@ -5,14 +5,17 @@
  */
 
 import { secret, authProxy } from '@/common/ipcBridge';
+import { buildNamespace } from '@/common/nexus/namespace';
+import { MossSecretClient } from '@/common/nexus/moss-secret-client';
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
 import { ConfigStorage } from '@/common/storage';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useAuth } from '@/renderer/context/AuthContext';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { TenantConfigEntry, TenantConfigItem, TenantConfigValues } from './types';
 
 const TENANT_ENABLED_STORAGE_KEY = 'settings.tenant.enabled';
-const CONFIG_ITEMS_API = `${SUDOWORK_SERVER_BASE_URL}/api/v1/config/items`;
+const MASKED_VALUE = '••••••••';
 
 interface UseTenantConfigItemsReturn {
   configItems: TenantConfigItem[];
@@ -36,12 +39,9 @@ async function fetchWithAuth(url: string, token: string, options: RequestInit = 
   return response;
 }
 
-function buildNamespace(pinyin: string): string {
-  return `service:${pinyin}`;
-}
-
 export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigItemsReturn {
-  const { ensureValidToken, forceRefreshToken } = useAuth();
+  const { ensureValidToken, forceRefreshToken, user } = useAuth();
+  const { isEnterprise } = useAppMode();
 
   const [configItems, setConfigItems] = useState<TenantConfigItem[]>([]);
   const [valuesMap, setValuesMap] = useState<Record<number, TenantConfigValues>>({});
@@ -52,13 +52,40 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
 
   const mountedRef = useRef(true);
 
-  const loadEnabledStates = useCallback(async (itemIds: number[]) => {
+  const loadEnabledStates = useCallback(async (items: TenantConfigItem[], token: string) => {
+    if (isEnterprise && user?.id) {
+      // B端: use MossSecretClient.listSecrets() for enabled status
+      try {
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        const mossClient = new MossSecretClient(serverUrl, token, user.id);
+        const allSecrets = await mossClient.listSecrets();
+        const newMap: Record<number, boolean> = {};
+        for (const item of items) {
+          const namespace = buildNamespace(item.pinyin!, user.id);
+          const itemEntries = allSecrets.filter(s => s.namespace === namespace);
+          newMap[item.id] = itemEntries.length > 0 && itemEntries.some(s => s.enabled);
+        }
+        if (mountedRef.current) {
+          setEnabledMap(newMap);
+        }
+      } catch {
+        // Fall back to all disabled
+        if (mountedRef.current) {
+          const newMap: Record<number, boolean> = {};
+          for (const item of items) { newMap[item.id] = false; }
+          setEnabledMap(newMap);
+        }
+      }
+      return;
+    }
+
+    // C端: read from ConfigStorage
     try {
       const stored = await ConfigStorage.get(TENANT_ENABLED_STORAGE_KEY);
       const storedMap = (stored || {}) as Record<number, boolean>;
       const newMap: Record<number, boolean> = {};
-      for (const id of itemIds) {
-        newMap[id] = storedMap[id] ?? false;
+      for (const item of items) {
+        newMap[item.id] = storedMap[item.id] ?? false;
       }
       if (mountedRef.current) {
         setEnabledMap(newMap);
@@ -66,42 +93,69 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
     } catch {
       // Ignore storage read errors
     }
-  }, []);
+  }, [isEnterprise, user?.id]);
 
-  const loadValuesFromNexus = useCallback(async (items: TenantConfigItem[]) => {
+  const loadValuesFromNexus = useCallback(async (items: TenantConfigItem[], token: string) => {
     const newValuesMap: Record<number, TenantConfigValues> = {};
+    const userId = user?.id;
 
-    const promises: Promise<void>[] = [];
-    for (const item of items) {
-      if (!item.pinyin) continue;
+    if (isEnterprise && userId) {
+      // B端: use MossSecretClient to GET values from moss API
+      const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+      const mossClient = new MossSecretClient(serverUrl, token, userId);
 
-      const namespace = buildNamespace(item.pinyin);
-      const values: TenantConfigValues = {};
-
-      for (const entry of item.entries) {
-        const p = secret.get
-          .invoke({ namespace, key: entry.config_key })
-          .then((res) => {
-            if (res.success && res.data) {
-              values[entry.config_key] = res.data;
+      for (const item of items) {
+        if (!item.pinyin) continue;
+        const namespace = buildNamespace(item.pinyin, userId);
+        const values: TenantConfigValues = {};
+        for (const entry of item.entries) {
+          try {
+            const value = await mossClient.getSecret(namespace, entry.config_key);
+            if (value) {
+              values[entry.config_key] = value;
             }
-          })
-          .catch(() => {
-            // Silently ignore, leave value empty
-          });
-        promises.push(p);
+          } catch {
+            // Secret not found, skip
+          }
+        }
+        newValuesMap[item.id] = values;
       }
-
-      // Ensure values object is created for this item even if all gets fail
-      newValuesMap[item.id] = values;
+    } else {
+      // C端: use IPC to local nexusd
+      const promises: Promise<void>[] = [];
+      for (const item of items) {
+        if (!item.pinyin) continue;
+        const namespace = buildNamespace(item.pinyin);
+        const values: TenantConfigValues = {};
+        for (const entry of item.entries) {
+          const p = secret.get
+            .invoke({ namespace, key: entry.config_key })
+            .then((res) => {
+              if (res.success && res.data) {
+                values[entry.config_key] = res.data;
+              }
+            })
+            .catch(() => {});
+          promises.push(p);
+        }
+        newValuesMap[item.id] = values;
+      }
+      await Promise.all(promises);
     }
-
-    await Promise.all(promises);
 
     if (mountedRef.current) {
-      setValuesMap(newValuesMap);
+      // Mask all loaded values — plain text should never appear in frontend state
+      const maskedMap: Record<number, TenantConfigValues> = {};
+      for (const [id, vals] of Object.entries(newValuesMap)) {
+        const masked: TenantConfigValues = {};
+        for (const [k, v] of Object.entries(vals)) {
+          masked[k] = v ? MASKED_VALUE : '';
+        }
+        maskedMap[Number(id)] = masked;
+      }
+      setValuesMap(maskedMap);
     }
-  }, []);
+  }, [isEnterprise, user?.id]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -118,14 +172,22 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
         return;
       }
 
-      let response = await fetchWithAuth(CONFIG_ITEMS_API, token);
+      let configItemsUrl: string;
+      if (isEnterprise) {
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        configItemsUrl = `${serverUrl}/api/v1/config/items`;
+      } else {
+        configItemsUrl = `${SUDOWORK_SERVER_BASE_URL}/api/v1/config/items`;
+      }
+
+      let response = await fetchWithAuth(configItemsUrl, token);
 
       // Retry with refreshed token on 401
       if (response.status === 401) {
         const newToken = await forceRefreshToken();
         if (newToken) {
           token = newToken;
-          response = await fetchWithAuth(CONFIG_ITEMS_API, token);
+          response = await fetchWithAuth(configItemsUrl, token);
         }
       }
 
@@ -136,13 +198,17 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
       const data = await response.json();
 
       if (data.success && Array.isArray(data.data)) {
-        const items: TenantConfigItem[] = data.data;
-        const validItems = items.filter((item) => item.pinyin !== null);
-        if (mountedRef.current) {
-          setConfigItems(validItems);
+        let items: TenantConfigItem[] = data.data;
+        items = items.filter((item) => item.pinyin !== null);
+        // B端: filter to user scope only
+        if (isEnterprise) {
+          items = items.filter((item) => item.scope === 'user');
         }
-        await loadValuesFromNexus(validItems);
-        await loadEnabledStates(validItems.map((i) => i.id));
+        if (mountedRef.current) {
+          setConfigItems(items);
+        }
+        await loadValuesFromNexus(items, token);
+        await loadEnabledStates(items, token);
       } else {
         if (mountedRef.current) {
           setConfigItems([]);
@@ -151,14 +217,18 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
     } catch (err) {
       console.error('[TenantConfig] Failed to load config items:', err);
       if (mountedRef.current) {
-        setError(err instanceof Error ? err.message : '加载失败');
+        if (isEnterprise) {
+          setConfigItems([]);
+        } else {
+          setError(err instanceof Error ? err.message : '加载失败');
+        }
       }
     } finally {
       if (mountedRef.current) {
         setLoading(false);
       }
     }
-  }, [ensureValidToken, forceRefreshToken, loadValuesFromNexus, loadEnabledStates]);
+  }, [ensureValidToken, forceRefreshToken, loadValuesFromNexus, loadEnabledStates, isEnterprise]);
 
   // Initial load and refresh trigger
   useEffect(() => {
@@ -180,10 +250,33 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
     async (configItemId: number, enabled: boolean) => {
       const newMap = { ...enabledMap, [configItemId]: enabled };
       setEnabledMap(newMap);
+
+      if (isEnterprise && user?.id) {
+        // B端: traverse entries and call moss API per key
+        try {
+          const token = await ensureValidToken();
+          const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+          const mossClient = new MossSecretClient(serverUrl, token, user.id);
+          const item = configItems.find(i => i.id === configItemId);
+          if (item?.pinyin) {
+            const namespace = buildNamespace(item.pinyin, user.id);
+            for (const entry of item.entries) {
+              if (enabled) {
+                await mossClient.enableSecret(namespace, entry.config_key);
+              } else {
+                await mossClient.disableSecret(namespace, entry.config_key);
+              }
+            }
+          }
+        } catch (err) {
+          console.error('[TenantConfig] Failed to toggle moss secret enabled state:', err);
+        }
+        return;
+      }
+
+      // C端: save to ConfigStorage and notify Auth Proxy
       try {
         await ConfigStorage.set(TENANT_ENABLED_STORAGE_KEY, newMap);
-
-        // Notify Auth Proxy to refresh rules cache
         const token = await ensureValidToken();
         if (token) {
           const enabledIds = Object.entries(newMap).filter(([, v]) => v).map(([k]) => Number(k));
@@ -195,53 +288,79 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
         console.error('[TenantConfig] Failed to save enabled state:', err);
       }
     },
-    [enabledMap, ensureValidToken],
+    [enabledMap, ensureValidToken, isEnterprise, user?.id, configItems],
   );
 
   const saveItem = useCallback(
     async (configItemId: number, pinyin: string, entries: TenantConfigEntry[], values: TenantConfigValues, oldValues: TenantConfigValues): Promise<boolean> => {
       setSavingId(configItemId);
-      const namespace = buildNamespace(pinyin);
+      const userId = user?.id;
 
       try {
+        if (isEnterprise && userId) {
+          // B端: use MossSecretClient directly
+          const token = await ensureValidToken();
+          const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+          const mossClient = new MossSecretClient(serverUrl, token, userId);
+          const namespace = buildNamespace(pinyin, userId);
+
+          const results = await Promise.all(
+            entries.map(async (entry) => {
+              const currentValue = values[entry.config_key]?.trim() ?? '';
+              try {
+                if (!currentValue) {
+                  if (!oldValues[entry.config_key]?.trim()) return { success: true as const };
+                  await mossClient.deleteSecret(namespace, entry.config_key);
+                  return { success: true as const };
+                }
+                await mossClient.putSecret(namespace, entry.config_key, currentValue);
+                return { success: true as const };
+              } catch {
+                return { success: false as const };
+              }
+            }),
+          );
+          const allSuccess = results.every(r => r.success);
+          if (allSuccess) {
+            const masked: TenantConfigValues = {};
+            for (const entry of entries) {
+              masked[entry.config_key] = values[entry.config_key]?.trim() ? MASKED_VALUE : '';
+            }
+            setValuesMap(prev => ({ ...prev, [configItemId]: masked }));
+          }
+          return allSuccess;
+        }
+
+        // C端: use IPC with get/restore/put pattern
+        const namespace = buildNamespace(pinyin);
         const results = await Promise.all(
           entries.map(async (entry) => {
             const currentValue = values[entry.config_key]?.trim() ?? '';
             const hasOldValue = !!oldValues[entry.config_key]?.trim();
 
             if (!currentValue) {
-              // Value is empty: delete old value if exists, otherwise skip
               if (!hasOldValue) return { success: true as const };
               try {
                 await secret.delete.invoke({ namespace, key: entry.config_key });
                 return { success: true as const };
               } catch {
-                // Delete failure (key may not exist or already deleted) is not blocking
                 return { success: true as const };
               }
             }
 
-            // Value is not empty: check current state via get
             try {
               const getResult = await secret.get.invoke({ namespace, key: entry.config_key });
               if (!getResult.success) {
-                // get failed — key may not exist or is deleted, try restore (ignore failure)
                 try {
                   await secret.restore.invoke({ namespace, key: entry.config_key });
-                } catch {
-                  // Restore failure is not blocking
-                }
+                } catch {}
               }
             } catch {
-              // get invoke itself failed (e.g. IPC not available), try restore as fallback
               try {
                 await secret.restore.invoke({ namespace, key: entry.config_key });
-              } catch {
-                // Restore failure is not blocking
-              }
+              } catch {}
             }
 
-            // Put the new value
             try {
               const result = await secret.put.invoke({ namespace, key: entry.config_key, value: currentValue, description: entry.name });
               return { success: !!result.success };
@@ -250,8 +369,14 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
             }
           }),
         );
-
-        const allSuccess = results.every((r) => r.success);
+        const allSuccess = results.every(r => r.success);
+        if (allSuccess) {
+          const masked: TenantConfigValues = {};
+          for (const entry of entries) {
+            masked[entry.config_key] = values[entry.config_key]?.trim() ? MASKED_VALUE : '';
+          }
+          setValuesMap(prev => ({ ...prev, [configItemId]: masked }));
+        }
         return allSuccess;
       } catch (err) {
         console.error('[TenantConfig] Failed to save config item:', err);
@@ -262,7 +387,7 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
         }
       }
     },
-    [],
+    [isEnterprise, user?.id, ensureValidToken],
   );
 
   return {


### PR DESCRIPTION
## Summary
- Add `MossSecretClient` for E-side credentials management with full CRUD operations
- Integrate E-side secret storage path in `useTenantConfigItems` for B-side enterprise mode
- Remove masking logic from tenant config items (values now displayed in plain text)

## Changes
- `src/common/nexus/moss-secret-client.ts` - Core Moss API client
- `src/common/nexus/moss-secret-client-factory.ts` - Singleton factory
- `src/common/nexus/namespace.ts` - Namespace utilities
- `src/renderer/components/SettingsModal/contents/secrets/EnterpriseSecretSection.tsx` - New E-side section
- Updates to `useTenantConfigItems.ts`, `TenantConfigItemGroup.tsx`, and related files