### PR TITLE
fix: resolve TypeScript type errors

### DIFF
--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -1143,7 +1143,7 @@ const initStorage = async () => {
     try {
       const CHANNEL_AGENT_KEYS = ['assistant.telegram.agent', 'assistant.lark.agent', 'assistant.dingtalk.agent', 'assistant.wechat.agent', 'assistant.wecom.agent'] as const;
       for (const key of CHANNEL_AGENT_KEYS) {
-        const saved = await configFile.get(key).catch(() => undefined);
+        const saved = await configFile.get(key).catch((): undefined => undefined);
         if (saved && typeof saved === 'object' && (saved as any).backend === 'openclaw-gateway') {
           (saved as any).backend = 'scode';
           (saved as any).name = 'Sudo Code';

--- a/src/process/services/mcpServices/agents/ScodeMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/ScodeMcpAgent.ts
@@ -144,6 +144,9 @@ export class ScodeMcpAgent extends AbstractMcpAgent {
             transport,
             enabled: true,
             status: 'disconnected',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            originalJson: JSON.stringify(config),
           });
         }
 

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -508,7 +508,7 @@ const useSendBoxDraft = (conversation_id: string) => {
       mutate((prev) => {
         const previousSkills = prev?.selectedSkills ?? [];
         const nextSkills = typeof skills === 'function' ? skills(previousSkills) : skills;
-        return { ...(prev as { selectedSkills?: string[] }), selectedSkills: nextSkills };
+        return { ...prev!, selectedSkills: nextSkills };
       });
     },
     [mutate]

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/__prototype__/mockData.ts
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/__prototype__/mockData.ts
@@ -21,8 +21,10 @@ export const MOCK_ENTERPRISE_SERVERS: EnterpriseMcpServerDto[] = [
     bound_skills: null,
     allow_read: true,
     allow_write: false,
+    allow_user_disable: true,
     enabled: true,
     status: 'enabled',
+    user_disabled: false,
   },
   {
     id: 'srv-org-002',
@@ -39,8 +41,10 @@ export const MOCK_ENTERPRISE_SERVERS: EnterpriseMcpServerDto[] = [
     bound_skills: null,
     allow_read: true,
     allow_write: false,
+    allow_user_disable: true,
     enabled: true,
     status: 'enabled',
+    user_disabled: false,
   },
   {
     id: 'srv-dept-001',
@@ -57,8 +61,10 @@ export const MOCK_ENTERPRISE_SERVERS: EnterpriseMcpServerDto[] = [
     bound_skills: null,
     allow_read: true,
     allow_write: false,
+    allow_user_disable: false,
     enabled: false,
     status: 'disabled',
+    user_disabled: false,
   },
 ];
 
@@ -78,8 +84,10 @@ export const MOCK_PERSONAL_SERVERS: EnterpriseMcpServerDto[] = [
     bound_skills: null,
     allow_read: true,
     allow_write: true,
+    allow_user_disable: true,
     enabled: true,
     status: 'enabled',
+    user_disabled: false,
   },
   {
     id: 'srv-user-002',
@@ -96,8 +104,10 @@ export const MOCK_PERSONAL_SERVERS: EnterpriseMcpServerDto[] = [
     bound_skills: null,
     allow_read: true,
     allow_write: false,
+    allow_user_disable: true,
     enabled: false,
     status: 'disabled',
+    user_disabled: true,
   },
 ];
 

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -23,6 +23,11 @@ declare module '*.jpg' {
   export default content;
 }
 
+declare module '*.gif' {
+  const content: string;
+  export default content;
+}
+
 declare module 'unocss';
 
 declare module 'pptx-preview' {


### PR DESCRIPTION
## Summary

只修复 TypeScript 类型错误，不包含格式化变更：

- Add `*.gif` module declaration to fix missing type error
- Add return type annotation to catch callback in initStorage.ts
- Add missing `IMcpServer` properties (`createdAt`, `updatedAt`, `originalJson`)
- Fix AcpSendBox mutate callback return type
- Add missing `EnterpriseMcpServerDto` fields (`allow_user_disable`, `user_disabled`)

## Changes

| File | Change |
|------|--------|
| `src/renderer/types.d.ts` | Add `*.gif` module declaration |
| `src/process/initStorage.ts` | Add return type `(): undefined` to catch callback |
| `src/process/services/mcpServices/agents/ScodeMcpAgent.ts` | Add `createdAt`, `updatedAt`, `originalJson` to IMcpServer |
| `src/renderer/pages/conversation/acp/AcpSendBox.tsx` | Fix mutate callback return type |
| `src/renderer/pages/settings/EnterpriseMcpSettings/__prototype__/mockData.ts` | Add `allow_user_disable`, `user_disabled` fields |

## Test plan

- [x] Run `bun run type:check` - TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)