### PR TITLE
feat(acp): 实现上下文超限恢复方案

### DIFF
--- a/docs/plans/2026-05-25-context-overflow-recovery-design.md
+++ b/docs/plans/2026-05-25-context-overflow-recovery-design.md
@@ -1,0 +1,304 @@
+# 上下文超限恢复方案
+
+## 背景
+
+当前项目在 ACP 对话中会持久化并复用底层模型 session，例如 `extra.acpSessionId`。当该 session 的历史上下文超过模型处理限制后，后续消息仍然继续发送到同一个已超限 session，因此用户无论再输入什么，都会反复收到“对话内容过长，超出模型处理限制”。
+
+相关位置：
+
+- `src/process/task/AcpAgent.ts`：ACP session 恢复与 prompt 发送错误处理
+- `src/process/bridge/conversationBridge.ts`：通用发送入口
+- `src/process/task/acp/AcpPersistence.ts`：context usage 持久化
+- `src/process/utils/llmErrorTranslation.ts`：LLM 错误翻译
+
+## 目标
+
+1. 超限后不再重复向旧 `acpSessionId` 发送消息。
+2. 在对话中给用户明确的恢复按钮。
+3. 用户无需手动总结，点击“压缩并继续”即可恢复。
+4. 保留 UI 聊天记录，但底层模型 session 可以重建。
+5. 支持接近上限时提前预警。
+
+## 非目标
+
+1. 不删除用户历史聊天记录。
+2. 不要求用户手动复制、总结、粘贴上下文。
+3. 不尝试在已经超限的旧 session 内完成摘要。
+
+## 用户流程
+
+正常对话时，系统持续监听 `acp_context_usage`。
+
+当接近上限时，在对话中插入系统动作卡片：
+
+```text
+当前对话上下文接近模型上限，继续发送可能失败。
+
+[压缩后继续] [新会话继续] [继续当前会话]
+```
+
+此时不阻断发送。
+
+当模型已经返回 context overflow 错误时，插入阻断卡片：
+
+```text
+当前模型会话已超过上下文限制，无法继续向原会话发送消息。
+
+你可以压缩历史后继续，或开启一个空白模型上下文继续。
+
+[压缩并继续] [开启空白新会话]
+```
+
+此时禁用普通发送，只允许用户执行恢复动作。
+
+## 超限判断
+
+超限判断分三层：
+
+1. 服务端错误，作为最终判定。
+2. `acp_context_usage`，用于提前预警。
+3. 发送前估算，用于防止明显会失败的请求继续发送。
+
+服务端错误命中以下模式时，直接判定为已超限：
+
+```text
+context_length_exceeded
+maximum context length
+context length
+token limit
+prompt is too long
+input is too long
+too many tokens
+exceeds the context
+超出模型处理限制
+```
+
+`acp_context_usage` 判断规则：
+
+```ts
+used / size >= 0.85 -> near_limit
+used / size >= 0.95 -> critical
+```
+
+发送前估算：
+
+```ts
+projectedUsed = used + estimatedNextInputTokens + reservedOutputTokens;
+```
+
+如果 `projectedUsed >= size`，可以发送前阻断并提示恢复。
+
+如果 `size = 0`，使用模型名查询 context window 兜底，例如现有的 `getModelContextLimit`。
+
+## 状态模型
+
+在 `TChatConversation.extra` 增加：
+
+```ts
+contextRecovery?: {
+  status: 'normal' | 'near_limit' | 'critical' | 'overflowed' | 'compressing' | 'compressed' | 'failed';
+  failedSessionId?: string;
+  recoveredSessionId?: string;
+  failedAt?: number;
+  recoveredAt?: number;
+  summaryMessageId?: string;
+  lastFailedMsgId?: string;
+  error?: string;
+}
+```
+
+状态含义：
+
+- `normal`：正常发送。
+- `near_limit`：接近上限，只提示。
+- `critical`：强提示压缩。
+- `overflowed`：已超限，阻断普通发送。
+- `compressing`：正在压缩，禁用输入。
+- `compressed`：已压缩并切换到新 session。
+- `failed`：恢复失败，可允许用户选择空白新会话。
+
+## 后端设计
+
+新增错误判断工具，例如 `src/process/utils/contextOverflow.ts`：
+
+```ts
+export function isContextOverflowError(message: string): boolean {
+  const text = message.toLowerCase();
+  return [
+    'context_length_exceeded',
+    'maximum context length',
+    'context length',
+    'token limit',
+    'prompt is too long',
+    'input is too long',
+    'too many tokens',
+    'exceeds the context',
+    '超出模型处理限制',
+  ].some((pattern) => text.includes(pattern));
+}
+```
+
+在 `AcpAgent.sendToConnection` 的错误处理中识别：
+
+```ts
+if (isContextOverflowError(errorMsg)) {
+  await this.markContextOverflow(data.msg_id, errorMsg);
+  this.emitContextRecoveryCard('overflowed');
+  return {
+    success: false,
+    error: createAcpError(AcpErrorType.UNKNOWN, errorMsg, false),
+  };
+}
+```
+
+关键点：这里不能只翻译错误，必须持久化 `contextRecovery.status = 'overflowed'`。
+
+## 发送阻断
+
+在 `conversationBridge.sendMessage` 或 `AcpAgent.sendMessage` 开头检查：
+
+```ts
+if (conversation.extra?.contextRecovery?.status === 'overflowed') {
+  return {
+    success: false,
+    msg: 'context_overflow_requires_recovery',
+  };
+}
+```
+
+这样可以避免继续打到同一个已失败 session。
+
+## 恢复 IPC
+
+新增接口：
+
+```ts
+conversation.recoverContext({
+  conversation_id: string;
+  strategy: 'compress' | 'fresh';
+});
+```
+
+### fresh 流程
+
+1. 查询 conversation。
+2. 清空 `extra.acpSessionId`。
+3. 清空或重置 `contextRecovery`。
+4. `WorkerManage.kill(conversation_id)`。
+5. 下一次发送重新创建底层 session。
+
+### compress 流程
+
+1. 设置 `status = 'compressing'`。
+2. 从数据库读取当前 conversation messages。
+3. 生成结构化摘要。
+4. 保存一条“上下文已压缩”的系统消息。
+5. 清空旧 `extra.acpSessionId`。
+6. `WorkerManage.kill(conversation_id)`。
+7. 重建 task，创建新 ACP session。
+8. 将摘要作为新 session 的首条上下文注入。
+9. 设置 `status = 'compressed'`，保存新 session id。
+
+## 摘要生成策略
+
+不能让已超限的旧 session 总结自己。摘要应基于本地数据库消息生成。
+
+摘要格式建议：
+
+```md
+# 压缩后的上下文摘要
+
+## 用户目标
+...
+
+## 已完成事项
+...
+
+## 关键决策
+...
+
+## 当前状态
+...
+
+## 涉及文件
+...
+
+## 最近对话
+...
+
+## 下一步
+...
+```
+
+注入新 session 的首条 prompt：
+
+```md
+以下是此前对话的压缩摘要。请把它作为当前会话上下文继续工作，不要要求用户重复说明。
+
+<compressed_context>
+...
+</compressed_context>
+```
+
+优先实现本地规则摘要兜底：
+
+- 保留最近 8-12 轮原文。
+- 长工具输出只保留摘要和结果。
+- 保留文件路径、命令、错误、关键决策。
+- 超长文本截断。
+
+后续再接入模型分块摘要，提高质量。
+
+## 前端设计
+
+新增消息类型，例如：
+
+```ts
+type: 'context_recovery'
+data: {
+  reason: 'near_limit' | 'critical' | 'overflowed';
+  used?: number;
+  size?: number;
+  actions: Array<{
+    id: 'compress' | 'fresh' | 'dismiss';
+    label: string;
+  }>;
+}
+```
+
+Renderer 渲染为系统动作卡片。按钮由应用生成，不由模型生成。
+
+按钮行为：
+
+- `压缩并继续`：调用 `conversation.recoverContext({ strategy: 'compress' })`
+- `开启空白新会话`：调用 `conversation.recoverContext({ strategy: 'fresh' })`
+- `继续当前会话`：仅隐藏 near limit 提示，不改变 session
+
+发送框状态：
+
+- `near_limit`：不禁用。
+- `critical`：不禁用，但强提示。
+- `overflowed`：禁用普通发送。
+- `compressing`：禁用发送，显示处理中。
+- `compressed`：恢复发送。
+
+## 落地顺序
+
+1. 增加 `isContextOverflowError`。
+2. 在 ACP 错误处理里标记 `overflowed`。
+3. 超限后阻断普通发送，避免重复失败。
+4. 增加 `context_recovery` UI 卡片和按钮。
+5. 实现 `fresh` 恢复，先解决核心问题。
+6. 实现本地规则摘要的 `compress` 恢复。
+7. 基于 `acp_context_usage` 增加 85%/95% 预警。
+8. 后续接入模型分块摘要。
+
+## 测试要点
+
+1. 模拟 context overflow 错误后，conversation 被标记为 `overflowed`。
+2. `overflowed` 状态下再次发送不会调用旧 session。
+3. 点击 `开启空白新会话` 后，`acpSessionId` 被清空，下一次发送创建新 session。
+4. 点击 `压缩并继续` 后，新 session 收到摘要上下文。
+5. UI 历史不丢失。
+6. 页面刷新后仍能显示恢复状态。
+7. `near_limit` 只提示，不阻断发送。

--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -660,10 +660,10 @@ export class AcpConnection {
         this.handleIncomingRequest(message as AcpIncomingMessage).catch((_error) => {
           // Handle request errors silently
         });
-      } else if ('id' in message && typeof message.id === 'number' && this.pendingRequests.has(message.id)) {
+      } else if ('id' in message && this.pendingRequests.has(message.id as number)) {
         // This is a response to a previous request
-        const { resolve, reject } = this.pendingRequests.get(message.id)!;
-        this.pendingRequests.delete(message.id);
+        const { resolve, reject } = this.pendingRequests.get(message.id as number)!;
+        this.pendingRequests.delete(message.id as number);
 
         if ('result' in message) {
           // Check for end_turn message and extract usage data
@@ -682,7 +682,10 @@ export class AcpConnection {
           }
           resolve(message.result);
         } else if ('error' in message) {
-          const errorMsg = message.error?.message || 'Unknown ACP error';
+          // Error message may be in message.error.message or message.error.data
+          const errorData = message.error;
+          const errorMsg = errorData?.data ? (typeof errorData.data === 'string' ? errorData.data : JSON.stringify(errorData.data)) : errorData?.message || 'Unknown ACP error';
+          console.log(`[ACP] Error response for request ${message.id}: ${errorMsg}`);
           reject(new Error(errorMsg));
         }
       } else {

--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CodexPermissionRequest } from '@/common/codex/types';
+import type { ContextRecoveryMessageData } from '@/common/contextRecovery';
 import type { ExecCommandBeginData, ExecCommandEndData, ExecCommandOutputDeltaData, McpToolCallBeginData, McpToolCallEndData, PatchApplyBeginData, PatchApplyEndData, TurnDiffData, WebSearchBeginData, WebSearchEndData } from '@/common/codex/types/eventData';
 import type { AcpBackend, AcpPermissionRequest, PlanUpdate, ToolCallUpdate } from '@/types/acpTypes';
 import type { IResponseMessage } from './ipcBridge';
@@ -54,7 +55,7 @@ export const joinPath = (basePath: string, relativePath: string): string => {
  * @description 跟对话相关的消息类型申明 及相关处理
  */
 
-type TMessageType = 'text' | 'tips' | 'tool_call' | 'tool_group' | 'agent_status' | 'acp_permission' | 'acp_question' | 'acp_tool_call' | 'codex_permission' | 'codex_tool_call' | 'plan' | 'available_commands' | 'file_send';
+type TMessageType = 'text' | 'tips' | 'tool_call' | 'tool_group' | 'agent_status' | 'acp_permission' | 'acp_question' | 'acp_tool_call' | 'codex_permission' | 'codex_tool_call' | 'plan' | 'available_commands' | 'file_send' | 'context_recovery';
 
 interface IMessage<T extends TMessageType, Content extends Record<string, any>> {
   /**
@@ -362,8 +363,10 @@ export interface IFileSendData {
 
 export type IMessageFileSend = IMessage<'file_send', IFileSendData>;
 
+export type IMessageContextRecovery = IMessage<'context_recovery', ContextRecoveryMessageData>;
+
 // eslint-disable-next-line max-len
-export type TMessage = IMessageText | IMessageTips | IMessageToolCall | IMessageToolGroup | IMessageAgentStatus | IMessageAcpPermission | IMessageAcpQuestion | IMessageAcpToolCall | IMessageCodexPermission | IMessageCodexToolCall | IMessagePlan | IMessageAvailableCommands | IMessageFileSend;
+export type TMessage = IMessageText | IMessageTips | IMessageToolCall | IMessageToolGroup | IMessageAgentStatus | IMessageAcpPermission | IMessageAcpQuestion | IMessageAcpToolCall | IMessageCodexPermission | IMessageCodexToolCall | IMessagePlan | IMessageAvailableCommands | IMessageFileSend | IMessageContextRecovery;
 
 // 统一所有需要用户交互的用户类型
 export interface IConfirmation<Option extends any = any> {
@@ -520,6 +523,16 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
         position: 'left',
         conversation_id: message.conversation_id,
         content: message.data as IFileSendData,
+      };
+    }
+    case 'context_recovery': {
+      return {
+        id: uuid(),
+        type: 'context_recovery',
+        msg_id: message.msg_id,
+        position: 'center',
+        conversation_id: message.conversation_id,
+        content: message.data as ContextRecoveryMessageData,
       };
     }
     case 'tips': {

--- a/src/common/contextRecovery.ts
+++ b/src/common/contextRecovery.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type ContextRecoveryStatus = 'normal' | 'near_limit' | 'critical' | 'overflowed' | 'compressing' | 'compressed' | 'failed';
+
+export type ContextRecoveryReason = 'near_limit' | 'critical' | 'overflowed' | 'compressing' | 'compressed' | 'failed';
+
+export type ContextRecoveryStrategy = 'compress' | 'fresh';
+
+export type ContextRecoveryActionId = 'compress' | 'fresh' | 'dismiss';
+
+export interface ContextRecoveryState {
+  status: ContextRecoveryStatus;
+  failedSessionId?: string;
+  recoveredSessionId?: string;
+  failedAt?: number;
+  recoveredAt?: number;
+  summaryMessageId?: string;
+  summary?: string;
+  lastFailedMsgId?: string;
+  error?: string;
+}
+
+export interface ContextRecoveryMessageData {
+  reason: ContextRecoveryReason;
+  used?: number;
+  size?: number;
+  error?: string;
+  actions: Array<{
+    id: ContextRecoveryActionId;
+    label: string;
+  }>;
+}
+
+export function isContextOverflowError(message: string): boolean {
+  const text = message.toLowerCase();
+  return ['context_length_exceeded', 'maximum context length', 'context length', 'token limit', 'prompt is too long', 'input is too long', 'too many tokens', 'exceeds the context', 'exceed context', 'context window', '超出模型处理限制', '超出了模型处理限制', '超过上下文', '超出上下文', '上下文过长', '内容过大', '超出'].some((pattern) => text.includes(pattern));
+}
+
+export interface ContextSummaryMessage {
+  type: string;
+  position?: 'left' | 'right' | 'center' | 'pop';
+  text: string;
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}\n...[truncated ${value.length - maxLength} chars]`;
+}
+
+export function buildContextSummaryFromMessages(messages: ContextSummaryMessage[]): string {
+  const visibleMessages = messages.filter((message) => message.type !== 'context_recovery' && message.text.trim());
+  const recentMessages = visibleMessages.slice(-20);
+  const userMessages = visibleMessages.filter((message) => message.position === 'right');
+  const assistantMessages = visibleMessages.filter((message) => message.position === 'left');
+  const filePaths = new Set<string>();
+  const commandHints = new Set<string>();
+  const pathPattern = /(?:\/[\w .@-]+)+(?:\.[\w-]+)?/g;
+  const commandPattern = /`([^`\n]{2,120})`/g;
+
+  for (const message of visibleMessages) {
+    for (const match of message.text.matchAll(pathPattern)) {
+      filePaths.add(match[0].trim());
+      if (filePaths.size >= 20) break;
+    }
+    for (const match of message.text.matchAll(commandPattern)) {
+      commandHints.add(match[1].trim());
+      if (commandHints.size >= 20) break;
+    }
+  }
+
+  const latestUserGoal = userMessages.length > 0 ? userMessages[userMessages.length - 1].text : '';
+  const latestAssistant = assistantMessages.length > 0 ? assistantMessages[assistantMessages.length - 1].text : '';
+
+  const recentBlock = recentMessages
+    .map((message, index) => {
+      const role = message.position === 'right' ? 'User' : message.position === 'left' ? 'Assistant' : 'System';
+      const text = truncate(message.text.trim(), 1200);
+      if (!text) return '';
+      return `### ${index + 1}. ${role}\n${text}`;
+    })
+    .filter(Boolean)
+    .join('\n\n');
+
+  return `# 压缩后的上下文摘要
+
+## 用户目标
+${truncate(latestUserGoal || '未能从历史中提取明确目标。', 1600)}
+
+## 当前状态
+${truncate(latestAssistant || '暂无最近助手输出。', 1600)}
+
+## 涉及文件
+${
+  Array.from(filePaths)
+    .slice(0, 20)
+    .map((item) => `- ${item}`)
+    .join('\n') || '- 未识别到明确文件路径。'
+}
+
+## 关键命令或标识
+${
+  Array.from(commandHints)
+    .slice(0, 20)
+    .map((item) => `- ${item}`)
+    .join('\n') || '- 未识别到明确命令。'
+}
+
+## 最近对话
+${recentBlock || '无可压缩的最近对话。'}
+
+## 下一步
+请基于以上摘要继续当前会话，不要要求用户重复说明此前上下文。`;
+}

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IConfirmation } from '@/common/chatLib';
+import type { ContextRecoveryStrategy } from '@/common/contextRecovery';
 import { bridge } from '@office-ai/platform';
 import type { OpenDialogOptions } from 'electron';
 import type { McpSource } from '../process/services/mcpServices/McpProtocol';
@@ -50,6 +51,7 @@ export const conversation = {
   reset: bridge.buildProvider<void, IResetConversationParams>('reset-conversation'), // 重置对话
   stop: bridge.buildProvider<IBridgeResponse<{}>, { conversation_id: string }>('chat.stop.stream'), // 停止会话
   sendMessage: bridge.buildProvider<IBridgeResponse<{}>, ISendMessageParams>('chat.send.message'), // 发送消息（统一接口）
+  recoverContext: bridge.buildProvider<IBridgeResponse<{ summary?: string }>, { conversation_id: string; strategy: ContextRecoveryStrategy }>('conversation.recover-context'),
   getSlashCommands: bridge.buildProvider<IBridgeResponse<{ commands: SlashCommandItem[] }>, { conversation_id: string }>('conversation.get-slash-commands'),
   confirmMessage: bridge.buildProvider<IBridgeResponse, IConfirmMessageParams>('conversation.confirm.message'), // 通用确认消息
   responseStream: bridge.buildEmitter<IResponseMessage>('chat.response.stream'), // 接收消息（统一接口）

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AcpBackend, AcpBackendAll, AcpBackendConfig } from '@/types/acpTypes';
+import type { ContextRecoveryState } from './contextRecovery';
 import { storage } from '@office-ai/platform';
 
 /**
@@ -252,6 +253,8 @@ export type TChatConversation =
           lastTokenUsage?: TokenUsageData;
           /** Context window capacity from usage_update */
           lastContextLimit?: number;
+          /** Context overflow recovery state / 上下文超限恢复状态 */
+          contextRecovery?: ContextRecoveryState;
           /** Persisted session mode for resume support / 持久化的会话模式，用于恢复 */
           sessionMode?: string;
           /** Persisted model ID for resume support / 持久化的模型 ID，用于恢复 */

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -37,6 +37,7 @@ import { ConversationManageWithDB } from '../message';
 import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
 import { startConversationTracking, endConversationSuccess, endConversationError } from '../telemetry';
 import { getConversationProvider, isRemoteProvider } from '../providers';
+import { addContextRecoveryTip, buildLocalContextSummary, emitContextRecoveryMessage, loadConversationMessagesForSummary, updateConversationContextRecovery } from '../utils/contextRecovery';
 
 const workspaceSkillSyncTasks = new Map<string, Promise<void>>();
 
@@ -712,9 +713,9 @@ export function initConversationBridge(): void {
 
   ipcBridge.conversation.reset.provider(({ id }) => {
     if (id) {
-      WorkerManage.kill(id);
+      void WorkerManage.kill(id);
     } else {
-      WorkerManage.clear();
+      void WorkerManage.clear();
     }
     return Promise.resolve();
   });
@@ -791,6 +792,83 @@ export function initConversationBridge(): void {
       return { success: false, msg: 'unsupported conversation type' };
     } catch (error) {
       mainWarn('[conversationBridge]', 'restartAndConnect failed:', error);
+      return { success: false, msg: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcBridge.conversation.recoverContext.provider(async ({ conversation_id, strategy }) => {
+    try {
+      const db = getDatabase();
+      const convResult = db.getConversation(conversation_id);
+      if (!convResult.success || !convResult.data || convResult.data.type !== 'acp') {
+        return { success: false, msg: 'conversation not found' };
+      }
+
+      const conversation = convResult.data;
+      const task = WorkerManage.getTaskById(conversation_id) as AcpAgent | undefined;
+      const failedSessionId = task?.type === 'acp' ? task.getCurrentSessionId() || conversation.extra.acpSessionId : conversation.extra.acpSessionId;
+
+      if (strategy === 'fresh') {
+        if (task?.type === 'acp') {
+          task.clearPersistedSession();
+        }
+        WorkerManage.kill(conversation_id);
+        const updatedExtra: TChatConversation['extra'] = { ...conversation.extra };
+        if ('acpSessionId' in updatedExtra) delete updatedExtra.acpSessionId;
+        if ('acpSessionUpdatedAt' in updatedExtra) delete updatedExtra.acpSessionUpdatedAt;
+        if ('contextRecovery' in updatedExtra) delete updatedExtra.contextRecovery;
+        db.updateConversation(conversation_id, { extra: updatedExtra } as Partial<TChatConversation>);
+        addContextRecoveryTip(conversation_id, '已开启新的模型上下文。聊天记录仍保留，但旧上下文不会自动带入模型。');
+        return { success: true };
+      }
+
+      updateConversationContextRecovery(conversation, {
+        status: 'compressing',
+        failedSessionId,
+        failedAt: conversation.extra.contextRecovery?.failedAt || Date.now(),
+      });
+
+      const messages = loadConversationMessagesForSummary(conversation_id);
+      const summary = buildLocalContextSummary(messages);
+      const summaryMessage = addContextRecoveryTip(conversation_id, `已压缩此前上下文，可以继续对话。\n\n${summary}`, 'success');
+
+      if (task?.type === 'acp') {
+        task.clearPersistedSession();
+      }
+      WorkerManage.kill(conversation_id);
+
+      const updatedExtra: TChatConversation['extra'] = {
+        ...conversation.extra,
+        contextRecovery: {
+          status: 'compressed' as const,
+          failedSessionId,
+          recoveredAt: Date.now(),
+          summaryMessageId: summaryMessage.id,
+          summary,
+        },
+      };
+      if ('acpSessionId' in updatedExtra) delete updatedExtra.acpSessionId;
+      if ('acpSessionUpdatedAt' in updatedExtra) delete updatedExtra.acpSessionUpdatedAt;
+      db.updateConversation(conversation_id, { extra: updatedExtra } as Partial<TChatConversation>);
+      return { success: true, data: { summary } };
+    } catch (error) {
+      mainWarn('[conversationBridge]', 'recoverContext failed:', error);
+      try {
+        const db = getDatabase();
+        const convResult = db.getConversation(conversation_id);
+        if (convResult.success && convResult.data && convResult.data.type === 'acp') {
+          updateConversationContextRecovery(convResult.data, {
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      } catch {
+        // ignore recovery state failure
+      }
+      emitContextRecoveryMessage(conversation_id, 'failed', {
+        msgId: 'context-recovery-failed',
+        error: error instanceof Error ? error.message : String(error),
+      });
       return { success: false, msg: error instanceof Error ? error.message : String(error) };
     }
   });
@@ -888,6 +966,19 @@ export function initConversationBridge(): void {
       return { success: false, msg: 'conversation not found' };
     }
     mainLog('conversationBridge', `sendMessage: found task type=${task.type}, status=${task.status}`);
+
+    try {
+      const convResult = getDatabase().getConversation(conversation_id);
+      if (convResult.success && convResult.data?.type === 'acp' && convResult.data.extra.contextRecovery?.status === 'overflowed') {
+        emitContextRecoveryMessage(conversation_id, 'overflowed', {
+          msgId: 'context-recovery-overflowed',
+          error: convResult.data.extra.contextRecovery.error,
+        });
+        return { success: false, msg: 'context_overflow_requires_recovery' };
+      }
+    } catch (error) {
+      mainWarn('conversationBridge', 'Failed to check context recovery state:', error);
+    }
 
     // 复制文件到工作空间（所有 agents 统一处理）
     let filesToProcess = files ?? [];

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -16,6 +16,8 @@ import { buildAcpModelInfo, summarizeAcpModelInfo } from '@/agent/acp/modelInfo'
 import { channelEventBus } from '@/channels/agent/ChannelEventBus';
 import { ipcBridge } from '@/common';
 import type { AcpQuestionData, CronMessageMeta, TMessage } from '@/common/chatLib';
+import type { ContextRecoveryMessageData, ContextRecoveryState } from '@/common/contextRecovery';
+import { isContextOverflowError } from '@/common/contextRecovery';
 import type { SlashCommandItem } from '@/common/slash/types';
 import { transformMessage } from '@/common/chatLib';
 import { NEXUS_FILES_MARKER } from '@/common/constants';
@@ -39,6 +41,7 @@ import { handlePreviewOpenEvent } from '../utils/previewUtils';
 import { cronBusyGuard } from '@process/services/cron/CronBusyGuard';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
 import { translateLLMError } from '@process/utils/llmErrorTranslation';
+import { updateConversationContextRecovery } from '@process/utils/contextRecovery';
 import { injectSkillsDirectoryHint, prepareFirstMessageWithSkillsIndex } from './agentUtils';
 import { cleanupIntermediateFiles, cleanupDraftsOnCancel, detectFileIntent, matchesDraftPattern } from './draftsCleanup';
 import { mergeScodeProxyModelInfo } from '@process/services/scode/scodeProxyModels';
@@ -866,6 +869,18 @@ This identity statement takes priority over the default identity in USER.md.
             workspace: this.workspace,
             presetAgentType: this.options.backend,
           });
+          const db = getDatabase();
+          const convResult = db.getConversation(this.conversation_id);
+          const recovery = convResult.success && convResult.data?.type === 'acp' ? convResult.data.extra.contextRecovery : undefined;
+          if (recovery?.status === 'compressed' && recovery.summary) {
+            contentToSend = `以下是此前对话的压缩摘要。请把它作为当前会话上下文继续工作，不要要求用户重复说明。\n\n` + `<compressed_context>\n${recovery.summary}\n</compressed_context>\n\n` + `[User Request]\n${contentToSend}`;
+            this.updateContextRecovery({
+              ...recovery,
+              summary: undefined,
+              recoveredSessionId: this.connection.currentSessionId || recovery.recoveredSessionId,
+              status: 'normal',
+            });
+          }
 
           if (this.options.backend === 'claude' || this.options.backend === 'scode') {
             const skillsDir = resolveWorkspaceSkillsDir({
@@ -1095,6 +1110,17 @@ This identity statement takes priority over the default identity in USER.md.
       return { success: true, data: null };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
+      console.log(`[AcpAgent] sendToConnection error: ${errorMsg.substring(0, 200)}`);
+      if (isContextOverflowError(errorMsg)) {
+        console.log(`[AcpAgent] Detected context overflow error, calling markContextOverflow`);
+        this.markContextOverflow(msg_id, errorMsg);
+        apiBreadcrumbs.responseError(`session/prompt`, 400, errorMsg);
+        return {
+          success: false,
+          error: createAcpError(AcpErrorType.UNKNOWN, errorMsg, false),
+        };
+      }
+
       if (errorMsg.includes('Internal error') && this.extra.backend === 'qwen') {
         const enhancedMsg = `Qwen ACP Internal Error: This usually means authentication failed or ` + `the Qwen CLI has compatibility issues. Please try: 1) Restart the application ` + `2) Use 'npx @qwen-code/qwen-code' instead of global qwen 3) Check if you have valid Qwen credentials.`;
         this.emitErrorMessage(enhancedMsg);
@@ -1512,6 +1538,84 @@ This identity statement takes priority over the default identity in USER.md.
     this.statusMessageId = null;
     // Re-initialize agent connection
     await this.initAgent();
+  }
+
+  getCurrentSessionId(): string | null {
+    return this.connection.currentSessionId;
+  }
+
+  clearPersistedSession(): void {
+    this.extra.acpSessionId = undefined;
+    this.options.acpSessionId = undefined;
+    this.bootstrap = undefined;
+  }
+
+  private updateContextRecovery(state: ContextRecoveryState | null): void {
+    try {
+      const db = getDatabase();
+      const result = db.getConversation(this.conversation_id);
+      if (!result.success || !result.data || result.data.type !== 'acp') return;
+      const success = updateConversationContextRecovery(result.data, state);
+      console.log(`[AcpAgent] updateContextRecovery: status=${state?.status}, success=${success}`);
+    } catch (error) {
+      mainWarn('[AcpAgent]', 'Failed to update context recovery state:', error);
+    }
+  }
+
+  private emitContextRecoveryCard(reason: ContextRecoveryMessageData['reason'], options?: { msgId?: string; error?: string }): void {
+    const actions: ContextRecoveryMessageData['actions'] =
+      reason === 'overflowed' || reason === 'failed'
+        ? [
+            { id: 'compress', label: '压缩并继续' },
+            { id: 'fresh', label: '开启空白新会话' },
+          ]
+        : [
+            { id: 'compress', label: '压缩后继续' },
+            { id: 'fresh', label: '新会话继续' },
+            { id: 'dismiss', label: '继续当前会话' },
+          ];
+
+    const message: IResponseMessage = {
+      type: 'context_recovery',
+      conversation_id: this.conversation_id,
+      msg_id: options?.msgId || `context-recovery-${reason}`,
+      data: {
+        reason,
+        error: options?.error,
+        actions,
+      } satisfies ContextRecoveryMessageData,
+    };
+
+    const tMessage = transformMessage(message);
+    if (tMessage) {
+      addOrUpdateMessage(this.conversation_id, tMessage, this.options.backend);
+    }
+    ipcBridge.acpConversation.responseStream.emit(message);
+    channelEventBus.emitAgentMessage(this.conversation_id, message);
+  }
+
+  private markContextOverflow(msgId: string | undefined, error: string): void {
+    this.updateContextRecovery({
+      status: 'overflowed',
+      failedSessionId: this.connection.currentSessionId || this.extra.acpSessionId,
+      failedAt: Date.now(),
+      lastFailedMsgId: msgId,
+      error,
+    });
+    this.emitContextRecoveryCard('overflowed', {
+      msgId: 'context-recovery-overflowed',
+      error,
+    });
+    this.status = 'finished';
+    this.turnActive = false;
+    this.processingStartTime = undefined;
+    cronBusyGuard.setProcessing(this.conversation_id, false);
+    void this.handleSignalEvent({
+      type: 'finish',
+      conversation_id: this.conversation_id,
+      msg_id: uuid(),
+      data: null,
+    });
   }
 
   async ensureYoloMode(): Promise<boolean> {
@@ -2281,8 +2385,14 @@ This identity statement takes priority over the default identity in USER.md.
   private handleDisconnect(error: { code: number | null; signal: NodeJS.Signals | null }): void {
     this.emitStatusMessage('disconnected');
 
-    const errorMsg = `${this.extra.backend} process disconnected unexpectedly ` + `(code: ${error.code}, signal: ${error.signal}). ` + `Please try sending a new message to reconnect.`;
-    this.emitErrorMessage(errorMsg, false); // Skip finish, will send below
+    // Check if this is a context recovery termination (SIGTERM from recoverContext)
+    // 检查是否是 context recovery 导致的终止（recoverContext 发送的 SIGTERM）
+    const isContextRecoveryTermination = error.signal === 'SIGTERM' && this.extra.contextRecovery?.status === 'compressing';
+
+    if (!isContextRecoveryTermination) {
+      const errorMsg = `${this.extra.backend} process disconnected unexpectedly ` + `(code: ${error.code}, signal: ${error.signal}). ` + `Please try sending a new message to reconnect.`;
+      this.emitErrorMessage(errorMsg, false); // Skip finish, will send below
+    }
 
     // Telemetry: end turn tracking (error)
     endTurnError(this.conversation_id, 'E001');
@@ -2291,7 +2401,7 @@ This identity statement takes priority over the default identity in USER.md.
     endConversationError(this.conversation_id, 'E001');
 
     // Breadcrumb: conversation ended (disconnect)
-    conversationBreadcrumbs.error(this.conversation_id, 'E001', errorMsg);
+    conversationBreadcrumbs.error(this.conversation_id, 'E001', `disconnected: code=${error.code}, signal=${error.signal}`);
 
     const finishMsg: IResponseMessage = {
       type: 'finish',
@@ -2321,6 +2431,16 @@ This identity statement takes priority over the default identity in USER.md.
     }
 
     const pipelineStart = Date.now();
+
+    // Check for context overflow error in stream messages
+    // 检测流消息中的上下文超限错误
+    if (message.type === 'error' || message.type === 'tips') {
+      const errorText = typeof message.data === 'string' ? message.data : (message.data as { content?: string })?.content || '';
+      if (errorText && isContextOverflowError(errorText)) {
+        this.markContextOverflow(message.msg_id, errorText);
+        return;
+      }
+    }
 
     if (message.type === 'agent_status') {
       const status = (message.data as { status?: string } | null)?.status;
@@ -2367,6 +2487,27 @@ This identity statement takes priority over the default identity in USER.md.
     if (message.type === 'acp_context_usage') {
       const usageData = message.data as { used: number; size: number };
       saveContextUsage(this.conversation_id, usageData);
+      if (usageData.size > 0) {
+        const ratio = usageData.used / usageData.size;
+        const reason: ContextRecoveryMessageData['reason'] | null = ratio >= 0.95 ? 'critical' : ratio >= 0.85 ? 'near_limit' : null;
+        if (reason) {
+          try {
+            const db = getDatabase();
+            const result = db.getConversation(this.conversation_id);
+            const currentRecovery = result.success && result.data?.type === 'acp' ? result.data.extra.contextRecovery : undefined;
+            if (!currentRecovery || currentRecovery.status === 'normal' || currentRecovery.status === 'near_limit' || currentRecovery.status === 'critical') {
+              this.updateContextRecovery({
+                status: reason,
+              });
+              this.emitContextRecoveryCard(reason, {
+                msgId: 'context-recovery-near-limit',
+              });
+            }
+          } catch (error) {
+            mainWarn('[AcpAgent]', 'Failed to emit context usage recovery card:', error);
+          }
+        }
+      }
     }
 
     if (message.type !== 'thought' && message.type !== 'acp_model_info' && message.type !== 'acp_context_usage') {
@@ -2619,6 +2760,16 @@ This identity statement takes priority over the default identity in USER.md.
   }
 
   private emitMessage(message: TMessage): void {
+    // Check for context overflow error in tips/error messages
+    // 检测 tips/error 消息中的上下文超限错误
+    if (message.type === 'tips') {
+      const content = message.content as { type?: string; content: string };
+      if (content.content && isContextOverflowError(content.content)) {
+        this.markContextOverflow(message.msg_id || message.id, content.content);
+        return;
+      }
+    }
+
     const responseMessage: IResponseMessage = {
       type: '',
       data: null,

--- a/src/process/utils/contextRecovery.ts
+++ b/src/process/utils/contextRecovery.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ContextRecoveryMessageData, ContextRecoveryState } from '@/common/contextRecovery';
+import { buildContextSummaryFromMessages } from '@/common/contextRecovery';
+import type { TMessage } from '@/common/chatLib';
+import { transformMessage } from '@/common/chatLib';
+import { ipcBridge } from '@/common';
+import { uuid } from '@/common/utils';
+import type { TChatConversation } from '@/common/storage';
+import { getDatabase } from '@process/database';
+import { addMessage } from '@process/message';
+import { mainWarn } from '@process/utils/mainLogger';
+
+function getRecoveryActions(reason: ContextRecoveryMessageData['reason']): ContextRecoveryMessageData['actions'] {
+  if (reason === 'overflowed' || reason === 'failed') {
+    return [
+      { id: 'compress', label: '压缩并继续' },
+      { id: 'fresh', label: '开启空白新会话' },
+    ];
+  }
+  return [
+    { id: 'compress', label: '压缩后继续' },
+    { id: 'fresh', label: '新会话继续' },
+    { id: 'dismiss', label: '继续当前会话' },
+  ];
+}
+
+export function buildContextRecoveryMessage(conversationId: string, reason: ContextRecoveryMessageData['reason'], options?: { msgId?: string; error?: string; used?: number; size?: number }): TMessage | undefined {
+  return transformMessage({
+    type: 'context_recovery',
+    conversation_id: conversationId,
+    msg_id: options?.msgId || `context-recovery-${reason}`,
+    data: {
+      reason,
+      used: options?.used,
+      size: options?.size,
+      error: options?.error,
+      actions: getRecoveryActions(reason),
+    } satisfies ContextRecoveryMessageData,
+  });
+}
+
+export function emitContextRecoveryMessage(conversationId: string, reason: ContextRecoveryMessageData['reason'], options?: { msgId?: string; error?: string; used?: number; size?: number }): void {
+  const message = {
+    type: 'context_recovery',
+    conversation_id: conversationId,
+    msg_id: options?.msgId || `context-recovery-${reason}`,
+    data: {
+      reason,
+      used: options?.used,
+      size: options?.size,
+      error: options?.error,
+      actions: getRecoveryActions(reason),
+    } satisfies ContextRecoveryMessageData,
+  };
+  ipcBridge.conversation.responseStream.emit(message);
+}
+
+export function updateConversationContextRecovery(conversation: TChatConversation, state: ContextRecoveryState | null): boolean {
+  if (conversation.type !== 'acp') return false;
+  const db = getDatabase();
+  const updatedExtra = {
+    ...conversation.extra,
+    contextRecovery: state || undefined,
+  };
+  const result = db.updateConversation(conversation.id, { extra: updatedExtra } as Partial<TChatConversation>);
+  return result.success;
+}
+
+export function addContextRecoveryTip(conversationId: string, content: string, type: 'success' | 'warning' | 'error' = 'success'): TMessage {
+  const message: TMessage = {
+    id: uuid(),
+    msg_id: uuid(),
+    conversation_id: conversationId,
+    type: 'tips',
+    position: 'center',
+    content: {
+      content,
+      type,
+    },
+    createdAt: Date.now(),
+  };
+  addMessage(conversationId, message);
+  return message;
+}
+
+function extractMessageText(message: TMessage): string {
+  if (message.type === 'text') return message.content.content || '';
+  if (message.type === 'tips') return `[${message.content.type}] ${message.content.content}`;
+  if (message.type === 'plan') return message.content.entries.map((entry) => `- [${entry.status}] ${entry.content}`).join('\n');
+  if (message.type === 'tool_group') return message.content.map((tool) => `Tool ${tool.name}: ${tool.status}`).join('\n');
+  if (message.type === 'acp_tool_call') return `Tool ${message.content.update?.title || message.content.update?.toolCallId || 'call'}: ${message.content.update?.status || 'pending'}`;
+  if (message.type === 'context_recovery') return '';
+  return '';
+}
+
+export function buildLocalContextSummary(messages: TMessage[]): string {
+  return buildContextSummaryFromMessages(
+    messages.map((message) => ({
+      type: message.type,
+      position: message.position,
+      text: extractMessageText(message),
+    }))
+  );
+}
+
+export function loadConversationMessagesForSummary(conversationId: string): TMessage[] {
+  try {
+    const db = getDatabase();
+    return db.getConversationMessages(conversationId, 0, 10000).data;
+  } catch (error) {
+    mainWarn('ContextRecovery', 'Failed to load messages for summary:', error);
+    return [];
+  }
+}

--- a/src/renderer/i18n/locales/en-US/messages.json
+++ b/src/renderer/i18n/locales/en-US/messages.json
@@ -37,6 +37,21 @@
   "questionSkipped": "Skipped",
   "yes": "Yes",
   "no": "No",
+  "contextRecovery": {
+    "overflowTitle": "This model session has exceeded its context limit",
+    "overflowDescription": "Messages can no longer be sent to the original session. You can compress the history and continue, or start a blank model context.",
+    "nearLimitTitle": "This conversation is close to the model context limit",
+    "nearLimitDescription": "Continuing may fail. You can compress the context now or keep going for now.",
+    "errorPrefix": "Error: ",
+    "recoverFailed": "Failed to recover context",
+    "compressSuccess": "Previous context compressed. You can continue.",
+    "freshSuccess": "Started a new model context.",
+    "compressAndContinue": "Compress and continue",
+    "compressLater": "Compress then continue",
+    "freshSession": "Start blank context",
+    "freshContinue": "New context",
+    "dismiss": "Continue current session"
+  },
   "confirmation": {
     "applyChange": "Apply this change?",
     "allowExecution": "Allow execution?",

--- a/src/renderer/i18n/locales/zh-CN/messages.json
+++ b/src/renderer/i18n/locales/zh-CN/messages.json
@@ -37,6 +37,21 @@
   "questionSkipped": "已跳过",
   "yes": "是",
   "no": "否",
+  "contextRecovery": {
+    "overflowTitle": "当前模型会话已超过上下文限制",
+    "overflowDescription": "无法继续向原会话发送消息。你可以压缩历史后继续，或开启一个空白模型上下文继续。",
+    "nearLimitTitle": "当前对话上下文接近模型上限",
+    "nearLimitDescription": "继续发送可能失败。你可以现在压缩上下文，或稍后继续。",
+    "errorPrefix": "错误信息：",
+    "recoverFailed": "恢复上下文失败",
+    "compressSuccess": "已压缩此前上下文，可以继续对话",
+    "freshSuccess": "已开启新的模型上下文",
+    "compressAndContinue": "压缩并继续",
+    "compressLater": "压缩后继续",
+    "freshSession": "开启空白新会话",
+    "freshContinue": "新会话继续",
+    "dismiss": "继续当前会话"
+  },
   "confirmation": {
     "applyChange": "应用此更改？",
     "allowExecution": "允许执行？",

--- a/src/renderer/messages/MessageContextRecovery.tsx
+++ b/src/renderer/messages/MessageContextRecovery.tsx
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { conversation } from '@/common/ipcBridge';
+import type { IMessageContextRecovery } from '@/common/chatLib';
+import { Button, Card, Message, Typography } from '@arco-design/web-react';
+import { IconExclamationCircle, IconRefresh } from '@arco-design/web-react/icon';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const { Text } = Typography;
+
+const MessageContextRecovery: React.FC<{ message: IMessageContextRecovery }> = React.memo(({ message }) => {
+  const { t } = useTranslation();
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const { reason, actions, error } = message.content;
+
+  if (dismissed) return null;
+
+  const isOverflowed = reason === 'overflowed' || reason === 'failed';
+  const title = isOverflowed ? t('messages.contextRecovery.overflowTitle', { defaultValue: '当前模型会话已超过上下文限制' }) : t('messages.contextRecovery.nearLimitTitle', { defaultValue: '当前对话上下文接近模型上限' });
+  const description = isOverflowed ? t('messages.contextRecovery.overflowDescription', { defaultValue: '无法继续向原会话发送消息。你可以压缩历史后继续，或开启一个空白模型上下文继续。' }) : t('messages.contextRecovery.nearLimitDescription', { defaultValue: '继续发送可能失败。你可以现在压缩上下文，或稍后继续。' });
+  const actionLabels: Record<string, string> = {
+    compress: isOverflowed ? t('messages.contextRecovery.compressAndContinue', { defaultValue: '压缩并继续' }) : t('messages.contextRecovery.compressLater', { defaultValue: '压缩后继续' }),
+    fresh: isOverflowed ? t('messages.contextRecovery.freshSession', { defaultValue: '开启空白新会话' }) : t('messages.contextRecovery.freshContinue', { defaultValue: '新会话继续' }),
+    dismiss: t('messages.contextRecovery.dismiss', { defaultValue: '继续当前会话' }),
+  };
+
+  const handleAction = async (actionId: string) => {
+    if (actionId === 'dismiss') {
+      setDismissed(true);
+      return;
+    }
+    if (actionId !== 'compress' && actionId !== 'fresh') return;
+
+    setBusyAction(actionId);
+    try {
+      const result = await conversation.recoverContext.invoke({
+        conversation_id: message.conversation_id,
+        strategy: actionId,
+      });
+      if (!result.success) {
+        Message.error(result.msg || t('messages.contextRecovery.recoverFailed', { defaultValue: '恢复上下文失败' }));
+        return;
+      }
+      Message.success(actionId === 'compress' ? t('messages.contextRecovery.compressSuccess', { defaultValue: '已压缩此前上下文，可以继续对话' }) : t('messages.contextRecovery.freshSuccess', { defaultValue: '已开启新的模型上下文' }));
+      setDismissed(true);
+    } catch (err) {
+      Message.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  return (
+    <Card className='w-full mb-2' bordered={false} style={{ background: 'var(--bg-1)' }}>
+      <div className='flex items-start gap-10px'>
+        <div className='mt-2px color-warning'>{isOverflowed ? <IconExclamationCircle fontSize={18} /> : <IconRefresh fontSize={18} />}</div>
+        <div className='flex-1 min-w-0'>
+          <div className='font-500 text-t-primary mb-4px'>{title}</div>
+          <Text type='secondary' className='block [word-break:break-word]'>
+            {description}
+          </Text>
+          {error && (
+            <div className='mt-8px text-12px color-#86909c [word-break:break-word]'>
+              {t('messages.contextRecovery.errorPrefix', { defaultValue: '错误信息：' })}
+              {error}
+            </div>
+          )}
+          <div className='mt-12px flex flex-wrap gap-8px'>
+            {actions.map((action) => (
+              <Button key={action.id} size='small' type={action.id === 'compress' ? 'primary' : 'secondary'} loading={busyAction === action.id} disabled={busyAction !== null && busyAction !== action.id} onClick={() => void handleAction(action.id)}>
+                {actionLabels[action.id] || action.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+});
+
+export default MessageContextRecovery;

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -24,6 +24,7 @@ import { Virtuoso } from 'react-virtuoso';
 import { uuid } from '../utils/common';
 import HOC from '../utils/HOC';
 import MessageCodexToolCall from './codex/MessageCodexToolCall';
+import MessageContextRecovery from './MessageContextRecovery';
 import type { FileChangeInfo } from './codex/MessageFileChanges';
 import MessageFileChanges, { parseDiff } from './codex/MessageFileChanges';
 import MessageFileSend from './MessageFileSend';
@@ -100,7 +101,7 @@ const MessageItem: React.FC<{ message: TMessage; isStreaming?: boolean }> = Reac
         })}
       >
         {isAiMessage && (
-          <div className="flex-shrink-0 mr-12px mt-4px w-24px h-24px relative">
+          <div className='flex-shrink-0 mr-12px mt-4px w-24px h-24px relative'>
             <img src={streamingAvatar} alt='AI Avatar' className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ${isStreaming ? 'w-40px h-40px max-w-none' : 'w-24px h-24px'} object-contain`} />
           </div>
         )}
@@ -135,6 +136,8 @@ const MessageItem: React.FC<{ message: TMessage; isStreaming?: boolean }> = Reac
         return <MessagePlan message={message}></MessagePlan>;
       case 'file_send':
         return <MessageFileSend message={message}></MessageFileSend>;
+      case 'context_recovery':
+        return <MessageContextRecovery message={message}></MessageContextRecovery>;
       case 'available_commands':
         return null;
       default:
@@ -386,7 +389,7 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
     if (shouldShowLoading) {
       withTimeSeparators.push({
         type: 'loading_indicator',
-        id: 'temp-loading-indicator'
+        id: 'temp-loading-indicator',
       });
     }
 
@@ -452,7 +455,7 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
       const streamingAvatarForSummary = isStreamingForSummary ? (isDarkMode() ? sudoclawProDark : sudoclawProWhite) : sudoworkIconDark;
       return (
         <div key={item.id} data-message-id={item.id} className={'min-w-0 flex items-start message-item px-8px m-t-10px max-w-full md:max-w-780px mx-auto ' + item.type}>
-          <div className="flex-shrink-0 mr-12px mt-4px w-24px h-24px relative">
+          <div className='flex-shrink-0 mr-12px mt-4px w-24px h-24px relative'>
             <img src={streamingAvatarForSummary} alt='AI Avatar' className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ${isStreamingForSummary ? 'w-40px h-40px max-w-none' : 'w-24px h-24px'} object-contain`} />
           </div>
           <div className='flex-1 min-w-0'>

--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -47,6 +47,9 @@ function buildMessageIndex(list: TMessage[]): MessageIndex {
     if (msg.type === 'acp_tool_call' && msg.content?.update?.toolCallId) {
       toolCallIdIndex.set(msg.content.update.toolCallId, i);
     }
+    if (msg.type === 'context_recovery' && msg.msg_id) {
+      msgIdIndex.set(msg.msg_id, i);
+    }
   }
 
   return { msgIdIndex, callIdIndex, toolCallIdIndex };
@@ -214,6 +217,12 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
       } as TMessage;
       return newList;
     }
+  }
+
+  if (message.type === 'context_recovery') {
+    const newIdx = list.length;
+    if (message.msg_id) index.msgIdIndex.set(message.msg_id, newIdx);
+    return list.concat(message);
   }
 
   // Other types: fallback to last message check

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -334,6 +334,13 @@ const useAcpMessage = (conversation_id: string) => {
           }
           break;
         }
+        case 'context_recovery':
+          setRunning(false);
+          runningRef.current = false;
+          setAiProcessing(false);
+          aiProcessingRef.current = false;
+          addOrUpdateMessage(transformedMessage);
+          break;
         case 'request_trace':
           {
             const trace = message.data as Record<string, unknown>;

--- a/tests/unit/contextRecovery.test.ts
+++ b/tests/unit/contextRecovery.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildContextSummaryFromMessages, isContextOverflowError } from '../../src/common/contextRecovery';
+
+describe('context recovery helpers', () => {
+  it('detects common context overflow errors', () => {
+    expect(isContextOverflowError('context_length_exceeded: maximum context length reached')).toBe(true);
+    expect(isContextOverflowError('Prompt is too long for this model token limit')).toBe(true);
+    expect(isContextOverflowError('对话内容过长，超出模型处理限制')).toBe(true);
+    expect(isContextOverflowError('图片或文本内容过大，超出了模型的处理限制')).toBe(true);
+    expect(isContextOverflowError('authentication failed')).toBe(false);
+  });
+
+  it('builds a local summary from recent messages and file paths', () => {
+    const messages = [
+      {
+        type: 'text',
+        position: 'right',
+        text: '请修改 /tmp/workspace/src/app.ts 并运行 `bun test`',
+      },
+      {
+        type: 'text',
+        position: 'left',
+        text: '已定位到 /tmp/workspace/src/app.ts，下一步会修复错误。',
+      },
+    ] as const;
+
+    const summary = buildContextSummaryFromMessages([...messages]);
+
+    expect(summary).toContain('压缩后的上下文摘要');
+    expect(summary).toContain('/tmp/workspace/src/app.ts');
+    expect(summary).toContain('bun test');
+    expect(summary).toContain('请基于以上摘要继续当前会话');
+  });
+});


### PR DESCRIPTION
## Summary

当 ACP 会话上下文超过模型处理限制时，提供用户友好的恢复机制：

**后端改动：**
- 新增 `isContextOverflowError` 函数检测上下文超限错误（支持中英文多种错误模式）
- 在 `AcpAgent` 中捕获 `context_window_blocked` 错误并标记会话状态为 `overflowed`
- 实现 `recoverContext` IPC 支持压缩和新建会话两种恢复策略
- 修复 `AcpConnection` 错误消息提取（优先使用 `error.data` 字段）
- 压缩时生成本地摘要注入新会话
- 修复压缩后显示 disconnected 错误的问题

**前端改动：**
- 新增 `context_recovery` 消息类型显示恢复操作卡片
- 发送框根据状态禁用/启用
- 支持压缩并继续、开启空白新会话两种操作

**测试：**
- 新增 `contextRecovery.test.ts` 单元测试

## Test plan

- [ ] 测试上下文超限后显示恢复卡片
- [ ] 测试点击"压缩并继续"能正常恢复
- [ ] 测试点击"开启空白新会话"能正常恢复
- [ ] 测试恢复后继续发送消息正常工作
- [ ] 测试压缩后不显示 disconnected 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)