### PR TITLE
fix(skills): support updating existing custom skills and improve UI refresh

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -292,6 +292,15 @@ scripts/install_skill.py <path/to/staged-skill-or-zip> --replace
 - 技能能力：更新 `SKILL.md` 的流程说明、触发场景、质量标准，以及相关 `scripts/`、`references/`、`assets/`。
 - 分类、emoji、版本：更新 `_sudowork_meta.json` 的 `category`、`categories`、`emoji`、`installed_version`。
 
+字段边界必须严格：
+
+- 用户说“修改技能名称”“改名”“显示成 XXX”时，默认只修改 UI 展示名称，也就是 `_sudowork_meta.json` 的 `display_name`；可同步更新 `SKILL.md` 首个 H1 标题，但不要修改 `SKILL.md` frontmatter 的 `description` 或 `_sudowork_meta.json` 的 `description`。
+- 只有用户明确要求修改“描述”“说明”“触发场景”“适用场景”时，才修改 description。
+- 只有用户明确要求修改“技能能力”“执行流程”“怎么做”“规则”时，才修改 `SKILL.md` 正文、`scripts/`、`references/` 或 `assets/`。
+- 只有用户明确要求修改 hyphen-case 技能 ID、目录名、内部 name，或给出类似 `ashare-hot-rank` 的名字时，才修改 `SKILL.md` frontmatter 的 `name`、`_sudowork_meta.json` 的 `name` 和目录名。
+- 安装或覆盖后，必须读取 `~/.nexus/skills/_my-custom-skill/<skill-name>/_sudowork_meta.json` 和 `~/.nexus/skills/_my-custom-skill/<skill-name>/SKILL.md` 核验最终落盘值。
+- 更新完成回复必须只列出安装目录中实际改变的字段；没有修改 description 时，不要声称 description 已修改。如果请求修改 description 但安装目录核验不一致，必须报告失败并继续修正。
+
 ### 使用更新脚本
 
 对于 metadata 和头像类更新，优先使用脚本避免漏改字段：
@@ -312,7 +321,8 @@ scripts/update_skill.py <path/to/skill-folder> \
 
 - 校验新的 hyphen-case `name`。
 - 必要时重命名技能目录。
-- 更新 `SKILL.md` frontmatter 中的 `name` 和 `description`。
+- 仅在传入 `--name` 时更新 `SKILL.md` frontmatter 中的 `name`。
+- 仅在传入 `--description` 时更新 `SKILL.md` frontmatter 和 metadata 中的 `description`。
 - 更新 `SKILL.md` 的首个 H1 标题；若未传 `--title`，默认跟随 `--display-name` 或 `--name`。
 - 更新 `_sudowork_meta.json` 中的展示字段。
 - 复制新的 icon 文件到技能目录并更新 `icon` 引用。

--- a/src/extensions/assetProtocol.ts
+++ b/src/extensions/assetProtocol.ts
@@ -166,7 +166,10 @@ export const resolveAssetByteRange = (rangeHeader: string | null, fileSize: numb
 const createRangeHeaders = (filePath: string, range: AssetByteRangeResult): Headers => {
   const headers = new Headers({
     'Accept-Ranges': 'bytes',
+    'Cache-Control': 'no-store',
     'Content-Type': getAssetContentType(filePath),
+    Expires: '0',
+    Pragma: 'no-cache',
   });
 
   if (range.status === 416) {

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -2253,7 +2253,8 @@ This identity statement takes priority over the default identity in USER.md.
       });
       const installed = results.filter((result) => result.status === 'installed');
       const registered = results.filter((result) => result.status === 'registered');
-      const changed = [...installed, ...registered];
+      const updated = results.filter((result) => result.status === 'updated');
+      const changed = [...installed, ...registered, ...updated];
 
       if (changed.length === 0) {
         if (results.length > 0) {
@@ -2269,7 +2270,8 @@ This identity statement takes priority over the default identity in USER.md.
       }
 
       for (const result of changed) {
-        mainLog('[AcpAgent]', `[SKILL-INSTALL] ${result.status === 'installed' ? 'Installed' : 'Registered'} workspace skill "${result.skillName}"`, {
+        const action = result.status === 'installed' ? 'Installed' : result.status === 'updated' ? 'Updated' : 'Registered';
+        mainLog('[AcpAgent]', `[SKILL-INSTALL] ${action} workspace skill "${result.skillName}"`, {
           sourceDir: result.sourceDir,
           targetDir: result.targetDir,
           installedVersion: result.installedVersion,
@@ -2286,14 +2288,16 @@ This identity statement takes priority over the default identity in USER.md.
     }
   }
 
-  private emitWorkspaceSkillInstallMessage(skills: Array<{ skillName: string; targetDir: string }>): void {
+  private emitWorkspaceSkillInstallMessage(skills: Array<{ skillName: string; targetDir: string; status?: 'installed' | 'registered' | 'updated' }>): void {
     const skillNames = Array.from(new Set(skills.map((skill) => skill.skillName))).filter(Boolean);
     if (skillNames.length === 0) {
       return;
     }
 
     const skillList = skillNames.map((skillName) => `- ${skillName}`).join('\n');
-    const content = skillNames.length === 1 ? `技能已安装到自定义技能：${skillNames[0]}\n\n你可以在“技能商店 > 我的技能 > 自定义技能”中查看。` : `以下技能已安装到自定义技能：\n\n${skillList}\n\n你可以在“技能商店 > 我的技能 > 自定义技能”中查看。`;
+    const allUpdated = skills.every((skill) => skill.status === 'updated');
+    const actionText = allUpdated ? '更新' : '安装/更新';
+    const content = skillNames.length === 1 ? `技能已${actionText}到自定义技能：${skillNames[0]}\n\n你可以在“技能商店 > 我的技能 > 自定义技能”中查看。` : `以下技能已${actionText}到自定义技能：\n\n${skillList}\n\n你可以在“技能商店 > 我的技能 > 自定义技能”中查看。`;
 
     this.emitMessage({
       id: uuid(),

--- a/src/process/task/workspaceSkillInstaller.ts
+++ b/src/process/task/workspaceSkillInstaller.ts
@@ -31,6 +31,13 @@ export type WorkspaceSkillInstallResult =
       targetDir: string;
     }
   | {
+      status: 'updated';
+      skillName: string;
+      installedVersion: string;
+      sourceDir: string;
+      targetDir: string;
+    }
+  | {
       status: 'skipped';
       sourceDir: string;
       reason: string;
@@ -220,6 +227,54 @@ async function copySkillDirectory(sourceDir: string, targetDir: string): Promise
   }
 }
 
+function createSiblingTempPath(targetDir: string, purpose: string): string {
+  const parentDir = path.dirname(targetDir);
+  const baseName = path.basename(targetDir);
+  const unique = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return path.join(parentDir, `.${baseName}-${purpose}-${unique}`);
+}
+
+async function replaceSkillDirectory(sourceDir: string, targetDir: string, metaFileName: string, meta: WorkspaceSkillMeta): Promise<void> {
+  const targetStat = await fs.lstat(targetDir).catch((): null => null);
+  if (targetStat && (!targetStat.isDirectory() || targetStat.isSymbolicLink())) {
+    throw new Error(`Target skill path is not a directory: ${targetDir}`);
+  }
+
+  const tempDir = createSiblingTempPath(targetDir, 'update');
+  const backupDir = createSiblingTempPath(targetDir, 'backup');
+  let hasBackup = false;
+
+  try {
+    await copySkillDirectory(sourceDir, tempDir);
+    await fs.writeFile(path.join(tempDir, metaFileName), JSON.stringify(meta, null, 2), 'utf-8');
+
+    if (targetStat) {
+      await fs.rename(targetDir, backupDir);
+      hasBackup = true;
+    }
+
+    await fs.rename(tempDir, targetDir);
+
+    if (hasBackup) {
+      await fs.rm(backupDir, { recursive: true, force: true });
+      hasBackup = false;
+    }
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch((): void => undefined);
+
+    if (hasBackup && !(await pathExists(targetDir))) {
+      await fs.rename(backupDir, targetDir).catch((): void => undefined);
+      hasBackup = false;
+    }
+
+    throw error;
+  } finally {
+    if (hasBackup) {
+      await fs.rm(backupDir, { recursive: true, force: true }).catch((): void => undefined);
+    }
+  }
+}
+
 async function inspectCandidateSkill(sourceDir: string): Promise<InspectedWorkspaceSkill> {
   const stat = await fs.lstat(sourceDir).catch((): null => null);
   if (!stat?.isDirectory() || stat.isSymbolicLink()) {
@@ -343,6 +398,31 @@ export async function installWorkspaceSkillsFromTrackedFiles(workspace: string, 
     }
 
     if (await pathExists(targetDir)) {
+      if (deps.existingCustomSkillNames?.has(inspected.skillName)) {
+        try {
+          const existingMeta = await readSkillMeta(targetDir);
+          inspected.meta.installed_at = existingMeta?.meta.installed_at || inspected.meta.installed_at;
+          inspected.meta.installed_version = inspected.installedVersion;
+          inspected.meta.enabled = existingMeta?.meta.enabled !== false;
+          await replaceSkillDirectory(sourceDir, targetDir, inspected.metaFileName, inspected.meta);
+          results.push({
+            status: 'updated',
+            skillName: inspected.skillName,
+            installedVersion: inspected.installedVersion,
+            sourceDir,
+            targetDir,
+          });
+        } catch (error) {
+          results.push({
+            status: 'skipped',
+            sourceDir,
+            reason: error instanceof Error ? error.message : String(error),
+            skillName: inspected.skillName,
+          });
+        }
+        continue;
+      }
+
       if (!deps.existingCustomSkillNames?.has(inspected.skillName)) {
         results.push({
           status: 'registered',
@@ -381,7 +461,7 @@ export async function installWorkspaceSkillsFromTrackedFiles(workspace: string, 
     }
   }
 
-  if (results.some((result) => result.status === 'installed' || result.status === 'registered')) {
+  if (results.some((result) => result.status === 'installed' || result.status === 'registered' || result.status === 'updated')) {
     deps.clearSkillsCache?.();
     deps.resetAcpSkillManager?.();
   }

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -14,7 +14,7 @@ import { Button, Spin, Message, Input, Progress, Modal, Popconfirm, Switch, Tool
 import { Download, Search, Delete, Close, Shield, Lightning, UploadOne, Install, Share, Plus, Check } from '@icon-park/react';
 import classNames from 'classnames';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { emitter } from '@/renderer/utils/emitter';
+import { addEventListener, emitter } from '@/renderer/utils/emitter';
 import type { ISkillHubSkill, ISkillHubDetail, ISkillHubListResponse, IInstalledSkillInfo, ISkillHubMeta } from '@/common/ipcBridge';
 import { useAuth } from '@/renderer/context/AuthContext';
 import { useTranslation } from 'react-i18next';
@@ -596,6 +596,7 @@ const SkillModalContent: React.FC = () => {
 
   // Installed tab state
   const [installedList, setInstalledList] = useState<IInstalledSkillInfo[]>([]);
+  const [installedListRevision, setInstalledListRevision] = useState(0);
   const [installedLoading, setInstalledLoading] = useState(false);
 
   // Installed skill detail modal state (separate from store detail modal)
@@ -702,6 +703,7 @@ const SkillModalContent: React.FC = () => {
       const res = await skillHub.getInstalledSkills.invoke();
       if (res.success && res.data) {
         setInstalledList(res.data);
+        setInstalledListRevision((revision) => revision + 1);
       }
     } catch (err) {
       console.error('Failed to fetch installed list:', err);
@@ -1147,6 +1149,23 @@ const SkillModalContent: React.FC = () => {
     void fetchInstalledList();
   }, [fetchInstalledList]);
 
+  // Refresh installed skills after agent-created skill changes.
+  useEffect(() => {
+    if (!isElectronDesktop()) return;
+
+    const refreshInstalledList = () => {
+      void fetchInstalledList();
+    };
+
+    const removeSkillHubChanged = skillHub.changed.on(refreshInstalledList);
+    const removeSkillsChanged = addEventListener('skills.changed', refreshInstalledList);
+
+    return () => {
+      removeSkillHubChanged();
+      removeSkillsChanged();
+    };
+  }, [fetchInstalledList]);
+
   // Listen for sync completed event (enterprise mode)
   useEffect(() => {
     if (!isEnterprise || !isElectronDesktop()) return;
@@ -1534,7 +1553,7 @@ const SkillModalContent: React.FC = () => {
         const skillCategory = skill.category as 'custom' | 'hub' | 'system' | 'tenant' | undefined;
         return (
           <InstalledSkillCard
-            key={skill.name}
+            key={`${skill.name}:${installedListRevision}`}
             skill={skill}
             onUninstall={() => void handleUninstall(skill.name, skillCategory)}
             uninstalling={uninstallingSkillName === skill.name}
@@ -1595,7 +1614,7 @@ const SkillModalContent: React.FC = () => {
 
         return (
           <InstalledSkillCard
-            key={skill.name}
+            key={`${skill.name}:${installedListRevision}`}
             skill={skill}
             onUninstall={() => void handleUninstall(skill.name, skillCategory)}
             uninstalling={uninstallingSkillName === skill.name}
@@ -1629,7 +1648,16 @@ const SkillModalContent: React.FC = () => {
           <button className={classNames('px-12px py-5px text-13px rd-6px transition-colors cursor-pointer border-none outline-none', activeTab === 'exclusive' ? 'bg-base text-t-primary font-medium shadow-sm' : 'bg-transparent text-t-secondary hover:text-t-primary')} onClick={() => setActiveTab('exclusive')}>
             {t('settings.skill.exclusiveTab', { defaultValue: '专属技能' })}
           </button>
-          <button className={classNames('px-12px py-5px text-13px rd-6px transition-colors cursor-pointer border-none outline-none', activeTab === 'installed' ? 'bg-base text-t-primary font-medium shadow-sm' : 'bg-transparent text-t-secondary hover:text-t-primary')} onClick={() => setActiveTab('installed')}>
+          <button
+            className={classNames('px-12px py-5px text-13px rd-6px transition-colors cursor-pointer border-none outline-none', activeTab === 'installed' ? 'bg-base text-t-primary font-medium shadow-sm' : 'bg-transparent text-t-secondary hover:text-t-primary')}
+            onClick={() => {
+              if (activeTab === 'installed') {
+                void fetchInstalledList();
+                return;
+              }
+              setActiveTab('installed');
+            }}
+          >
             {t('settings.skill.installedTab', { defaultValue: '我的技能' })}
             {getInstalledSkillBadgeCount(installedList) > 0 && <span className='ml-5px px-5px py-0px bg-primary text-white text-10px rd-full leading-16px'>{getInstalledSkillBadgeCount(installedList)}</span>}
           </button>
@@ -1692,7 +1720,7 @@ const SkillModalContent: React.FC = () => {
                     // Tenant skills have category 'tenant'
                     return (
                       <InstalledSkillCard
-                        key={skill.name}
+                        key={`${skill.name}:${installedListRevision}`}
                         skill={skill}
                         onUninstall={() => void handleUninstall(skill.name, 'tenant')}
                         uninstalling={uninstallingSkillName === skill.name}

--- a/tests/unit/assetProtocol.test.ts
+++ b/tests/unit/assetProtocol.test.ts
@@ -76,7 +76,10 @@ describe('createAssetProtocolResponse', () => {
 
       expect(response.status).toBe(206);
       expect(response.headers.get('accept-ranges')).toBe('bytes');
+      expect(response.headers.get('cache-control')).toBe('no-store');
       expect(response.headers.get('content-type')).toBe('video/mp4');
+      expect(response.headers.get('expires')).toBe('0');
+      expect(response.headers.get('pragma')).toBe('no-cache');
       expect(response.headers.get('content-length')).toBe('4');
       expect(response.headers.get('content-range')).toBe('bytes 2-5/10');
       expect(await response.text()).toBe('2345');

--- a/tests/unit/workspaceSkillInstaller.test.ts
+++ b/tests/unit/workspaceSkillInstaller.test.ts
@@ -127,21 +127,73 @@ version: 2.0.0
     expect(resetAcpSkillManager).toHaveBeenCalledTimes(1);
   });
 
-  it('skips installing over an existing custom skill', async () => {
+  it('updates an existing custom skill in the installed custom skills directory', async () => {
     const skillDir = path.join(workspace, 'video-generation');
-    await fs.mkdir(skillDir, { recursive: true });
+    const targetDir = path.join(customSkillsDir, 'video-generation');
+    await fs.mkdir(path.join(skillDir, 'scripts'), { recursive: true });
     await fs.writeFile(
       path.join(skillDir, 'SKILL.md'),
       `---
 name: video-generation
+display_name: A Share Hot Rank
+description: "New skill description"
+version: 2.0.0
 ---
+
+# A Share Hot Rank
+
+Updated workflow instructions.
 `,
       'utf-8'
     );
-    await fs.writeFile(path.join(skillDir, '_sudowork_meta.json'), JSON.stringify({ name: 'video-generation' }), 'utf-8');
-    await fs.mkdir(path.join(customSkillsDir, 'video-generation'), { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, '_sudowork_meta.json'),
+      JSON.stringify({
+        name: 'video-generation',
+        display_name: 'A Share Hot Rank',
+        description: 'New skill description',
+        icon: 'icon.svg',
+        enabled: true,
+      }),
+      'utf-8'
+    );
+    await fs.writeFile(path.join(skillDir, 'icon.svg'), '<svg>new icon</svg>', 'utf-8');
+    await fs.writeFile(path.join(skillDir, 'scripts', 'run.ts'), 'export const version = 2;', 'utf-8');
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(
+      path.join(targetDir, 'SKILL.md'),
+      `---
+name: video-generation
+display_name: Old Name
+description: "Old skill description"
+version: 1.0.0
+---
+
+# Old Name
+
+Old workflow instructions.
+`,
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(targetDir, '_sudowork_meta.json'),
+      JSON.stringify({
+        name: 'video-generation',
+        display_name: 'Old Name',
+        description: 'Old skill description',
+        icon: 'old-icon.svg',
+        source_type: 'upload',
+        enabled: false,
+        installed_version: '1.0.0',
+        installed_at: '2026-05-01T00:00:00.000Z',
+      }),
+      'utf-8'
+    );
+    await fs.writeFile(path.join(targetDir, 'old-icon.svg'), '<svg>old icon</svg>', 'utf-8');
+    await fs.writeFile(path.join(targetDir, 'obsolete.txt'), 'remove me', 'utf-8');
 
     const clearSkillsCache = vi.fn();
+    const resetAcpSkillManager = vi.fn();
     const results = await installWorkspaceSkillsFromTrackedFiles(
       workspace,
       new Map<string, TrackedWorkspaceFile>([
@@ -158,18 +210,37 @@ name: video-generation
         getCustomSkillsDir: () => customSkillsDir,
         existingCustomSkillNames: new Set(['video-generation']),
         clearSkillsCache,
+        resetAcpSkillManager,
       }
     );
 
     expect(results).toEqual([
-      {
-        status: 'skipped',
-        sourceDir: skillDir,
-        reason: 'custom-skill-already-exists',
+      expect.objectContaining({
+        status: 'updated',
         skillName: 'video-generation',
-      },
+        installedVersion: '2.0.0',
+        sourceDir: skillDir,
+        targetDir,
+      }),
     ]);
-    expect(clearSkillsCache).not.toHaveBeenCalled();
+    await expect(fs.readFile(path.join(targetDir, 'SKILL.md'), 'utf-8')).resolves.toContain('Updated workflow instructions.');
+    await expect(fs.readFile(path.join(targetDir, 'icon.svg'), 'utf-8')).resolves.toBe('<svg>new icon</svg>');
+    await expect(fs.readFile(path.join(targetDir, 'scripts', 'run.ts'), 'utf-8')).resolves.toBe('export const version = 2;');
+    await expect(fs.access(path.join(targetDir, 'obsolete.txt'))).rejects.toThrow();
+
+    const meta = JSON.parse(await fs.readFile(path.join(targetDir, '_sudowork_meta.json'), 'utf-8'));
+    expect(meta).toMatchObject({
+      name: 'video-generation',
+      display_name: 'A Share Hot Rank',
+      description: 'New skill description',
+      icon: 'icon.svg',
+      source_type: 'upload',
+      enabled: false,
+      installed_version: '2.0.0',
+      installed_at: '2026-05-01T00:00:00.000Z',
+    });
+    expect(clearSkillsCache).toHaveBeenCalledTimes(1);
+    expect(resetAcpSkillManager).toHaveBeenCalledTimes(1);
   });
 
   it('registers a skill already moved into custom skills by the install script', async () => {


### PR DESCRIPTION
## Summary
- Add support for updating existing custom skills in the installed directory with atomic directory replacement (backup/restore on failure)
- Add 'updated' status to `WorkspaceSkillInstallResult` type to distinguish updates from new installs
- Preserve `installed_at` and `enabled` state when updating skills to maintain user preferences
- Add cache-control headers (`no-store`, `no-cache`) to asset protocol responses for video/audio assets
- Refresh installed skills list when agent-created skills change via event listeners
- Add revision-based key for `InstalledSkillCard` to force re-render on skill updates
- Allow manual refresh by clicking active 'installed' tab
- Update `SKILL.md` with strict field boundary rules for skill modifications

## Test plan
- [ ] Verify workspace skills update correctly when source files change
- [ ] Verify `installed_at` and `enabled` state are preserved after update
- [ ] Verify UI refreshes properly after skill installation/update
- [ ] Verify clicking 'installed' tab while active triggers a refresh
- [ ] Verify video/audio assets are not cached by browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)