### PR TITLE
fix(moss): persist session details to config on lazy creation

### DIFF
--- a/src/agent/remote/MossWsConnection.ts
+++ b/src/agent/remote/MossWsConnection.ts
@@ -104,18 +104,24 @@ export class MossWsConnection {
     this.state = 'connecting';
     mainLog('MossWsConnection', `Connecting to ${this.config.serverUrl}`);
 
-    const isResumeMode = !!this.config.wsUrl;
+    const isResumeMode = !!(this.config.wsUrl || this.wsUrl || this.config.sessionId || this.sessionId);
 
     try {
       this.accessToken = await this.exchangeToken();
 
       if (isResumeMode) {
-        this.sessionId = this.config.sessionId!;
-        this.wsUrl = this.config.wsUrl!;
+        this.sessionId = this.config.sessionId || this.sessionId!;
+        this.wsUrl = this.config.wsUrl || this.wsUrl!;
+        mainLog('MossWsConnection', `Resuming session: ${this.sessionId}`);
       } else {
         const sessionData = await this.createMossSession();
         this.sessionId = sessionData.session_id;
         this.wsUrl = sessionData.ws_url;
+        // CRITICAL: Persist created session details back to config
+        // This ensures reconnects/scheduleReconnect() enter resume mode
+        // instead of creating duplicate sessions (the "session storm")
+        this.config.wsUrl = sessionData.ws_url;
+        this.config.sessionId = sessionData.session_id;
         mainLog('MossWsConnection', `Session created: ${this.sessionId}`);
       }
 


### PR DESCRIPTION
Enterprise mode Moss runtime quit caused "session storm" — reconnects always created new sessions because `isResumeMode` was based only on `config.wsUrl` (never updated after `createMossSession()`).

Now persist `wsUrl`/`sessionId` back to config object. Updated `isResumeMode` check covers both initial create and subsequent reconnects from `scheduleReconnect()`.

Non-enterprise and explicit resume paths unchanged. Matches prior audit.

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
