### PR TITLE
feat(mcp): 接入用户级启用/禁用 API，支持企业/部门/个人 MCP 开关

### DIFF
--- a/src/renderer/pages/settings/EnterpriseMcpSettings/api/client.ts
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/api/client.ts
@@ -125,12 +125,13 @@ async function normalizeResponse<T>(res: Response): Promise<T> {
 
   // Success
   if (typeof json === 'object' && json !== null && 'success' in json) {
-    const env = json as { success: boolean; data?: unknown };
+    const env = json as { success: boolean; data?: unknown; error?: { code?: string; message?: string } };
     if (!env.success) {
+      const err = env.error;
       throw new EnterpriseMcpError(
         {
-          code: 'unknown_error',
-          message: '请求失败',
+          code: err?.code || 'unknown_error',
+          message: err?.message || '请求失败',
           httpStatus: res.status,
         },
         json

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/api/mcpServers.ts
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/api/mcpServers.ts
@@ -35,6 +35,8 @@ export interface McpServersApi {
   test(id: string): Promise<TestResponse['data']>;
   getUserConfig(id: string): Promise<UserConfigResponse['data']>;
   updateUserConfig(id: string, config_values: Record<string, string>): Promise<void>;
+  enable(id: string): Promise<void>;
+  disable(id: string): Promise<void>;
 }
 
 export function createMcpServersApi(client: EnterpriseMcpClient): McpServersApi {
@@ -69,6 +71,16 @@ export function createMcpServersApi(client: EnterpriseMcpClient): McpServersApi 
       await client.request<{ success: true }>(`/api/v1/me/mcp-servers/${encodeURIComponent(id)}/user-config`, {
         method: 'PUT',
         body: { config_values },
+      });
+    },
+    async enable(id) {
+      await client.request<{ success: true }>(`/api/v1/me/mcp-servers/${encodeURIComponent(id)}/enable`, {
+        method: 'PUT',
+      });
+    },
+    async disable(id) {
+      await client.request<{ success: true }>(`/api/v1/me/mcp-servers/${encodeURIComponent(id)}/disable`, {
+        method: 'PUT',
       });
     },
   };

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/index.tsx
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/index.tsx
@@ -99,25 +99,23 @@ const EnterpriseMcpSettings: React.FC = () => {
     [templatesApi, mutateServers]
   );
 
-  // === Toggle enabled on personal MCP ===
+  // === Toggle user-level enabled/disabled on MCP ===
   const handleToggleEnabled = useCallback(
     async (srv: EnterpriseMcpServerDto, enabled: boolean) => {
-      // optimistic update
-      const prev = servers;
-      const next = prev.map((s) => (s.id === srv.id ? { ...s, enabled } : s));
-      await mutateServers(); // ensure baseline
       try {
-        await serversApi.patch(srv.id, { enabled });
+        if (enabled) {
+          await serversApi.enable(srv.id);
+        } else {
+          await serversApi.disable(srv.id);
+        }
         await mutateServers();
       } catch (err) {
         Message.error(describeMcpError(err));
-        // revert by re-fetching authoritative state
         await mutateServers();
         throw err;
       }
-      void next; // (no SWR optimistic api used to keep this simple — re-fetch is authoritative)
     },
-    [serversApi, mutateServers, servers]
+    [serversApi, mutateServers]
   );
 
   // === Delete personal MCP ===
@@ -148,7 +146,7 @@ const EnterpriseMcpSettings: React.FC = () => {
       if (serversError) {
         return <ErrorBlock message={describeMcpError(serversError)} />;
       }
-      return <EnterpriseMcpTab servers={servers} loading={serversLoading} />;
+      return <EnterpriseMcpTab servers={servers} loading={serversLoading} onToggleUserDisabled={handleToggleEnabled} />;
     }
     if (key === 'library') {
       if (templatesLoading && templates.length === 0) {

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/tabs/EnterpriseMcpTab.tsx
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/tabs/EnterpriseMcpTab.tsx
@@ -9,23 +9,36 @@ import type { EnterpriseMcpServerDto } from '../types';
 interface EnterpriseMcpTabProps {
   servers: EnterpriseMcpServerDto[];
   loading?: boolean;
+  onToggleUserDisabled?: (server: EnterpriseMcpServerDto, enabled: boolean) => Promise<void> | void;
 }
 
 /**
  * Tab1 — 企业 MCP：列出 scope=org/department 的实例。
- * 已知缺口 §8.2：员工对企业 MCP 的启停 API 不存在。Switch 暂作 UI 占位，
- * 点击会弹 toast 提示，不发请求。Phase B 接 PATCH 后预期 403 → toast。
+ * allow_user_disable=false 的 MCP 排在最上面，不显示开关；
+ * allow_user_disable=true 的 MCP 显示开关，基于 user_disabled 字段驱动状态。
  */
-const EnterpriseMcpTab: React.FC<EnterpriseMcpTabProps> = ({ servers, loading = false }) => {
-  const filtered = useMemo(() => servers.filter((s) => s.scope === 'org' || s.scope === 'department'), [servers]);
+const EnterpriseMcpTab: React.FC<EnterpriseMcpTabProps> = ({ servers, loading = false, onToggleUserDisabled }) => {
+  const filtered = useMemo(() => {
+    const orgDept = servers.filter((s) => s.scope === 'org' || s.scope === 'department');
+    // allow_user_disable=false 排最上面，同组保持原始顺序
+    return orgDept.sort((a, b) => {
+      if (a.allow_user_disable === b.allow_user_disable) return 0;
+      return a.allow_user_disable ? 1 : -1;
+    });
+  }, [servers]);
 
   if (!loading && filtered.length === 0) {
     return <EmptyState illustrationType='default' title='暂无企业 MCP' description='管理员尚未发布任何企业级或部门级 MCP 实例。' simple />;
   }
 
-  const handleToggle = () => {
-    // §8.2: backend gap — UI only.
-    Message.info('该 MCP 暂不支持自助开关，请联系管理员');
+  const handleToggle = async (srv: EnterpriseMcpServerDto, enabled: boolean) => {
+    if (onToggleUserDisabled) {
+      try {
+        await onToggleUserDisabled(srv, enabled);
+      } catch (err) {
+        Message.error(err instanceof Error ? err.message : '操作失败');
+      }
+    }
   };
 
   return (
@@ -44,9 +57,13 @@ const EnterpriseMcpTab: React.FC<EnterpriseMcpTabProps> = ({ servers, loading = 
             <ScopeBadge scope={srv.scope} />
           </div>
           <div className='shrink-0 w-44px flex justify-end'>
-            <Tooltip content='当前版本暂不支持员工自助启停企业 MCP'>
-              <Switch checked={srv.enabled} onChange={handleToggle} size='small' />
-            </Tooltip>
+            {srv.allow_user_disable ? (
+              <Switch checked={!srv.user_disabled} onChange={(v: boolean) => void handleToggle(srv, v)} size='small' />
+            ) : (
+              <Tooltip content='管理员已锁定该 MCP，不允许员工自行启停'>
+                <Switch checked={!srv.user_disabled} size='small' disabled />
+              </Tooltip>
+            )}
           </div>
         </div>
       ))}

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/tabs/MyMcpTab.tsx
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/tabs/MyMcpTab.tsx
@@ -71,7 +71,7 @@ const MyMcpTab: React.FC<MyMcpTabProps> = ({ servers, loading = false, onToggleE
                 修改配置
               </Button>
             )}
-            <Switch checked={srv.enabled} onChange={(v) => void handleToggle(srv, v)} size='small' />
+            <Switch checked={!srv.user_disabled} onChange={(v) => void handleToggle(srv, v)} size='small' />
             <Popconfirm title='确认删除该 MCP？' content='此操作不可撤销，已写入的配置将被一并清除。' onOk={() => void handleDelete(srv)} okText='删除' cancelText='取消' okButtonProps={{ status: 'danger' }}>
               <Button type='text' size='mini' status='danger' icon={<Delete theme='outline' size='14' />} />
             </Popconfirm>

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/types.ts
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/types.ts
@@ -26,8 +26,10 @@ export interface EnterpriseMcpServerDto {
   bound_skills: string[] | null;
   allow_read: boolean;
   allow_write: boolean;
+  allow_user_disable: boolean;
   enabled: boolean;
   status: EnterpriseMcpStatus;
+  user_disabled: boolean;
 }
 
 export type EnterpriseMcpUserConfigTarget = 'env' | 'headers';


### PR DESCRIPTION
- types.ts: 新增 user_disabled、allow_user_disable 字段
- api/mcpServers.ts: 新增 enable()/disable() 方法
- api/client.ts: 修复 success:false 时未提取 error.code/message
- index.tsx: handler 改用 PUT enable/disable API
- EnterpriseMcpTab: 替换占位符，排序+条件Switch+锁定Tooltip
- MyMcpTab: Switch 状态改用 user_disabled

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
