### PR TITLE
fix(authProxy): fix minimatch dynamic import crash in URL pattern matching

### DIFF
--- a/src/process/services/authProxy/index.ts
+++ b/src/process/services/authProxy/index.ts
@@ -40,9 +40,14 @@ export async function startAuthProxy(): Promise<number> {
 
   try {
     // Dynamic import minimatch to avoid bundling issues
-    const minimatchDefault = (await import('minimatch' as string) as unknown as { default: (str: string, pattern: string) => boolean }).default;
+    const minimatchModule = await import('minimatch' as string) as unknown as Record<string, unknown>;
+    const minimatchFn = (typeof minimatchModule.minimatch === 'function')
+      ? minimatchModule.minimatch
+      : typeof minimatchModule.default === 'function'
+        ? minimatchModule.default
+        : (minimatchModule as unknown as (str: string, pattern: string) => boolean);
 
-    server = new AuthProxyServer(minimatchDefault);
+    server = new AuthProxyServer(minimatchFn as (str: string, pattern: string) => boolean);
     serverPort = await server.start();
     return serverPort;
   } catch (error) {


### PR DESCRIPTION
## Summary
- 修复 `startAuthProxy` 中 `minimatch` 动态导入在某些环境下因导出格式不一致导致崩溃的问题
- 按优先级依次尝试 `minimatchModule.minimatch`、`minimatchModule.default`、模块本身作为函数

## Test plan
- [ ] 验证 auth proxy 正常启动
- [ ] 验证 URL pattern matching 功能正常
- [ ] 验证在不同打包环境下 minimatch 函数能正确获取

🤖 Generated with [Claude Code](https://claude.com/claude-code)