### PR TITLE
fix: auto-reset MossSessionApi when enterprise server URL changes

### DIFF
--- a/src/process/bridge/mossBridge.ts
+++ b/src/process/bridge/mossBridge.ts
@@ -6,8 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import { isEnterpriseMode, getEnterpriseConfig } from '@/common/enterpriseDebugConfig';
-import { initMossApi, getMossApi } from '../remote/MossSessionApi';
-import type { MossSessionApi, type MossSession } from '../remote/MossSessionApi';
+import { initMossApi, getMossApi, getMossApiServerUrl, resetMossApi, type MossSessionApi, type MossSession } from '../remote/MossSessionApi';
 import { mainLog, mainError } from '@process/utils/mainLogger';
 import type { IResponseMessage } from '@/common/ipcBridge';
 import { uuid } from '@/common/utils';
@@ -22,26 +21,43 @@ import { uuid } from '@/common/utils';
 /**
  * Ensure Moss API is initialized with enterprise config
  * Returns the API instance or null if initialization fails
+ *
+ * If server URL has changed since last initialization, resets and re-initializes.
+ * 如果服务器 URL 自上次初始化后发生变化，重置并重新初始化。
  */
 async function ensureMossApiInitialized(): Promise<MossSessionApi | null> {
-  let api = getMossApi();
-  if (api) {
+  const config = getEnterpriseConfig();
+
+  // Check if server URL has changed since last initialization
+  // 检查服务器 URL 自上次初始化后是否发生变化
+  const currentServerUrl = getMossApiServerUrl();
+  const api = getMossApi();
+
+  if (api && currentServerUrl === config.mossServerUrl) {
+    // URL unchanged, return existing instance
+    // URL 未变化，返回现有实例
     return api;
   }
 
+  if (api && currentServerUrl !== config.mossServerUrl) {
+    // URL changed, reset existing instance
+    // URL 变化，重置现有实例
+    mainLog('MossBridge', `Server URL changed from ${currentServerUrl} to ${config.mossServerUrl}, resetting Moss API`);
+    resetMossApi();
+  }
+
   // Initialize from enterprise config
-  const config = getEnterpriseConfig();
   if (!config.mossServerUrl) {
     mainError('MossBridge', 'Moss Server URL not configured');
     return null;
   }
 
-  api = initMossApi(config.mossServerUrl);
+  const newApi = initMossApi(config.mossServerUrl);
   if (config.authToken) {
-    api.setAccessToken(config.authToken);
+    newApi.setAccessToken(config.authToken);
   }
 
-  return api;
+  return newApi;
 }
 
 export function initMossBridge(): void {

--- a/src/process/providers/index.ts
+++ b/src/process/providers/index.ts
@@ -10,21 +10,45 @@ import { RemoteConversationProvider } from './RemoteConversationProvider';
 import { isEnterpriseMode, getEnterpriseConfig, getCachedSessionMode } from '@/common/enterpriseDebugConfig';
 import { mainLog } from '@process/utils/mainLogger';
 import { ProcessConfig } from '@process/initStorage';
+import { resetMossApi } from '@process/remote/MossSessionApi';
 
 let currentProvider: IConversationProvider | null = null;
 let currentProviderType: 'local' | 'remote' | null = null;
+let currentServerUrl: string | null = null;
 
 export function getConversationProvider(sessionMode?: 'remote' | 'local'): IConversationProvider {
   const isEnterprise = isEnterpriseMode();
   // Determine effective target provider type based on sessionMode parameter or cache
   // 根据 sessionMode 参数或缓存确定有效的目标 Provider 类型
-  const effectiveMode = isEnterprise
-    ? (sessionMode ?? getCachedSessionMode())
-    : 'local'; // C端始终 local
+  const effectiveMode = isEnterprise ? (sessionMode ?? getCachedSessionMode()) : 'local'; // C端始终 local
   const targetType: 'local' | 'remote' = effectiveMode === 'remote' ? 'remote' : 'local';
 
   if (currentProvider && currentProviderType === targetType) {
-    return currentProvider;
+    // For remote provider, check if serverUrl has changed
+    // 对于 remote provider，检查 serverUrl 是否变化
+    if (targetType === 'remote') {
+      try {
+        const storedUrl = ProcessConfig.getSync('eeclaw.serverUrl');
+        if (storedUrl && storedUrl !== currentServerUrl) {
+          mainLog('Provider', `Server URL changed from ${currentServerUrl} to ${storedUrl}, resetting provider`);
+          resetConversationProvider();
+          // Continue to create new provider below
+          // 继续在下面创建新的 provider
+        } else {
+          // URL unchanged, return existing provider
+          // URL 未变化，返回现有 provider
+          return currentProvider;
+        }
+      } catch {
+        // On error, return existing provider
+        // 出错时返回现有 provider
+        return currentProvider;
+      }
+    } else {
+      // Local provider, return existing instance
+      // Local provider，返回现有实例
+      return currentProvider;
+    }
   }
 
   if (targetType === 'remote') {
@@ -42,7 +66,9 @@ export function getConversationProvider(sessionMode?: 'remote' | 'local'): IConv
       if (storedUrl) {
         serverUrl = storedUrl;
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
 
     mainLog('Provider', `Using REMOTE provider (Enterprise Mode) - Server: ${serverUrl || 'not set'}, Token: ${freshestToken ? 'set' : 'not set'}`);
 
@@ -61,12 +87,14 @@ export function getConversationProvider(sessionMode?: 'remote' | 'local'): IConv
       mossServerUrl: serverUrl,
     });
     currentProviderType = 'remote';
+    currentServerUrl = serverUrl;
     return currentProvider;
   }
 
   mainLog('Provider', 'Using LOCAL provider (Local Mode)');
   currentProvider = new LocalConversationProvider();
   currentProviderType = 'local';
+  currentServerUrl = null;
   return currentProvider;
 }
 
@@ -82,7 +110,11 @@ export function getConversationProvider(sessionMode?: 'remote' | 'local'): IConv
 export function resetConversationProvider(): void {
   currentProvider = null;
   currentProviderType = null;
-  mainLog('Provider', 'Provider reset - will create new instance on next call');
+  currentServerUrl = null;
+  // Also reset MossSessionApi singleton to ensure fresh initialization
+  // 同时重置 MossSessionApi 单例以确保重新初始化
+  resetMossApi();
+  mainLog('Provider', 'Provider and Moss API reset - will create new instance on next call');
 }
 
 /**

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -473,7 +473,7 @@ export class MossSessionApi {
    * GET /api/v1/users/{userId}/model
    */
   // 返回类型：用户偏好 + 系统默认模型
-// 保持返回类型声明不变，或者改成更完整的结构
+  // 保持返回类型声明不变，或者改成更完整的结构
   async getUserModelPreference(): Promise<{
     modelId: string;
     updatedAt: number;
@@ -1019,12 +1019,31 @@ export interface MossSession {
  * Global Moss API instance for enterprise mode
  */
 let mossApiInstance: MossSessionApi | null = null;
+let mossApiServerUrl: string | null = null;
 
 export function getMossApi(): MossSessionApi | null {
   return mossApiInstance;
 }
 
+/**
+ * Reset Moss API instance (call when server URL changes)
+ * 重置 Moss API 实例（当服务器 URL 变化时调用）
+ */
+export function resetMossApi(): void {
+  mossApiInstance = null;
+  mossApiServerUrl = null;
+}
+
 export function initMossApi(serverUrl: string): MossSessionApi {
   mossApiInstance = new MossSessionApi(serverUrl);
+  mossApiServerUrl = serverUrl;
   return mossApiInstance;
+}
+
+/**
+ * Get current Moss API server URL
+ * 获取当前 Moss API 服务器 URL
+ */
+export function getMossApiServerUrl(): string | null {
+  return mossApiServerUrl;
 }


### PR DESCRIPTION
## Summary

修复企业模式下修改远程服务器地址后，`MossSessionApi` 和 `RemoteConversationProvider` 单例缓存旧 URL 导致 API 请求发送到错误服务器的问题。

### Problem

当企业远程服务器地址被修改（例如从 `153` 改为 `159`）后：
- `MossSessionApi` 单例在初始化时缓存了旧的 URL (`153`)，后续 API 请求继续使用旧地址
- `eeclawBridge.getValidToken()` 直接从 `ProcessConfig` 读取最新值 (`159`)，token 刷新使用新地址
- 导致 API 请求和 token 刷新访问不同的服务器

### Solution

1. **MossSessionApi.ts**: 添加 `resetMossApi()` 和 `getMossApiServerUrl()` 函数，跟踪初始化时使用的 `serverUrl`
2. **mossBridge.ts**: 在 `ensureMossApiInitialized()` 中检查 URL 变化，变化时自动重置并重新初始化
3. **providers/index.ts**: 跟踪 `currentServerUrl`，在 `getConversationProvider()` 中检测变化并重置 Provider

## Test plan

- [ ] 在企业模式下登录，确认正常工作
- [ ] 修改 `eeclaw.serverUrl` 配置为新的服务器地址
- [ ] 触发 API 调用（如获取模型列表），确认请求发送到新地址
- [ ] 确认 token 刷新也使用相同的新地址

🤖 Generated with [Claude Code](https://claude.com/claude-code)