### PR TITLE
feat(auth): OAuth2 enterprise login via browser deep link

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from 'path';
 
 /**
  * AionUI应用程序共用常量
@@ -215,8 +214,21 @@ export const COMMENT_SYNTAX_MAP: Record<string, string> = {
  * Get comment prefix for a file extension
  */
 export function getCommentPrefix(filePath: string): string {
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = fileExtname(filePath).toLowerCase();
   return COMMENT_SYNTAX_MAP[ext] || COMMENT_SYNTAX_MAP.default;
+}
+
+/**
+ * Browser-safe equivalent of node's path.extname: returns the extension
+ * including the leading dot (e.g. ".ts"), or "" when there is none. Avoids
+ * importing node:path so this shared module bundles cleanly in the renderer.
+ */
+function fileExtname(filePath: string): string {
+  const base = filePath.replace(/\\/g, '/').split('/').pop() ?? '';
+  const dot = base.lastIndexOf('.');
+  // No dot, or a leading dot (dotfile like ".gitignore") → no extension.
+  if (dot <= 0) return '';
+  return base.slice(dot);
 }
 
 // ===== AI Provider 相关常量 =====

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1816,8 +1816,13 @@ export const eeclaw = {
       model_service_url?: string;
       models?: string[];
     }>,
-    { serverUrl: string; body: { grant_type: string; username?: string; password?: string; api_key?: string }; deviceId: string }
+    { serverUrl: string; body: { grant_type: string; username?: string; password?: string; api_key?: string; params?: Record<string, string> }; deviceId: string }
   >('eeclaw.login'),
+  /** Check whether OAuth2 login is enabled on the MOSS server and get the ready-to-open authorize URL (runs in main process to avoid CORS) */
+  oauth2Config: bridge.buildProvider<
+    IBridgeResponse<{ enabled: boolean; authorize_url?: string }>,
+    { serverUrl: string }
+  >('eeclaw.oauth2-config'),
   /** Set app mode and update main process cache */
   setAppMode: bridge.buildProvider<void, { mode: 'c' | 'e' }>('eeclaw.set-app-mode'),
   /** Set session mode (remote/local) for enterprise mode and update main process cache */

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -183,7 +183,7 @@ export interface IConfigStorageRefer {
   // Enterprise user info / 企业用户信息
   'eeclaw.userInfo'?: { id: string; username: string; role?: string };
   // Enterprise auth token for main process (no user field, unlike localStorage eeclaw_auth_v1)
-  'eeclaw.authStorage'?: { access_token: string; refresh_token: string; expires_at: number; device_id: string };
+  'eeclaw.authStorage'?: { access_token: string; refresh_token: string; expires_at: number; device_id: string; session_type?: 'password' | 'api_key' | 'oauth2' };
   // Consumer (personal) mode user info for telemetry / 个人模式用户信息（用于遥测）
   'consumer.userInfo'?: { id: string; nickname?: string; phone?: string; tenant_id?: string };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,11 @@ if (process.env.ELECTRON_RUN_AS_NODE === '1' && process.platform === 'darwin' &&
 // ============ Deep Link Protocol ============
 // Register aionui:// protocol scheme for external app integration (e.g., New API token quick-add)
 const PROTOCOL_SCHEME = 'aionui';
+// Additional schemes the app also handles. `sudowork` is what the packaged
+// macOS/Windows build registers in its manifest (electron-builder.yml), so the
+// OAuth2 redirect (sudowork://oauth2-callback) routes to a packaged app.
+const PROTOCOL_SCHEMES = [PROTOCOL_SCHEME, 'sudowork'];
+const isDeepLinkArg = (arg: string): boolean => PROTOCOL_SCHEMES.some((s) => arg.startsWith(`${s}://`));
 
 /**
  * Parse an aionui:// URL into action and params.
@@ -86,7 +91,7 @@ const PROTOCOL_SCHEME = 'aionui';
 const parseDeepLinkUrl = (url: string): { action: string; params: Record<string, string> } | null => {
   try {
     const parsed = new URL(url);
-    if (parsed.protocol !== `${PROTOCOL_SCHEME}:`) return null;
+    if (!PROTOCOL_SCHEMES.some((s) => parsed.protocol === `${s}:`)) return null;
 
     // Build action from hostname + pathname, e.g. "provider/add" or "add-provider"
     const hostname = parsed.hostname || '';
@@ -119,7 +124,7 @@ const parseDeepLinkUrl = (url: string): { action: string; params: Record<string,
 };
 
 /** Pending deep-link URL received before the window was ready */
-let pendingDeepLinkUrl: string | null = process.argv.find((arg) => arg.startsWith(`${PROTOCOL_SCHEME}://`)) || null;
+let pendingDeepLinkUrl: string | null = process.argv.find(isDeepLinkArg) || null;
 
 /**
  * Send the deep-link payload to the renderer via IPC bridge.
@@ -144,7 +149,7 @@ const handleDeepLinkUrl = (url: string) => {
 // When a second instance starts (e.g. from protocol URL), it sends its data
 // to the first instance via second-instance event, then quits.
 const isE2ETestMode = process.env.NEXUS_E2E_TEST === '1';
-const deepLinkFromArgv = process.argv.find((arg) => arg.startsWith(`${PROTOCOL_SCHEME}://`));
+const deepLinkFromArgv = process.argv.find(isDeepLinkArg);
 const gotTheLock = isE2ETestMode ? true : app.requestSingleInstanceLock({ deepLinkUrl: deepLinkFromArgv });
 
 if (!gotTheLock) {
@@ -153,7 +158,7 @@ if (!gotTheLock) {
 } else {
   app.on('second-instance', (_event, argv, _workingDirectory, additionalData) => {
     // Prefer additionalData (reliable on all platforms), fallback to argv scan
-    const deepLinkUrl = (additionalData as { deepLinkUrl?: string })?.deepLinkUrl || argv.find((arg) => arg.startsWith(`${PROTOCOL_SCHEME}://`));
+    const deepLinkUrl = (additionalData as { deepLinkUrl?: string })?.deepLinkUrl || argv.find(isDeepLinkArg);
     if (deepLinkUrl) {
       handleDeepLinkUrl(deepLinkUrl);
     }
@@ -1064,12 +1069,15 @@ const handleAppReady = async (): Promise<void> => {
 };
 
 // ============ Protocol Registration ============
-// Register aionui:// as the default protocol client
-if (process.defaultApp) {
-  // Dev mode: need to pass execPath explicitly
-  app.setAsDefaultProtocolClient(PROTOCOL_SCHEME, process.execPath, [path.resolve(process.argv[1])]);
-} else {
-  app.setAsDefaultProtocolClient(PROTOCOL_SCHEME);
+// Register all supported schemes (aionui:// for legacy integrations, sudowork://
+// for the packaged-app manifest used by the OAuth2 redirect) as default clients.
+for (const scheme of PROTOCOL_SCHEMES) {
+  if (process.defaultApp) {
+    // Dev mode: need to pass execPath explicitly
+    app.setAsDefaultProtocolClient(scheme, process.execPath, [path.resolve(process.argv[1])]);
+  } else {
+    app.setAsDefaultProtocolClient(scheme);
+  }
 }
 
 // macOS: handle aionui:// URLs via the open-url event

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -21,6 +21,9 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
   }
 
   const { access_token, refresh_token, expires_at, device_id } = authStorage;
+  // OAuth2 sessions refresh via a distinct grant so MOSS routes them through the
+  // credential script; password/api_key sessions use the standard refresh grant.
+  const refreshGrantType = authStorage.session_type === 'oauth2' ? 'oauth2_refresh_token' : 'refresh_token';
 
   const now = Date.now();
   const remainingMs = expires_at - now;
@@ -43,6 +46,14 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
         throw new Error('No refresh token available');
       }
 
+      // OAuth2 sessions send the provider refresh_token inside a generic `params`
+      // dict (moss forwards it to the credential script); other sessions send the
+      // moss refresh_token at the top level as before.
+      const refreshBody =
+        refreshGrantType === 'oauth2_refresh_token'
+          ? { grant_type: refreshGrantType, params: { refresh_token } }
+          : { grant_type: refreshGrantType, refresh_token };
+
       mainLog('eeclawBridge', `[getValidToken] Sending refresh request to ${serverUrl}/api/v1/auth/token`);
       const response = await fetch(`${serverUrl}/api/v1/auth/token`, {
         method: 'POST',
@@ -50,10 +61,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
           'Content-Type': 'application/json',
           'X-Device-Id': device_id,
         },
-        body: JSON.stringify({
-          grant_type: 'refresh_token',
-          refresh_token,
-        }),
+        body: JSON.stringify(refreshBody),
         signal: AbortSignal.timeout(15000),
       });
 
@@ -68,16 +76,17 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
           const latestAuth = ProcessConfig.getSync('eeclaw.authStorage');
           if (latestAuth?.refresh_token && latestAuth.refresh_token !== refresh_token) {
             mainLog('eeclawBridge', `[getValidToken] Found different refresh_token in file, retrying with ${latestAuth.refresh_token.slice(0, 20)}...`);
+            const retryBody =
+              latestAuth.session_type === 'oauth2'
+                ? { grant_type: 'oauth2_refresh_token', params: { refresh_token: latestAuth.refresh_token } }
+                : { grant_type: 'refresh_token', refresh_token: latestAuth.refresh_token };
             const retryResponse = await fetch(`${serverUrl}/api/v1/auth/token`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
                 'X-Device-Id': latestAuth.device_id,
               },
-              body: JSON.stringify({
-                grant_type: 'refresh_token',
-                refresh_token: latestAuth.refresh_token,
-              }),
+              body: JSON.stringify(retryBody),
               signal: AbortSignal.timeout(15000),
             });
             const retryData = await retryResponse.json();
@@ -87,6 +96,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
                 refresh_token: retryData.refresh_token || latestAuth.refresh_token,
                 expires_at: Date.now() + (retryData.expires_in || 3600) * 1000,
                 device_id: latestAuth.device_id,
+                session_type: latestAuth.session_type,
               };
               mainLog('eeclawBridge', `[getValidToken] Retry refresh successful! new_expires_at=${newAuthStorage.expires_at}`);
               await ProcessConfig.set('eeclaw.authStorage', newAuthStorage);
@@ -116,6 +126,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
         refresh_token: data.refresh_token || refresh_token,
         expires_at: Date.now() + (data.expires_in || 3600) * 1000,
         device_id,
+        session_type: authStorage.session_type,
       };
 
       mainLog('eeclawBridge', `[getValidToken] Refresh successful! new_expires_at=${newAuthStorage.expires_at}, new_refresh_token=${newAuthStorage.refresh_token ? newAuthStorage.refresh_token.slice(0, 20) + '...' : 'NONE'}`);
@@ -199,6 +210,29 @@ export function initEeclawBridge(): void {
     }
   });
 
+  ipcBridge.eeclaw.oauth2Config.provider(async ({ serverUrl }) => {
+    try {
+      const response = await fetch(`${serverUrl}/api/v1/auth/oauth2/config`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!response.ok) {
+        return { success: false, error: 'server_error' as const, data: undefined };
+      }
+      const data = await response.json();
+      return {
+        success: true,
+        data: {
+          enabled: data?.enabled === true,
+          authorize_url: typeof data?.authorize_url === 'string' ? data.authorize_url : undefined,
+        },
+      };
+    } catch (error) {
+      mainWarn('eeclawBridge', 'oauth2Config error:', error);
+      return { success: false, error: 'network_error' as const, data: undefined };
+    }
+  });
+
   ipcBridge.eeclaw.login.provider(async ({ serverUrl, body, deviceId }) => {
     try {
       const response = await fetch(`${serverUrl}/api/v1/auth/login`, {
@@ -219,12 +253,15 @@ export function initEeclawBridge(): void {
 
       // Save server URL and auth storage to ProcessConfig
       // 将服务器 URL 和认证存储保存到 ProcessConfig
+      const sessionType: 'password' | 'api_key' | 'oauth2' =
+        body.grant_type === 'oauth2' ? 'oauth2' : body.grant_type === 'api_key' ? 'api_key' : 'password';
       await ProcessConfig.set('eeclaw.serverUrl', serverUrl);
       await ProcessConfig.set('eeclaw.authStorage', {
         access_token: data.access_token,
         refresh_token: data.refresh_token,
         expires_at: Date.now() + (data.expires_in || 3600) * 1000,
         device_id: deviceId,
+        session_type: sessionType,
       });
 
       // Update enterprise cache for synchronous access

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -45,6 +45,8 @@ interface EeclawAuthStorage {
   expires_at: number;
   user: AuthUser;
   device_id: string;
+  /** How this session was established; drives which grant_type is used on refresh. */
+  session_type?: 'password' | 'api_key' | 'oauth2';
 }
 
 interface LoginParams {
@@ -126,6 +128,7 @@ interface AuthContextValue {
   ensureValidToken: (forceRefresh?: boolean) => Promise<string | null>;
   forceRefreshToken: () => Promise<string | null>;
   enterpriseLogin: (params: EnterpriseLoginParams | EnterpriseLoginParamsByKey) => Promise<LoginResult>;
+  enterpriseLoginWithOAuth2: (params: Record<string, string>) => Promise<LoginResult>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -492,9 +495,17 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
           if (forceRefresh || (expires_at && Date.now() > expires_at - 5 * 60 * 1000)) {
             const refreshed = await refreshTokens();
-            if (!refreshed) return null;
-            const newStorage = JSON.parse(localStorage.getItem(EECLAW_AUTH_STORAGE_KEY) || '{}');
-            return newStorage.access_token || null;
+            if (refreshed) {
+              const newStorage = JSON.parse(localStorage.getItem(EECLAW_AUTH_STORAGE_KEY) || '{}');
+              return newStorage.access_token || null;
+            }
+            // Refresh failed (e.g. provider has no refresh API). Keep using the
+            // current access_token while it is still valid; only give up once it
+            // has actually expired, at which point re-login is required.
+            if (!forceRefresh && expires_at && Date.now() < expires_at) {
+              return access_token;
+            }
+            return null;
           }
 
           return access_token;
@@ -887,28 +898,14 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     }
   }, []);
 
-  // Enterprise login — independent from C-side login flow
-  const enterpriseLogin = useCallback(async (params: EnterpriseLoginParams | EnterpriseLoginParamsByKey): Promise<LoginResult> => {
-    try {
-      const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
-      if (!serverUrl) {
-        return { success: false, message: '未配置企业服务器地址' };
-      }
-
-      const deviceId = getDeviceId();
-      // Build MOSS-compatible request body with grant_type
-      const isApiKeyLogin = 'api_key' in params;
-      const requestBody = isApiKeyLogin
-        ? { grant_type: 'api_key', api_key: (params as EnterpriseLoginParamsByKey).api_key }
-        : { grant_type: 'password', username: (params as EnterpriseLoginParams).username, password: (params as EnterpriseLoginParams).password };
-
-      // Use IPC bridge to avoid CORS (main process has no CORS restrictions)
-      const result = await ipcBridge.eeclaw.login.invoke({
-        serverUrl,
-        body: requestBody,
-        deviceId,
-      });
-
+  // Shared post-login handling for all enterprise grant types (password / api_key / oauth2).
+  // Persists tokens, sets up scode/session mode, and updates auth state.
+  const finalizeEnterpriseLogin = useCallback(
+    async (
+      result: Awaited<ReturnType<typeof ipcBridge.eeclaw.login.invoke>>,
+      deviceId: string,
+      sessionType: 'password' | 'api_key' | 'oauth2',
+    ): Promise<LoginResult> => {
       if (!result.success || !result.data) {
         return {
           success: false,
@@ -934,6 +931,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         expires_at: Date.now() + (data.expires_in || 3600) * 1000,
         user: mappedUser,
         device_id: deviceId,
+        session_type: sessionType,
       };
       localStorage.setItem(EECLAW_AUTH_STORAGE_KEY, JSON.stringify(eeclawAuthStorage));
 
@@ -972,23 +970,20 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       }
 
       // Sync token to ConfigStorage for eeclawBridge
+      const configAuthStorage = {
+        access_token: data.access_token,
+        refresh_token: data.refresh_token || '',
+        expires_at: eeclawAuthStorage.expires_at,
+        device_id: deviceId,
+        session_type: sessionType,
+      };
       try {
-        await ConfigStorage.set('eeclaw.authStorage', {
-          access_token: data.access_token,
-          refresh_token: data.refresh_token || '',
-          expires_at: eeclawAuthStorage.expires_at,
-          device_id: deviceId,
-        });
+        await ConfigStorage.set('eeclaw.authStorage', configAuthStorage);
       } catch (e) {
         console.warn('[Auth] Failed to sync eeclaw auth to ConfigStorage (will retry):', e);
         // Retry once
         try {
-          await ConfigStorage.set('eeclaw.authStorage', {
-            access_token: data.access_token,
-            refresh_token: data.refresh_token || '',
-            expires_at: eeclawAuthStorage.expires_at,
-            device_id: deviceId,
-          });
+          await ConfigStorage.set('eeclaw.authStorage', configAuthStorage);
         } catch (e2) {
           console.error('[Auth] Failed to sync eeclaw auth to ConfigStorage after retry:', e2);
         }
@@ -1000,6 +995,33 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setReady(true);
 
       return { success: true };
+    },
+    [],
+  );
+
+  // Enterprise login — independent from C-side login flow
+  const enterpriseLogin = useCallback(async (params: EnterpriseLoginParams | EnterpriseLoginParamsByKey): Promise<LoginResult> => {
+    try {
+      const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+      if (!serverUrl) {
+        return { success: false, message: '未配置企业服务器地址' };
+      }
+
+      const deviceId = getDeviceId();
+      // Build MOSS-compatible request body with grant_type
+      const isApiKeyLogin = 'api_key' in params;
+      const requestBody = isApiKeyLogin
+        ? { grant_type: 'api_key', api_key: (params as EnterpriseLoginParamsByKey).api_key }
+        : { grant_type: 'password', username: (params as EnterpriseLoginParams).username, password: (params as EnterpriseLoginParams).password };
+
+      // Use IPC bridge to avoid CORS (main process has no CORS restrictions)
+      const result = await ipcBridge.eeclaw.login.invoke({
+        serverUrl,
+        body: requestBody,
+        deviceId,
+      });
+
+      return finalizeEnterpriseLogin(result, deviceId, isApiKeyLogin ? 'api_key' : 'password');
     } catch (error) {
       console.error('[Auth] Enterprise login failed:', error);
       return {
@@ -1008,7 +1030,38 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         code: 'networkError',
       };
     }
-  }, []);
+  }, [finalizeEnterpriseLogin]);
+
+  // Enterprise OAuth2 login — completes after the browser redirects back via the
+  // sudowork:// deep link. `params` is the opaque dict of deep-link query params
+  // (code / access_token / refresh_token / …); moss hands it to the credential script.
+  const enterpriseLoginWithOAuth2 = useCallback(
+    async (params: Record<string, string>): Promise<LoginResult> => {
+      try {
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        if (!serverUrl) {
+          return { success: false, message: '未配置企业服务器地址' };
+        }
+
+        const deviceId = getDeviceId();
+        const result = await ipcBridge.eeclaw.login.invoke({
+          serverUrl,
+          body: { grant_type: 'oauth2', params },
+          deviceId,
+        });
+
+        return finalizeEnterpriseLogin(result, deviceId, 'oauth2');
+      } catch (error) {
+        console.error('[Auth] Enterprise OAuth2 login failed:', error);
+        return {
+          success: false,
+          message: error instanceof Error ? error.message : '连接到企业服务器失败',
+          code: 'networkError',
+        };
+      }
+    },
+    [finalizeEnterpriseLogin],
+  );
 
   const logout = useCallback(async () => {
     // Enterprise mode logout
@@ -1142,8 +1195,9 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       ensureValidToken,
       forceRefreshToken,
       enterpriseLogin,
+      enterpriseLoginWithOAuth2,
     }),
-    [login, register, logout, ready, refresh, status, syncMessage, user, ensureValidToken, forceRefreshToken, enterpriseLogin]
+    [login, register, logout, ready, refresh, status, syncMessage, user, ensureValidToken, forceRefreshToken, enterpriseLogin, enterpriseLoginWithOAuth2]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -10,7 +10,15 @@ import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import WindowControls from '../../components/WindowControls';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { ConfigStorage } from '@/common/storage';
+import { ipcBridge } from '@/common';
 import './LoginPage.css';
+
+// Generate a random state token to bind the OAuth2 authorize request to its callback.
+function generateOAuth2State(): string {
+  const bytes = new Uint8Array(16);
+  (globalThis.crypto || window.crypto).getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
 
 // 运行时判断 / Runtime check
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
@@ -43,15 +51,21 @@ function getCachedTenantConfig(): Required<typeof DEFAULT_TENANT_CONFIG> {
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
-  const { status, login, register, enterpriseLogin, logout } = useAuth();
+  const { status, login, register, enterpriseLogin, enterpriseLoginWithOAuth2, logout } = useAuth();
   const { isEnterprise } = useAppMode();
 
   // Enterprise login state
-  const [loginTab, setLoginTab] = useState<'password' | 'key'>('password');
+  const [loginTab, setLoginTab] = useState<'password' | 'key' | 'oauth2'>('password');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [apiKey, setApiKey] = useState('');
   const [tenantName, setTenantName] = useState<string>('');
+
+  // OAuth2 login state
+  const [oauth2Config, setOauth2Config] = useState<{ enabled: boolean; authorize_url?: string } | null>(null);
+  const [oauth2Loading, setOauth2Loading] = useState(false);
+  const [oauth2Waiting, setOauth2Waiting] = useState(false);
+  const oauth2StateRef = React.useRef<string | null>(null);
 
   // 从 localStorage 读取缓存的租户配置
   const tenantConfig = getCachedTenantConfig();
@@ -62,6 +76,84 @@ const LoginPage: React.FC = () => {
       ConfigStorage.get('eeclaw.tenantName').then(setTenantName);
     }
   }, [isEnterprise]);
+
+  // OAuth2: fetch config from MOSS when the OAuth2 tab is selected
+  useEffect(() => {
+    if (!isEnterprise || loginTab !== 'oauth2' || oauth2Config) return;
+    let cancelled = false;
+    setOauth2Loading(true);
+    (async () => {
+      try {
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        if (!serverUrl) {
+          if (!cancelled) setOauth2Config({ enabled: false });
+          return;
+        }
+        const res = await ipcBridge.eeclaw.oauth2Config.invoke({ serverUrl });
+        if (cancelled) return;
+        setOauth2Config(res.success && res.data ? res.data : { enabled: false });
+      } finally {
+        if (!cancelled) setOauth2Loading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isEnterprise, loginTab, oauth2Config]);
+
+  // OAuth2: listen for the sudowork://oauth2-callback deep link and complete login.
+  // The provider redirects straight back to the desktop app (no server-side callback page).
+  // `sudowork` is the scheme the packaged app registers, so this routes in production.
+  useEffect(() => {
+    if (!isEnterprise) return;
+    return ipcBridge.deepLink.received.on((payload) => {
+      if (payload.action !== 'oauth2-callback') return;
+      const { state, ...rest } = payload.params || {};
+      if (!oauth2StateRef.current || state !== oauth2StateRef.current) {
+        setOauth2Waiting(false);
+        Message.error('授权回调验证失败,请重试');
+        return;
+      }
+      oauth2StateRef.current = null;
+      // Forward ALL non-state params to moss as an opaque dict — supports both
+      // standard (code) and non-standard (access_token/refresh_token) providers.
+      const params: Record<string, string> = {};
+      for (const [k, v] of Object.entries(rest)) {
+        if (typeof v === 'string' && v.length > 0) params[k] = v;
+      }
+      if (Object.keys(params).length === 0) {
+        setOauth2Waiting(false);
+        Message.error('OAuth2 登录失败');
+        return;
+      }
+      void (async () => {
+        const result = await enterpriseLoginWithOAuth2(params);
+        setOauth2Waiting(false);
+        if (result.success) {
+          setTimeout(() => navigate('/guid', { replace: true }), 300);
+        } else {
+          Message.error(result.message || 'OAuth2 登录失败');
+        }
+      })();
+    });
+  }, [isEnterprise, enterpriseLoginWithOAuth2, navigate]);
+
+  const handleOAuth2Login = async () => {
+    if (!oauth2Config?.enabled || !oauth2Config.authorize_url) return;
+    const state = generateOAuth2State();
+    oauth2StateRef.current = state;
+    // moss returns the authorize URL with {state} placeholder (or none); fill/append it.
+    const url = oauth2Config.authorize_url.includes('{state}')
+      ? oauth2Config.authorize_url.replace('{state}', encodeURIComponent(state))
+      : `${oauth2Config.authorize_url}${oauth2Config.authorize_url.includes('?') ? '&' : '?'}state=${encodeURIComponent(state)}`;
+    setOauth2Waiting(true);
+    try {
+      await ipcBridge.shell.openExternal.invoke(url);
+    } catch {
+      setOauth2Waiting(false);
+      Message.error('无法打开浏览器');
+    }
+  };
 
   const [mode, setMode] = useState<'login' | 'register'>('login');
   const [loginPhone, setLoginPhone] = useState('');
@@ -413,13 +505,16 @@ const LoginPage: React.FC = () => {
             <p className='text-13px text-t-secondary'>企业版登录</p>
           </div>
 
-          {/* Enterprise login tabs: password / key */}
+          {/* Enterprise login tabs: password / key / oauth2 */}
           <div className='login-tabs'>
             <button type='button' className={`login-tab ${loginTab === 'password' ? 'login-tab--active' : ''}`} onClick={() => setLoginTab('password')}>
               密码登录
             </button>
             <button type='button' className={`login-tab ${loginTab === 'key' ? 'login-tab--active' : ''}`} onClick={() => setLoginTab('key')}>
               密钥登录
+            </button>
+            <button type='button' className={`login-tab ${loginTab === 'oauth2' ? 'login-tab--active' : ''}`} onClick={() => setLoginTab('oauth2')}>
+              OAuth2 登录
             </button>
           </div>
 
@@ -435,16 +530,39 @@ const LoginPage: React.FC = () => {
                   <Input.Password size='large' prefix={<Lock className='text-t-tertiary' />} placeholder='请输入密码' value={password} onChange={setPassword} className='login-input !rd-12px h-48px' />
                 </div>
               </>
-            ) : (
+            ) : loginTab === 'key' ? (
               <div className='flex flex-col gap-8px'>
                 <div className='text-12px font-600 text-t-secondary ml-4px'>API Key</div>
                 <Input size='large' prefix={<Key className='text-t-tertiary' />} placeholder='moss_sk_xxx.yyy' value={apiKey} onChange={setApiKey} className='login-input !rd-12px h-48px' />
               </div>
+            ) : (
+              <div className='flex flex-col gap-8px text-center'>
+                {oauth2Loading ? (
+                  <div className='text-13px text-t-tertiary py-12px'>正在检查 OAuth2 配置…</div>
+                ) : oauth2Config?.enabled ? (
+                  <div className='text-13px text-t-secondary py-4px'>点击下方按钮，将在浏览器中完成身份认证。</div>
+                ) : (
+                  <div className='text-13px text-t-tertiary py-12px'>管理员未启用 OAuth2 登录</div>
+                )}
+              </div>
             )}
 
-            <Button type='primary' size='large' loading={loading} onClick={() => handleSubmit()} className='login-btn-primary !rd-12px h-52px mt-12px font-700 text-16px'>
-              登录
-            </Button>
+            {loginTab === 'oauth2' ? (
+              <Button
+                type='primary'
+                size='large'
+                loading={oauth2Waiting}
+                disabled={oauth2Loading || !oauth2Config?.enabled}
+                onClick={() => handleOAuth2Login()}
+                className='login-btn-primary !rd-12px h-52px mt-12px font-700 text-16px'
+              >
+                {oauth2Waiting ? '等待浏览器授权…' : '通过浏览器登录'}
+              </Button>
+            ) : (
+              <Button type='primary' size='large' loading={loading} onClick={() => handleSubmit()} className='login-btn-primary !rd-12px h-52px mt-12px font-700 text-16px'>
+                登录
+              </Button>
+            )}
 
             <div className='text-center mt-12px'>
               <span


### PR DESCRIPTION
## Summary
Adds a third enterprise login option (**OAuth2 登录**) alongside password/key. The client opens the provider's authorize URL in the browser; the provider redirects back to the `sudowork://oauth2-callback` deep link, and sudowork forwards the returned params (`code` / `access_token` / `refresh_token` / …) as an **opaque dictionary** to moss, which resolves identity via a server-side credential script. Supports both standard (code-exchange) and non-standard (direct-token, e.g. Ruigu) providers with no per-provider client code.

Pairs with the moss PR: sudoprivacy/moss `feat/oauth2-login`.

## Changes
- **Deep link** (`src/index.ts`): register the `sudowork://` scheme in addition to `aionui://` (the packaged app's manifest registers `sudowork`), and accept either scheme in the parser/registration/`open-url`/single-instance paths.
- **Login UI** (`renderer/pages/login/index.tsx`): OAuth2 tab; validate `state`; forward all non-`state` callback params as a dict.
- **Auth context** (`renderer/context/AuthContext.tsx`): `enterpriseLoginWithOAuth2(params)` → `grant_type=oauth2`; refresh uses `grant_type=oauth2_refresh_token` with the provider refresh_token (client-held, symmetric with other login types).
- **Refresh path** (`process/bridge/eeclawBridge.ts`): send oauth2 refresh as `{ grant_type, params:{ refresh_token } }`; `session_type` drives the grant.
- **Storage/IPC** (`common/storage.ts`, `common/ipcBridge.ts`): `session_type` field; login body allows a `params` dict.
- **Build fix** (`common/constants.ts`): replace node `path.extname` with a browser-safe helper so the shared module bundles in the renderer build (unrelated to OAuth2; folded in because it blocks the packaged build — see note below).

## Notes for reviewers
- Lockfile (`bun.lock`) changes from local dependency work are intentionally **excluded** to avoid pushing a full re-resolution onto everyone's dev env.
- The OAuth2 feature adds **no new runtime dependency** (uses existing libs + Node builtins).
- Packaged builds in this tree separately require some declared-but-uninstalled deps (`echarts-for-react`, etc.) — pre-existing, out of scope here.

## Test plan
- [ ] Enterprise mode → OAuth2 tab → 通过浏览器登录 → browser auth → deep link routes back to the (packaged) app → login completes.
- [ ] Password/key enterprise login unaffected.
- [ ] OAuth2 refresh: provider with no refresh API → session ends and re-login is prompted at token expiry.
- [ ] Existing `aionui://` deep-link flows (add-provider) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)