### PR TITLE
fix(conversation): persist draft state across page switches

### DIFF
--- a/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/DingTalkConfigForm.tsx
@@ -397,7 +397,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
                   handleCredentialsChange();
                 }}
                 onBlur={() => setTouched((prev) => ({ ...prev, clientId: true }))}
-                placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'dingxxxxxxxxxx'}
+                placeholder={hasExistingUsers ? '••••••••••••••••' : 'dingxxxxxxxxxx'}
                 style={{ width: 240 }}
                 status={touched.clientId && !clientId.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
                 disabled={hasExistingUsers}
@@ -412,7 +412,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
               handleCredentialsChange();
             }}
             onBlur={() => setTouched((prev) => ({ ...prev, clientId: true }))}
-            placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'dingxxxxxxxxxx'}
+            placeholder={hasExistingUsers ? '••••••••••••••••' : 'dingxxxxxxxxxx'}
             style={{ width: 240 }}
             status={touched.clientId && !clientId.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
             disabled={hasExistingUsers}
@@ -450,7 +450,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
                   handleCredentialsChange();
                 }}
                 onBlur={() => setTouched((prev) => ({ ...prev, clientSecret: true }))}
-                placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
+                placeholder={hasExistingUsers ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
                 style={{ width: 240 }}
                 status={touched.clientSecret && !clientSecret.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
                 visibilityToggle
@@ -466,7 +466,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
               handleCredentialsChange();
             }}
             onBlur={() => setTouched((prev) => ({ ...prev, clientSecret: true }))}
-            placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
+            placeholder={hasExistingUsers ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
             style={{ width: 240 }}
             status={touched.clientSecret && !clientSecret.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
             visibilityToggle

--- a/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
+++ b/src/renderer/components/SettingsModal/contents/LarkConfigForm.tsx
@@ -408,7 +408,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
                   handleCredentialsChange();
                 }}
                 onBlur={() => setTouched((prev) => ({ ...prev, appId: true }))}
-                placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'cli_xxxxxxxxxx'}
+                placeholder={hasExistingUsers ? '••••••••••••••••' : 'cli_xxxxxxxxxx'}
                 style={{ width: 240 }}
                 status={touched.appId && !appId.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
                 disabled={hasExistingUsers}
@@ -423,7 +423,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
               handleCredentialsChange();
             }}
             onBlur={() => setTouched((prev) => ({ ...prev, appId: true }))}
-            placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'cli_xxxxxxxxxx'}
+            placeholder={hasExistingUsers ? '••••••••••••••••' : 'cli_xxxxxxxxxx'}
             style={{ width: 240 }}
             status={touched.appId && !appId.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
             disabled={hasExistingUsers}
@@ -461,7 +461,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
                   handleCredentialsChange();
                 }}
                 onBlur={() => setTouched((prev) => ({ ...prev, appSecret: true }))}
-                placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
+                placeholder={hasExistingUsers ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
                 style={{ width: 240 }}
                 status={touched.appSecret && !appSecret.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
                 visibilityToggle
@@ -477,7 +477,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
               handleCredentialsChange();
             }}
             onBlur={() => setTouched((prev) => ({ ...prev, appSecret: true }))}
-            placeholder={hasExistingUsers || pluginStatus?.hasToken ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
+            placeholder={hasExistingUsers ? '••••••••••••••••' : 'xxxxxxxxxxxxxxxxxx'}
             style={{ width: 240 }}
             status={touched.appSecret && !appSecret.trim() && !pluginStatus?.hasToken ? 'error' : undefined}
             visibilityToggle

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -56,11 +56,13 @@ const SendBox: React.FC<{
   slashCommands?: SlashCommandItem[];
   onSlashBuiltinCommand?: (name: string) => void;
   onSkillsChange?: (skills: string[]) => void;
+  /** Initial selected skills restored from draft state */
+  initialSelectedSkills?: string[];
   /** Workspace files for @ file references */
   workspaceFiles?: WorkspaceFileItem[];
   /** Called when a file is selected via @ selector, allowing parent to track the file */
   onAtFileSelected?: (file: WorkspaceFileItem) => void;
-}> = ({ onSend, onStop, prefix, className, loading, tools, disabled, placeholder, value: input = '', onChange: setInput = constVoid, onFilesAdded, supportedExts = allSupportedExts, defaultMultiLine = false, lockMultiLine = false, sendButtonPrefix, slashCommands = [], onSlashBuiltinCommand, onSkillsChange, workspaceFiles, onAtFileSelected }) => {
+}> = ({ onSend, onStop, prefix, className, loading, tools, disabled, placeholder, value: input = '', onChange: setInput = constVoid, onFilesAdded, supportedExts = allSupportedExts, defaultMultiLine = false, lockMultiLine = false, sendButtonPrefix, slashCommands = [], onSlashBuiltinCommand, onSkillsChange, initialSelectedSkills = [], workspaceFiles, onAtFileSelected }) => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const { t } = useTranslation();
@@ -240,7 +242,7 @@ const SendBox: React.FC<{
 
   // Skill selector state
   const [installedSkills, setInstalledSkills] = useState<IInstalledSkillInfo[]>([]);
-  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [selectedSkills, setSelectedSkills] = useState<string[]>(() => initialSelectedSkills);
   const [loadingSkills, setLoadingSkills] = useState(false);
 
   // Fetch installed skills on mount and after agent-created skills are installed.

--- a/src/renderer/hooks/useSendBoxDraft.ts
+++ b/src/renderer/hooks/useSendBoxDraft.ts
@@ -11,18 +11,21 @@ type Draft =
       content: string;
       atPath: Array<string | FileOrFolderItem>;
       uploadFile: string[];
+      selectedSkills: string[];
     }
   | {
       _type: 'openclaw-gateway';
       content: string;
       atPath: Array<string | FileOrFolderItem>;
       uploadFile: string[];
+      selectedSkills: string[];
     }
   | {
       _type: 'remote-agent';
       content: string;
       atPath: Array<string | FileOrFolderItem>;
       uploadFile: string[];
+      selectedSkills: string[];
     };
 
 /**

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -39,6 +39,7 @@ const useAcpSendBoxDraft = getSendBoxDraftHook('acp', {
   atPath: [],
   content: '',
   uploadFile: [],
+  selectedSkills: [],
 });
 
 const useAcpMessage = (conversation_id: string) => {
@@ -501,6 +502,17 @@ const useSendBoxDraft = (conversation_id: string) => {
   const atPath = data?.atPath ?? EMPTY_AT_PATH;
   const uploadFile = data?.uploadFile ?? EMPTY_UPLOAD_FILES;
   const content = data?.content ?? '';
+  const selectedSkills = data?.selectedSkills ?? [];
+  const setSelectedSkills = useCallback(
+    (skills: string[] | ((prev: string[]) => string[])) => {
+      mutate((prev) => {
+        const previousSkills = prev?.selectedSkills ?? [];
+        const nextSkills = typeof skills === 'function' ? skills(previousSkills) : skills;
+        return { ...(prev as { selectedSkills?: string[] }), selectedSkills: nextSkills };
+      });
+    },
+    [mutate]
+  );
 
   const setAtPath = useCallback(
     (atPath: Array<string | FileOrFolderItem>) => {
@@ -525,6 +537,8 @@ const useSendBoxDraft = (conversation_id: string) => {
     setUploadFile,
     content,
     setContent,
+    selectedSkills,
+    setSelectedSkills,
   };
 };
 
@@ -540,10 +554,8 @@ const AcpSendBox: React.FC<{
   const workspaceFiles = useWorkspaceFiles();
   const { checkAndUpdateTitle } = useAutoTitle();
   const slashCommands = useSlashCommands(conversation_id, { agentStatus: acpStatus });
-  const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent } = useSendBoxDraft(conversation_id);
+  const { atPath, uploadFile, setAtPath, setUploadFile, content, setContent, selectedSkills, setSelectedSkills } = useSendBoxDraft(conversation_id);
   const { setSendBoxHandler } = usePreviewContext();
-  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
-
   // Sync local aiProcessing state to parent via onAiProcessingChange
   // 将本地 aiProcessing 状态同步到父组件
   useEffect(() => {
@@ -852,6 +864,7 @@ const AcpSendBox: React.FC<{
       <SendBox
         value={content}
         onChange={setContent}
+        initialSelectedSkills={selectedSkills}
         loading={running || aiProcessing}
         disabled={false}
         placeholder={t('acp.sendbox.placeholder', { backend: agentName || backend, defaultValue: `Send message to {{backend}}...` })}

--- a/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
+++ b/src/renderer/pages/conversation/openclaw/OpenClawSendBox.tsx
@@ -40,6 +40,7 @@ interface OpenClawDraftData {
   atPath: Array<string | FileOrFolderItem>;
   content: string;
   uploadFile: string[];
+  selectedSkills: string[];
 }
 
 const useOpenClawSendBoxDraft = getSendBoxDraftHook('openclaw-gateway', {
@@ -47,6 +48,7 @@ const useOpenClawSendBoxDraft = getSendBoxDraftHook('openclaw-gateway', {
   atPath: [],
   content: '',
   uploadFile: [],
+  selectedSkills: [],
 });
 
 /**
@@ -114,8 +116,6 @@ const OpenClawSendBox: React.FC<{
   const slashCommands = useSlashCommands(conversation_id);
   const addOrUpdateMessage = useAddOrUpdateMessage();
   const { setSendBoxHandler } = usePreviewContext();
-  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
-
   const [aiProcessing, setAiProcessing] = useState(false);
   const [openclawStatus, setOpenClawStatus] = useState<string | null>(null);
   const [thought, setThought] = useState<ThoughtData>({
@@ -205,6 +205,18 @@ const OpenClawSendBox: React.FC<{
   const atPath = draftData?.atPath ?? EMPTY_AT_PATH;
   const uploadFile = draftData?.uploadFile ?? EMPTY_UPLOAD_FILES;
   const content = draftData?.content ?? '';
+  const selectedSkills = draftData?.selectedSkills ?? [];
+
+  const setSelectedSkills = useCallback(
+    (skills: string[] | ((prev: string[]) => string[])) => {
+      mutateDraft((prev) => {
+        const previousSkills = prev?.selectedSkills ?? [];
+        const nextSkills = typeof skills === 'function' ? skills(previousSkills) : skills;
+        return { ...(prev as OpenClawDraftData), selectedSkills: nextSkills };
+      });
+    },
+    [mutateDraft]
+  );
 
   const setAtPath = useCallback(
     (val: Array<string | FileOrFolderItem>) => {
@@ -665,6 +677,7 @@ const OpenClawSendBox: React.FC<{
       <SendBox
         value={content}
         onChange={setContent}
+        initialSelectedSkills={selectedSkills}
         loading={aiProcessing}
         disabled={false}
         className='z-10'

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -40,6 +40,7 @@ import { useGuidMention } from './hooks/useGuidMention';
 import { useGuidModelSelection } from './hooks/useGuidModelSelection';
 import { useGuidSend } from './hooks/useGuidSend';
 import { useTypewriterPlaceholder } from './hooks/useTypewriterPlaceholder';
+import { getGuidDraft, setGuidDraft } from './hooks/useGuidDraft';
 import type { AcpBackendConfig } from './types';
 import { DEFAULT_PRESET_AGENT_TYPE, normalizePresetAgentType } from '@/types/acpTypes';
 import { ConfigProvider, Message } from '@arco-design/web-react';
@@ -62,6 +63,7 @@ const GuidPage: React.FC = () => {
   const localeKey = resolveLocaleKey(i18n.language);
   const { isEnterprise } = useAppMode();
   const { user } = useAuth();
+  const draft = getGuidDraft();
   // Read current menu and skill from URL query params
   const searchParams = new URLSearchParams(location.search);
   const selectedMenu = searchParams.get('menu');
@@ -70,7 +72,7 @@ const GuidPage: React.FC = () => {
 
   // Skill selector state
   const [installedSkills, setInstalledSkills] = useState<any[]>([]);
-  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [selectedSkills, setSelectedSkills] = useState<string[]>(draft?.selectedSkills ?? []);
   const [cursorPosition, setCursorPosition] = useState(0);
 
   // Edit drawer state
@@ -128,6 +130,10 @@ const GuidPage: React.FC = () => {
       void navigate('/guid', { replace: true, state: location.state });
     }
   }, [skillParam, installedSkillsLoaded]);
+
+  useEffect(() => {
+    setGuidDraft({ selectedSkills });
+  }, [selectedSkills]);
 
   // Open external link
   const openLink = useCallback(async (url: string) => {
@@ -299,13 +305,9 @@ const GuidPage: React.FC = () => {
     t,
   });
 
-  // Listen for guid.reset event to reset all user input state
+  // Listen for guid.reset event to reset agent/mention state only
   const handleGuidReset = useCallback(() => {
-    guidInput.setInput('');
-    guidInput.setFiles([]);
-    guidInput.setDir('');
     agentSelection.resetSelection();
-    setSelectedSkills([]);
     setCursorPosition(0);
     mention.setMentionOpen(false);
     mention.setMentionQuery(null);
@@ -313,7 +315,7 @@ const GuidPage: React.FC = () => {
     mention.setMentionSelectorOpen(false);
     mention.setMentionActiveIndex(0);
     prefilledAssistantRef.current = null;
-  }, [guidInput, agentSelection, mention]);
+  }, [agentSelection, mention]);
 
   useAddEventListener('guid.reset', handleGuidReset, [handleGuidReset]);
 

--- a/src/renderer/pages/guid/hooks/useGuidDraft.ts
+++ b/src/renderer/pages/guid/hooks/useGuidDraft.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type GuidDraftState = {
+  input: string;
+  files: string[];
+  dir: string;
+  selectedSkills: string[];
+};
+
+const GUID_DRAFT_KEY = 'guid';
+
+const guidDraftStore = new Map<string, GuidDraftState>();
+
+export const getGuidDraft = (): GuidDraftState | undefined => guidDraftStore.get(GUID_DRAFT_KEY);
+
+export const setGuidDraft = (draft: Partial<GuidDraftState>): void => {
+  const prev = getGuidDraft() ?? {
+    input: '',
+    files: [],
+    dir: '',
+    selectedSkills: [],
+  };
+  guidDraftStore.set(GUID_DRAFT_KEY, {
+    input: draft.input ?? prev.input,
+    files: draft.files ?? prev.files,
+    dir: draft.dir ?? prev.dir,
+    selectedSkills: draft.selectedSkills ?? prev.selectedSkills,
+  });
+};
+
+export const clearGuidDraft = (): void => {
+  guidDraftStore.delete(GUID_DRAFT_KEY);
+};

--- a/src/renderer/pages/guid/hooks/useGuidInput.ts
+++ b/src/renderer/pages/guid/hooks/useGuidInput.ts
@@ -9,6 +9,7 @@ import { usePasteService } from '@/renderer/hooks/usePasteService';
 import { allSupportedExts, type FileMetadata } from '@/renderer/services/FileService';
 import { measureCaretTop, scrollCaretToLastLine } from '../utils/caretUtils';
 import { useCallback, useEffect, useState } from 'react';
+import { getGuidDraft, setGuidDraft } from './useGuidDraft';
 
 export type GuidInputResult = {
   input: string;
@@ -38,18 +39,44 @@ type UseGuidInputOptions = {
  * Hook that manages input state, file handling, and drag/paste for the Guid page.
  */
 export const useGuidInput = ({ locationState }: UseGuidInputOptions): GuidInputResult => {
-  const [input, setInput] = useState('');
-  const [files, setFiles] = useState<string[]>([]);
-  const [dir, setDir] = useState<string>('');
+  const draft = getGuidDraft();
+  const [input, setInputState] = useState(draft?.input ?? '');
+  const [files, setFilesState] = useState<string[]>(draft?.files ?? []);
+  const [dir, setDirState] = useState<string>(draft?.dir ?? '');
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [loading, setLoading] = useState(false);
 
   // Read workspace from location.state (passed from tabs add button)
   useEffect(() => {
     if (locationState?.workspace) {
-      setDir(locationState.workspace);
+      setDirState(locationState.workspace);
+      setGuidDraft({ dir: locationState.workspace });
     }
   }, [locationState]);
+
+  const setInput = useCallback((value: string | ((prev: string) => string)) => {
+    setInputState((prev) => {
+      const next = typeof value === 'function' ? value(prev) : value;
+      setGuidDraft({ input: next });
+      return next;
+    });
+  }, []);
+
+  const setFiles = useCallback((value: string[] | ((prev: string[]) => string[])) => {
+    setFilesState((prev) => {
+      const next = typeof value === 'function' ? value(prev) : value;
+      setGuidDraft({ files: next });
+      return next;
+    });
+  }, []);
+
+  const setDir = useCallback((value: string | ((prev: string) => string)) => {
+    setDirState((prev) => {
+      const next = typeof value === 'function' ? value(prev) : value;
+      setGuidDraft({ dir: next });
+      return next;
+    });
+  }, []);
 
   // Handle pasted files (append mode to support multiple pastes)
   const handleFilesPasted = useCallback((pastedFiles: FileMetadata[]) => {


### PR DESCRIPTION
## Summary\n- Preserve guide-page draft state across page switches\n- Preserve conversation-page @ skills across page switches\n- Fix Feishu/DingTalk credential placeholders so clearing fields restores normal placeholders instead of bullet masks\n\n## Notes\n- Draft state remains in-memory for the current app session\n- No backend storage or protocol changes were added\n\n## Validation\n- Verified locally during implementation; repository still has unrelated pre-existing TypeScript issues outside this change set