### PR TITLE
fix(assistant): 修复专属助手显示名称问题及同步删除功能

### DIFF
--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -367,7 +367,7 @@ export function initAssistantHubBridge(): void {
             if (metaResult) {
               const meta = JSON.parse(metaResult.content) as AssistantHubMeta;
 
-              const displayName = meta.nameI18n?.['en-US'] || meta.nameI18n?.['zh-CN'] || assistantName;
+              const displayName = meta.nameI18n?.['en-US'] || meta.nameI18n?.['zh-CN'] || meta.display_name || meta.name || assistantName;
               const description = meta.descriptionI18n?.['en-US'] || meta.descriptionI18n?.['zh-CN'] || '';
 
               // Search filter: search by name, display_name, and description

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -49,10 +49,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
       // OAuth2 sessions send the provider refresh_token inside a generic `params`
       // dict (moss forwards it to the credential script); other sessions send the
       // moss refresh_token at the top level as before.
-      const refreshBody =
-        refreshGrantType === 'oauth2_refresh_token'
-          ? { grant_type: refreshGrantType, params: { refresh_token } }
-          : { grant_type: refreshGrantType, refresh_token };
+      const refreshBody = refreshGrantType === 'oauth2_refresh_token' ? { grant_type: refreshGrantType, params: { refresh_token } } : { grant_type: refreshGrantType, refresh_token };
 
       mainLog('eeclawBridge', `[getValidToken] Sending refresh request to ${serverUrl}/api/v1/auth/token`);
       const response = await fetch(`${serverUrl}/api/v1/auth/token`, {
@@ -76,10 +73,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
           const latestAuth = ProcessConfig.getSync('eeclaw.authStorage');
           if (latestAuth?.refresh_token && latestAuth.refresh_token !== refresh_token) {
             mainLog('eeclawBridge', `[getValidToken] Found different refresh_token in file, retrying with ${latestAuth.refresh_token.slice(0, 20)}...`);
-            const retryBody =
-              latestAuth.session_type === 'oauth2'
-                ? { grant_type: 'oauth2_refresh_token', params: { refresh_token: latestAuth.refresh_token } }
-                : { grant_type: 'refresh_token', refresh_token: latestAuth.refresh_token };
+            const retryBody = latestAuth.session_type === 'oauth2' ? { grant_type: 'oauth2_refresh_token', params: { refresh_token: latestAuth.refresh_token } } : { grant_type: 'refresh_token', refresh_token: latestAuth.refresh_token };
             const retryResponse = await fetch(`${serverUrl}/api/v1/auth/token`, {
               method: 'POST',
               headers: {
@@ -253,8 +247,7 @@ export function initEeclawBridge(): void {
 
       // Save server URL and auth storage to ProcessConfig
       // 将服务器 URL 和认证存储保存到 ProcessConfig
-      const sessionType: 'password' | 'api_key' | 'oauth2' =
-        body.grant_type === 'oauth2' ? 'oauth2' : body.grant_type === 'api_key' ? 'api_key' : 'password';
+      const sessionType: 'password' | 'api_key' | 'oauth2' = body.grant_type === 'oauth2' ? 'oauth2' : body.grant_type === 'api_key' ? 'api_key' : 'password';
       await ProcessConfig.set('eeclaw.serverUrl', serverUrl);
       await ProcessConfig.set('eeclaw.authStorage', {
         access_token: data.access_token,
@@ -461,8 +454,8 @@ export function initEeclawBridge(): void {
       return {
         success: false,
         data: {
-          skills: { hub: { installed: [], skipped: [], failed: [] }, tenant: { installed: [], skipped: [], failed: [] } },
-          assistants: { hub: { installed: [], skipped: [], failed: [] }, tenant: { installed: [], skipped: [], failed: [] } },
+          skills: { hub: { installed: [], skipped: [], deleted: [], failed: [] }, tenant: { installed: [], skipped: [], deleted: [], failed: [] } },
+          assistants: { hub: { installed: [], skipped: [], deleted: [], failed: [] }, tenant: { installed: [], skipped: [], deleted: [], failed: [] } },
         },
         msg: error instanceof Error ? error.message : String(error),
       };

--- a/src/process/constants/assistantStorage.ts
+++ b/src/process/constants/assistantStorage.ts
@@ -45,6 +45,8 @@ export interface IAssistantMeta {
   id?: string;
   /** Assistant name (directory name, used as identifier) */
   name?: string;
+  /** Display name from API (may be snake_case) */
+  display_name?: string;
   nameI18n?: Record<string, string>;
   descriptionI18n?: Record<string, string>;
   promptsI18n?: Record<string, string[]>;

--- a/src/process/sync/remoteToLocalSync.ts
+++ b/src/process/sync/remoteToLocalSync.ts
@@ -29,7 +29,7 @@ import JSZip from 'jszip';
 import { skillManager } from '@process/SkillManager';
 import { assistantManager } from '@process/AssistantManager';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
-import { initEnterpriseDirs, getEnterpriseHubSkillsDir, getEnterpriseHubAssistantsDir, getEnterpriseTenantSkillsDir, getEnterpriseTenantAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName } from '@/process/constants/enterpriseStorage';
+import { initEnterpriseDirs, getEnterpriseHubSkillsDir, getEnterpriseHubAssistantsDir, getEnterpriseTenantSkillsDir, getEnterpriseTenantAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName, getAssistantInstallDir, getSkillInstallDir } from '@/process/constants/enterpriseStorage';
 import { SKILL_HUB_META_FILE } from '@/process/constants/skillStorage';
 import type { IAssistantMeta } from '@/process/constants/assistantStorage';
 import { ASSISTANT_META_FILE } from '@/process/constants/assistantStorage';
@@ -40,6 +40,7 @@ import type { ISkillHubMeta } from '@/common/ipcBridge';
 export type SyncResult = {
   installed: string[];
   skipped: string[];
+  deleted: string[];
   failed: Array<{ id: string; name: string; error: string }>;
 };
 
@@ -171,8 +172,12 @@ function getRemoteAssistantSourceType(assistant: RemoteAssistantInfo): string {
   return assistant.sourceType || assistant.meta?.source_type || assistant.tag || assistant.meta?.tag || (assistant.isHubInstalled ? 'hub' : '');
 }
 
-function getLocalAssistantSourceType(assistant: RemoteAssistantInfo): 'hub' | 'custom' {
-  return getRemoteAssistantSourceType(assistant) === 'custom' ? 'custom' : 'hub';
+function getLocalAssistantSourceType(assistant: RemoteAssistantInfo): 'hub' | 'custom' | 'tenant' {
+  const remoteType = getRemoteAssistantSourceType(assistant);
+  // Map remote source_type to local directory
+  if (remoteType === 'custom') return 'custom';
+  if (remoteType === 'tenant') return 'tenant';
+  return 'hub'; // Default for hub, upload, and unknown
 }
 
 function isSyncableInstalledAssistant(assistant: RemoteAssistantInfo): boolean {
@@ -746,11 +751,12 @@ async function installAssistantById(assistant: RemoteAssistantInfo, serverUrl: s
     initEnterpriseDirs();
   }
 
-  // Get hub assistants directory (mode-aware)
-  const hubAssistantsDir = await getHubAssistantsDirForMode();
-  await fs.mkdir(hubAssistantsDir, { recursive: true });
+  // Determine source type and get appropriate install directory
+  const assistantSourceType = getLocalAssistantSourceType(assistant);
+  const assistantDir = getAssistantInstallDir(assistantName, assistantSourceType);
+  mainLog('remoteToLocalSync', `Install directory for ${assistantName}: ${assistantDir} (source_type: ${assistantSourceType})`);
 
-  const assistantDir = path.join(hubAssistantsDir, assistantName);
+  await fs.mkdir(path.dirname(assistantDir), { recursive: true });
 
   // Remove existing if present
   try {
@@ -788,7 +794,6 @@ async function installAssistantById(assistant: RemoteAssistantInfo, serverUrl: s
   }
 
   // Merge existing meta with remote info
-  const assistantSourceType = getLocalAssistantSourceType(assistant);
   const meta: IAssistantMeta = {
     // Start with existing meta or defaults
     id: existingMeta?.id || assistant.id,
@@ -867,6 +872,111 @@ async function getLocalInstalledAssistants(): Promise<Set<string>> {
   return new Set(assistants.map((a) => a.name));
 }
 
+// ============ 删除远程已删除项目的逻辑 ============
+
+type LocalItemDetail = {
+  id: string;
+  name: string;
+  path: string;
+  category: string;
+};
+
+/**
+ * 获取本地 hub 技能详情列表（包含路径）
+ */
+async function getLocalHubSkillDetails(): Promise<LocalItemDetail[]> {
+  const skills = await skillManager.getInstalledSkills();
+  return skills
+    .filter((s) => s.category === 'hub' || s.meta?.source_type === 'hub')
+    .map((s) => ({
+      id: s.meta?.id || s.name,
+      name: s.name,
+      path: '', // SkillManager 不提供路径，需要通过名称构建
+      category: 'hub',
+    }));
+}
+
+/**
+ * 获取本地 hub 助手详情列表（包含路径）
+ */
+async function getLocalHubAssistantDetails(): Promise<LocalItemDetail[]> {
+  const assistants = await assistantManager.getInstalledAssistants();
+  return assistants
+    .filter((a) => a.category === 'hub' || a.meta?.source_type === 'hub')
+    .map((a) => {
+      const hubDir = getEnterpriseHubAssistantsDir();
+      return {
+        id: a.meta?.id || a.id || a.name,
+        name: a.name,
+        path: path.join(hubDir, a.name),
+        category: 'hub',
+      };
+    });
+}
+
+/**
+ * 获取本地 tenant 技能详情列表（包含路径）
+ */
+async function getLocalTenantSkillDetails(): Promise<LocalItemDetail[]> {
+  const skills = await skillManager.getInstalledSkills();
+  return skills
+    .filter((s) => s.category === 'tenant')
+    .map((s) => ({
+      id: s.meta?.id || s.name,
+      name: s.name,
+      path: '', // SkillManager 不提供路径
+      category: 'tenant',
+    }));
+}
+
+/**
+ * 获取本地 tenant 助手详情列表（包含路径）
+ */
+async function getLocalTenantAssistantDetails(): Promise<LocalItemDetail[]> {
+  const assistants = await assistantManager.getInstalledAssistants();
+  return assistants
+    .filter((a) => a.category === 'tenant' || a.meta?.source_type === 'tenant')
+    .map((a) => {
+      const tenantDir = getEnterpriseTenantAssistantsDir();
+      return {
+        id: a.meta?.id || a.id || a.name,
+        name: a.name,
+        path: path.join(tenantDir, a.meta?.id || a.name),
+        category: 'tenant',
+      };
+    });
+}
+
+/**
+ * 删除远程已删除的项目
+ * 只删除 hub 和 tenant 类型，custom 类型不删除
+ */
+async function deleteRemoteDeletedItems(remoteIds: Set<string>, localItems: LocalItemDetail[], itemType: 'skill' | 'assistant'): Promise<string[]> {
+  const toDelete = localItems.filter((item) => !remoteIds.has(item.id));
+  const deleted: string[] = [];
+
+  for (const item of toDelete) {
+    try {
+      if (item.path) {
+        await fs.rm(item.path, { recursive: true, force: true });
+        mainLog('remoteToLocalSync', `Deleted ${itemType} (remote removed): ${item.name} (${item.id})`);
+        deleted.push(item.name);
+      } else {
+        // 对于技能，通过 SkillManager 删除
+        if (itemType === 'skill') {
+          await skillManager.uninstallSkill(item.name, item.category as 'hub' | 'tenant' | 'custom' | 'system');
+          mainLog('remoteToLocalSync', `Deleted skill (remote removed): ${item.name} (${item.id})`);
+          deleted.push(item.name);
+        }
+      }
+    } catch (error) {
+      mainWarn('remoteToLocalSync', `Failed to delete ${itemType} ${item.name}:`, error);
+    }
+  }
+
+  return deleted;
+}
+
 // ============ 核心同步逻辑 ============
 
 /**
@@ -907,6 +1017,7 @@ export async function syncRemoteSkillsToLocal(): Promise<SyncResult> {
   const result: SyncResult = {
     installed: [],
     skipped: alreadyInstalled.map((s) => s.name),
+    deleted: [],
     failed: [],
   };
 
@@ -933,7 +1044,13 @@ export async function syncRemoteSkillsToLocal(): Promise<SyncResult> {
     }
   }
 
-  mainLog('remoteToLocalSync', `Skill sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+  // 5. 删除远程已删除的本地 hub 技能
+  const remoteSkillIds = new Set(hubSkills.map((s) => s.id));
+  const localHubSkills = await getLocalHubSkillDetails();
+  const deletedSkills = await deleteRemoteDeletedItems(remoteSkillIds, localHubSkills, 'skill');
+  result.deleted = deletedSkills;
+
+  mainLog('remoteToLocalSync', `Skill sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, deleted=${result.deleted.length}, failed=${result.failed.length}`);
 
   return result;
 }
@@ -975,6 +1092,7 @@ export async function syncRemoteAssistantsToLocal(): Promise<SyncResult> {
   const result: SyncResult = {
     installed: [],
     skipped: alreadyInstalled.map((a) => a.name),
+    deleted: [],
     failed: [],
   };
 
@@ -1001,7 +1119,13 @@ export async function syncRemoteAssistantsToLocal(): Promise<SyncResult> {
     }
   }
 
-  mainLog('remoteToLocalSync', `Assistant sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+  // 5. 删除远程已删除的本地 hub 助手
+  const remoteAssistantIds = new Set(syncableAssistants.map((a) => a.id));
+  const localHubAssistants = await getLocalHubAssistantDetails();
+  const deletedAssistants = await deleteRemoteDeletedItems(remoteAssistantIds, localHubAssistants, 'assistant');
+  result.deleted = deletedAssistants;
+
+  mainLog('remoteToLocalSync', `Assistant sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, deleted=${result.deleted.length}, failed=${result.failed.length}`);
 
   return result;
 }
@@ -1018,19 +1142,19 @@ export async function syncAllFromRemote(): Promise<SyncAllResult> {
   const [hubSkills, hubAssistants, tenantSkills, tenantAssistants] = await Promise.all([
     syncRemoteSkillsToLocal().catch((error) => {
       mainError('remoteToLocalSync', 'Hub skill sync failed:', error);
-      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+      return { installed: [] as string[], skipped: [] as string[], deleted: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
     }),
     syncRemoteAssistantsToLocal().catch((error) => {
       mainError('remoteToLocalSync', 'Hub assistant sync failed:', error);
-      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+      return { installed: [] as string[], skipped: [] as string[], deleted: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
     }),
     syncTenantSkillsToLocal().catch((error) => {
       mainError('remoteToLocalSync', 'Tenant skill sync failed:', error);
-      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+      return { installed: [] as string[], skipped: [] as string[], deleted: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
     }),
     syncTenantAssistantsToLocal().catch((error) => {
       mainError('remoteToLocalSync', 'Tenant assistant sync failed:', error);
-      return { installed: [] as string[], skipped: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
+      return { installed: [] as string[], skipped: [] as string[], deleted: [] as string[], failed: [] as Array<{ id: string; name: string; error: string }> };
     }),
   ]);
 
@@ -1085,6 +1209,7 @@ async function syncTenantSkillsToLocal(): Promise<SyncResult> {
   const result: SyncResult = {
     installed: [],
     skipped: alreadyInstalled.map((s) => s.name),
+    deleted: [],
     failed: [],
   };
 
@@ -1111,7 +1236,13 @@ async function syncTenantSkillsToLocal(): Promise<SyncResult> {
     }
   }
 
-  mainLog('remoteToLocalSync', `Tenant skill sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+  // 5. 删除远程已删除的本地 tenant 技能
+  const remoteSkillIds = new Set(approvedSkills.map((s) => s.id));
+  const localTenantSkills = await getLocalTenantSkillDetails();
+  const deletedSkills = await deleteRemoteDeletedItems(remoteSkillIds, localTenantSkills, 'skill');
+  result.deleted = deletedSkills;
+
+  mainLog('remoteToLocalSync', `Tenant skill sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, deleted=${result.deleted.length}, failed=${result.failed.length}`);
 
   return result;
 }
@@ -1141,6 +1272,7 @@ async function syncTenantAssistantsToLocal(): Promise<SyncResult> {
   const result: SyncResult = {
     installed: [],
     skipped: alreadyInstalled.map((a) => a.name),
+    deleted: [],
     failed: [],
   };
 
@@ -1167,7 +1299,13 @@ async function syncTenantAssistantsToLocal(): Promise<SyncResult> {
     }
   }
 
-  mainLog('remoteToLocalSync', `Tenant assistant sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, failed=${result.failed.length}`);
+  // 5. 删除远程已删除的本地 tenant 助手
+  const remoteAssistantIds = new Set(approvedAssistants.map((a) => a.id));
+  const localTenantAssistants = await getLocalTenantAssistantDetails();
+  const deletedAssistants = await deleteRemoteDeletedItems(remoteAssistantIds, localTenantAssistants, 'assistant');
+  result.deleted = deletedAssistants;
+
+  mainLog('remoteToLocalSync', `Tenant assistant sync completed: installed=${result.installed.length}, skipped=${result.skipped.length}, deleted=${result.deleted.length}, failed=${result.failed.length}`);
 
   return result;
 }

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -307,7 +307,7 @@ const TenantAssistantCard: React.FC<{
 }> = ({ assistant, isInstalled, installing, installProgress, onDuplicate, onClick }) => {
   const { t } = useTranslation();
 
-  const displayName = assistant.displayName || assistant.name;
+  const displayName = assistant.displayName || (assistant as { display_name?: string }).display_name || assistant.name;
 
   // Tenant assistants are synced from server and always considered installed
   // Show "已安装" badge and duplicate button (same as hub installed assistants)
@@ -762,9 +762,9 @@ const AgentModalContent: React.FC = () => {
   // Sync status state
   const [syncStatus, setSyncStatus] = useState<{
     syncing: boolean;
-    skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-    assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-  }>({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+    skills: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> };
+    assistants: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> };
+  }>({ syncing: false, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
 
   const avatarImageMap = React.useMemo<Record<string, string>>(
     () => ({
@@ -1016,21 +1016,25 @@ const AgentModalContent: React.FC = () => {
   useEffect(() => {
     if (!isEnterprise || !isElectronDesktop()) return;
 
-    const handleSyncCompleted = (data: { skills: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } }; assistants: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } } }) => {
+    const handleSyncCompleted = (data: { skills: { hub: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> } }; assistants: { hub: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> } } }) => {
       // Merge hub and tenant results for display
       const mergedSkills = {
         installed: [...data.skills.hub.installed, ...data.skills.tenant.installed],
         skipped: [...data.skills.hub.skipped, ...data.skills.tenant.skipped],
+        deleted: [...data.skills.hub.deleted, ...data.skills.tenant.deleted],
         failed: [...data.skills.hub.failed, ...data.skills.tenant.failed],
       };
       const mergedAssistants = {
         installed: [...data.assistants.hub.installed, ...data.assistants.tenant.installed],
         skipped: [...data.assistants.hub.skipped, ...data.assistants.tenant.skipped],
+        deleted: [...data.assistants.hub.deleted, ...data.assistants.tenant.deleted],
         failed: [...data.assistants.hub.failed, ...data.assistants.tenant.failed],
       };
       setSyncStatus({ syncing: false, skills: mergedSkills, assistants: mergedAssistants });
       // Refresh installed list after sync
       void fetchInstalledAssistantNames();
+      // Refresh local assistants list (for "我的助手" tab)
+      void loadAssistants();
     };
 
     const unsubscribe = eeclaw.syncCompleted.on(handleSyncCompleted);
@@ -1051,7 +1055,7 @@ const AgentModalContent: React.FC = () => {
 
     // Mark as triggered and start sync
     syncTriggeredRef.current = true;
-    setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+    setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
 
     eeclaw.syncFromRemote
       .invoke()
@@ -1059,13 +1063,13 @@ const AgentModalContent: React.FC = () => {
         if (!res.success) {
           // Sync failed, reset status (syncCompleted event won't be emitted)
           console.error('Sync failed:', res.msg);
-          setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+          setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
         }
         // If success, syncCompleted event will be emitted and handled separately
       })
       .catch((err) => {
         console.error('Failed to trigger sync:', err);
-        setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+        setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
       });
   }, [isEnterprise, activeTab]);
 

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -660,9 +660,9 @@ const SkillModalContent: React.FC = () => {
   // Sync status state
   const [syncStatus, setSyncStatus] = useState<{
     syncing: boolean;
-    skills: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-    assistants: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> };
-  }>({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+    skills: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> };
+    assistants: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> };
+  }>({ syncing: false, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
 
   // ---- Fetch installed skills ----
   const fetchInstalledSkills = useCallback(async () => {
@@ -1170,16 +1170,18 @@ const SkillModalContent: React.FC = () => {
   useEffect(() => {
     if (!isEnterprise || !isElectronDesktop()) return;
 
-    const handleSyncCompleted = (data: { skills: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } }; assistants: { hub: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; failed: Array<{ id: string; name: string; error: string }> } } }) => {
+    const handleSyncCompleted = (data: { skills: { hub: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> } }; assistants: { hub: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> }; tenant: { installed: string[]; skipped: string[]; deleted: string[]; failed: Array<{ id: string; name: string; error: string }> } } }) => {
       // Merge hub and tenant results for display
       const mergedSkills = {
         installed: [...data.skills.hub.installed, ...data.skills.tenant.installed],
         skipped: [...data.skills.hub.skipped, ...data.skills.tenant.skipped],
+        deleted: [...data.skills.hub.deleted, ...data.skills.tenant.deleted],
         failed: [...data.skills.hub.failed, ...data.skills.tenant.failed],
       };
       const mergedAssistants = {
         installed: [...data.assistants.hub.installed, ...data.assistants.tenant.installed],
         skipped: [...data.assistants.hub.skipped, ...data.assistants.tenant.skipped],
+        deleted: [...data.assistants.hub.deleted, ...data.assistants.tenant.deleted],
         failed: [...data.assistants.hub.failed, ...data.assistants.tenant.failed],
       };
       setSyncStatus({ syncing: false, skills: mergedSkills, assistants: mergedAssistants });
@@ -1205,7 +1207,7 @@ const SkillModalContent: React.FC = () => {
 
     // Mark as triggered and start sync
     syncTriggeredRef.current = true;
-    setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+    setSyncStatus({ syncing: true, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
 
     eeclaw.syncFromRemote
       .invoke()
@@ -1213,13 +1215,13 @@ const SkillModalContent: React.FC = () => {
         if (!res.success) {
           // Sync failed, reset status (syncCompleted event won't be emitted)
           console.error('Sync failed:', res.msg);
-          setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+          setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
         }
         // If success, syncCompleted event will be emitted and handled separately
       })
       .catch((err) => {
         console.error('Failed to trigger sync:', err);
-        setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], failed: [] }, assistants: { installed: [], skipped: [], failed: [] } });
+        setSyncStatus({ syncing: false, skills: { installed: [], skipped: [], deleted: [], failed: [] }, assistants: { installed: [], skipped: [], deleted: [], failed: [] } });
       });
   }, [isEnterprise, activeTab]);
 

--- a/src/renderer/shared/agents/assistantAdapter.ts
+++ b/src/renderer/shared/agents/assistantAdapter.ts
@@ -24,7 +24,7 @@ export function toBackendConfig(info: IAssistantInfo): AcpBackendConfig {
   const isPreset = info.isBuiltin || info.isHubInstalled;
   return {
     id,
-    name: meta.nameI18n?.['zh-CN'] || meta.nameI18n?.['en-US'] || meta.name || meta.id || info.name,
+    name: meta.nameI18n?.['zh-CN'] || meta.nameI18n?.['en-US'] || meta.display_name || meta.name || meta.id || info.name,
     nameI18n: meta.nameI18n,
     descriptionI18n: meta.descriptionI18n,
     avatar: meta.avatar,


### PR DESCRIPTION
## Summary
- 修复专属助手显示名称为 UUID 的问题
- 新增同步删除远程已删除的技能/助手功能

## Changes

### 显示名称修复
- `assistantAdapter.ts` - 我的助手显示，增加 `display_name` 回退
- `AgentModalContent.tsx` - TenantAssistantCard 组件，支持 `display_name` 字段
- `assistantHubBridge.ts` - 专属助手标签页数据映射，增加 `display_name` 和 `name` 回退

### 同步删除功能
- `remoteToLocalSync.ts` - 新增删除远程已删除项目的逻辑
  - 只删除 `hub` 和 `tenant` 类型，`custom` 类型不删除
  - `SyncResult` 类型增加 `deleted` 字段
- `eeclawBridge.ts` - 错误处理返回类型增加 `deleted` 字段
- `AgentModalContent.tsx` / `SkillModalContent.tsx` - 同步完成后刷新本地列表

## Test plan
- [ ] 验证专属助手显示正确的名称而非 UUID
- [ ] 在 Moss Server 删除技能/助手后，同步时本地自动删除对应项目
- [ ] 验证 custom 类型的技能/助手不会被删除

🤖 Generated with [Claude Code](https://claude.com/claude-code)