### PR TITLE
feat(oauth2): honor moss require_state flag on callback

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1901,7 +1901,7 @@ export const eeclaw = {
     { serverUrl: string; body: { grant_type: string; username?: string; password?: string; api_key?: string; params?: Record<string, string> }; deviceId: string }
   >('eeclaw.login'),
   /** Check whether OAuth2 login is enabled on the MOSS server and get the ready-to-open authorize URL (runs in main process to avoid CORS) */
-  oauth2Config: bridge.buildProvider<IBridgeResponse<{ enabled: boolean; authorize_url?: string }>, { serverUrl: string }>('eeclaw.oauth2-config'),
+  oauth2Config: bridge.buildProvider<IBridgeResponse<{ enabled: boolean; authorize_url?: string; require_state?: boolean }>, { serverUrl: string }>('eeclaw.oauth2-config'),
   /** Set app mode and update main process cache */
   setAppMode: bridge.buildProvider<void, { mode: 'c' | 'e' }>('eeclaw.set-app-mode'),
   /** Set session mode (remote/local) for enterprise mode and update main process cache */

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -219,6 +219,9 @@ export function initEeclawBridge(): void {
         data: {
           enabled: data?.enabled === true,
           authorize_url: typeof data?.authorize_url === 'string' ? data.authorize_url : undefined,
+          // Default true when absent — older moss builds didn't send this field
+          // and we should preserve the CSRF check in that case.
+          require_state: data?.require_state !== false,
         },
       };
     } catch (error) {

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -61,7 +61,9 @@ const LoginPage: React.FC = () => {
   const [apiKey, setApiKey] = useState('');
 
   // OAuth2 login state
-  const [oauth2Config, setOauth2Config] = useState<{ enabled: boolean; authorize_url?: string } | null>(null);
+  // `require_state` defaults to true on the moss side; older moss builds omit
+  // the field, so the absence is treated as "verify state" for backwards safety.
+  const [oauth2Config, setOauth2Config] = useState<{ enabled: boolean; authorize_url?: string; require_state?: boolean } | null>(null);
   const [oauth2Loading, setOauth2Loading] = useState(false);
   const [oauth2Waiting, setOauth2Waiting] = useState(false);
   const oauth2StateRef = React.useRef<string | null>(null);
@@ -101,7 +103,13 @@ const LoginPage: React.FC = () => {
     return ipcBridge.deepLink.received.on((payload) => {
       if (payload.action !== 'oauth2-callback') return;
       const { state, ...rest } = payload.params || {};
-      if (!oauth2StateRef.current || state !== oauth2StateRef.current) {
+      // When the moss admin has disabled state verification (`require_state: false`),
+      // skip the local equality check. Trusted-internal deployments use this to
+      // accept logins even when the IdP rewrites or drops `state` on round-trip.
+      // We still generate + carry state on the outbound authorize URL for IdP
+      // compatibility — only the CSRF check on return is bypassed.
+      const verifyState = oauth2Config?.require_state !== false;
+      if (verifyState && (!oauth2StateRef.current || state !== oauth2StateRef.current)) {
         setOauth2Waiting(false);
         Message.error('授权回调验证失败,请重试');
         return;
@@ -128,7 +136,7 @@ const LoginPage: React.FC = () => {
         }
       })();
     });
-  }, [isEnterprise, enterpriseLoginWithOAuth2, navigate]);
+  }, [isEnterprise, enterpriseLoginWithOAuth2, navigate, oauth2Config]);
 
   const handleOAuth2Login = async () => {
     if (!oauth2Config?.enabled || !oauth2Config.authorize_url) return;


### PR DESCRIPTION
## Summary
- Read `require_state` from `GET /api/v1/auth/oauth2/config` (added on the moss side in companion PR).
- In the OAuth2 deep-link callback, skip the local `state` equality check when `require_state === false`. Authorize URL still carries `state` for IdP compatibility.
- Default to **verify** when the field is absent (older moss builds) — preserves current CSRF behaviour.

Companion moss PR: https://github.com/sudoprivacy/moss/pull/new/feat/oauth2-configurable-state-check

## Context
Used in trusted-internal deployments where the IdP rewrites or drops `state` on round-trip (e.g. corporate gateway swallowing query strings on the callback hop). The policy is set centrally on moss-server (admin UI toggle) and applies to every sudowork connected to it.

## Test plan
- [ ] **Default on:** point sudowork at a moss with `require_state: true` (or older moss missing the field) → tampered state in callback → "授权回调验证失败".
- [ ] **Off:** flip the moss toggle off → reopen login page (re-fetches config) → same tampered callback now logs in successfully.
- [ ] **Authorize URL still carries state** in both cases (DevTools network tab or log the constructed URL).
- [ ] **Back-compat:** point sudowork at older moss that omits `require_state` → behaviour is identical to before this change (verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)