### PR TITLE
fix(acp): 错误发生后正确重置前端处理状态

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -2282,7 +2282,7 @@ This identity statement takes priority over the default identity in USER.md.
     this.emitStatusMessage('disconnected');
 
     const errorMsg = `${this.extra.backend} process disconnected unexpectedly ` + `(code: ${error.code}, signal: ${error.signal}). ` + `Please try sending a new message to reconnect.`;
-    this.emitErrorMessage(errorMsg);
+    this.emitErrorMessage(errorMsg, false); // Skip finish, will send below
 
     // Telemetry: end turn tracking (error)
     endTurnError(this.conversation_id, 'E001');
@@ -2571,7 +2571,7 @@ This identity statement takes priority over the default identity in USER.md.
     });
   }
 
-  private emitErrorMessage(error: string): void {
+  private emitErrorMessage(error: string, withFinish: boolean = true): void {
     const errorMessage: TMessage = {
       id: uuid(),
       conversation_id: this.conversation_id,
@@ -2584,6 +2584,23 @@ This identity statement takes priority over the default identity in USER.md.
       },
     };
     this.emitMessage(errorMessage);
+
+    // Emit finish event to reset frontend processing state (unless skipped)
+    // Clear processingStartTime immediately on error (no delay)
+    // 发送 finish 事件以重置前端处理状态（除非跳过），错误时立即清除 processingStartTime（不延迟）
+    if (withFinish) {
+      // Immediately clear processingStartTime on error
+      // 错误时立即清除 processingStartTime
+      this.processingStartTime = undefined;
+
+      const finishMessage: IResponseMessage = {
+        type: 'finish',
+        conversation_id: this.conversation_id,
+        msg_id: uuid(),
+        data: null,
+      };
+      ipcBridge.acpConversation.responseStream.emit(finishMessage);
+    }
   }
 
   private emitModelInfoEvent(): void {


### PR DESCRIPTION
## Summary

- 修复了普通用户模式下会话报错后 UI 一直显示"处理中"的问题
- 在 `emitErrorMessage` 方法中发送 `finish` 事件重置前端状态
- 立即清除 `processingStartTime`，避免切换会话时误判为"处理中"

## 问题描述

普通用户模式下开启会话，会话过程中报错返回错误信息后，UI 一直显示"处理中"状态。

## 根因分析

`AcpAgent.emitErrorMessage()` 方法只发送错误消息（tips 类型），没有：
1. 发送 `finish` 事件重置前端 `aiProcessing` 状态
2. 清除 `processingStartTime`，导致切换会话时误判为"处理中"

## 修复方案

- 在 `emitErrorMessage` 中立即清除 `processingStartTime`（错误时不需要延迟）
- 发送 `finish` 事件重置前端状态
- `handleDisconnect` 使用 `withFinish: false` 避免重复发送

## Test plan

- [x] 触发错误后 UI 正确停止"处理中"状态
- [x] 错误后切换会话再切回来，不显示"处理中"
- [x] 正常会话处理中切换会话，计时器正确恢复