### PR TITLE
Disable QMS reporting outside personal mode

### DIFF
--- a/src/process/bridge/telemetryBridge.ts
+++ b/src/process/bridge/telemetryBridge.ts
@@ -12,12 +12,7 @@
 
 import { ipcBridge } from '../../common';
 import { ProcessConfig } from '../initStorage';
-import {
-  getTelemetryReporter,
-  getPerfTracker,
-  getConversationTracker,
-  flushTelemetry,
-} from '../telemetry';
+import { getTelemetryReporter, getPerfTracker, getConversationTracker, flushTelemetry, getUserContextSync } from '../telemetry';
 
 export function initTelemetryBridge(): void {
   // 获取遥测状态
@@ -31,7 +26,8 @@ export function initTelemetryBridge(): void {
   ipcBridge.telemetry.setEnabled.provider(async ({ enabled }) => {
     const reporter = getTelemetryReporter();
     await reporter.setEnabled(enabled);
-    await ProcessConfig.set('telemetry.enabled', enabled);
+    const isPersonal = getUserContextSync().login_mode === 'personal';
+    await ProcessConfig.set('telemetry.enabled', isPersonal ? enabled : false);
     return { success: true };
   });
 

--- a/src/process/telemetry/CrashReporter.ts
+++ b/src/process/telemetry/CrashReporter.ts
@@ -18,24 +18,12 @@
 import { app } from 'electron';
 import { ProcessConfig } from '../initStorage';
 import { buildVersion } from '../../common/buildInfo';
-import type {
-  CrashEvent,
-  NativeCrashEvent,
-  RendererCrashEvent,
-  JsExceptionEvent,
-  Breadcrumb,
-  CrashContext,
-  CrashBatchRequest,
-  CrashBatchResponse,
-  StoredCrashEvent,
-  CrashReporterConfig,
-  CrashProcessType,
-  CrashReason,
-} from '../../shared/types/crash';
+import type { NativeCrashEvent, RendererCrashEvent, JsExceptionEvent, Breadcrumb, CrashContext, CrashBatchRequest, CrashBatchResponse, StoredCrashEvent, CrashReporterConfig, CrashProcessType, CrashReason } from '../../shared/types/crash';
 import { DEFAULT_CRASH_REPORTER_CONFIG } from '../../shared/types/crash';
 import { mapElectronArch } from '../../shared/types/telemetry';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
 import { getTelemetryEncryptor, initTelemetryEncryptor } from './TelemetryEncryptor';
+import { getUserContextSync } from './UserContext';
 import { ENCRYPTION_CONFIG } from './keys';
 
 // ============================================================
@@ -53,6 +41,8 @@ const MAX_QUEUE_SIZE = 100;
 
 /** 存储事件最大年龄 (毫秒) - 超过此时间的事件将被丢弃 */
 const MAX_EVENT_AGE = 7 * 24 * 60 * 60 * 1000; // 7 天
+
+const isPersonalMode = (): boolean => getUserContextSync().login_mode === 'personal';
 
 // ============================================================
 // CrashReporter 类
@@ -102,6 +92,17 @@ export class CrashReporter {
   public async initialize(): Promise<void> {
     if (this.initialized) {
       mainWarn('CrashReporter', 'Already initialized, skipping');
+      return;
+    }
+
+    if (!isPersonalMode()) {
+      this.enabled = false;
+      this.initialized = true;
+      this.eventQueue = [];
+      this.cachedEvents = [];
+      this.breadcrumbs = [];
+      await this.clearCacheFile();
+      mainLog('CrashReporter', 'Crash reporting disabled outside personal mode');
       return;
     }
 
@@ -349,7 +350,7 @@ export class CrashReporter {
     data?: Record<string, unknown>,
     level?: 'debug' | 'info' | 'warning' | 'error',
   ): void {
-    if (!this.enabled) {
+    if (!isPersonalMode() || !this.enabled) {
       return;
     }
 
@@ -382,6 +383,14 @@ export class CrashReporter {
    * 用于应用退出前上报剩余事件
    */
   public async flushAll(): Promise<void> {
+    if (!isPersonalMode()) {
+      this.eventQueue = [];
+      this.cachedEvents = [];
+      this.breadcrumbs = [];
+      await this.clearCacheFile();
+      return;
+    }
+
     if (this.eventQueue.length === 0) {
       return;
     }
@@ -393,6 +402,17 @@ export class CrashReporter {
    * 更新启用状态
    */
   public async setEnabled(enabled: boolean): Promise<void> {
+    if (!isPersonalMode()) {
+      this.enabled = false;
+      this.stopFlushTimer();
+      this.eventQueue = [];
+      this.cachedEvents = [];
+      this.breadcrumbs = [];
+      await this.clearCacheFile();
+      mainLog('CrashReporter', 'Crash reporting remains disabled outside personal mode');
+      return;
+    }
+
     this.enabled = enabled;
 
     if (enabled && !this.flushTimer) {
@@ -446,6 +466,11 @@ export class CrashReporter {
    * 否则缓存事件，等待初始化后上报
    */
   private cacheOrAddEvent(event: StoredCrashEvent): void {
+    if (!isPersonalMode()) {
+      this.cachedEvents = [];
+      return;
+    }
+
     if (this.initialized && this.enabled) {
       // 已初始化，直接添加到队列
       this.addToQueue(event);
@@ -464,6 +489,11 @@ export class CrashReporter {
    * 在初始化后调用，将缓存的事件添加到队列
    */
   private flushCachedEvents(): void {
+    if (!isPersonalMode()) {
+      this.cachedEvents = [];
+      return;
+    }
+
     if (this.cachedEvents.length === 0) {
       return;
     }
@@ -516,6 +546,14 @@ export class CrashReporter {
 
   /** 执行批量上报 */
   private async flush(): Promise<void> {
+    if (!isPersonalMode()) {
+      this.eventQueue = [];
+      this.cachedEvents = [];
+      this.breadcrumbs = [];
+      await this.clearCacheFile();
+      return;
+    }
+
     if (this.isFlushing || this.eventQueue.length === 0) {
       return;
     }

--- a/src/process/telemetry/TelemetryBatchReporter.ts
+++ b/src/process/telemetry/TelemetryBatchReporter.ts
@@ -71,6 +71,8 @@ const MAX_QUEUE_SIZE = 500;
 /** 存储事件最大年龄 (毫秒) - 超过此时间的事件将被丢弃 */
 const MAX_EVENT_AGE = 7 * 24 * 60 * 60 * 1000; // 7 天
 
+const isPersonalMode = (): boolean => getUserContextSync().login_mode === 'personal';
+
 // ============================================================
 // TelemetryBatchReporter 类
 // ============================================================
@@ -111,6 +113,15 @@ export class TelemetryBatchReporter {
   public async initialize(): Promise<void> {
     if (this.initialized) {
       mainWarn('Telemetry', 'Already initialized, skipping');
+      return;
+    }
+
+    if (!isPersonalMode()) {
+      this.enabled = false;
+      this.initialized = true;
+      this.eventQueue = [];
+      await this.clearCacheFile();
+      mainLog('Telemetry', 'Telemetry disabled outside personal mode');
       return;
     }
 
@@ -165,7 +176,7 @@ export class TelemetryBatchReporter {
    * @param agentType - Agent 类型 (sudocode, claude 等)
    */
   public record<K extends TelemetryEventType>(type: K, data: TelemetryEventPayloadMap[K], agentType?: string): void {
-    if (!this.enabled || !this.initialized) {
+    if (!isPersonalMode() || !this.enabled || !this.initialized) {
       return;
     }
 
@@ -206,6 +217,12 @@ export class TelemetryBatchReporter {
    * 用于应用退出前上报剩余事件
    */
   public async flushAll(): Promise<void> {
+    if (!isPersonalMode()) {
+      this.eventQueue = [];
+      await this.clearCacheFile();
+      return;
+    }
+
     if (this.eventQueue.length === 0) {
       return;
     }
@@ -217,6 +234,16 @@ export class TelemetryBatchReporter {
    * 更新启用状态
    */
   public async setEnabled(enabled: boolean): Promise<void> {
+    if (!isPersonalMode()) {
+      this.enabled = false;
+      this.stopFlushTimer();
+      this.eventQueue = [];
+      await this.clearCacheFile();
+      await ProcessConfig.set('telemetry.enabled', false);
+      mainLog('Telemetry', 'Telemetry remains disabled outside personal mode');
+      return;
+    }
+
     this.enabled = enabled;
 
     if (enabled && !this.flushTimer) {
@@ -291,6 +318,12 @@ export class TelemetryBatchReporter {
 
   /** 执行批量上报 */
   private async flush(): Promise<void> {
+    if (!isPersonalMode()) {
+      this.eventQueue = [];
+      await this.clearCacheFile();
+      return;
+    }
+
     if (this.isFlushing || this.eventQueue.length === 0) {
       return;
     }

--- a/src/process/telemetry/UserContext.ts
+++ b/src/process/telemetry/UserContext.ts
@@ -111,15 +111,12 @@ export function getUserContext(): UserContext {
       user_nickname = consumerUserInfo?.nickname;
       user_phone = consumerUserInfo?.phone;
       tenant_id = consumerUserInfo?.tenant_id; // 个人模式下也可能有 tenant_id
-      mainLog(TAG, `[DEBUG] Personal mode - userInfo from ConfigStorage: ${JSON.stringify(consumerUserInfo)}`);
 
       // 个人模式下，org_id 应为空
       org_id = undefined;
     }
 
-    if (user_id) {
-      mainLog(TAG, `User context resolved: user_id=${user_id}, org_id=${org_id || 'N/A'}, tenant_id=${tenant_id || 'N/A'}, login_mode=${login_mode}, nickname=${user_nickname || 'N/A'}, phone=${user_phone || 'N/A'}`);
-    } else {
+    if (!user_id) {
       mainWarn(TAG, `User context not resolved: appMode=${appMode}, login_mode=${login_mode}`);
     }
 

--- a/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { ThemeSwitcher } from '@/renderer/components/ThemeSwitcher';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useSettingsViewMode } from '../settingsViewContext';
 
 /** Default prompt timeout in seconds */
@@ -122,6 +123,7 @@ const SystemModalContent: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
+  const { isEnterprise } = useAppMode();
   const initializingRef = useRef(true);
 
   // 关闭到托盘状态 / Close to tray state
@@ -173,6 +175,13 @@ const SystemModalContent: React.FC = () => {
 
   // 获取产品体验改进计划设置 / Fetch product improvement setting
   useEffect(() => {
+    if (isEnterprise) {
+      setProductImprovementEnabled(false);
+      setProductImprovementLoading(false);
+      setShowProductImprovementDialog(false);
+      return;
+    }
+
     ipcBridge.telemetry.getStatus
       .invoke()
       .then((res) => {
@@ -184,7 +193,7 @@ const SystemModalContent: React.FC = () => {
       .finally(() => {
         setProductImprovementLoading(false);
       });
-  }, []);
+  }, [isEnterprise]);
 
   // 处理产品体验改进计划开关变更 / Handle product improvement toggle change
   const handleProductImprovementChange = useCallback((checked: boolean) => {
@@ -284,16 +293,16 @@ const SystemModalContent: React.FC = () => {
       hint: t('settings.avatarEnabledDesc'),
       component: <Switch checked={avatarEnabled} onChange={handleAvatarEnabledChange} />,
     },
-    {
-      key: 'productImprovement',
-      label: t('settings.productImprovement.title'),
-      hint: t('settings.productImprovement.hint'),
-      component: productImprovementLoading ? (
-        <div style={{ width: 44, height: 22 }} />
-      ) : (
-        <Switch checked={productImprovementEnabled} onChange={handleProductImprovementChange} />
-      ),
-    },
+    ...(isEnterprise
+      ? []
+      : [
+          {
+            key: 'productImprovement',
+            label: t('settings.productImprovement.title'),
+            hint: t('settings.productImprovement.hint'),
+            component: productImprovementLoading ? <div style={{ width: 44, height: 22 }} /> : <Switch checked={productImprovementEnabled} onChange={handleProductImprovementChange} />,
+          },
+        ]),
     {
       key: 'promptTimeout',
       label: t('settings.promptTimeout'),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -29,6 +29,11 @@ const Main = () => {
 
   // Check if opt-in dialog should be shown when init is ready (only for new users)
   useEffect(() => {
+    if (isEnterprise) {
+      setShowOptInDialog(false);
+      return;
+    }
+
     if (initReady && !optInChecked) {
       ipcBridge.telemetry.getOptInShown
         .invoke()
@@ -44,7 +49,7 @@ const Main = () => {
           setOptInChecked(true);
         });
     }
-  }, [initReady, optInChecked]);
+  }, [initReady, isEnterprise, optInChecked]);
 
   // Handle opt-in dialog close
   const handleOptInClose = useCallback(async (confirmed: boolean) => {


### PR DESCRIPTION
## Summary
- Hide the product improvement program controls in enterprise mode.
- Restrict QMS telemetry and crash reporting to `login_mode=personal`.
- Remove noisy personal user-context telemetry logs.

## Test plan
- [x] Verified changed telemetry files have no TypeScript errors.
- [x] Ran `git diff --check`.
- [ ] Manually verify enterprise mode does not show the product improvement option or send QMS events.
- [ ] Manually verify personal mode still reports telemetry when enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)