### PR TITLE
fix(conversation): filter hidden workspace files from mentions

### DIFF
--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -275,6 +275,7 @@ const skillFilePattern = (id: string, loc: string) => `${id}-skills.${loc}.md`;
 
 // 在文件顶部添加一个新的 Map 来跟踪每个目录的 AbortController
 const directoryAbortControllers = new Map<string, AbortController>();
+const FILE_SELECTOR_MAX_DEPTH = 10;
 
 export function initFsBridge(): void {
   const canceledZipRequests = new Set<string>();
@@ -299,7 +300,10 @@ export function initFsBridge(): void {
     directoryAbortControllers.set(dir, abortController);
 
     try {
-      const tree = await readDirectoryRecursive(dir, { abortController });
+      const tree = await readDirectoryRecursive(dir, {
+        abortController,
+        maxDepth: FILE_SELECTOR_MAX_DEPTH,
+      });
 
       // 请求完成后清理 abort controller
       directoryAbortControllers.delete(dir);

--- a/src/renderer/hooks/useWorkspaceFiles.ts
+++ b/src/renderer/hooks/useWorkspaceFiles.ts
@@ -11,6 +11,9 @@ import { DRAFTS_DIR_NAME } from '@/common/constants';
 import { useConversationContextSafe } from '@/renderer/context/ConversationContext';
 import { useAddEventListener } from '@/renderer/utils/emitter';
 
+const HIDDEN_PATH_PREFIXES = ['skills/', '.nexus/', '.scode/', '.claude/'];
+const HIDDEN_PATHS = new Set(['skills', '.nexus', '.scode', '.claude']);
+
 /**
  * Flattened workspace file item for @ mention selection
  */
@@ -32,6 +35,11 @@ export interface WorkspaceFileItem {
  */
 function flattenFileTree(nodes: IDirOrFile[], result: WorkspaceFileItem[] = []): WorkspaceFileItem[] {
   for (const node of nodes) {
+    const relativePath = node.relativePath.replace(/\\/g, '/');
+    if (HIDDEN_PATHS.has(relativePath) || HIDDEN_PATH_PREFIXES.some((prefix) => relativePath.startsWith(prefix))) {
+      continue;
+    }
+
     if (node.isFile) {
       result.push({
         name: node.name,


### PR DESCRIPTION
## Summary
- load nested workspace files for @ mention suggestions
- exclude hidden runtime and skill directories from @ file candidates

## Testing
- not run; targeted eslint is blocked by existing lint issues in touched files