### PR TITLE
fix: centralize tenant config resolution and support enterprise mode

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1790,12 +1790,12 @@ export const crash = {
 
 export interface TenantConfigData {
   id: string;
-  logo: string;
-  app_name: string;
-  top_name: string;
-  about_name: string;
-  app_company_name: string;
-  login_desp: string;
+  logo: string | null;
+  app_name: string | null;
+  top_name: string | null;
+  about_name: string | null;
+  app_company_name: string | null;
+  login_desp: string | null;
   updated_at: number;
 }
 

--- a/src/common/types/tenantConfig.ts
+++ b/src/common/types/tenantConfig.ts
@@ -36,6 +36,10 @@ export interface TenantConfigResponse {
   msg?: string;
 }
 
+export type TenantConfigInput = Partial<Record<keyof TenantConfig, string | null | undefined>>;
+
+export const TENANT_CONFIG_STORAGE_KEY = 'sudowork_tenant_config';
+
 /**
  * 默认租户配置
  * 当接口未返回或字段为空时使用此默认值
@@ -48,3 +52,14 @@ export const DEFAULT_TENANT_CONFIG: Required<TenantConfig> = {
   about_name: 'SudoWork',
   app_company_name: '北京数牍科技有限公司',
 };
+
+export function resolveTenantConfig(config?: TenantConfigInput | null): Required<TenantConfig> {
+  return {
+    logo: config?.logo || DEFAULT_TENANT_CONFIG.logo,
+    app_name: config?.app_name || DEFAULT_TENANT_CONFIG.app_name,
+    top_name: config?.top_name || DEFAULT_TENANT_CONFIG.top_name,
+    login_desp: config?.login_desp || DEFAULT_TENANT_CONFIG.login_desp,
+    about_name: config?.about_name || DEFAULT_TENANT_CONFIG.about_name,
+    app_company_name: config?.app_company_name || DEFAULT_TENANT_CONFIG.app_company_name,
+  };
+}

--- a/src/renderer/context/TenantConfigContext.tsx
+++ b/src/renderer/context/TenantConfigContext.tsx
@@ -7,10 +7,12 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ipcBridge } from '@/common';
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
-import { TenantConfig, TenantConfigResponse, DEFAULT_TENANT_CONFIG } from '@/common/types/tenantConfig';
+import { ConfigStorage } from '@/common/storage';
+import type { TenantConfig, TenantConfigResponse } from '@/common/types/tenantConfig';
+import { DEFAULT_TENANT_CONFIG, TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
 import { useAuth } from './AuthContext';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 
-const TENANT_CONFIG_STORAGE_KEY = 'sudowork_tenant_config';
 const POLL_INTERVAL_MS = 10 * 60 * 1000; // 10 分钟
 
 interface TenantConfigContextValue {
@@ -34,6 +36,7 @@ const TenantConfigContext = createContext<TenantConfigContextValue | undefined>(
  */
 export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { user, status, ensureValidToken } = useAuth();
+  const { isEnterprise } = useAppMode();
 
   // 初始化时从 localStorage 加载缓存
   const [config, setConfig] = useState<Required<TenantConfig>>(() => {
@@ -41,7 +44,7 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
       const cached = localStorage.getItem(TENANT_CONFIG_STORAGE_KEY);
       if (cached) {
         const parsed = JSON.parse(cached);
-        return { ...DEFAULT_TENANT_CONFIG, ...parsed };
+        return resolveTenantConfig(parsed);
       }
     } catch {
       // ignore parse error
@@ -57,8 +60,12 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
    * 从服务端获取租户配置
    */
   const fetchConfig = useCallback(async () => {
-    // 未登录或缺少 enterprise_code，不请求
-    if (status !== 'authenticated' || !user?.enterprise_code) {
+    if (status !== 'authenticated') {
+      return;
+    }
+
+    // Personal mode still depends on sudowork-server enterprise_code.
+    if (!isEnterprise && !user?.enterprise_code) {
       return;
     }
 
@@ -68,19 +75,40 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
     setLoading(true);
 
     try {
+      if (isEnterprise) {
+        const configuredServerUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        const serverUrl = configuredServerUrl?.trim().replace(/\/+$/, '');
+
+        if (!serverUrl) {
+          console.warn('[TenantConfig] No enterprise server URL configured');
+          return;
+        }
+
+        const data = await ipcBridge.eeclaw.verifyServer.invoke({ serverUrl });
+
+        if (data.success && data.data) {
+          const mergedConfig = resolveTenantConfig(data.data);
+          setConfig(mergedConfig);
+          localStorage.setItem(TENANT_CONFIG_STORAGE_KEY, JSON.stringify(mergedConfig));
+          await ConfigStorage.set('eeclaw.tenantName', mergedConfig.app_company_name);
+          console.log('[TenantConfig] Enterprise config updated:', mergedConfig);
+        } else {
+          console.warn('[TenantConfig] Enterprise API returned unsuccessful:', data.msg);
+        }
+        return;
+      }
+
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
       const baseUrl = serverConfig.baseUrl || SUDOWORK_SERVER_BASE_URL;
       const token = await ensureValidToken();
 
       if (!token) {
         console.warn('[TenantConfig] No valid token');
-        isRefreshing.current = false;
-        setLoading(false);
         return;
       }
 
       // 使用 enterprise_code 作为租户 code 参数
-      const url = `${baseUrl}/api/v1/tenant/config?code=${user.enterprise_code}`;
+      const url = `${baseUrl}/api/v1/tenant/config?code=${user?.enterprise_code}`;
 
       const response = await fetch(url, {
         method: 'GET',
@@ -92,23 +120,13 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
 
       if (!response.ok) {
         console.warn('[TenantConfig] API response not OK:', response.status);
-        isRefreshing.current = false;
-        setLoading(false);
         return;
       }
 
       const data: TenantConfigResponse = await response.json();
 
       if (data.success && data.data) {
-        // 合并默认值，空字段使用默认值
-        const mergedConfig: Required<TenantConfig> = {
-          logo: data.data.logo || DEFAULT_TENANT_CONFIG.logo,
-          app_name: data.data.app_name || DEFAULT_TENANT_CONFIG.app_name,
-          top_name: data.data.top_name || DEFAULT_TENANT_CONFIG.top_name,
-          login_desp: data.data.login_desp || DEFAULT_TENANT_CONFIG.login_desp,
-          about_name: data.data.about_name || DEFAULT_TENANT_CONFIG.about_name,
-          app_company_name: data.data.app_company_name || DEFAULT_TENANT_CONFIG.app_company_name,
-        };
+        const mergedConfig = resolveTenantConfig(data.data);
         setConfig(mergedConfig);
         // 缓存到 localStorage
         localStorage.setItem(TENANT_CONFIG_STORAGE_KEY, JSON.stringify(mergedConfig));
@@ -118,11 +136,11 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
       }
     } catch (error) {
       console.error('[TenantConfig] Fetch failed:', error);
+    } finally {
+      isRefreshing.current = false;
+      setLoading(false);
     }
-
-    isRefreshing.current = false;
-    setLoading(false);
-  }, [status, user?.enterprise_code, ensureValidToken]);
+  }, [status, isEnterprise, user?.enterprise_code, ensureValidToken]);
 
   /**
    * 启动定时轮询
@@ -150,7 +168,7 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
 
   // 监听登录状态变化
   useEffect(() => {
-    if (status === 'authenticated' && user?.enterprise_code) {
+    if (status === 'authenticated' && (isEnterprise || user?.enterprise_code)) {
       // 登录成功 → 立即刷新 + 启动轮询
       void fetchConfig();
       startPolling();
@@ -160,7 +178,7 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
       setConfig(DEFAULT_TENANT_CONFIG);
       stopPolling();
     }
-  }, [status, user?.enterprise_code, fetchConfig, startPolling, stopPolling]);
+  }, [status, isEnterprise, user?.enterprise_code, fetchConfig, startPolling, stopPolling]);
 
   // 清理定时器
   useEffect(() => {
@@ -178,11 +196,7 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
     [config, loading, fetchConfig]
   );
 
-  return (
-    <TenantConfigContext.Provider value={value}>
-      {children}
-    </TenantConfigContext.Provider>
-  );
+  return <TenantConfigContext.Provider value={value}>{children}</TenantConfigContext.Provider>;
 };
 
 /**

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../context/AuthContext';
 import { Button, Input, Message, Space } from '@arco-design/web-react';
 import { Phone, Protect, Key, User, Lock } from '@icon-park/react';
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
-import { DEFAULT_TENANT_CONFIG } from '@/common/types/tenantConfig';
+import { DEFAULT_TENANT_CONFIG, TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
 import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import WindowControls from '../../components/WindowControls';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
@@ -38,10 +38,10 @@ function isValidPhone(phone: string): boolean {
 // 从 localStorage 读取缓存的租户配置
 function getCachedTenantConfig(): Required<typeof DEFAULT_TENANT_CONFIG> {
   try {
-    const cached = localStorage.getItem('sudowork_tenant_config');
+    const cached = localStorage.getItem(TENANT_CONFIG_STORAGE_KEY);
     if (cached) {
       const parsed = JSON.parse(cached);
-      return { ...DEFAULT_TENANT_CONFIG, ...parsed };
+      return resolveTenantConfig(parsed);
     }
   } catch {
     // ignore
@@ -51,7 +51,7 @@ function getCachedTenantConfig(): Required<typeof DEFAULT_TENANT_CONFIG> {
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
-  const { status, login, register, enterpriseLogin, enterpriseLoginWithOAuth2, logout } = useAuth();
+  const { status, login, register, enterpriseLogin, enterpriseLoginWithOAuth2 } = useAuth();
   const { isEnterprise } = useAppMode();
 
   // Enterprise login state
@@ -59,7 +59,6 @@ const LoginPage: React.FC = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [apiKey, setApiKey] = useState('');
-  const [tenantName, setTenantName] = useState<string>('');
 
   // OAuth2 login state
   const [oauth2Config, setOauth2Config] = useState<{ enabled: boolean; authorize_url?: string } | null>(null);
@@ -70,19 +69,12 @@ const LoginPage: React.FC = () => {
   // 从 localStorage 读取缓存的租户配置
   const tenantConfig = getCachedTenantConfig();
 
-  // Enterprise: load tenantName on mount
-  useEffect(() => {
-    if (isEnterprise) {
-      ConfigStorage.get('eeclaw.tenantName').then(setTenantName);
-    }
-  }, [isEnterprise]);
-
   // OAuth2: fetch config from MOSS when the OAuth2 tab is selected
   useEffect(() => {
     if (!isEnterprise || loginTab !== 'oauth2' || oauth2Config) return;
     let cancelled = false;
     setOauth2Loading(true);
-    (async () => {
+    void (async () => {
       try {
         const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
         if (!serverUrl) {
@@ -143,9 +135,7 @@ const LoginPage: React.FC = () => {
     const state = generateOAuth2State();
     oauth2StateRef.current = state;
     // moss returns the authorize URL with {state} placeholder (or none); fill/append it.
-    const url = oauth2Config.authorize_url.includes('{state}')
-      ? oauth2Config.authorize_url.replace('{state}', encodeURIComponent(state))
-      : `${oauth2Config.authorize_url}${oauth2Config.authorize_url.includes('?') ? '&' : '?'}state=${encodeURIComponent(state)}`;
+    const url = oauth2Config.authorize_url.includes('{state}') ? oauth2Config.authorize_url.replace('{state}', encodeURIComponent(state)) : `${oauth2Config.authorize_url}${oauth2Config.authorize_url.includes('?') ? '&' : '?'}state=${encodeURIComponent(state)}`;
     setOauth2Waiting(true);
     try {
       await ipcBridge.shell.openExternal.invoke(url);
@@ -463,13 +453,14 @@ const LoginPage: React.FC = () => {
   const handleBackToModeSelect = async () => {
     try {
       // Clear all enterprise-related ConfigStorage keys
-      await ConfigStorage.remove('eeclaw.authStorage' as any);
-      await ConfigStorage.remove('eeclaw.userInfo' as any);
-      await ConfigStorage.remove('eeclaw.serverUrl' as any);
-      await ConfigStorage.remove('eeclaw.tenantName' as any);
-      await ConfigStorage.remove('system.appMode' as any);
+      await ConfigStorage.set('eeclaw.authStorage', undefined);
+      await ConfigStorage.set('eeclaw.userInfo', undefined);
+      await ConfigStorage.set('eeclaw.serverUrl', undefined);
+      await ConfigStorage.set('eeclaw.tenantName', undefined);
+      await ConfigStorage.set('system.appMode', undefined);
       // Clear enterprise auth from localStorage
       localStorage.removeItem('eeclaw_auth_v1');
+      localStorage.removeItem(TENANT_CONFIG_STORAGE_KEY);
       // Clear C-side auth to avoid falling into authenticated state
       localStorage.removeItem('sudowork_auth_v2');
       localStorage.removeItem('sudowork_auth_v1');
@@ -495,14 +486,10 @@ const LoginPage: React.FC = () => {
         <div className='login-page__card'>
           <div className='login-page__header'>
             <div className='login-page__logo'>
-              <img
-                src={SudoworkIcon}
-                alt={tenantName || 'SudoWork'}
-                className='w-64px h-64px object-contain'
-              />
+              <img src={tenantConfig.logo || SudoworkIcon} alt={tenantConfig.app_name} className='w-64px h-64px object-contain' />
             </div>
-            <h1 className='text-28px font-800 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>{tenantName || 'SudoWork'}</h1>
-            <p className='text-13px text-t-secondary'>企业版登录</p>
+            <h1 className='text-28px font-800 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>{tenantConfig.app_name}</h1>
+            <p className='text-13px text-t-secondary'>{tenantConfig.login_desp}</p>
           </div>
 
           {/* Enterprise login tabs: password / key / oauth2 */}
@@ -536,26 +523,11 @@ const LoginPage: React.FC = () => {
                 <Input size='large' prefix={<Key className='text-t-tertiary' />} placeholder='moss_sk_xxx.yyy' value={apiKey} onChange={setApiKey} className='login-input !rd-12px h-48px' />
               </div>
             ) : (
-              <div className='flex flex-col gap-8px text-center'>
-                {oauth2Loading ? (
-                  <div className='text-13px text-t-tertiary py-12px'>正在检查 OAuth2 配置…</div>
-                ) : oauth2Config?.enabled ? (
-                  <div className='text-13px text-t-secondary py-4px'>点击下方按钮，将在浏览器中完成身份认证。</div>
-                ) : (
-                  <div className='text-13px text-t-tertiary py-12px'>管理员未启用 OAuth2 登录</div>
-                )}
-              </div>
+              <div className='flex flex-col gap-8px text-center'>{oauth2Loading ? <div className='text-13px text-t-tertiary py-12px'>正在检查 OAuth2 配置…</div> : oauth2Config?.enabled ? <div className='text-13px text-t-secondary py-4px'>点击下方按钮，将在浏览器中完成身份认证。</div> : <div className='text-13px text-t-tertiary py-12px'>管理员未启用 OAuth2 登录</div>}</div>
             )}
 
             {loginTab === 'oauth2' ? (
-              <Button
-                type='primary'
-                size='large'
-                loading={oauth2Waiting}
-                disabled={oauth2Loading || !oauth2Config?.enabled}
-                onClick={() => handleOAuth2Login()}
-                className='login-btn-primary !rd-12px h-52px mt-12px font-700 text-16px'
-              >
+              <Button type='primary' size='large' loading={oauth2Waiting} disabled={oauth2Loading || !oauth2Config?.enabled} onClick={() => handleOAuth2Login()} className='login-btn-primary !rd-12px h-52px mt-12px font-700 text-16px'>
                 {oauth2Waiting ? '等待浏览器授权…' : '通过浏览器登录'}
               </Button>
             ) : (
@@ -565,10 +537,7 @@ const LoginPage: React.FC = () => {
             )}
 
             <div className='text-center mt-12px'>
-              <span
-                className='text-12px text-t-tertiary cursor-pointer hover:text-t-secondary transition-colors'
-                onClick={handleBackToModeSelect}
-              >
+              <span className='text-12px text-t-tertiary cursor-pointer hover:text-t-secondary transition-colors' onClick={handleBackToModeSelect}>
                 ← 返回模式选择
               </span>
             </div>
@@ -593,11 +562,7 @@ const LoginPage: React.FC = () => {
       <div className='login-page__card'>
         <div className='login-page__header'>
           <div className='login-page__logo'>
-            <img
-              src={tenantConfig.logo || SudoworkIcon}
-              alt={tenantConfig.app_name}
-              className='w-64px h-64px object-contain'
-            />
+            <img src={tenantConfig.logo || SudoworkIcon} alt={tenantConfig.app_name} className='w-64px h-64px object-contain' />
           </div>
           <h1 className='text-28px font-800 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>{tenantConfig.app_name}</h1>
           <p className='text-13px text-t-secondary'>{tenantConfig.login_desp}</p>
@@ -648,10 +613,7 @@ const LoginPage: React.FC = () => {
           </Button>
 
           <div className='text-center mt-12px'>
-            <span
-              className='text-12px text-t-tertiary cursor-pointer hover:text-t-secondary transition-colors'
-              onClick={handleBackToModeSelect}
-            >
+            <span className='text-12px text-t-tertiary cursor-pointer hover:text-t-secondary transition-colors' onClick={handleBackToModeSelect}>
               ← 返回模式选择
             </span>
           </div>

--- a/src/renderer/pages/settings/EnterpriseSettings.tsx
+++ b/src/renderer/pages/settings/EnterpriseSettings.tsx
@@ -9,6 +9,7 @@ import { Button, Input, Message, Spin } from '@arco-design/web-react';
 import { BuildingTwo, Success, Close } from '@icon-park/react';
 import { ConfigStorage } from '@/common/storage';
 import { ipcBridge } from '@/common';
+import { TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
 import { useAuth } from '@/renderer/context/AuthContext';
 import SettingsPageWrapper from './components/SettingsPageWrapper';
 
@@ -24,10 +25,7 @@ const EnterpriseSettings: React.FC = () => {
   useEffect(() => {
     const loadConfig = async () => {
       try {
-        const [name, url] = await Promise.all([
-          ConfigStorage.get('eeclaw.tenantName'),
-          ConfigStorage.get('eeclaw.serverUrl'),
-        ]);
+        const [name, url] = await Promise.all([ConfigStorage.get('eeclaw.tenantName'), ConfigStorage.get('eeclaw.serverUrl')]);
         setTenantName(name || '');
         setServerUrl(url || '');
         setEditingServerUrl(url || '');
@@ -63,11 +61,14 @@ const EnterpriseSettings: React.FC = () => {
         return;
       }
 
+      const tenantConfig = resolveTenantConfig(result.data);
+
       // Step 2: Update ConfigStorage
       await ConfigStorage.set('eeclaw.serverUrl', normalizedUrl);
-      await ConfigStorage.set('eeclaw.tenantName', result.data.app_company_name);
+      await ConfigStorage.set('eeclaw.tenantName', tenantConfig.app_company_name);
+      localStorage.setItem(TENANT_CONFIG_STORAGE_KEY, JSON.stringify(tenantConfig));
       setServerUrl(normalizedUrl);
-      setTenantName(result.data.app_company_name);
+      setTenantName(tenantConfig.app_company_name);
       setEditingServerUrl(normalizedUrl);
 
       // Step 3: Clear auth data (SECURITY-2)
@@ -120,38 +121,18 @@ const EnterpriseSettings: React.FC = () => {
           {/* Connection Status */}
           <div className='flex items-center justify-between py-8px'>
             <div className='flex items-center gap-8px'>
-              {connectionStatus === 'connected' ? (
-                <Success theme='filled' size={16} fill={['#00b42a']} />
-              ) : connectionStatus === 'checking' ? (
-                <Spin size={16} />
-              ) : (
-                <Close theme='filled' size={16} fill={['#f53f3f']} />
-              )}
+              {connectionStatus === 'connected' ? <Success theme='filled' size={16} fill={['#00b42a']} /> : connectionStatus === 'checking' ? <Spin size={16} /> : <Close theme='filled' size={16} fill={['#f53f3f']} />}
               <span className='text-14px text-t-secondary'>连接状态</span>
             </div>
-            <span className={`text-14px font-500 ${connectionStatus === 'connected' ? 'text-[rgb(var(--green-6))]' : connectionStatus === 'disconnected' ? 'text-[rgb(var(--red-6))]' : 'text-[var(--color-text-3)]'}`}>
-              {connectionStatus === 'connected' ? '已连接' : connectionStatus === 'checking' ? '检查中...' : '未连接'}
-            </span>
+            <span className={`text-14px font-500 ${connectionStatus === 'connected' ? 'text-[rgb(var(--green-6))]' : connectionStatus === 'disconnected' ? 'text-[rgb(var(--red-6))]' : 'text-[var(--color-text-3)]'}`}>{connectionStatus === 'connected' ? '已连接' : connectionStatus === 'checking' ? '检查中...' : '未连接'}</span>
           </div>
 
           {/* Server URL (editable) */}
           <div className='flex flex-col gap-8px pt-8px'>
             <span className='text-14px text-t-secondary'>服务器地址</span>
             <div className='flex gap-8px'>
-              <Input
-                value={editingServerUrl}
-                onChange={setEditingServerUrl}
-                placeholder='https://your-company-server.com'
-                className='flex-1 h-[32px] rounded-8px bg-[var(--fill-0)]'
-                disabled={saving}
-              />
-              <Button
-                type='primary'
-                size='small'
-                loading={saving}
-                onClick={() => void handleSaveServerUrl()}
-                disabled={editingServerUrl.trim() === serverUrl.trim() || !editingServerUrl.trim()}
-              >
+              <Input value={editingServerUrl} onChange={setEditingServerUrl} placeholder='https://your-company-server.com' className='flex-1 h-[32px] rounded-8px bg-[var(--fill-0)]' disabled={saving} />
+              <Button type='primary' size='small' loading={saving} onClick={() => void handleSaveServerUrl()} disabled={editingServerUrl.trim() === serverUrl.trim() || !editingServerUrl.trim()}>
                 保存
               </Button>
             </div>

--- a/src/renderer/pages/setup/ModeSetup.tsx
+++ b/src/renderer/pages/setup/ModeSetup.tsx
@@ -9,6 +9,7 @@ import { Button, Input, Message } from '@arco-design/web-react';
 import { ipcBridge } from '@/common';
 import { ConfigStorage } from '@/common/storage';
 import { setAppMode } from '@/common/eeclawMode';
+import { TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
 import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import WindowControls from '@/renderer/components/WindowControls';
 import './ModeSetup.css';
@@ -16,6 +17,11 @@ import './ModeSetup.css';
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
 
 type CardType = 'consumer' | 'enterprise' | null;
+type WebkitAppRegionStyle = React.CSSProperties & { WebkitAppRegion?: 'drag' | 'no-drag' };
+
+function getModeActionStyle(visible: boolean): WebkitAppRegionStyle {
+  return { display: visible ? 'block' : 'none', width: '100%', WebkitAppRegion: 'no-drag' };
+}
 
 function isValidServerUrl(url: string): boolean {
   // E2E test bypass
@@ -91,10 +97,13 @@ const ModeSetup: React.FC = () => {
       const result = await ipcBridge.eeclaw.verifyServer.invoke({ serverUrl: normalizedUrl });
 
       if (result.success && result.data) {
+        const tenantConfig = resolveTenantConfig(result.data);
+
         // Save mode + serverUrl + tenantName first, then reload
         await setAppMode('e');
         await ConfigStorage.set('eeclaw.serverUrl', normalizedUrl);
-        await ConfigStorage.set('eeclaw.tenantName', result.data.app_company_name);
+        await ConfigStorage.set('eeclaw.tenantName', tenantConfig.app_company_name);
+        localStorage.setItem(TENANT_CONFIG_STORAGE_KEY, JSON.stringify(tenantConfig));
 
         // Notify main process to start local services, then reload renderer
         await ipcBridge.application.startConsumerServices.invoke();
@@ -131,19 +140,14 @@ const ModeSetup: React.FC = () => {
         {/* Logo & Title */}
         <div className='mode-setup__header'>
           <img src={SudoworkIcon} alt='Sudowork' className='mode-setup__logo' />
-          <h1 className='text-28px font-700 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>
-            欢迎使用 SudoWork
-          </h1>
+          <h1 className='text-28px font-700 tracking-tighter bg-gradient-to-br from-primary to-purple-600 bg-clip-text text-transparent mb-8px'>欢迎使用 SudoWork</h1>
           <p className='text-14px text-t-secondary'>请选择您的使用模式</p>
         </div>
 
         {/* Cards */}
         <div className='mode-setup__cards'>
           {/* Consumer Card */}
-          <div
-            className={`mode-setup__card ${selectedCard === 'consumer' ? 'mode-setup__card--selected' : ''}`}
-            onClick={() => handleCardSelect('consumer')}
-          >
+          <div className={`mode-setup__card ${selectedCard === 'consumer' ? 'mode-setup__card--selected' : ''}`} onClick={() => handleCardSelect('consumer')}>
             <div className='mode-setup__card__icon'>
               <svg viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
                 <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2' />
@@ -159,10 +163,7 @@ const ModeSetup: React.FC = () => {
           </div>
 
           {/* Enterprise Card */}
-          <div
-            className={`mode-setup__card ${selectedCard === 'enterprise' ? 'mode-setup__card--selected' : ''}`}
-            onClick={() => handleCardSelect('enterprise')}
-          >
+          <div className={`mode-setup__card ${selectedCard === 'enterprise' ? 'mode-setup__card--selected' : ''}`} onClick={() => handleCardSelect('enterprise')}>
             <div className='mode-setup__card__icon'>
               <svg viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'>
                 <path d='M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z' />
@@ -183,51 +184,24 @@ const ModeSetup: React.FC = () => {
           <div className='flex flex-col gap-12px w-full'>
             <div className='flex flex-col gap-8px'>
               <div className='text-13px font-600 text-t-primary'>企业服务器地址</div>
-              <Input
-                size='large'
-                placeholder='https://your-company-server.com'
-                value={serverUrl}
-                onChange={setServerUrl}
-                className='mode-setup__input'
-              />
-              {serverUrl && !isValidServerUrl(serverUrl) ? (
-                <p className='text-12px text-danger ml-4px'>请输入有效的 HTTP/HTTPS 地址</p>
-              ) : serverUrl.startsWith('http://') ? (
-                <p className='text-12px text-warning ml-4px'>建议使用 HTTPS 协议以确保安全</p>
-              ) : (
-                <p className='text-12px text-t-tertiary ml-4px'>请输入管理员提供的企业服务器地址</p>
-              )}
+              <Input size='large' placeholder='https://your-company-server.com' value={serverUrl} onChange={setServerUrl} className='mode-setup__input' />
+              {serverUrl && !isValidServerUrl(serverUrl) ? <p className='text-12px text-danger ml-4px'>请输入有效的 HTTP/HTTPS 地址</p> : serverUrl.startsWith('http://') ? <p className='text-12px text-warning ml-4px'>建议使用 HTTPS 协议以确保安全</p> : <p className='text-12px text-t-tertiary ml-4px'>请输入管理员提供的企业服务器地址</p>}
             </div>
 
-            {verifyResult && (
-              <div className={`mode-setup__verify-result ${verifyResult.success ? 'mode-setup__verify-result--success' : 'mode-setup__verify-result--error'}`}>
-                {verifyResult.success ? (
-                  <span>{verifyResult.tenantName} — 连接成功</span>
-                ) : (
-                  <span>{verifyResult.message}</span>
-                )}
-              </div>
-            )}
+            {verifyResult && <div className={`mode-setup__verify-result ${verifyResult.success ? 'mode-setup__verify-result--success' : 'mode-setup__verify-result--error'}`}>{verifyResult.success ? <span>{verifyResult.tenantName} — 连接成功</span> : <span>{verifyResult.message}</span>}</div>}
           </div>
         </div>
 
         {/* Consumer button */}
-        <div style={{ display: selectedCard === 'consumer' ? 'block' : 'none', width: '100%', WebkitAppRegion: 'no-drag' }}>
+        <div style={getModeActionStyle(selectedCard === 'consumer')}>
           <Button type='primary' size='large' onClick={handleConsumerNext} className='mode-setup__btn mode-setup__btn--consumer'>
             开始使用
           </Button>
         </div>
 
         {/* Enterprise button */}
-        <div style={{ display: selectedCard === 'enterprise' ? 'block' : 'none', width: '100%', WebkitAppRegion: 'no-drag' }}>
-          <Button
-            type='primary'
-            size='large'
-            loading={verifying}
-            onClick={handleEnterpriseNext}
-            className='mode-setup__btn'
-            disabled={!serverUrl.trim() || verifying}
-          >
+        <div style={getModeActionStyle(selectedCard === 'enterprise')}>
+          <Button type='primary' size='large' loading={verifying} onClick={handleEnterpriseNext} className='mode-setup__btn' disabled={!serverUrl.trim() || verifying}>
             {verifying ? '验证中...' : '下一步'}
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- Extract `resolveTenantConfig()` helper to centralize null-field merging with defaults, replacing scattered inline logic across components
- Support enterprise mode tenant config fetching from MOSS `verifyServer` API (not only sudowork-server)
- Allow `TenantConfigData` fields to be `null` to match actual API responses

## Details
- `TenantConfigData` fields now accept `string | null`
- `TENANT_CONFIG_STORAGE_KEY` constant replaces hardcoded string
- Enterprise mode fetches config via `ipcBridge.eeclaw.verifyServer` and caches to localStorage
- `finally` block ensures loading/refreshing state is always reset on fetch
- `ConfigStorage.set(key, undefined)` replaces unsafe `ConfigStorage.remove('key' as any)`
- Login page uses `tenantConfig` directly instead of separate `tenantName` state
- `WebkitAppRegion` style helper extracted in ModeSetup

## Test plan
- [ ] Verify personal mode login still shows correct tenant branding
- [ ] Verify enterprise mode login fetches and displays tenant config from MOSS
- [ ] Verify enterprise setup flow (ModeSetup) saves tenant config to localStorage
- [ ] Verify EnterpriseSettings save properly resolves null fields with defaults
- [ ] Verify loading state resets correctly on API failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)