### PR TITLE
feat: add Python runtime install option to runtime settings

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -690,6 +690,21 @@ export const libreOffice = {
   installResult: bridge.buildEmitter<{ success: boolean; msg?: string }>('libreoffice.install-result'),
 };
 
+// Python runtime installer / Python 运行环境安装
+export type IPythonInstallPhase = 'downloading' | 'installing' | 'configuring' | 'cleanup';
+
+export const pythonRuntime = {
+  checkInstalled: bridge.buildProvider<IBridgeResponse<ICliStatus>, void>('python-runtime.check-installed'),
+  install: bridge.buildProvider<IBridgeResponse<void>, void>('python-runtime.install'),
+  uninstall: bridge.buildProvider<IBridgeResponse<void>, void>('python-runtime.uninstall'),
+  /** Returns the current install state so the UI can restore progress after navigation */
+  getInstallState: bridge.buildProvider<IBridgeResponse<{ installing: boolean; phase?: IPythonInstallPhase; percent?: number }>, void>('python-runtime.get-install-state'),
+  /** Emitted periodically during installation with current phase and download percent */
+  installProgress: bridge.buildEmitter<{ phase: IPythonInstallPhase; percent?: number }>('python-runtime.install-progress'),
+  /** Emitted once when installation completes (success or failure) */
+  installResult: bridge.buildEmitter<{ success: boolean; msg?: string }>('python-runtime.install-result'),
+};
+
 // Sudoclaw config (~/.nexus/sudoclaw) / OpenClaw 配置
 // Matches sudoclaw.json schema: models.providers, agents.defaults, etc.
 export type SudoclawProviderModel = { id: string; name?: string; input?: string[] };

--- a/src/process/bridge/index.ts
+++ b/src/process/bridge/index.ts
@@ -40,6 +40,7 @@ import { initSudoclawBridge } from './sudoclawBridge';
 import { initInitBridge } from './initBridge';
 import { initSudoworkServerBridge } from './sudoworkServerBridge';
 import { initNodeRuntimeBridge } from './nodeRuntimeBridge';
+import { initPythonRuntimeBridge } from './pythonRuntimeBridge';
 // Safety hook IPC is temporarily disabled; keep safetyBridge.ts for restoration.
 // import { initSafetyBridge } from './safetyBridge';
 import { initBdpanBridge } from './bdpanBridge';
@@ -97,6 +98,7 @@ export function initAllBridges(): void {
   initAssistantHubBridge();
   initSudoclawBridge();
   initNodeRuntimeBridge();
+  initPythonRuntimeBridge();
   initSudoworkServerBridge();
   // Safety hook IPC is hidden while the feature is disabled.
   // initSafetyBridge();

--- a/src/process/bridge/pythonRuntimeBridge.ts
+++ b/src/process/bridge/pythonRuntimeBridge.ts
@@ -1,0 +1,64 @@
+import { ipcBridge } from '../../common';
+import type { InstallPhase } from '../services/python/PythonRuntimeService';
+import { pythonRuntimeService } from '../services/python/PythonRuntimeService';
+
+interface InstallState {
+  installing: boolean;
+  phase?: InstallPhase;
+  percent?: number;
+}
+
+let installState: InstallState = { installing: false };
+
+export function initPythonRuntimeBridge(): void {
+  ipcBridge.pythonRuntime.checkInstalled.provider(async () => {
+    try {
+      const status = await pythonRuntimeService.checkInstalled();
+      return {
+        success: true,
+        data: {
+          installed: status.installed,
+          version: status.version,
+          path: status.path,
+          source: 'system' as const,
+        },
+      };
+    } catch (err) {
+      return { success: false, msg: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcBridge.pythonRuntime.getInstallState.provider(async () => {
+    return { success: true, data: installState };
+  });
+
+  ipcBridge.pythonRuntime.install.provider(async () => {
+    installState = { installing: true };
+    try {
+      await pythonRuntimeService.install((phase, percent) => {
+        installState = { installing: true, phase, percent };
+        ipcBridge.pythonRuntime.installProgress.emit({ phase, percent });
+      });
+      ipcBridge.pythonRuntime.installResult.emit({ success: true });
+      return { success: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ipcBridge.pythonRuntime.installResult.emit({ success: false, msg });
+      return { success: false, msg };
+    } finally {
+      // Delay reset so renderer gets final progress + result events before state clears
+      setTimeout(() => {
+        installState = { installing: false };
+      }, 0);
+    }
+  });
+
+  ipcBridge.pythonRuntime.uninstall.provider(async () => {
+    try {
+      await pythonRuntimeService.uninstall();
+      return { success: true };
+    } catch (err) {
+      return { success: false, msg: err instanceof Error ? err.message : String(err) };
+    }
+  });
+}

--- a/src/process/services/python/PythonRuntimeService.ts
+++ b/src/process/services/python/PythonRuntimeService.ts
@@ -1,0 +1,399 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Python Runtime Service
+ *
+ * Detects, installs, and uninstalls Python to the system environment.
+ * Installation follows the same pattern as LibreOffice: download the official
+ * installer and run it with appropriate privileges on each platform.
+ *
+ * - macOS: downloads the official python.org .pkg installer and runs it via
+ *   `installer -pkg` with administrator privileges.
+ * - Windows: downloads the official python.org .exe installer and runs it
+ *   silently with `InstallAllUsers=1` (system-wide).
+ * - Linux: installs via the system package manager (apt / dnf / pacman).
+ */
+
+import { execFile, exec } from 'child_process';
+import * as fs from 'fs';
+import * as https from 'https';
+import * as http from 'http';
+import * as path from 'path';
+import { app } from 'electron';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+const execAsync = promisify(exec);
+
+// Update this version constant when a new Python stable release is available.
+// Download page: https://www.python.org/downloads/
+const PYTHON_VERSION = '3.13.4';
+
+interface PythonStatus {
+  installed: boolean;
+  version?: string;
+  path?: string;
+}
+
+export type InstallPhase = 'downloading' | 'installing' | 'configuring' | 'cleanup';
+
+export type ProgressCallback = (phase: InstallPhase, percent?: number) => void;
+
+export class PythonRuntimeService {
+  async checkInstalled(): Promise<PythonStatus> {
+    if (process.platform === 'darwin') {
+      return this.checkInstalledMac();
+    } else if (process.platform === 'win32') {
+      return this.checkInstalledWindows();
+    } else {
+      return this.checkInstalledLinux();
+    }
+  }
+
+  private async checkInstalledMac(): Promise<PythonStatus> {
+    // Check for Homebrew python3, official python.org install, or system python3
+    const candidates = ['/usr/local/bin/python3', '/opt/homebrew/bin/python3', '/Library/Frameworks/Python.framework/Versions/Current/bin/python3'];
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        try {
+          const { stdout } = await execAsync(`"${candidate}" --version`);
+          const match = stdout.trim().match(/Python\s+(\S+)/);
+          return { installed: true, version: match?.[1], path: candidate };
+        } catch {
+          return { installed: true, path: candidate };
+        }
+      }
+    }
+    // Fallback: check PATH
+    try {
+      const { stdout } = await execAsync('which python3 2>/dev/null');
+      const pythonPath = stdout.trim();
+      if (pythonPath) {
+        const { stdout: verOut } = await execAsync(`"${pythonPath}" --version`);
+        const match = verOut.trim().match(/Python\s+(\S+)/);
+        return { installed: true, version: match?.[1], path: pythonPath };
+      }
+    } catch {
+      /* not found */
+    }
+    return { installed: false };
+  }
+
+  private async checkInstalledWindows(): Promise<PythonStatus> {
+    // Check common install locations
+    const programFiles = process.env['ProgramFiles'] ?? 'C:\\Program Files';
+    const localAppData = process.env['LOCALAPPDATA'] ?? '';
+
+    // Check system-wide install
+    try {
+      const entries = fs.readdirSync(programFiles).filter((d) => d.toLowerCase().startsWith('python'));
+      for (const entry of entries) {
+        const pythonExe = path.join(programFiles, entry, 'python.exe');
+        if (fs.existsSync(pythonExe)) {
+          try {
+            const { stdout } = await execAsync(`"${pythonExe}" --version`);
+            const match = stdout.trim().match(/Python\s+(\S+)/);
+            return { installed: true, version: match?.[1], path: pythonExe };
+          } catch {
+            return { installed: true, path: pythonExe };
+          }
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Check user-level install
+    if (localAppData) {
+      try {
+        const pyDir = path.join(localAppData, 'Programs', 'Python');
+        if (fs.existsSync(pyDir)) {
+          const entries = fs.readdirSync(pyDir).filter((d) => d.toLowerCase().startsWith('python'));
+          for (const entry of entries) {
+            const pythonExe = path.join(pyDir, entry, 'python.exe');
+            if (fs.existsSync(pythonExe)) {
+              try {
+                const { stdout } = await execAsync(`"${pythonExe}" --version`);
+                const match = stdout.trim().match(/Python\s+(\S+)/);
+                return { installed: true, version: match?.[1], path: pythonExe };
+              } catch {
+                return { installed: true, path: pythonExe };
+              }
+            }
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+
+    // Fallback: check PATH
+    try {
+      const { stdout } = await execAsync('where python 2>nul');
+      const pythonPath = stdout.trim().split(/\r?\n/)[0];
+      if (pythonPath && fs.existsSync(pythonPath)) {
+        const { stdout: verOut } = await execAsync(`"${pythonPath}" --version`);
+        const match = verOut.trim().match(/Python\s+(\S+)/);
+        return { installed: true, version: match?.[1], path: pythonPath };
+      }
+    } catch {
+      /* not found */
+    }
+    return { installed: false };
+  }
+
+  private async checkInstalledLinux(): Promise<PythonStatus> {
+    try {
+      const { stdout } = await execAsync('which python3 2>/dev/null || which python 2>/dev/null');
+      const pythonPath = stdout.trim().split(/\n/)[0];
+      if (pythonPath) {
+        try {
+          const { stdout: verOut } = await execAsync(`"${pythonPath}" --version`);
+          const match = verOut.trim().match(/Python\s+(\S+)/);
+          return { installed: true, version: match?.[1], path: pythonPath };
+        } catch {
+          return { installed: true, path: pythonPath };
+        }
+      }
+    } catch {
+      /* not found */
+    }
+    return { installed: false };
+  }
+
+  getDownloadUrl(): string {
+    const v = PYTHON_VERSION;
+    if (process.platform === 'darwin') {
+      // Universal installer for macOS (works on both Intel and Apple Silicon)
+      return `https://www.python.org/ftp/python/${v}/python-${v}-macos11.pkg`;
+    } else if (process.platform === 'win32') {
+      // Windows installer
+      const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
+      return `https://www.python.org/ftp/python/${v}/python-${v}-${arch}.exe`;
+    } else {
+      // Linux: use package manager, no direct download
+      return '';
+    }
+  }
+
+  private getCacheDir(): string {
+    const cacheDir = path.join(app.getPath('userData'), 'python-cache');
+    if (!fs.existsSync(cacheDir)) fs.mkdirSync(cacheDir, { recursive: true });
+    return cacheDir;
+  }
+
+  private getCachedFilePath(): string {
+    const cacheDir = this.getCacheDir();
+    let ext: string;
+    if (process.platform === 'darwin') {
+      ext = 'pkg';
+    } else if (process.platform === 'win32') {
+      ext = 'exe';
+    } else {
+      ext = 'tar.gz';
+    }
+    return path.join(cacheDir, `python-${PYTHON_VERSION}.${ext}`);
+  }
+
+  async install(onProgress: ProgressCallback): Promise<void> {
+    if (process.platform === 'darwin') {
+      return this.installMac(onProgress);
+    } else if (process.platform === 'win32') {
+      return this.installWindows(onProgress);
+    } else {
+      return this.installLinux(onProgress);
+    }
+  }
+
+  private async installMac(onProgress: ProgressCallback): Promise<void> {
+    const pkgPath = this.getCachedFilePath();
+
+    try {
+      // Download if not cached
+      if (fs.existsSync(pkgPath) && fs.statSync(pkgPath).size > 0) {
+        onProgress('downloading', 100);
+      } else {
+        await this.downloadFile(this.getDownloadUrl(), pkgPath, (percent) => {
+          onProgress('downloading', percent);
+        });
+      }
+
+      onProgress('installing');
+      // Use osascript to run the installer with admin privileges
+      const script = `do shell script "installer -pkg '${pkgPath.replace(/'/g, "'\\''")}' -target /" with administrator privileges`;
+      await execFileAsync('osascript', ['-e', script]);
+
+      onProgress('configuring');
+    } catch (err) {
+      try {
+        if (fs.existsSync(pkgPath)) fs.rmSync(pkgPath);
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    } finally {
+      onProgress('cleanup');
+    }
+  }
+
+  private async installWindows(onProgress: ProgressCallback): Promise<void> {
+    const exePath = this.getCachedFilePath();
+
+    try {
+      // Download if not cached
+      if (fs.existsSync(exePath) && fs.statSync(exePath).size > 0) {
+        onProgress('downloading', 100);
+      } else {
+        await this.downloadFile(this.getDownloadUrl(), exePath, (percent) => {
+          onProgress('downloading', percent);
+        });
+      }
+
+      onProgress('installing');
+      // Run the official Python installer silently with system-wide install
+      // InstallAllUsers=1 installs for all users (system-wide)
+      // PrependPath=1 adds Python to PATH
+      // Include_pip=1 includes pip
+      await execFileAsync(exePath, ['/passive', 'InstallAllUsers=1', 'PrependPath=1', 'Include_pip=1', 'Include_launcher=1']);
+    } catch (err) {
+      try {
+        if (fs.existsSync(exePath)) fs.rmSync(exePath);
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    } finally {
+      onProgress('cleanup');
+    }
+  }
+
+  private async installLinux(onProgress: ProgressCallback): Promise<void> {
+    onProgress('installing');
+    try {
+      // Try apt (Debian/Ubuntu)
+      try {
+        await execAsync('which apt-get');
+        await execFileAsync('pkexec', ['bash', '-c', 'apt-get update && apt-get install -y python3 python3-pip python3-venv']);
+        return;
+      } catch {
+        /* not apt-based */
+      }
+
+      // Try dnf (Fedora/RHEL)
+      try {
+        await execAsync('which dnf');
+        await execFileAsync('pkexec', ['dnf', 'install', '-y', 'python3', 'python3-pip']);
+        return;
+      } catch {
+        /* not dnf-based */
+      }
+
+      // Try pacman (Arch)
+      try {
+        await execAsync('which pacman');
+        await execFileAsync('pkexec', ['pacman', '-S', '--noconfirm', 'python', 'python-pip']);
+        return;
+      } catch {
+        /* not pacman-based */
+      }
+
+      throw new Error('Unsupported Linux distribution. Please install Python manually using your system package manager.');
+    } finally {
+      onProgress('cleanup');
+    }
+  }
+
+  async uninstall(): Promise<void> {
+    if (process.platform === 'darwin') {
+      // Remove the official python.org framework install
+      const script = `do shell script "rm -rf /Library/Frameworks/Python.framework" with administrator privileges`;
+      try {
+        await execFileAsync('osascript', ['-e', script]);
+      } catch {
+        /* ignore – may not be a framework install */
+      }
+    } else if (process.platform === 'win32') {
+      // Run the cached installer in uninstall mode
+      const exePath = this.getCachedFilePath();
+      if (fs.existsSync(exePath)) {
+        try {
+          await execFileAsync(exePath, ['/uninstall', '/passive']);
+        } catch {
+          /* ignore */
+        }
+      }
+      // Also try via Programs and Features registry
+      try {
+        await execAsync('wmic product where "name like \'Python%\'" call uninstall /nointeractive');
+      } catch {
+        /* ignore */
+      }
+    } else {
+      // Linux: remove via package manager
+      try {
+        await execAsync('which apt-get');
+        await execFileAsync('pkexec', ['apt-get', 'remove', '-y', 'python3']);
+        return;
+      } catch {
+        /* not apt */
+      }
+      try {
+        await execAsync('which dnf');
+        await execFileAsync('pkexec', ['dnf', 'remove', '-y', 'python3']);
+        return;
+      } catch {
+        /* not dnf */
+      }
+      try {
+        await execAsync('which pacman');
+        await execFileAsync('pkexec', ['pacman', '-R', '--noconfirm', 'python']);
+        return;
+      } catch {
+        /* not pacman */
+      }
+    }
+    // Clean download cache
+    const cacheDir = this.getCacheDir();
+    if (fs.existsSync(cacheDir)) fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+
+  private downloadFile(url: string, dest: string, onPercent: (n: number) => void): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const doRequest = (reqUrl: string, redirectCount = 0) => {
+        if (redirectCount > 10) return reject(new Error('Too many redirects'));
+        const mod = reqUrl.startsWith('https') ? https : http;
+        mod
+          .get(reqUrl, (res) => {
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+              return doRequest(res.headers.location, redirectCount + 1);
+            }
+            if (res.statusCode !== 200) {
+              return reject(new Error(`HTTP ${res.statusCode} for ${reqUrl}`));
+            }
+            const total = parseInt(res.headers['content-length'] ?? '0', 10);
+            let received = 0;
+            const file = fs.createWriteStream(dest);
+            res.on('data', (chunk: Buffer) => {
+              received += chunk.length;
+              if (total > 0) onPercent(Math.round((received / total) * 100));
+            });
+            res.pipe(file);
+            file.on('finish', () => file.close(() => resolve()));
+            file.on('error', (e) => {
+              fs.rmSync(dest, { force: true });
+              reject(e);
+            });
+            res.on('error', reject);
+          })
+          .on('error', reject);
+      };
+      doRequest(url);
+    });
+  }
+}
+
+export const pythonRuntimeService = new PythonRuntimeService();

--- a/src/renderer/components/SettingsModal/contents/RuntimeModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/RuntimeModalContent.tsx
@@ -10,9 +10,9 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
 import { useSettingsViewMode } from '../settingsViewContext';
-import { nexus as nexusIpc, claudeCli as claudeCliIpc, libreOffice as libreOfficeIpc, scode as scodeIpc, nodeRuntime as nodeRuntimeIpc, acpConversation, shareoneCli } from '@/common/ipcBridge';
+import { nexus as nexusIpc, claudeCli as claudeCliIpc, libreOffice as libreOfficeIpc, pythonRuntime as pythonRuntimeIpc, scode as scodeIpc, nodeRuntime as nodeRuntimeIpc, acpConversation, shareoneCli } from '@/common/ipcBridge';
 import { mutate } from 'swr';
-import type { ICliStatus, ILibreOfficeInstallPhase, NexusInstallPhase } from '@/common/ipcBridge';
+import type { ICliStatus, ILibreOfficeInstallPhase, IPythonInstallPhase, NexusInstallPhase } from '@/common/ipcBridge';
 import { getRuntimeActions, getStatusInfo, isInstalled, type LoadState, type ToolRow } from './runtimeStatus';
 
 type RefreshOptions = {
@@ -45,6 +45,11 @@ const RuntimeModalContent: React.FC = () => {
   const [libreOfficeLoad, setLibreOfficeLoad] = useState<LoadState>('idle');
   const [libreOfficePhase, setLibreOfficePhase] = useState<ILibreOfficeInstallPhase | undefined>(undefined);
   const [libreOfficePercent, setLibreOfficePercent] = useState<number | undefined>(undefined);
+
+  const [pythonStatus, setPythonStatus] = useState<ICliStatus | null>(null);
+  const [pythonLoad, setPythonLoad] = useState<LoadState>('idle');
+  const [pythonPhase, setPythonPhase] = useState<IPythonInstallPhase | undefined>(undefined);
+  const [pythonPercent, setPythonPercent] = useState<number | undefined>(undefined);
 
   const [scodeStatus, setScodeStatus] = useState<ICliStatus | null>(null);
   const [scodeLoad, setScodeLoad] = useState<LoadState>('idle');
@@ -224,6 +229,56 @@ const RuntimeModalContent: React.FC = () => {
     }
   }, [refreshLibreOffice, t]);
 
+  const refreshPython = useCallback(async (options?: RefreshOptions) => {
+    if (!options?.silent) {
+      setPythonLoad('loading');
+    }
+    try {
+      const res = await pythonRuntimeIpc.checkInstalled.invoke();
+      if (res?.success && res.data) setPythonStatus(res.data);
+    } finally {
+      if (!options?.silent) {
+        setPythonLoad('idle');
+      }
+    }
+  }, []);
+
+  const installPython = useCallback(async () => {
+    setPythonLoad('installing');
+    try {
+      const res = await pythonRuntimeIpc.install.invoke();
+      if (res?.success) {
+        await refreshPython();
+        Message.success(t('settings.runtimeSettings.installSuccess', { name: 'Python' }));
+      } else {
+        Message.error(res?.msg || t('settings.runtimeSettings.installFailed', { name: 'Python' }));
+      }
+    } catch (e) {
+      Message.error(e instanceof Error ? e.message : t('settings.runtimeSettings.installFailed', { name: 'Python' }));
+    } finally {
+      setPythonLoad('idle');
+      setPythonPhase(undefined);
+      setPythonPercent(undefined);
+    }
+  }, [refreshPython, t]);
+
+  const uninstallPython = useCallback(async () => {
+    setPythonLoad('loading');
+    try {
+      const res = await pythonRuntimeIpc.uninstall.invoke();
+      if (res?.success) {
+        Message.success(t('settings.runtimeSettings.uninstallSuccess', { name: 'Python' }));
+        await refreshPython();
+      } else {
+        Message.error(res?.msg || t('settings.runtimeSettings.uninstallFailed', { name: 'Python' }));
+      }
+    } catch (e) {
+      Message.error(e instanceof Error ? e.message : t('settings.runtimeSettings.uninstallFailed', { name: 'Python' }));
+    } finally {
+      setPythonLoad('idle');
+    }
+  }, [refreshPython, t]);
+
   const refreshScode = useCallback(async () => {
     try {
       const res = await scodeIpc.getStatus.invoke();
@@ -362,9 +417,9 @@ const RuntimeModalContent: React.FC = () => {
 
   const refreshRuntimePage = useCallback(
     async (options?: RefreshOptions) => {
-      await Promise.all([refreshNode(options), refreshClaude(options), refreshScode(), refreshShareone(), refreshNexus(), refreshLibreOffice(options)]);
+      await Promise.all([refreshNode(options), refreshClaude(options), refreshScode(), refreshShareone(), refreshNexus(), refreshLibreOffice(options), refreshPython(options)]);
     },
-    [refreshClaude, refreshLibreOffice, refreshNexus, refreshNode, refreshScode, refreshShareone]
+    [refreshClaude, refreshLibreOffice, refreshNexus, refreshNode, refreshPython, refreshScode, refreshShareone]
   );
 
   // Load all on mount; also restore install state if an install is already in progress
@@ -375,6 +430,13 @@ const RuntimeModalContent: React.FC = () => {
         setLibreOfficeLoad('installing');
         if (res.data.phase) setLibreOfficePhase(res.data.phase);
         if (res.data.percent != null) setLibreOfficePercent(res.data.percent);
+      }
+    });
+    void pythonRuntimeIpc.getInstallState.invoke().then((res) => {
+      if (res?.success && res.data?.installing) {
+        setPythonLoad('installing');
+        if (res.data.phase) setPythonPhase(res.data.phase);
+        if (res.data.percent != null) setPythonPercent(res.data.percent);
       }
     });
   }, [refreshRuntimePage]);
@@ -422,6 +484,11 @@ const RuntimeModalContent: React.FC = () => {
       if (percent != null) setLibreOfficePercent((prev) => (prev != null ? Math.max(prev, percent) : percent));
     });
     const unsubLoResult = libreOfficeIpc.installResult.on(() => void refreshLibreOffice());
+    const unsubPyProgress = pythonRuntimeIpc.installProgress.on(({ phase, percent }) => {
+      setPythonPhase(phase);
+      if (percent != null) setPythonPercent((prev) => (prev != null ? Math.max(prev, percent) : percent));
+    });
+    const unsubPyResult = pythonRuntimeIpc.installResult.on(() => void refreshPython());
     return () => {
       unsubNode();
       unsubClaude();
@@ -433,8 +500,10 @@ const RuntimeModalContent: React.FC = () => {
       unsubNexusResult();
       unsubLoProgress();
       unsubLoResult();
+      unsubPyProgress();
+      unsubPyResult();
     };
-  }, [refreshNode, refreshClaude, refreshAvailableAgents, refreshNexus, refreshScode, refreshShareone, refreshLibreOffice]);
+  }, [refreshNode, refreshClaude, refreshAvailableAgents, refreshNexus, refreshScode, refreshShareone, refreshLibreOffice, refreshPython]);
 
   const tableData: ToolRow[] = [
     {
@@ -472,6 +541,19 @@ const RuntimeModalContent: React.FC = () => {
       onRefresh: refreshLibreOffice,
       onInstall: installLibreOffice,
       onUninstall: uninstallLibreOffice,
+    },
+    {
+      key: 'python',
+      displayName: 'Python',
+      command: 'python3',
+      badge: 'PY',
+      status: pythonStatus,
+      loadState: pythonLoad,
+      installPhase: pythonPhase,
+      installPercent: pythonPercent,
+      onRefresh: refreshPython,
+      onInstall: installPython,
+      onUninstall: uninstallPython,
     },
     {
       key: 'sudocode',
@@ -517,6 +599,7 @@ const RuntimeModalContent: React.FC = () => {
     node: 'bg-cyan-1 color-cyan-6 border border-cyan-3',
     claude: 'bg-orange-1 color-orange-6 border border-orange-3',
     libreoffice: 'bg-green-1 color-green-6 border border-green-3',
+    python: 'bg-[#fef3c7] color-[#d97706] border border-[#fcd34d]',
     sudocode: 'bg-purple-1 color-purple-6 border border-purple-3',
     shareone: 'bg-blue-1 color-blue-6 border border-blue-3',
     nexus: 'text-[#f6c65b] border border-[#6f5520] bg-[#2b2212]',


### PR DESCRIPTION
Add Python as a new runtime option in the settings page, following the same pattern as LibreOffice for system-level installation.

Changes:
- PythonRuntimeService: detects, installs, and uninstalls Python across macOS (.pkg), Windows (.exe), and Linux (apt/dnf/pacman)
- pythonRuntimeBridge: IPC bridge connecting renderer to the service
- ipcBridge: new pythonRuntime IPC channel definitions
- RuntimeModalContent: Python entry in the runtime tools table with install progress tracking and status display

Closes #697

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
