### PR TITLE
fix(agents): refresh agent list when assistants change

### DIFF
--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -6,7 +6,7 @@
 
 import { ipcBridge, skillHub, assistantHub } from '@/common';
 import { eeclaw } from '@/common/ipcBridge';
-import type { IInstalledSkillInfo, IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill, TProviderWithModel } from '@/common/ipcBridge';
+import type { IInstalledSkillInfo, IAssistantHubSkill, IAssistantHubDetail, ISkillHubSkill } from '@/common/ipcBridge';
 import { toBackendConfig, resolveAssistantName } from '@/renderer/shared/agents/assistantAdapter';
 import type { AssistantCategory } from '@/process/AssistantManager';
 import { resolveLocaleKey, uuid } from '@/common/utils';
@@ -1016,10 +1016,7 @@ const AgentModalContent: React.FC = () => {
   useEffect(() => {
     if (!isEnterprise || !isElectronDesktop()) return;
 
-    const handleSyncCompleted = (data: {
-      skills: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } };
-      assistants: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } };
-    }) => {
+    const handleSyncCompleted = (data: { skills: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } }; assistants: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } } }) => {
       // Merge hub and tenant results for display
       const mergedSkills = {
         installed: [...data.skills.hub.installed, ...data.skills.tenant.installed],
@@ -1056,7 +1053,8 @@ const AgentModalContent: React.FC = () => {
     syncTriggeredRef.current = true;
     setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
 
-    eeclaw.syncFromRemote.invoke()
+    eeclaw.syncFromRemote
+      .invoke()
       .then((res) => {
         if (!res.success) {
           // Sync failed, reset status (syncCompleted event won't be emitted)
@@ -1138,6 +1136,8 @@ const AgentModalContent: React.FC = () => {
       } else {
         await ipcBridge.acpConversation.refreshCustomAgents.invoke();
         await mutate('acp.agents.available');
+        await mutate('assistantHub.installed');
+        emitter.emit('assistants.changed');
       }
     } catch {
       // ignore
@@ -1316,13 +1316,7 @@ const AgentModalContent: React.FC = () => {
   }, []);
 
   // Open duplicate confirm modal for tenant assistant (enterprise mode)
-  const handleOpenDuplicateModalFromTenant = useCallback((assistant: {
-    id: string;
-    name: string;
-    displayName?: string;
-    description?: string;
-    enabledSkills?: string[];
-  }) => {
+  const handleOpenDuplicateModalFromTenant = useCallback((assistant: { id: string; name: string; displayName?: string; description?: string; enabledSkills?: string[] }) => {
     setDuplicateAssistant(null);
     setDuplicateInstalledAssistant(null);
     setDuplicateTenantAssistant(assistant);

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -1051,6 +1051,16 @@ This identity statement takes priority over the default identity in USER.md.
     void refreshCustomAgents();
   }, [refreshCustomAgents]);
 
+  useEffect(() => {
+    const handler = () => {
+      void refreshCustomAgents();
+    };
+    emitter.on('assistants.changed', handler);
+    return () => {
+      emitter.off('assistants.changed', handler);
+    };
+  }, [refreshCustomAgents]);
+
   // Defensive: re-scan available agents whenever the user clicks "New Chat"
   // so that newly installed agents (e.g. Claude Code) appear even if the
   // Guid page was never unmounted and the mount-only effect didn't re-run.

--- a/src/renderer/utils/emitter.ts
+++ b/src/renderer/utils/emitter.ts
@@ -43,6 +43,8 @@ interface EventTypes {
   'staroffice.install.finished': [{ conversationId: string }];
   // 技能列表变更事件 / Skills list changed event (install, uninstall, update, import, toggle)
   'skills.changed': void;
+  // Assistants list/meta changed event (create, update, delete, toggle)
+  'assistants.changed': void;
   // Guide 页面重置事件 / Guide page reset event (triggered by "New Conversation")
   'guid.reset': void;
   // Command palette events


### PR DESCRIPTION
## Summary
- Add `assistants.changed` event to the emitter for notifying when assistants are created, updated, or deleted
- Listen for this event in `useGuidAgentSelection` to refresh the custom agents list
- Mutate `assistantHub.installed` cache after assistant installation to ensure UI consistency

## Test plan
- [x] Install a new assistant and verify it appears in the agent selector without page refresh
- [x] Delete an assistant and verify it disappears from the agent selector
- [x] Update an assistant and verify the changes are reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)