### PR TITLE
feat: pass traceId (msg_id) through ACP _meta for request tracking

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -628,9 +628,7 @@ export class AcpConnection {
   private sendResponseMessage(response: AcpResponse): void {
     if (this.child) {
       try {
-        mainLog(
-          `[ACP-DIAG] sendResponseMessage id=${JSON.stringify((response as { id?: unknown }).id)} hasResult=${'result' in response} hasError=${'error' in response} preview=${JSON.stringify(response).slice(0, 400)}`,
-        );
+        mainLog(`[ACP-DIAG] sendResponseMessage id=${JSON.stringify((response as { id?: unknown }).id)} hasResult=${'result' in response} hasError=${'error' in response} preview=${JSON.stringify(response).slice(0, 400)}`);
       } catch {
         // ignore log errors
       }
@@ -967,7 +965,7 @@ export class AcpConnection {
     return defaultPath;
   }
 
-  async sendPrompt(prompt: string, images?: Array<{ type: 'image'; data: string; mimeType: string }>): Promise<AcpResponse> {
+  async sendPrompt(prompt: string, images?: Array<{ type: 'image'; data: string; mimeType: string }>, traceId?: string): Promise<AcpResponse> {
     if (!this.sessionId) {
       throw new Error('No active ACP session');
     }
@@ -983,11 +981,12 @@ export class AcpConnection {
       }
     }
 
-    console.log(`[ACP] sendPrompt: ${promptBlocks.length} block(s) [${promptBlocks.map((b) => (b.type === 'image' ? `image(${b.mimeType}, ${b.data?.length ?? 0} b64 chars)` : `text(${b.text?.length ?? 0} chars)`)).join(', ')}]`);
+    console.log(`[ACP] sendPrompt: ${promptBlocks.length} block(s) [${promptBlocks.map((b) => (b.type === 'image' ? `image(${b.mimeType}, ${b.data?.length ?? 0} b64 chars)` : `text(${b.text?.length ?? 0} chars)`)).join(', ')}]${traceId ? ` traceId=${traceId}` : ''}`);
 
     return await this.sendRequest('session/prompt', {
       sessionId: this.sessionId,
       prompt: promptBlocks,
+      _meta: traceId ? { traceId } : undefined,
     });
   }
 

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -1047,7 +1047,7 @@ This identity statement takes priority over the default identity in USER.md.
       // Breadcrumb: API request
       apiBreadcrumbs.request(`session/prompt`, 'POST', this.conversation_id);
 
-      await this.connection.sendPrompt(processedContent, images);
+      await this.connection.sendPrompt(processedContent, images, msg_id);
       if (ACP_PERF_LOG) mainLog('ACP-PERF', `send: sendPrompt completed ${Date.now() - promptStart}ms (total send: ${Date.now() - sendStart}ms)`);
 
       // Breadcrumb: API response success


### PR DESCRIPTION
## Summary
- Enable end-to-end request tracking by passing msg_id as traceId through ACP protocol's `_meta` extension field
- AcpConnection.sendPrompt now accepts traceId parameter and passes it via `_meta`
- AcpAgent passes msg_id to sendPrompt for each message

## Data Flow
```
SudoWork (msg_id) -> ACP session/prompt _meta.traceId -> scode -> X-Request-ID header -> SudoRouter
```

This enables reconciliation between SudoWork's message records and SudoRouter's consumption records using msg_id as the traceId.

## Test plan
- [ ] Verify msg_id is passed through ACP _meta field
- [ ] Verify scode receives traceId and sends X-Request-ID header
- [ ] Verify SudoRouter can use X-Request-ID for reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)