### PR TITLE
fix: improve ACP error handling and auth flow reliability

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -39,6 +39,22 @@ interface PendingRequest<T = unknown> {
 
 const numberOrUndefined = (value: unknown): number | undefined => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
 
+function formatAcpErrorMessage(error: AcpResponse['error']): string {
+  const message = error?.message || 'Unknown ACP error';
+  const data = error?.data;
+
+  if (data === undefined || data === null) {
+    return message;
+  }
+
+  const detail = typeof data === 'string' ? data : JSON.stringify(data);
+  if (!detail || detail === message) {
+    return message;
+  }
+
+  return `${message}: ${detail.slice(0, 2000)}`;
+}
+
 export class AcpConnection {
   private child: ChildProcess | null = null;
   private pendingRequests = new Map<number, PendingRequest<unknown>>();
@@ -692,7 +708,7 @@ export class AcpConnection {
           }
           resolve(message.result);
         } else if ('error' in message) {
-          const errorMsg = message.error?.message || 'Unknown ACP error';
+          const errorMsg = formatAcpErrorMessage(message.error);
           reject(new Error(errorMsg));
         }
       } else {

--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -13,7 +13,7 @@
 import type { ChildProcess, SpawnOptions } from 'child_process';
 import { execFile as execFileCb, execFileSync, spawn } from 'child_process';
 import { promisify } from 'util';
-import { mkdirSync, promises as fs, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, promises as fs, readFileSync, writeFileSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import { CLAUDE_ACP_NPX_PACKAGE, CODEBUDDY_ACP_NPX_PACKAGE, CODEX_ACP_BRIDGE_VERSION, CODEX_ACP_NPX_PACKAGE } from '@/types/acpTypes';
@@ -267,7 +267,7 @@ export function prepareCleanEnv({ injectSafetyHook = true }: PrepareCleanEnvOpti
   // Add sudoclaw/bin to PATH so the `browser` CLI wrapper is available to ACP agents.
   const sudoclawBinDir = path.join(os.homedir(), '.nexus', 'sudoclaw', 'bin');
   const prevPath = cleanEnv.PATH || '';
-  if (!prevPath.includes(sudoclawBinDir)) {
+  if (existsSync(sudoclawBinDir) && !prevPath.includes(sudoclawBinDir)) {
     cleanEnv.PATH = `${sudoclawBinDir}${path.delimiter}${prevPath}`;
   }
 

--- a/src/process/bridge/authBridge.ts
+++ b/src/process/bridge/authBridge.ts
@@ -250,7 +250,7 @@ WQIDAQAB
     try {
       const dataPath = getDataPath();
       const filePath = path.join(dataPath, CONSUMER_USER_ID_FILE);
-      await fsPromises.writeFile(filePath, userId, 'utf-8');
+      await fsPromises.writeFile(filePath, String(userId), 'utf-8');
       mainLog('Sudowork Auth', 'Consumer user ID saved');
       return { success: true };
     } catch (error) {

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -147,9 +147,11 @@ const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electro
  */
 async function refreshAuthProxyRulesAfterLogin(): Promise<void> {
   try {
-    const enabledMap = await ConfigStorage.get('settings.tenant.enabled') as Record<number, boolean> | undefined;
+    const enabledMap = (await ConfigStorage.get('settings.tenant.enabled')) as Record<number, boolean> | undefined;
     const enabledIds = enabledMap
-      ? Object.entries(enabledMap).filter(([, v]) => v).map(([k]) => Number(k))
+      ? Object.entries(enabledMap)
+          .filter(([, v]) => v)
+          .map(([k]) => Number(k))
       : [];
 
     const stored = localStorage.getItem(AUTH_STORAGE_KEY);
@@ -311,57 +313,61 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
     setReady(true);
 
     try {
-      const currentConfig = await ipcBridge.sudoclaw.getConfig.invoke();
-      const hadSudoclawApiKey = hasSudoclawApiKey(currentConfig?.data);
-      const patch = mergeSudorouterProvidersIntoConfig(currentConfig?.data, {
-        modelIds: loginSudoclawPayload.models,
-        apiKey: loginSudoclawPayload.sudorouterKey,
-        baseUrl: loginSudoclawPayload.modelServiceUrl,
-        preservePrimary: hadSudoclawApiKey,
+      const currentScodeConfig = await ipcBridge.scode.getConfig.invoke().catch((): null => null);
+      const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data);
+      const scodeSaveRes = await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig });
+      if (!scodeSaveRes?.success) {
+        throw new Error(scodeSaveRes?.msg || 'Sudocode saveConfig failed');
+      }
+
+      const restoreRes = await ipcBridge.scode.restoreCustomModelProviders.invoke({ userId: authData.id }).catch((err): null => {
+        console.warn('[Auth] Failed to restore custom scode models:', err);
+        return null;
       });
+      await ipcBridge.scode.setImageModel.invoke({ modelId: DEFAULT_IMAGE_GENERATION_MODEL }).catch(() => {});
+      // Sync settings.json to the merged default model while preserving a user-selected custom model.
+      const defaultModel = restoreRes?.data?.default_model || scodeConfig.default_model;
+      if (defaultModel) {
+        await ipcBridge.scode.setDefaultModel.invoke({ modelId: defaultModel }).catch(() => {});
+      }
 
-      if (!hadSudoclawApiKey) {
-        patch.agents = {
-          ...patch.agents,
-          defaults: {
-            ...patch.agents?.defaults,
-            model: {
-              ...patch.agents?.defaults?.model,
-              primary: getSudorouterPrimaryModelPath('gemini-3.5-flash'),
+      // Sync sudoclaw.json only for legacy gateway compatibility. Failure must not block Sudocode.
+      try {
+        const currentConfig = await ipcBridge.sudoclaw.getConfig.invoke();
+        const hadSudoclawApiKey = hasSudoclawApiKey(currentConfig?.data);
+        const patch = mergeSudorouterProvidersIntoConfig(currentConfig?.data, {
+          modelIds: loginSudoclawPayload.models,
+          apiKey: loginSudoclawPayload.sudorouterKey,
+          baseUrl: loginSudoclawPayload.modelServiceUrl,
+          preservePrimary: hadSudoclawApiKey,
+        });
+
+        if (!hadSudoclawApiKey) {
+          patch.agents = {
+            ...patch.agents,
+            defaults: {
+              ...patch.agents?.defaults,
+              model: {
+                ...patch.agents?.defaults?.model,
+                primary: getSudorouterPrimaryModelPath('gemini-3.5-flash'),
+              },
             },
-          },
-        };
-      }
-
-      const saveRes = await ipcBridge.sudoclaw.saveConfig.invoke({ config: patch });
-      if (!saveRes?.success) {
-        throw new Error(saveRes?.msg || 'Sudoclaw saveConfig failed');
-      }
-
-      // 同步写入 sudocode.json（C 端登录，与 sudoclaw.json 并行过渡期）
-      if (loginSudoclawPayload) {
-        const currentScodeConfig = await ipcBridge.scode.getConfig.invoke().catch((): null => null);
-        const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data);
-        await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig }).catch((err) => {
-          console.warn('[Auth] Failed to save scode config:', err);
-        });
-        const restoreRes = await ipcBridge.scode.restoreCustomModelProviders.invoke({ userId: authData.id }).catch((err): null => {
-          console.warn('[Auth] Failed to restore custom scode models:', err);
-          return null;
-        });
-        await ipcBridge.scode.setImageModel.invoke({ modelId: DEFAULT_IMAGE_GENERATION_MODEL }).catch(() => {});
-        // 同步 settings.json 模型到合并后的默认模型；保留用户已选择的自定义模型。
-        const defaultModel = restoreRes?.data?.default_model || scodeConfig.default_model;
-        if (defaultModel) {
-          await ipcBridge.scode.setDefaultModel.invoke({ modelId: defaultModel }).catch(() => {});
+          };
         }
+
+        const saveRes = await ipcBridge.sudoclaw.saveConfig.invoke({ config: patch });
+        if (!saveRes?.success) {
+          throw new Error(saveRes?.msg || 'Sudoclaw saveConfig failed');
+        }
+      } catch (error) {
+        console.warn('[Auth] Failed to sync sudoclaw backup config:', error);
       }
     } catch (error) {
       setSyncMessage(null);
       setUser(null);
       setStatus('unauthenticated');
       setReady(true);
-      console.error('[Auth] Sudoclaw 配置失败:', error);
+      console.error('[Auth] Sudocode 配置失败:', error);
       throw error;
     }
   }
@@ -372,18 +378,26 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
   setReady(true);
 
   if (isDesktopRuntime) {
-    void ipcBridge.sudoclaw.restartGateway
-      .invoke()
-      .then((restartRes) => {
-        if (!restartRes?.success) {
-          console.error('[Auth] Sudoclaw 后台重启失败:', restartRes?.msg || 'Sudoclaw restartGateway failed');
-          return;
-        }
-        console.log('[Auth] Sudoclaw 正在后台重启');
-      })
-      .catch((error) => {
-        console.error('[Auth] Sudoclaw 后台重启失败:', error);
-      });
+    void restartSudoclawGatewayIfInstalled();
+  }
+}
+
+async function restartSudoclawGatewayIfInstalled(): Promise<void> {
+  try {
+    const statusRes = await ipcBridge.sudoclaw.getStatus.invoke();
+    if (!statusRes?.success || !statusRes.data?.installed) {
+      console.warn('[Auth] Sudoclaw gateway restart skipped because Sudoclaw CLI is not installed');
+      return;
+    }
+
+    const restartRes = await ipcBridge.sudoclaw.restartGateway.invoke();
+    if (!restartRes?.success) {
+      console.error('[Auth] Sudoclaw 后台重启失败:', restartRes?.msg || 'Sudoclaw restartGateway failed');
+      return;
+    }
+    console.log('[Auth] Sudoclaw 正在后台重启');
+  } catch (error) {
+    console.error('[Auth] Sudoclaw 后台重启失败:', error);
   }
 }
 
@@ -617,8 +631,8 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             // Use the newer refresh_token: the one from ProcessConfig if it was refreshed by main process
             const useConfigRefreshToken = configRefreshToken && configRefreshToken !== authStorage.refresh_token;
             const finalRefreshToken = useConfigRefreshToken ? configRefreshToken : authStorage.refresh_token;
-            const finalExpiresAt = (configExpiresAt && configExpiresAt > authStorage.expires_at) ? configExpiresAt : authStorage.expires_at;
-            const finalAccessToken = (configExpiresAt && configExpiresAt > authStorage.expires_at && existingConfig?.access_token) ? existingConfig.access_token : authStorage.access_token;
+            const finalExpiresAt = configExpiresAt && configExpiresAt > authStorage.expires_at ? configExpiresAt : authStorage.expires_at;
+            const finalAccessToken = configExpiresAt && configExpiresAt > authStorage.expires_at && existingConfig?.access_token ? existingConfig.access_token : authStorage.access_token;
 
             await ConfigStorage.set('eeclaw.authStorage', {
               access_token: finalAccessToken,
@@ -905,143 +919,136 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
   // Shared post-login handling for all enterprise grant types (password / api_key / oauth2).
   // Persists tokens, sets up scode/session mode, and updates auth state.
-  const finalizeEnterpriseLogin = useCallback(
-    async (
-      result: Awaited<ReturnType<typeof ipcBridge.eeclaw.login.invoke>>,
-      deviceId: string,
-      sessionType: 'password' | 'api_key' | 'oauth2',
-    ): Promise<LoginResult> => {
-      if (!result.success || !result.data) {
-        return {
-          success: false,
-          message: (result as any).error === 'network_error' ? '连接到企业服务器失败' : ((result as any).error || result.msg || '登录失败'),
-          code: 'invalidCredentials',
-        };
-      }
-
-      const data = result.data;
-
-      // Map MOSS user to AuthUser compatible type
-      const mappedUser = mapEnterpriseUser(data.user, data.access_token);
-
-      // --- localModeAvailable calculation (before localStorage serialization) ---
-      const localModeAvailable = !!(data.user.localAuth && data.sudorouter_key
-        && data.model_service_url && Array.isArray(data.models) && data.models.length > 0);
-      mappedUser.localModeAvailable = localModeAvailable;
-
-      // Save to localStorage (eeclaw_auth_v1, separate from C-side)
-      const eeclawAuthStorage: EeclawAuthStorage = {
-        access_token: data.access_token,
-        refresh_token: data.refresh_token || '',
-        expires_at: Date.now() + (data.expires_in || 3600) * 1000,
-        user: mappedUser,
-        device_id: deviceId,
-        session_type: sessionType,
-      };
-      localStorage.setItem(EECLAW_AUTH_STORAGE_KEY, JSON.stringify(eeclawAuthStorage));
-
-      // --- sudocode.json generation/cleanup + sessionMode reset ---
-      if (isDesktopRuntime) {
-        if (localModeAvailable) {
-          const loginSudoclawPayload = extractLoginSudoclawPayload(result);
-          if (loginSudoclawPayload) {
-            const currentScodeConfig = await ipcBridge.scode.getConfig.invoke().catch((): null => null);
-            const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data);
-            await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig }).catch((err) => {
-              console.warn('[Auth] Failed to save scode config on enterprise login:', err);
-            });
-            const restoreRes = await ipcBridge.scode.restoreCustomModelProviders.invoke({ userId: mappedUser.id }).catch((err): null => {
-              console.warn('[Auth] Failed to restore custom scode models on enterprise login:', err);
-              return null;
-            });
-            await ipcBridge.scode.setImageModel.invoke({ modelId: DEFAULT_IMAGE_GENERATION_MODEL }).catch(() => {});
-            // Sync settings.json to the merged default model while preserving a user-selected custom model.
-            const defaultModel = restoreRes?.data?.default_model || scodeConfig.default_model;
-            if (defaultModel) {
-              await ipcBridge.scode.setDefaultModel.invoke({ modelId: defaultModel }).catch(() => {});
-            }
-          }
-        } else {
-          await ipcBridge.scode.saveConfig.invoke({ config: {} }).catch(() => {});
-          await ConfigStorage.set('guid.sessionMode', 'remote').catch(() => {});
-          await ipcBridge.eeclaw.setSessionMode.invoke({ mode: 'remote' }).catch(() => {});
-        }
-      }
-
-      // Save user info to ConfigStorage
-      try {
-        await ConfigStorage.set('eeclaw.userInfo', {
-          id: data.user.id,
-          username: data.user.name,
-          role: data.user.role,
-        });
-        await ConfigStorage.set('eeclaw.localModeAvailable', localModeAvailable);
-      } catch (e) {
-        console.warn('[Auth] Failed to save enterprise user info:', e);
-      }
-
-      // Sync token to ConfigStorage for eeclawBridge
-      const configAuthStorage = {
-        access_token: data.access_token,
-        refresh_token: data.refresh_token || '',
-        expires_at: eeclawAuthStorage.expires_at,
-        device_id: deviceId,
-        session_type: sessionType,
-      };
-      try {
-        await ConfigStorage.set('eeclaw.authStorage', configAuthStorage);
-      } catch (e) {
-        console.warn('[Auth] Failed to sync eeclaw auth to ConfigStorage (will retry):', e);
-        // Retry once
-        try {
-          await ConfigStorage.set('eeclaw.authStorage', configAuthStorage);
-        } catch (e2) {
-          console.error('[Auth] Failed to sync eeclaw auth to ConfigStorage after retry:', e2);
-        }
-      }
-
-      // Set auth state
-      setUser(mappedUser);
-      setStatus('authenticated');
-      setReady(true);
-
-      return { success: true };
-    },
-    [],
-  );
-
-  // Enterprise login — independent from C-side login flow
-  const enterpriseLogin = useCallback(async (params: EnterpriseLoginParams | EnterpriseLoginParamsByKey): Promise<LoginResult> => {
-    try {
-      const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
-      if (!serverUrl) {
-        return { success: false, message: '未配置企业服务器地址' };
-      }
-
-      const deviceId = getDeviceId();
-      // Build MOSS-compatible request body with grant_type
-      const isApiKeyLogin = 'api_key' in params;
-      const requestBody = isApiKeyLogin
-        ? { grant_type: 'api_key', api_key: (params as EnterpriseLoginParamsByKey).api_key }
-        : { grant_type: 'password', username: (params as EnterpriseLoginParams).username, password: (params as EnterpriseLoginParams).password };
-
-      // Use IPC bridge to avoid CORS (main process has no CORS restrictions)
-      const result = await ipcBridge.eeclaw.login.invoke({
-        serverUrl,
-        body: requestBody,
-        deviceId,
-      });
-
-      return finalizeEnterpriseLogin(result, deviceId, isApiKeyLogin ? 'api_key' : 'password');
-    } catch (error) {
-      console.error('[Auth] Enterprise login failed:', error);
+  const finalizeEnterpriseLogin = useCallback(async (result: Awaited<ReturnType<typeof ipcBridge.eeclaw.login.invoke>>, deviceId: string, sessionType: 'password' | 'api_key' | 'oauth2'): Promise<LoginResult> => {
+    if (!result.success || !result.data) {
       return {
         success: false,
-        message: error instanceof Error ? error.message : '连接到企业服务器失败',
-        code: 'networkError',
+        message: (result as any).error === 'network_error' ? '连接到企业服务器失败' : (result as any).error || result.msg || '登录失败',
+        code: 'invalidCredentials',
       };
     }
-  }, [finalizeEnterpriseLogin]);
+
+    const data = result.data;
+
+    // Map MOSS user to AuthUser compatible type
+    const mappedUser = mapEnterpriseUser(data.user, data.access_token);
+
+    // --- localModeAvailable calculation (before localStorage serialization) ---
+    const localModeAvailable = !!(data.user.localAuth && data.sudorouter_key && data.model_service_url && Array.isArray(data.models) && data.models.length > 0);
+    mappedUser.localModeAvailable = localModeAvailable;
+
+    // Save to localStorage (eeclaw_auth_v1, separate from C-side)
+    const eeclawAuthStorage: EeclawAuthStorage = {
+      access_token: data.access_token,
+      refresh_token: data.refresh_token || '',
+      expires_at: Date.now() + (data.expires_in || 3600) * 1000,
+      user: mappedUser,
+      device_id: deviceId,
+      session_type: sessionType,
+    };
+    localStorage.setItem(EECLAW_AUTH_STORAGE_KEY, JSON.stringify(eeclawAuthStorage));
+
+    // --- sudocode.json generation/cleanup + sessionMode reset ---
+    if (isDesktopRuntime) {
+      if (localModeAvailable) {
+        const loginSudoclawPayload = extractLoginSudoclawPayload(result);
+        if (loginSudoclawPayload) {
+          const currentScodeConfig = await ipcBridge.scode.getConfig.invoke().catch((): null => null);
+          const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data);
+          await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig }).catch((err) => {
+            console.warn('[Auth] Failed to save scode config on enterprise login:', err);
+          });
+          const restoreRes = await ipcBridge.scode.restoreCustomModelProviders.invoke({ userId: mappedUser.id }).catch((err): null => {
+            console.warn('[Auth] Failed to restore custom scode models on enterprise login:', err);
+            return null;
+          });
+          await ipcBridge.scode.setImageModel.invoke({ modelId: DEFAULT_IMAGE_GENERATION_MODEL }).catch(() => {});
+          // Sync settings.json to the merged default model while preserving a user-selected custom model.
+          const defaultModel = restoreRes?.data?.default_model || scodeConfig.default_model;
+          if (defaultModel) {
+            await ipcBridge.scode.setDefaultModel.invoke({ modelId: defaultModel }).catch(() => {});
+          }
+        }
+      } else {
+        await ipcBridge.scode.saveConfig.invoke({ config: {} }).catch(() => {});
+        await ConfigStorage.set('guid.sessionMode', 'remote').catch(() => {});
+        await ipcBridge.eeclaw.setSessionMode.invoke({ mode: 'remote' }).catch(() => {});
+      }
+    }
+
+    // Save user info to ConfigStorage
+    try {
+      await ConfigStorage.set('eeclaw.userInfo', {
+        id: data.user.id,
+        username: data.user.name,
+        role: data.user.role,
+      });
+      await ConfigStorage.set('eeclaw.localModeAvailable', localModeAvailable);
+    } catch (e) {
+      console.warn('[Auth] Failed to save enterprise user info:', e);
+    }
+
+    // Sync token to ConfigStorage for eeclawBridge
+    const configAuthStorage = {
+      access_token: data.access_token,
+      refresh_token: data.refresh_token || '',
+      expires_at: eeclawAuthStorage.expires_at,
+      device_id: deviceId,
+      session_type: sessionType,
+    };
+    try {
+      await ConfigStorage.set('eeclaw.authStorage', configAuthStorage);
+    } catch (e) {
+      console.warn('[Auth] Failed to sync eeclaw auth to ConfigStorage (will retry):', e);
+      // Retry once
+      try {
+        await ConfigStorage.set('eeclaw.authStorage', configAuthStorage);
+      } catch (e2) {
+        console.error('[Auth] Failed to sync eeclaw auth to ConfigStorage after retry:', e2);
+      }
+    }
+
+    // Set auth state
+    setUser(mappedUser);
+    setStatus('authenticated');
+    setReady(true);
+
+    return { success: true };
+  }, []);
+
+  // Enterprise login — independent from C-side login flow
+  const enterpriseLogin = useCallback(
+    async (params: EnterpriseLoginParams | EnterpriseLoginParamsByKey): Promise<LoginResult> => {
+      try {
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        if (!serverUrl) {
+          return { success: false, message: '未配置企业服务器地址' };
+        }
+
+        const deviceId = getDeviceId();
+        // Build MOSS-compatible request body with grant_type
+        const isApiKeyLogin = 'api_key' in params;
+        const requestBody = isApiKeyLogin ? { grant_type: 'api_key', api_key: (params as EnterpriseLoginParamsByKey).api_key } : { grant_type: 'password', username: (params as EnterpriseLoginParams).username, password: (params as EnterpriseLoginParams).password };
+
+        // Use IPC bridge to avoid CORS (main process has no CORS restrictions)
+        const result = await ipcBridge.eeclaw.login.invoke({
+          serverUrl,
+          body: requestBody,
+          deviceId,
+        });
+
+        return finalizeEnterpriseLogin(result, deviceId, isApiKeyLogin ? 'api_key' : 'password');
+      } catch (error) {
+        console.error('[Auth] Enterprise login failed:', error);
+        return {
+          success: false,
+          message: error instanceof Error ? error.message : '连接到企业服务器失败',
+          code: 'networkError',
+        };
+      }
+    },
+    [finalizeEnterpriseLogin]
+  );
 
   // Enterprise OAuth2 login — completes after the browser redirects back via the
   // sudowork:// deep link. `params` is the opaque dict of deep-link query params
@@ -1071,7 +1078,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         };
       }
     },
-    [finalizeEnterpriseLogin],
+    [finalizeEnterpriseLogin]
   );
 
   const logout = useCallback(async () => {
@@ -1123,13 +1130,19 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       // Clear enterprise ConfigStorage (but keep system.appMode = 'e')
       try {
         await ConfigStorage.set('eeclaw.authStorage', undefined);
-      } catch { /* noop */ }
+      } catch {
+        /* noop */
+      }
       try {
         await ConfigStorage.set('eeclaw.userInfo', undefined);
-      } catch { /* noop */ }
+      } catch {
+        /* noop */
+      }
       try {
         await ConfigStorage.set('eeclaw.localModeAvailable', undefined);
-      } catch { /* noop */ }
+      } catch {
+        /* noop */
+      }
 
       setUser(null);
       setStatus('unauthenticated');

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -609,6 +609,7 @@ export interface AcpResponse {
   error?: {
     code: number;
     message: string;
+    data?: unknown;
   };
 }
 

--- a/tests/unit/acpConnectionResponseOrder.test.ts
+++ b/tests/unit/acpConnectionResponseOrder.test.ts
@@ -192,6 +192,34 @@ describe('AcpConnection prompt response ordering', () => {
     });
   });
 
+  it('includes ACP error data when rejecting pending requests', async () => {
+    const { AcpConnection } = await loadAcpConnection();
+    const connection = new AcpConnection();
+    const harness = connection as unknown as AcpConnectionTestHarness;
+    const reject = vi.fn();
+
+    harness.pendingRequests.set(4, {
+      resolve: vi.fn(),
+      reject,
+      method: 'session/new',
+      isPaused: false,
+      startTime: Date.now(),
+      timeoutDuration: 300000,
+    });
+
+    harness.handleMessage({
+      jsonrpc: '2.0',
+      id: 4,
+      error: {
+        code: -32603,
+        message: 'Internal error',
+        data: 'failed to build runtime: missing sudocode config',
+      },
+    });
+
+    expect(reject).toHaveBeenCalledWith(new Error('Internal error: failed to build runtime: missing sudocode config'));
+  });
+
   it('abandons cancel locally after timeout without disconnecting the session', async () => {
     const { AcpConnection } = await loadAcpConnection();
     const connection = new AcpConnection();


### PR DESCRIPTION
## Summary
- Include ACP error data field in error messages for better debugging
- Check sudoclaw bin directory existence before adding to PATH
- Convert userId to string before writing to file in authBridge
- Make Sudocode config primary source in login flow, Sudoclaw sync as legacy backup
- Add error.data field to AcpResponse type definition

## Test plan
- [ ] Verify ACP error messages include data field when present
- [ ] Test login flow works correctly with Sudocode config as primary
- [ ] Verify no errors when sudoclaw bin directory doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)