### PR TITLE
feat(doctor): 诊断医生 bug 上报改造 — 飞书三级可降级通道

### DIFF
--- a/assistant/doctor/doctor.md
+++ b/assistant/doctor/doctor.md
@@ -56,4 +56,79 @@ python tests/e2e/run_op.py --port 9230 --op click --x <n> --y <n> --screenshot b
 
 ## Bug Filing
 
-When you find a bug, file it immediately as a GitHub issue — don't wait until the end. Use `python assistant/doctor/scripts/file_bug.py` (standalone, no browser needed). Run with `--help` for options.
+When a bug needs to be filed, FIRST decide which of two distinct targets it
+belongs to. These are different systems — never mix them up.
+
+### Step 1 — Route the bug to the correct target
+
+| 目标 | 含义 | 上报方式 |
+|---|---|---|
+| **SudoWork 产品自身的 Bug** | SudoWork 这个应用本身的缺陷（界面、功能、崩溃等） | 走 `file_bug.py`（见下方） |
+| **业务项目的 Bug** | 用户自己项目的缺陷，需要进禅道（ZenTao）等项目管理系统 | 走禅道流程 |
+
+Routing rules:
+
+- 用户明确说"给 SudoWork 上报 bug" / "SudoWork 有个 bug" / "这个应用有问题"
+  → **直接走 `file_bug.py`，不要询问禅道配置**。
+- 用户明确说"上报到禅道" / "报到禅道产品里"
+  → 走禅道流程。
+- 用户只说"我要上报一个 bug"，意图不明确
+  → **必须先反问一句**："请问这个 bug 是给 **SudoWork 产品本身**，还是要上报到 **禅道（ZenTao）项目**？"
+  根据回答再选择对应方式。**不要默认走禅道。**
+
+When you find a bug yourself during exploratory testing of SudoWork, it is by
+definition a SudoWork product bug — go straight to `file_bug.py`.
+
+### Step 2 — File a SudoWork product bug via file_bug.py
+
+Use the `file_bug.py` script. File it immediately — don't wait until the end
+of testing.
+
+**Locating the script — IMPORTANT**: do NOT guess the path and do NOT `find`
+for it. The runtime injects the script's absolute path into your context under
+a **`## Available Scripts`** section near the end of these instructions. Always
+copy the absolute path from there, e.g.:
+
+```bash
+python /absolute/path/to/doctor/scripts/file_bug.py --title "..." --body "..."
+```
+
+If, and only if, no `## Available Scripts` section is present, fall back to
+locating it once with `ls` in the assistant directory — never run a
+filesystem-wide `find`.
+
+**How reports are delivered** — the script routes through layered, degradable
+channels automatically; you do not pick the channel:
+
+1. **Feishu group bot** — primary channel; works in end-user environments
+2. **GitHub issue** — secondary; only when `gh` is available and GitHub is reachable
+3. **Local file** — last-resort fallback; the report is never lost
+
+**Write a structured report** — the report goes into a Feishu card, so a vague
+one-liner is not useful. Always produce a structured `--body` in markdown:
+
+```
+**复现步骤 / Repro steps**
+1. ...
+2. ...
+
+**期望 / Expected**: ...
+**实际 / Actual**: ...
+```
+
+Attach the screenshot you captured when the bug appeared via `--screenshot`.
+
+**Command** (replace the path with the absolute one from `## Available Scripts`):
+
+```bash
+python <ABSOLUTE_PATH>/file_bug.py \
+  --title "<concise bug title>" \
+  --body "<structured markdown body>" \
+  --screenshot <path/to/shot.png>
+```
+
+Run with `--dry-run` first to confirm the resolved config, or `--help` for
+all options (channel order, webhook / secret / repo overrides). The Feishu
+webhook and signing secret are supplied by the deployment via the
+`SUDOWORK_FEISHU_BUG_WEBHOOK` / `SUDOWORK_FEISHU_BUG_SECRET` environment
+variables — do not hardcode them.

--- a/assistant/doctor/scripts/file_bug.py
+++ b/assistant/doctor/scripts/file_bug.py
@@ -1,45 +1,215 @@
-"""File a bug: create GitHub issue + notify Feishu Engineering.
+"""File a bug report through a layered, degradable set of channels.
 
-This is a standalone CLI script. It does NOT use the browser — it runs
-shell commands (gh, npx) directly.
+This is a standalone CLI script. It does NOT use the browser — it talks to
+Feishu / GitHub directly and falls back to a local file when both are
+unreachable. Designed for both internal developers and external end users
+whose environment may not have `gh` installed or cannot reach GitHub.
+
+Channel order (each step runs only if the previous one failed / is disabled):
+
+    1. Feishu group-bot webhook   — primary channel (works for end users)
+    2. GitHub issue (`gh` CLI)    — secondary channel (internal / developers)
+    3. Local markdown file        — last-resort fallback (never lost)
 
 Usage:
     python assistant/doctor/scripts/file_bug.py --title "Bug title" --body "Description"
-    python assistant/doctor/scripts/file_bug.py --title "Test" --body "Test" --dry-run
+    python assistant/doctor/scripts/file_bug.py --title "T" --body "B" --dry-run
+    python assistant/doctor/scripts/file_bug.py --title "T" --body "B" \\
+        --channels feishu,github --screenshot shot.png
+
+Configuration (highest priority first):
+    Feishu webhook : --feishu-webhook  >  env SUDOWORK_FEISHU_BUG_WEBHOOK  >  default
+    Feishu secret  : --feishu-secret   >  env SUDOWORK_FEISHU_BUG_SECRET   >  embedded
+    GitHub repo    : --repo            >  env SUDOWORK_BUG_GITHUB_REPO     >  default
+
+The Feishu group bot uses signature verification, so a signing secret is
+required. The secret ships embedded in this file in obfuscated (not
+plaintext) form and is decoded at runtime; a deployment can still override
+it via --feishu-secret or the SUDOWORK_FEISHU_BUG_SECRET environment
+variable, both of which take precedence over the embedded value.
 """
 
 import argparse
+import base64
+import datetime
+import hashlib
+import hmac
 import json
 import os
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 
 
-def file_bug(title: str, body: str, screenshot: str = None,
-             repo: str = "sudoprivacy/sudowork",
-             feishu_chat: str = "oc_69746e233ba561ec748a6371e737501b",
-             label: str = "bug",
-             dry_run: bool = False) -> dict:
-    """Create a GitHub issue and notify Feishu Engineering channel.
+# ── Defaults (overridable via CLI flags or environment variables) ──────────
 
-    Args:
-        title: Issue title
-        body: Issue body (markdown)
-        screenshot: Optional screenshot path to reference in issue body
-        repo: GitHub repo (owner/name)
-        feishu_chat: Feishu chat ID for notifications
-        label: GitHub issue label
-        dry_run: If True, print commands without executing
+DEFAULT_FEISHU_WEBHOOK = (
+    "https://open.feishu.cn/open-apis/bot/v2/hook/"
+    "73c56d72-0b01-4625-8e7d-c8ea3ade152e"
+)
+DEFAULT_GITHUB_REPO = "sudoprivacy/sudowork"
+HTTP_TIMEOUT = 20  # seconds
 
-    Returns:
-        {"issue_url": str, "notified": bool} or {"error": str}
+# Obfuscated Feishu signing secret. The group bot has signature verification
+# ("签名校验") enabled, so a secret is required. To avoid shipping the secret
+# in plaintext (which a casual code scan / grep would expose), it is stored
+# here as a passphrase-derived stream cipher and decoded at runtime.
+#
+# NOTE: this is obfuscation, not cryptographic protection — the passphrase
+# travels with the code. It defends against plaintext exposure, not against a
+# deliberate reverse-engineer. A deployment that wants real protection should
+# override it via the SUDOWORK_FEISHU_BUG_SECRET environment variable, which
+# always takes precedence over this embedded value.
+_FEISHU_SECRET_CIPHER = "Kg4l5jljgvDuEoTeL8nmd7J+0xAojA=="
+_FEISHU_SECRET_PASSPHRASE = "sudosudo"
+
+
+def _stream_keystream(passphrase: str, length: int) -> bytes:
+    """Derive `length` bytes of key stream from a passphrase via SHA-256.
+
+    Standard-library only — no third-party crypto dependency, so the script
+    keeps running in minimal external user environments.
     """
-    # Build issue body
+    out = b""
+    counter = 0
+    while len(out) < length:
+        out += hashlib.sha256(f"{passphrase}:{counter}".encode("utf-8")).digest()
+        counter += 1
+    return out[:length]
+
+
+def _decode_embedded_secret() -> str:
+    """Decode the obfuscated embedded Feishu signing secret.
+
+    Returns the plaintext secret, or "" if decoding fails (in which case the
+    Feishu channel simply runs unsigned and Feishu will reject it — the
+    report then degrades to the next channel).
+    """
+    try:
+        cipher = base64.b64decode(_FEISHU_SECRET_CIPHER)
+        keystream = _stream_keystream(_FEISHU_SECRET_PASSPHRASE, len(cipher))
+        return bytes(a ^ b for a, b in zip(cipher, keystream)).decode("utf-8")
+    except Exception:  # noqa: BLE001 — never let secret decode break filing
+        return ""
+
+
+# ── Feishu webhook channel ─────────────────────────────────────────────────
+
+def _feishu_sign(timestamp: str, secret: str) -> str:
+    """Compute the Feishu custom-bot request signature.
+
+    Algorithm (per Feishu docs): the string `"{timestamp}\\n{secret}"` is used
+    as the HMAC-SHA256 *key* over an empty message, then base64-encoded.
+    """
+    string_to_sign = f"{timestamp}\n{secret}"
+    digest = hmac.new(
+        string_to_sign.encode("utf-8"), b"", digestmod=hashlib.sha256
+    ).digest()
+    return base64.b64encode(digest).decode("utf-8")
+
+
+def _build_feishu_card(title: str, body: str, screenshot: str = None) -> dict:
+    """Build a Feishu interactive card payload for a bug report.
+
+    The body is shown verbatim — the Doctor is expected to produce a
+    structured report (repro steps / expected / actual). Keeping it as one
+    lark_md block preserves whatever structure the Doctor wrote.
+    """
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    elements = [
+        {
+            "tag": "div",
+            "text": {"tag": "lark_md", "content": body or "*(no description)*"},
+        },
+    ]
+    if screenshot:
+        elements.append({
+            "tag": "div",
+            "text": {"tag": "lark_md", "content": f"**截图**: `{screenshot}`"},
+        })
+    elements.append({"tag": "hr"})
+    elements.append({
+        "tag": "note",
+        "elements": [
+            {"tag": "plain_text", "content": f"上报时间 {now}  ·  来源 Sudowork 诊断医生"},
+        ],
+    })
+
+    return {
+        "msg_type": "interactive",
+        "card": {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"tag": "plain_text", "content": "🩺 诊断医生 · 新 Bug"},
+                "subtitle": {"tag": "plain_text", "content": title},
+                "template": "red",
+            },
+            "elements": elements,
+        },
+    }
+
+
+def _notify_feishu_webhook(webhook_url: str, title: str, body: str,
+                           secret: str = "", screenshot: str = None) -> dict:
+    """POST a structured bug card to a Feishu group-bot webhook.
+
+    Returns {"ok": True} on success, {"ok": False, "error": str} otherwise.
+    Uses only the standard library so external environments need no extra deps.
+    """
+    if not webhook_url:
+        return {"ok": False, "error": "no feishu webhook configured"}
+
+    payload = _build_feishu_card(title, body, screenshot)
+
+    # Signed-request mode: only when the bot has signature verification on.
+    if secret:
+        timestamp = str(int(datetime.datetime.now().timestamp()))
+        payload["timestamp"] = timestamp
+        payload["sign"] = _feishu_sign(timestamp, secret)
+
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        webhook_url, data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as e:
+        return {"ok": False, "error": f"feishu request failed: {e}"}
+    except Exception as e:  # noqa: BLE001 — network layer can throw broadly
+        return {"ok": False, "error": f"feishu request error: {e}"}
+
+    # Feishu returns {"code":0,...} on success, non-zero code on rejection
+    # (e.g. bad signature, keyword filter miss).
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"ok": False, "error": f"feishu bad response: {raw[:200]}"}
+
+    code = result.get("code", result.get("StatusCode", -1))
+    if code == 0:
+        return {"ok": True}
+    return {"ok": False, "error": f"feishu rejected (code={code}): {result.get('msg', raw[:200])}"}
+
+
+# ── GitHub issue channel ───────────────────────────────────────────────────
+
+def _file_github_issue(repo: str, title: str, body: str,
+                        label: str = "bug", screenshot: str = None) -> dict:
+    """Create a GitHub issue via the `gh` CLI.
+
+    Returns {"ok": True, "issue_url": str} or {"ok": False, "error": str}.
+    Requires `gh` to be installed and authenticated, and network access to
+    GitHub — both common internally but unlikely on an end-user machine.
+    """
     full_body = body
     if screenshot:
         full_body += f"\n\n**Screenshot**: `{screenshot}`"
 
-    # 1. Create GitHub issue
     gh_cmd = [
         "gh", "issue", "create",
         "--repo", repo,
@@ -47,58 +217,154 @@ def file_bug(title: str, body: str, screenshot: str = None,
         "--body", full_body,
         "--label", label,
     ]
+    try:
+        result = subprocess.run(gh_cmd, capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        return {"ok": False, "error": "gh CLI not found"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "gh issue create timed out"}
+
+    if result.returncode != 0:
+        return {"ok": False, "error": f"gh issue create failed: {result.stderr.strip()}"}
+    return {"ok": True, "issue_url": result.stdout.strip()}
+
+
+# ── Local fallback channel ─────────────────────────────────────────────────
+
+def _default_report_dir() -> str:
+    """Resolve a writable directory for last-resort local bug reports."""
+    env_dir = os.environ.get("SUDOWORK_BUG_REPORT_DIR")
+    if env_dir:
+        return env_dir
+    return os.path.join(os.path.expanduser("~"), ".sudowork", "bug-reports")
+
+
+def _save_local_report(report_dir: str, title: str, body: str,
+                       screenshot: str = None) -> dict:
+    """Write the bug report to a timestamped markdown file.
+
+    Returns {"ok": True, "path": str} or {"ok": False, "error": str}.
+    """
+    try:
+        os.makedirs(report_dir, exist_ok=True)
+        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        safe = "".join(c if c.isalnum() or c in "-_ " else "_" for c in title)[:40].strip()
+        path = os.path.join(report_dir, f"bug-{stamp}-{safe or 'report'}.md")
+        lines = [
+            f"# {title}",
+            "",
+            f"> 上报时间: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            "> 来源: Sudowork 诊断医生",
+            "",
+            body or "*(no description)*",
+        ]
+        if screenshot:
+            lines += ["", f"**截图**: `{screenshot}`"]
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+        return {"ok": True, "path": path}
+    except OSError as e:
+        return {"ok": False, "error": f"local report write failed: {e}"}
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────
+
+def file_bug(title: str, body: str, screenshot: str = None,
+             channels: list = None,
+             feishu_webhook: str = None, feishu_secret: str = None,
+             repo: str = None, label: str = "bug",
+             local_fallback_dir: str = None,
+             dry_run: bool = False) -> dict:
+    """File a bug through layered, degradable channels.
+
+    Channels are tried in the order given by `channels` (default
+    ["feishu", "github"]). The first channel that succeeds wins. If every
+    requested channel fails, the report is always written to a local file
+    so it is never lost.
+
+    Returns a dict describing which channel handled the report:
+        {"channel": "feishu"|"github"|"local", "ok": bool, ...attempts}
+    """
+    channels = channels or ["feishu", "github"]
+    feishu_webhook = (feishu_webhook
+                      or os.environ.get("SUDOWORK_FEISHU_BUG_WEBHOOK")
+                      or DEFAULT_FEISHU_WEBHOOK)
+    feishu_secret = (feishu_secret
+                     or os.environ.get("SUDOWORK_FEISHU_BUG_SECRET")
+                     or _decode_embedded_secret())
+    repo = repo or os.environ.get("SUDOWORK_BUG_GITHUB_REPO") or DEFAULT_GITHUB_REPO
+    report_dir = local_fallback_dir or _default_report_dir()
 
     if dry_run:
-        return {"dry_run": True, "gh_cmd": " ".join(gh_cmd), "feishu_chat": feishu_chat}
+        return {
+            "dry_run": True,
+            "channels": channels,
+            "feishu_webhook": feishu_webhook,
+            "feishu_signed": bool(feishu_secret),
+            "github_repo": repo,
+            "local_fallback_dir": report_dir,
+        }
 
-    try:
-        result = subprocess.run(
-            gh_cmd, capture_output=True, text=True, timeout=30
-        )
-        if result.returncode != 0:
-            return {"error": f"gh issue create failed: {result.stderr.strip()}"}
-        issue_url = result.stdout.strip()
-    except FileNotFoundError:
-        return {"error": "gh CLI not found. Install: https://cli.github.com/"}
-    except subprocess.TimeoutExpired:
-        return {"error": "gh issue create timed out"}
+    attempts = []
 
-    # 2. Notify Feishu Engineering
-    notified = False
-    feishu_tool = os.path.expanduser("~/cursor-projects/feishu-automation/tools/message.ts")
-    if os.path.exists(feishu_tool):
-        feishu_msg = f"[Doctor] New bug filed: {title}\n{issue_url}"
-        feishu_cmd = f'echo "{feishu_msg}" | npx tsx "{feishu_tool}" send {feishu_chat}'
-        try:
-            feishu_result = subprocess.run(
-                feishu_cmd, shell=True, capture_output=True, text=True,
-                timeout=30, cwd=os.path.dirname(feishu_tool)
-            )
-            notified = feishu_result.returncode == 0
-        except Exception:
-            pass  # Notification failure is non-fatal
+    for channel in channels:
+        if channel == "feishu":
+            r = _notify_feishu_webhook(feishu_webhook, title, body,
+                                       secret=feishu_secret, screenshot=screenshot)
+            attempts.append({"channel": "feishu", **r})
+            if r.get("ok"):
+                return {"channel": "feishu", "ok": True, "attempts": attempts}
+        elif channel == "github":
+            r = _file_github_issue(repo, title, body, label=label,
+                                   screenshot=screenshot)
+            attempts.append({"channel": "github", **r})
+            if r.get("ok"):
+                return {"channel": "github", "ok": True,
+                        "issue_url": r.get("issue_url"), "attempts": attempts}
+        else:
+            attempts.append({"channel": channel, "ok": False,
+                             "error": f"unknown channel '{channel}'"})
 
-    return {"issue_url": issue_url, "notified": notified}
+    # Every requested channel failed — never drop the report.
+    local = _save_local_report(report_dir, title, body, screenshot=screenshot)
+    attempts.append({"channel": "local", **local})
+    return {
+        "channel": "local",
+        "ok": local.get("ok", False),
+        "local_path": local.get("path"),
+        "attempts": attempts,
+    }
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="File a bug as a GitHub issue")
-    parser.add_argument("--title", required=True, help="Issue title")
-    parser.add_argument("--body", required=True, help="Issue body (markdown)")
+    parser = argparse.ArgumentParser(
+        description="File a bug through Feishu / GitHub / local fallback channels"
+    )
+    parser.add_argument("--title", required=True, help="Bug title")
+    parser.add_argument("--body", required=True, help="Bug body (markdown)")
     parser.add_argument("--screenshot", help="Screenshot path to reference")
-    parser.add_argument("--repo", default="sudoprivacy/sudowork", help="GitHub repo")
-    parser.add_argument("--label", default="bug", help="Issue label")
-    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
+    parser.add_argument("--channels", default="feishu,github",
+                        help="Comma-separated channel order (default: feishu,github)")
+    parser.add_argument("--feishu-webhook", help="Feishu group-bot webhook URL")
+    parser.add_argument("--feishu-secret", help="Feishu signing secret (when 签名校验 is on)")
+    parser.add_argument("--repo", help="GitHub repo (owner/name)")
+    parser.add_argument("--label", default="bug", help="GitHub issue label")
+    parser.add_argument("--local-fallback-dir", help="Directory for local fallback reports")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print resolved config without sending")
 
     args = parser.parse_args()
     result = file_bug(
         title=args.title,
         body=args.body,
         screenshot=args.screenshot,
+        channels=[c.strip() for c in args.channels.split(",") if c.strip()],
+        feishu_webhook=args.feishu_webhook,
+        feishu_secret=args.feishu_secret,
         repo=args.repo,
         label=args.label,
+        local_fallback_dir=args.local_fallback_dir,
         dry_run=args.dry_run,
     )
-    print(json.dumps(result, indent=2))
-    if "error" in result:
-        sys.exit(1)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    sys.exit(0 if result.get("ok") or result.get("dry_run") else 1)

--- a/src/process/AssistantManager.ts
+++ b/src/process/AssistantManager.ts
@@ -265,6 +265,30 @@ export class AssistantManager {
   }
 
   /**
+   * Read an assistant's metadata together with its resolved on-disk directory.
+   *
+   * `getAssistantMeta` discards the directory `findAssistantDir` resolved, which
+   * forces downstream code (e.g. presetRuntime) to fall back to the relative
+   * `resourceDir` field in the meta JSON — that relative path is wrong once the
+   * assistant is installed under hub/custom/system. Callers that need to locate
+   * the assistant's `scripts/` or ops entry point on disk must use this method
+   * and resolve paths against `dir`.
+   */
+  async getAssistantMetaWithDir(name: string): Promise<{ meta: IAssistantMeta; dir: string; category: AssistantCategory } | null> {
+    const result = this.findAssistantDir(name);
+    if (!result) return null;
+
+    const metaResult = await this.readAssistantMetaFile(result.dir);
+    if (!metaResult) return null;
+
+    return {
+      meta: JSON.parse(metaResult.content) as IAssistantMeta,
+      dir: result.dir,
+      category: result.category,
+    };
+  }
+
+  /**
    * Merge partial updates into an assistant's metadata file.
    */
   async updateAssistantMeta(name: string, updates: Partial<IAssistantMeta>, category?: AssistantCategory): Promise<{ success: boolean; msg?: string }> {

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -48,22 +48,8 @@ import BaseAgent from './BaseAgent';
 import { startConversationTracking, endConversationSuccess, endConversationError, endConversationUserCancel } from '../telemetry';
 
 // Telemetry imports for turn/step tracking
-import {
-  startTurnTracking,
-  updateTurnTokens,
-  endTurnSuccess,
-  endTurnError,
-  getCurrentTurnId,
-} from '../telemetry';
-import {
-  startToolCallTracking,
-  endToolCallTracking,
-  startPermissionRequestTracking,
-  endPermissionRequestTracking,
-  recordFileOperationStep,
-  startThinkingTracking,
-  endThinkingTracking,
-} from '../telemetry';
+import { startTurnTracking, updateTurnTokens, endTurnSuccess, endTurnError, getCurrentTurnId } from '../telemetry';
+import { startToolCallTracking, endToolCallTracking, startPermissionRequestTracking, endPermissionRequestTracking, recordFileOperationStep, startThinkingTracking, endThinkingTracking } from '../telemetry';
 
 // CrashReporter imports for breadcrumb tracking
 import { conversationBreadcrumbs, apiBreadcrumbs, systemBreadcrumbs, mcpBreadcrumbs } from '../telemetry/BreadcrumbTracker';
@@ -360,8 +346,13 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
         cdpPort,
       });
       customEnv = { ...customEnv, ...presetResult.envOverrides };
-      if (presetResult.contextAppendix && this.options.presetContext) {
-        this.options.presetContext += presetResult.contextAppendix;
+      // Always fold the runtime context appendix (auto-discovered scripts /
+      // ops entry point) into presetContext — even when presetContext started
+      // empty. Gating this on a non-empty presetContext dropped the absolute
+      // script paths for assistants whose rule file produced no context,
+      // forcing the agent to `find` for its own scripts.
+      if (presetResult.contextAppendix) {
+        this.options.presetContext = (this.options.presetContext || '') + presetResult.contextAppendix;
       }
 
       // Store resolved config for connection
@@ -799,6 +790,32 @@ This identity statement takes priority over the default identity in USER.md.
 
           // Update presetContext with the fresh rules (for subsequent use)
           this.options.presetContext = loadedRules;
+
+          // Re-append the preset runtime context appendix (auto-discovered
+          // scripts/ absolute paths + ops entry point). This block reloads the
+          // rule file on every message and would otherwise overwrite the
+          // appendix that applyPresetRuntime injected at init — leaving the
+          // assistant unable to locate its own scripts and forcing a `find`.
+          try {
+            let cdpPort = 9230;
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-var-requires
+              cdpPort = require('@/utils/configureChromium').cdpPort || 9230;
+            } catch {
+              /* use default */
+            }
+            const reloadPresetResult = await applyPresetRuntime({
+              presetAssistantId: this.options.presetAssistantId,
+              backend: this.extra.backend,
+              workspace: this.extra.workspace,
+              cdpPort,
+            });
+            if (reloadPresetResult.contextAppendix) {
+              this.options.presetContext = (this.options.presetContext || '') + reloadPresetResult.contextAppendix;
+            }
+          } catch (appendixError) {
+            mainWarn('[AcpAgent]', 'Failed to re-append preset runtime appendix:', appendixError);
+          }
 
           // Also update agentName for placeholder display
           if (latestAgentName) {

--- a/src/process/task/presetRuntime.ts
+++ b/src/process/task/presetRuntime.ts
@@ -38,39 +38,84 @@ export interface PresetRuntimeResult {
 export async function applyPresetRuntime(ctx: PresetRuntimeContext): Promise<PresetRuntimeResult> {
   const result: PresetRuntimeResult = { envOverrides: {}, contextAppendix: '' };
 
-  if (!ctx.presetAssistantId) return result;
+  if (!ctx.presetAssistantId) {
+    mainLog('[PresetRuntime]', 'no presetAssistantId — skipping');
+    return result;
+  }
 
-  // Look up from AssistantManager (reads _sudowork_meta.json)
+  // Look up from AssistantManager (reads _sudowork_meta.json). Use the
+  // *WithDir variant so we get the assistant's real on-disk directory —
+  // the relative `resourceDir` in the meta JSON is wrong once the assistant
+  // is installed under hub/custom/system.
   const strippedId = ctx.presetAssistantId.startsWith('builtin-') ? ctx.presetAssistantId.slice('builtin-'.length) : ctx.presetAssistantId;
-  const meta = await assistantManager.getAssistantMeta(strippedId);
-  if (!meta) return result;
+  const found = await assistantManager.getAssistantMetaWithDir(strippedId);
+  if (!found) {
+    mainWarn('[PresetRuntime]', `getAssistantMetaWithDir("${strippedId}") returned null — scripts/ context will be missing`);
+    return result;
+  }
 
-  return applyPresetRuntimeFromMeta(meta, ctx);
+  const applied = applyPresetRuntimeFromMeta(found.meta, ctx, found.dir);
+  mainLog('[PresetRuntime]', `id=${strippedId} dir=${found.dir} contextAppendix=${applied.contextAppendix.length}B`);
+  return applied;
+}
+
+/**
+ * Resolve the assistant's `scripts/` directory.
+ *
+ * Prefers the real install directory (`installDir`) when known — that is
+ * always correct regardless of where the assistant was installed. Falls back
+ * to resolving the meta's relative `resourceDir` against CWD only when the
+ * install directory is unavailable (legacy callers).
+ */
+function resolveScriptsDir(installDir: string | undefined, resourceDir: string | undefined): string | null {
+  if (installDir) {
+    return path.join(installDir, 'scripts');
+  }
+  if (resourceDir) {
+    return path.resolve(resourceDir, 'scripts');
+  }
+  return null;
 }
 
 /**
  * Apply preset runtime from a pre-loaded IAssistantMeta.
- * Useful when the caller already has the meta (avoids redundant disk read).
+ *
+ * `installDir` is the assistant's resolved on-disk directory. When provided,
+ * the assistant's `scripts/` are located under it (correct for hub / custom /
+ * system installs). When omitted, paths fall back to the meta's relative
+ * `resourceDir`, which only works when CWD happens to be the repo root.
  */
-export function applyPresetRuntimeFromMeta(meta: IAssistantMeta, ctx: PresetRuntimeContext): PresetRuntimeResult {
+export function applyPresetRuntimeFromMeta(meta: IAssistantMeta, ctx: PresetRuntimeContext, installDir?: string): PresetRuntimeResult {
   const result: PresetRuntimeResult = { envOverrides: {}, contextAppendix: '' };
 
-  // 1. opsEntryPoint → AI_DEV_BROWSER_REDIRECT env var
+  // opsEntryPoint → AI_DEV_BROWSER_REDIRECT env var + context entry.
+  // Prefer resolving it inside the assistant's install dir; fall back to a
+  // CWD-relative resolve for entry points that live outside the assistant.
+  let absOpsPath: string | null = null;
   if (meta.opsEntryPoint) {
-    const absOpsPath = path.resolve(meta.opsEntryPoint).replace(/\\/g, '/');
+    const candidates: string[] = [];
+    if (installDir) {
+      candidates.push(path.join(installDir, meta.opsEntryPoint));
+    }
+    candidates.push(path.resolve(meta.opsEntryPoint));
+    absOpsPath = (candidates.find((p) => fs.existsSync(p)) ?? candidates[candidates.length - 1]).replace(/\\/g, '/');
+  }
+
+  if (absOpsPath) {
     result.envOverrides.AI_DEV_BROWSER_REDIRECT = `Direct tool access is disabled for this assistant. Use: python "${absOpsPath}" --port ${ctx.cdpPort} --op <tool_name> [args]`;
   }
 
-  // 2. resourceDir/scripts/ → auto-append to context, plus resolved ops path
-  if (meta.resourceDir) {
-    result.contextAppendix = discoverScripts(meta.resourceDir);
+  // scripts/ → auto-append an absolute-path listing to the context so the
+  // assistant never has to `find` for its own scripts.
+  const scriptsDir = resolveScriptsDir(installDir, meta.resourceDir);
+  if (scriptsDir) {
+    result.contextAppendix = discoverScripts(scriptsDir);
   }
-  if (meta.opsEntryPoint) {
-    const absOpsPath = path.resolve(meta.opsEntryPoint).replace(/\\/g, '/');
+  if (absOpsPath) {
     result.contextAppendix += `\n\n## Ops Entry Point\n\n\`\`\`\npython "${absOpsPath}" --port ${ctx.cdpPort} --op <name> [args]\n\`\`\`\n`;
   }
 
-  // 3. modelConfigs → .gemini/settings.json
+  // modelConfigs → .gemini/settings.json
   if (ctx.backend === 'gemini' && meta.modelConfigs && ctx.workspace) {
     writeGeminiConfig(meta.modelConfigs, ctx.workspace);
   }
@@ -78,10 +123,9 @@ export function applyPresetRuntimeFromMeta(meta: IAssistantMeta, ctx: PresetRunt
   return result;
 }
 
-/** Scan resourceDir/scripts/ and return markdown listing with absolute paths. */
-function discoverScripts(resourceDir: string): string {
+/** Scan a scripts directory and return a markdown listing with absolute paths. */
+function discoverScripts(scriptsDir: string): string {
   try {
-    const scriptsDir = path.resolve(resourceDir, 'scripts');
     const entries = fs.readdirSync(scriptsDir).filter((e) => e.endsWith('.py') || e.endsWith('.sh'));
     if (entries.length > 0) {
       const lines = entries.map((s) => `python ${path.join(scriptsDir, s)} --help`);


### PR DESCRIPTION
## 背景

诊断医生原先上报 bug 只能走 GitHub Issue（依赖 `gh` CLI + 能访问 GitHub），外部用户环境基本用不了；且模糊说"上报 bug"时会默认引导到禅道，体验混乱。

## 改动

### 1. 上报通道：飞书优先 + 三级可降级
`file_bug.py` 重写为：
- **飞书群机器人 Webhook**（主通道，外部用户可用，走签名校验）
- **GitHub Issue**（次通道，内部/开发者）
- **本地 markdown 文件**（兜底，报告永不丢失）

飞书签名密钥以混淆形式内嵌（口令 `sudosudo`，标准库 SHA-256 流加密，零第三方依赖），支持 `SUDOWORK_FEISHU_BUG_SECRET` 环境变量覆盖。

### 2. 上报目标分流
`doctor.md` 新增分流逻辑：
- "给 SudoWork 上报 bug" → 走 `file_bug.py`
- "上报到禅道" → 走禅道流程
- 意图不明 → 先反问"SudoWork 产品本身 还是 禅道"，不再默认走禅道

### 3. 修复 preset 脚本路径解析 bug
- `presetRuntime` 原先用 meta 里的相对 `resourceDir` 解析 `scripts/`，对 hub/custom 安装的助手是错的 → 改用助手真实安装目录
- 新增 `AssistantManager.getAssistantMetaWithDir`，带出真实目录

### 4. 修复 presetContext 被覆盖 bug
`AcpAgent` 每次发消息会重载 rule 文件并直接覆盖 `presetContext`，把 `applyPresetRuntime` 注入的脚本绝对路径冲掉 → 导致诊断医生只能 `find /` 全盘搜自身脚本。重载后重新追加 runtime appendix。

## 验证

- 命令行直接跑 `file_bug.py`：飞书签名校验通过（`code=0`），群收到结构化 bug 卡片
- 三级降级：飞书失败 → 本地落盘，实测正常
- 诊断医生对话：分流正确，脚本路径通过 `## Available Scripts` 注入上下文

## 测试计划

- [ ] 新建会话选诊断医生，"给 SudoWork 上报 bug" → 直接走 file_bug.py，无 find
- [ ] "上报到禅道" → 走禅道流程
- [ ] 模糊"上报 bug" → 先反问目标
- [ ] 飞书群收到 bug 卡片

🤖 Generated with [Claude Code](https://claude.com/claude-code)