### PR TITLE
fix(workspace): normalize drafts directory aliases

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 /**
  * AionUI应用程序共用常量
  */
@@ -54,6 +53,15 @@ export const DEFAULT_IMAGE_EXTENSION = '.png';
 
 /** 草稿箱物理目录名（固定，不随语言变化）/ Drafts directory name (fixed, language-independent) */
 export const DRAFTS_DIR_NAME = '.drafts';
+
+/** 草稿箱常见误写别名（不应作为普通目录创建）/ Common mistaken aliases for the drafts directory */
+export const DRAFTS_DIR_ALIASES = ['drafts', 'Drafts', '草稿箱'] as const;
+
+/** 判断目录名是否指向草稿箱保留目录 / Check whether a directory name is reserved for drafts */
+export function isReservedDraftsDirName(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return normalized === DRAFTS_DIR_NAME || DRAFTS_DIR_ALIASES.some((alias) => alias.toLowerCase() === normalized);
+}
 
 /**
  * 文件意图标记系统

--- a/src/process/bridge/workspaceBridge.ts
+++ b/src/process/bridge/workspaceBridge.ts
@@ -9,7 +9,7 @@
  * 工作空间管理桥接 - 处理工作空间重命名和草稿箱操作
  */
 
-import { DRAFTS_DIR_NAME } from '@/common/constants';
+import { DRAFTS_DIR_NAME, isReservedDraftsDirName } from '@/common/constants';
 import { ipcBridge } from '@/common';
 import { isValidDirectoryName } from '@/common/utils/pathValidation';
 import { getDatabase } from '@process/database';
@@ -31,7 +31,7 @@ export function initWorkspaceBridge(): void {
   ipcBridge.workspaceManage.renameDirectory.provider(async ({ oldPath, newName }) => {
     try {
       // 1. Validate new name
-      if (!isValidDirectoryName(newName)) {
+      if (!isValidDirectoryName(newName) || isReservedDraftsDirName(newName)) {
         return { success: false, error: 'Invalid directory name' };
       }
 

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -137,6 +137,13 @@ export function buildDraftsInstruction(workspace: string): string {
 Your workspace is: ${workspace}
 A drafts directory exists at: ${draftsPath}
 
+**Drafts path mapping**:
+- "草稿箱" and "Drafts" are UI display names only.
+- The real filesystem directory is always ${draftsPath}
+- When the user says "copy/move to 草稿箱" or "copy/move to Drafts", use ${DRAFTS_DIR_NAME}/
+- Never create or use "drafts/", "Drafts/", or "草稿箱/" directories.
+- Correct command example: \`cp file.ext ${DRAFTS_DIR_NAME}/\`
+
 **CORE RULE: When creating files using write() tool, ALWAYS add intent markers**
 
 **Intent Markers** (add as FIRST LINE in file content):

--- a/src/process/task/draftsCleanup.ts
+++ b/src/process/task/draftsCleanup.ts
@@ -13,17 +13,18 @@
  * directly to the workspace root instead of .drafts/.
  */
 
-import { DRAFTS_DIR_NAME, FILE_INTENT_MARKERS, COMMENT_SYNTAX_MAP, DRAFT_FILE_PATTERNS, FINAL_FILE_PATTERNS, DRAFT_EXTENSIONS, FINAL_EXTENSIONS } from '@/common/constants';
+import { DRAFTS_DIR_ALIASES, DRAFTS_DIR_NAME, FILE_INTENT_MARKERS, COMMENT_SYNTAX_MAP, DRAFT_FILE_PATTERNS, FINAL_FILE_PATTERNS, DRAFT_EXTENSIONS, FINAL_EXTENSIONS } from '@/common/constants';
 import { mainLog, mainError } from '@process/utils/mainLogger';
 import fs from 'fs/promises';
 import fsSync from 'fs';
+import type { Dirent } from 'fs';
 import path from 'path';
 
 /**
  * Files/directories that should never be moved
  * 永远不应被移动的文件/目录
  */
-const EXCLUDED_NAMES = new Set([DRAFTS_DIR_NAME, '.git', '.gitignore', '.env', '.env.local', 'README.md', 'readme.md', 'LICENSE', 'package.json', 'package-lock.json', 'node_modules', '.DS_Store', 'Thumbs.db']);
+const EXCLUDED_NAMES = new Set([DRAFTS_DIR_NAME, ...DRAFTS_DIR_ALIASES, '.git', '.gitignore', '.env', '.env.local', 'README.md', 'readme.md', 'LICENSE', 'package.json', 'package-lock.json', 'node_modules', '.DS_Store', 'Thumbs.db']);
 
 /**
  * 检测文件意图标记结果
@@ -89,6 +90,64 @@ function matchesFinalPattern(fileName: string): boolean {
   }
 
   return false;
+}
+
+function appendTimestamp(filePath: string, attempt: number = 0): string {
+  const dir = path.dirname(filePath);
+  const ext = path.extname(filePath);
+  const base = path.basename(filePath, ext);
+  const suffix = attempt > 0 ? `_${attempt}` : '';
+  return path.join(dir, `${base}_${Date.now()}${suffix}${ext}`);
+}
+
+async function moveWithTimestampCollision(srcPath: string, destPath: string): Promise<string> {
+  let finalDestPath = destPath;
+  let attempt = 0;
+  while (fsSync.existsSync(finalDestPath)) {
+    finalDestPath = appendTimestamp(destPath, attempt);
+    attempt++;
+  }
+  await fs.rename(srcPath, finalDestPath);
+  return finalDestPath;
+}
+
+async function normalizeDraftsAliasDirectories(workspace: string, draftsDir: string, entries: Dirent[]): Promise<number> {
+  const aliasEntries = entries.filter((entry) => entry.isDirectory() && DRAFTS_DIR_ALIASES.some((alias) => alias.toLowerCase() === entry.name.toLowerCase()));
+  if (aliasEntries.length === 0) {
+    return 0;
+  }
+
+  await fs.mkdir(draftsDir, { recursive: true });
+
+  let movedCount = 0;
+  for (const aliasEntry of aliasEntries) {
+    const aliasDir = path.join(workspace, aliasEntry.name);
+    const children = await fs.readdir(aliasDir, { withFileTypes: true });
+
+    for (const child of children) {
+      const srcPath = path.join(aliasDir, child.name);
+      const destPath = path.join(draftsDir, child.name);
+      try {
+        const finalDestPath = await moveWithTimestampCollision(srcPath, destPath);
+        movedCount++;
+        mainLog('draftsCleanup', `Moved misplaced drafts alias entry ${aliasEntry.name}/${child.name} to ${path.relative(workspace, finalDestPath)}`);
+      } catch (err) {
+        mainError('draftsCleanup', `Failed to move misplaced drafts alias entry ${aliasEntry.name}/${child.name}:`, err);
+      }
+    }
+
+    try {
+      const remaining = await fs.readdir(aliasDir);
+      if (remaining.length === 0) {
+        await fs.rmdir(aliasDir);
+        mainLog('draftsCleanup', `Removed empty drafts alias directory ${aliasEntry.name}`);
+      }
+    } catch (err) {
+      mainError('draftsCleanup', `Failed to remove drafts alias directory ${aliasEntry.name}:`, err);
+    }
+  }
+
+  return movedCount;
 }
 
 /**
@@ -180,6 +239,7 @@ export async function cleanupIntermediateFiles(workspace: string): Promise<void>
     }
 
     const entries = await fs.readdir(workspace, { withFileTypes: true });
+    const movedAliasCount = await normalizeDraftsAliasDirectories(workspace, draftsDir, entries);
     const filesToMove: Array<{ name: string; reason: string }> = [];
     const filesToKeep: Array<{ name: string; reason: string }> = [];
 
@@ -255,6 +315,9 @@ export async function cleanupIntermediateFiles(workspace: string): Promise<void>
 
     // 如果没有需要移动的文件，直接返回
     if (filesToMove.length === 0) {
+      if (movedAliasCount > 0) {
+        mainLog('draftsCleanup', `Cleanup completed: normalized ${movedAliasCount} misplaced drafts alias entr${movedAliasCount === 1 ? 'y' : 'ies'}`);
+      }
       return;
     }
 
@@ -271,9 +334,7 @@ export async function cleanupIntermediateFiles(workspace: string): Promise<void>
 
       // Handle name collision: append timestamp
       if (fsSync.existsSync(destPath)) {
-        const ext = path.extname(name);
-        const base = path.basename(name, ext);
-        destPath = path.join(draftsDir, `${base}_${Date.now()}${ext}`);
+        destPath = appendTimestamp(destPath);
       }
 
       try {

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -6,7 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';
-import { DRAFTS_DIR_NAME } from '@/common/constants';
+import { DRAFTS_DIR_NAME, isReservedDraftsDirName } from '@/common/constants';
 import { STORAGE_KEYS } from '@/common/storageKeys';
 import { showShareLoading, updateShareSuccess, updateShareError } from '@/renderer/utils/shareNotify';
 import FlexFullContainer from '@/renderer/components/FlexFullContainer';
@@ -330,8 +330,8 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
       Message.error(t('conversation.workspace.newFolder.invalidName'));
       return;
     }
-    // Prevent creating folder named .drafts (reserved)
-    if (folderName === DRAFTS_DIR_NAME) {
+    // Prevent creating folders that conflict with the reserved drafts directory.
+    if (isReservedDraftsDirName(folderName)) {
       Message.error(t('conversation.workspace.newFolder.reservedName'));
       return;
     }
@@ -705,7 +705,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
   const isContextMenuNodeRoot = !!contextMenuNode && (!contextMenuNode.relativePath || contextMenuNode.relativePath === '');
   // Drafts directory (.drafts/) should not be renameable or deleteable
   // 草稿箱目录不支持重命名和删除
-  const isContextMenuNodeDrafts = !!contextMenuNode && contextMenuNode.name === '.drafts' && !contextMenuNode.isFile;
+  const isContextMenuNodeDrafts = !!contextMenuNode && contextMenuNode.name === DRAFTS_DIR_NAME && !contextMenuNode.isFile;
 
   // ShareOne CLI installation state
   const [shareoneInstalled, setShareoneInstalled] = useState(false);
@@ -1266,7 +1266,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
                   const nodeData = node.dataRef as IDirOrFile;
                   const directFileCount = !isFile ? (nodeData.children ?? []).filter((child) => child.isFile && !isHiddenWorkspaceEntry(child.name)).length : 0;
                   // Display .drafts with i18n name / 草稿箱目录显示本地化名称
-                  const isDraftsDir = node.title === '.drafts' && !isFile;
+                  const isDraftsDir = node.title === DRAFTS_DIR_NAME && !isFile;
                   const displayTitle = isDraftsDir ? t('conversation.workspace.drafts.title') : node.title;
 
                   return (

--- a/tests/unit/draftsCleanup.test.ts
+++ b/tests/unit/draftsCleanup.test.ts
@@ -160,4 +160,37 @@ describe('cleanupIntermediateFiles with markers', () => {
     expect(fsSync.existsSync(path.join(testWorkspace, '.drafts', 'package.json'))).toBe(true);
     expect(fsSync.existsSync(path.join(testWorkspace, 'node_modules'))).toBe(false);
   });
+
+  test('normalizes files copied to drafts alias directory into .drafts/', async () => {
+    await fs.mkdir(path.join(testWorkspace, 'drafts'));
+    await fs.writeFile(path.join(testWorkspace, 'drafts', 'helper.js'), '// helper');
+
+    await cleanupIntermediateFiles(testWorkspace);
+
+    expect(fsSync.existsSync(path.join(testWorkspace, '.drafts', 'helper.js'))).toBe(true);
+    expect(fsSync.existsSync(path.join(testWorkspace, 'drafts'))).toBe(false);
+  });
+
+  test('normalizes files copied to Chinese drafts alias directory into .drafts/', async () => {
+    await fs.mkdir(path.join(testWorkspace, '草稿箱'));
+    await fs.writeFile(path.join(testWorkspace, '草稿箱', 'notes.md'), 'draft notes');
+
+    await cleanupIntermediateFiles(testWorkspace);
+
+    expect(fsSync.existsSync(path.join(testWorkspace, '.drafts', 'notes.md'))).toBe(true);
+    expect(fsSync.existsSync(path.join(testWorkspace, '草稿箱'))).toBe(false);
+  });
+
+  test('preserves existing .drafts file when normalizing alias directory collisions', async () => {
+    await fs.writeFile(path.join(testWorkspace, '.drafts', 'helper.js'), 'existing');
+    await fs.mkdir(path.join(testWorkspace, 'drafts'));
+    await fs.writeFile(path.join(testWorkspace, 'drafts', 'helper.js'), 'new');
+
+    await cleanupIntermediateFiles(testWorkspace);
+
+    expect(await fs.readFile(path.join(testWorkspace, '.drafts', 'helper.js'), 'utf-8')).toBe('existing');
+    const draftsFiles = await fs.readdir(path.join(testWorkspace, '.drafts'));
+    expect(draftsFiles.some((name) => /^helper_\d+\.js$/.test(name))).toBe(true);
+    expect(fsSync.existsSync(path.join(testWorkspace, 'drafts'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- clarify that Drafts/草稿箱 maps to the physical .drafts directory for agents
- normalize mistaken root-level drafts aliases into .drafts during cleanup
- block UI/workspace rename flows from creating reserved drafts aliases

## Tests
- bunx vitest run tests/unit/draftsCleanup.test.ts tests/unit/workspaceTreeFilter.test.ts

## Notes
- bunx tsc --noEmit was checked before commit and fails on existing unrelated type errors in AcpConnection.ts, initStorage.ts, ScodeMcpAgent.ts, avatar/App.tsx, and AcpSendBox.tsx.