### PR TITLE
Show turn token usage in chat

### DIFF
--- a/docs/plans/2026-06-02-turn-token-usage-display.md
+++ b/docs/plans/2026-06-02-turn-token-usage-display.md
@@ -1,0 +1,57 @@
+# Turn Token Usage Display
+
+## Goal
+
+After an ACP-based agent such as Sudo Code finishes a turn, show that turn's token usage below the assistant response in the chat transcript.
+
+## Source Of Truth
+
+Sudo Code returns per-turn token data through ACP `PromptResponse.result.usage`. The existing `AcpConnection` already extracts this as `AcpPromptResponseUsage` and sends it to `AcpAgent.onPromptUsage`.
+
+This should be treated differently from `usage_update`:
+
+- `PromptResponse.result.usage` is the per-turn usage to display below the response.
+- `usage_update.used/size` is current context window utilization and remains the send-box context indicator source.
+
+## Data Model
+
+Assistant text messages carry optional usage metadata:
+
+```ts
+interface TurnTokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens: number;
+  cachedReadTokens?: number | null;
+  cachedWriteTokens?: number | null;
+  thoughtTokens?: number | null;
+  contextWindowTokens?: number | null;
+  estimatedSessionTokens?: number | null;
+}
+```
+
+The metadata lives on `IMessageText.content.tokenUsage` so it is persisted with the message and restored with the conversation history.
+
+## Flow
+
+1. `AcpConnection` receives the prompt response and extracts `result.usage`.
+2. `AcpAgent.handlePromptUsage()` updates telemetry as before.
+3. `AcpAgent` flushes any buffered assistant text and emits a content patch with the same `msg_id` as the latest assistant text message.
+4. `transformMessage()` preserves `tokenUsage` from rich content payloads.
+5. Message merge logic appends text chunks while shallow-merging metadata, so the usage patch updates the existing assistant message instead of creating a new bubble.
+6. `MessageList` carries the latest assistant text usage into the turn action row.
+7. `TurnActions` renders a compact muted usage badge and exposes detail fields in a tooltip.
+
+## UI
+
+The badge appears in the existing action row below the assistant answer, next to copy/share actions:
+
+```text
+12.4K tokens · in 10.8K / out 1.6K
+```
+
+When available, reasoning, cache, and context details are shown in the tooltip to keep the transcript quiet.
+
+## Fallback Behavior
+
+If an agent does not provide per-turn usage, no token badge is shown. The UI does not estimate token usage from text length.

--- a/docs/plans/2026-06-02-turn-token-usage-display.md
+++ b/docs/plans/2026-06-02-turn-token-usage-display.md
@@ -47,10 +47,10 @@ The metadata lives on `IMessageText.content.tokenUsage` so it is persisted with 
 The badge appears in the existing action row below the assistant answer, next to copy/share actions:
 
 ```text
-12.4K tokens · in 10.8K / out 1.6K
+12.4K tokens · 24.8 积分 · in 10.8K / out 1.6K
 ```
 
-When available, reasoning and cache details are shown in the tooltip to keep the transcript quiet. Context window usage is intentionally not shown here because the send box already has the context usage indicator.
+Points are calculated from `totalTokens / 500` and displayed with one decimal place. The tooltip shows the point value without the conversion formula. When available, reasoning and non-zero cache details are shown in the tooltip to keep the transcript quiet. Context window usage is intentionally not shown here because the send box already has the context usage indicator.
 
 ## Fallback Behavior
 

--- a/docs/plans/2026-06-02-turn-token-usage-display.md
+++ b/docs/plans/2026-06-02-turn-token-usage-display.md
@@ -50,7 +50,7 @@ The badge appears in the existing action row below the assistant answer, next to
 12.4K tokens · in 10.8K / out 1.6K
 ```
 
-When available, reasoning, cache, and context details are shown in the tooltip to keep the transcript quiet.
+When available, reasoning and cache details are shown in the tooltip to keep the transcript quiet. Context window usage is intentionally not shown here because the send box already has the context usage indicator.
 
 ## Fallback Behavior
 

--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -97,7 +97,18 @@ export type CronMessageMeta = {
   triggeredAt: number;
 };
 
-export type IMessageText = IMessage<'text', { content: string; cronMeta?: CronMessageMeta; skills?: string[] }>;
+export interface TurnTokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens: number;
+  cachedReadTokens?: number | null;
+  cachedWriteTokens?: number | null;
+  thoughtTokens?: number | null;
+  contextWindowTokens?: number | null;
+  estimatedSessionTokens?: number | null;
+}
+
+export type IMessageText = IMessage<'text', { content: string; cronMeta?: CronMessageMeta; skills?: string[]; tokenUsage?: TurnTokenUsage }>;
 
 export type IMessageTips = IMessage<'tips', { content: string; type: 'error' | 'success' | 'warning' }>;
 
@@ -421,6 +432,7 @@ export const transformMessage = (message: IResponseMessage): TMessage => {
               content: (data as any).content,
               ...((data as any).cronMeta ? { cronMeta: (data as any).cronMeta } : {}),
               ...((data as any).skills ? { skills: (data as any).skills } : {}),
+              ...((data as any).tokenUsage ? { tokenUsage: (data as any).tokenUsage } : {}),
             }
           : { content: data as string },
       };
@@ -707,7 +719,11 @@ export const composeMessage = (message: TMessage | undefined, list: TMessage[] |
     return pushMessage(message);
   }
   if (message.type === 'text' && last.type === 'text') {
-    message.content.content = last.content.content + message.content.content;
+    message.content = {
+      ...last.content,
+      ...message.content,
+      content: last.content.content + message.content.content,
+    };
   }
   return updateMessage(list.length - 1, Object.assign({}, last, message));
 };

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -15,7 +15,7 @@ import { getClaudeModel } from '@/agent/acp/utils';
 import { buildAcpModelInfo, summarizeAcpModelInfo } from '@/agent/acp/modelInfo';
 import { channelEventBus } from '@/channels/agent/ChannelEventBus';
 import { ipcBridge } from '@/common';
-import type { AcpQuestionData, CronMessageMeta, TMessage } from '@/common/chatLib';
+import type { AcpQuestionData, CronMessageMeta, TMessage, TurnTokenUsage } from '@/common/chatLib';
 import type { SlashCommandItem } from '@/common/slash/types';
 import { transformMessage } from '@/common/chatLib';
 import { DRAFTS_DIR_NAME, NEXUS_FILES_MARKER } from '@/common/constants';
@@ -123,6 +123,20 @@ function normalizeToolCallStatus(status: string | undefined): 'pending' | 'in_pr
   return status as 'pending' | 'in_progress' | 'completed' | 'failed';
 }
 
+function normalizePromptUsageForMessage(usage: AcpPromptResponseUsage): TurnTokenUsage | null {
+  if (typeof usage.totalTokens !== 'number') return null;
+  return {
+    totalTokens: usage.totalTokens,
+    ...(typeof usage.inputTokens === 'number' && { inputTokens: usage.inputTokens }),
+    ...(typeof usage.outputTokens === 'number' && { outputTokens: usage.outputTokens }),
+    ...(usage.cachedReadTokens !== undefined && { cachedReadTokens: usage.cachedReadTokens }),
+    ...(usage.cachedWriteTokens !== undefined && { cachedWriteTokens: usage.cachedWriteTokens }),
+    ...(usage.thoughtTokens !== undefined && { thoughtTokens: usage.thoughtTokens }),
+    ...(usage.contextWindowTokens !== undefined && { contextWindowTokens: usage.contextWindowTokens }),
+    ...(usage.estimatedSessionTokens !== undefined && { estimatedSessionTokens: usage.estimatedSessionTokens }),
+  };
+}
+
 export interface AcpAgentData {
   workspace?: string;
   backend: AcpBackend;
@@ -172,6 +186,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
   private userModelOverride: string | null = null;
   private pendingModelSwitchNotice: string | null = null;
   private hasReceivedUsageUpdate = false;
+  private lastAssistantTextMsgId: string | null = null;
   private lastUserMessage: string | null = null;
   private plannedRestartInProgress = false;
   private contextOverflowRecoveryPending = false;
@@ -192,17 +207,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
   // Turn-level file tracking for precise cleanup on cancel
   private currentTurnFiles: Map<string, TrackedTurnFile> = new Map();
   private readonly fileIntentClassifier = new FileIntentClassifier();
-  private static readonly WORKSPACE_TRACKING_SKIP_DIRS = new Set([
-    '.codex',
-    '.drafts',
-    '.git',
-    '.nexus',
-    '.scode',
-    'node_modules',
-    '__pycache__',
-    '.venv',
-    'venv',
-  ]);
+  private static readonly WORKSPACE_TRACKING_SKIP_DIRS = new Set(['.codex', '.drafts', '.git', '.nexus', '.scode', 'node_modules', '__pycache__', '.venv', 'venv']);
   private static readonly WORKSPACE_TRACKING_SKIP_FILES = new Set(['.gitignore', '.env', '.env.local', '.DS_Store', 'Thumbs.db']);
 
   // Extra config passed to connection
@@ -690,6 +695,8 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
     // Reset user cancelled flag for new message
     this.userCancelled = false;
     this.stopPromise = null;
+    this.hasReceivedUsageUpdate = false;
+    this.lastAssistantTextMsgId = null;
 
     // ★ Reset turn-level file tracking for new turn
     // 重置 Turn 级别文件追踪，开始新的 Turn
@@ -2581,6 +2588,25 @@ This identity statement takes priority over the default identity in USER.md.
     // Telemetry: update turn token usage
     updateTurnTokens(this.conversation_id, usage);
 
+    const tokenUsage = normalizePromptUsageForMessage(usage);
+    if (tokenUsage && this.lastAssistantTextMsgId) {
+      this.streamTextBuffer.flushAll();
+      const usagePatch: IResponseMessage = {
+        type: 'content',
+        conversation_id: this.conversation_id,
+        msg_id: this.lastAssistantTextMsgId,
+        data: {
+          content: '',
+          tokenUsage,
+        },
+      };
+      const tMessage = transformMessage(usagePatch);
+      if (tMessage) {
+        addOrUpdateMessage(this.conversation_id, tMessage, this.options.backend);
+      }
+      ipcBridge.acpConversation.responseStream.emit(usagePatch);
+    }
+
     if (this.hasReceivedUsageUpdate) return;
     const used = usage.estimatedSessionTokens ?? usage.totalTokens;
     const size = usage.contextWindowTokens ?? 0;
@@ -3040,6 +3066,9 @@ This identity statement takes priority over the default identity in USER.md.
 
     switch (message.type) {
       case 'text':
+        if (message.position === 'left') {
+          this.lastAssistantTextMsgId = message.msg_id || message.id;
+        }
         responseMessage.type = 'content';
         responseMessage.data = message.content.content;
         break;

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CodexToolCallUpdate, IMessageAcpToolCall, IMessageToolGroup, TMessage } from '@/common/chatLib';
+import type { CodexToolCallUpdate, IMessageAcpToolCall, IMessageToolGroup, TMessage, TurnTokenUsage } from '@/common/chatLib';
 import { useConversationContextSafe } from '@/renderer/context/ConversationContext';
 import { iconColors } from '@/renderer/theme/colors';
 import { CHAT_MESSAGE_JUMP_EVENT, type ChatMessageJumpDetail } from '@/renderer/utils/chatMinimapEvents';
@@ -56,7 +56,7 @@ type IMessageVO =
       id: string;
       messages: Array<IMessageToolGroup | IMessageAcpToolCall>;
     }
-  | { type: 'turn_actions'; id: string; turnTexts: string[]; turnTextsRaw: string[]; conversationId?: string }
+  | { type: 'turn_actions'; id: string; turnTexts: string[]; turnTextsRaw: string[]; conversationId?: string; tokenUsage?: TurnTokenUsage }
   | { type: 'time_separator'; id: string; timestamp: number }
   | { type: 'loading_indicator'; id: string };
 
@@ -269,13 +269,15 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
     let toolList: Array<IMessageToolGroup | IMessageAcpToolCall> = [];
     let turnTexts: string[] = [];
     let turnTextsRaw: string[] = [];
+    let turnTokenUsage: TurnTokenUsage | undefined;
     let lastAiTextId = '';
 
     const flushTurnActions = () => {
       if (turnTexts.length > 0) {
-        result.push({ type: 'turn_actions', id: `turn-actions-${lastAiTextId}`, turnTexts, turnTextsRaw, conversationId: conversationContext?.conversationId });
+        result.push({ type: 'turn_actions', id: `turn-actions-${lastAiTextId}`, turnTexts, turnTextsRaw, conversationId: conversationContext?.conversationId, tokenUsage: turnTokenUsage });
         turnTexts = [];
         turnTextsRaw = [];
+        turnTokenUsage = undefined;
         lastAiTextId = '';
       }
     };
@@ -317,6 +319,9 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
       // Collect AI text content for turn-level copy
       if (message.type === 'text' && message.position === 'left') {
         const rawContent = message.content.content;
+        if (message.content.tokenUsage) {
+          turnTokenUsage = message.content.tokenUsage;
+        }
         if (typeof rawContent === 'string' && rawContent.trim()) {
           let cleaned = hasThinkTags(rawContent) ? stripThinkTags(rawContent) : rawContent;
           const markerIdx = cleaned.indexOf(NEXUS_FILES_MARKER);
@@ -494,7 +499,7 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
     if ('type' in item && item.type === 'turn_actions') {
       return (
         <div key={item.id} className='group min-w-0 message-item px-8px max-w-full md:max-w-780px mx-auto'>
-          <TurnActions turnTexts={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTexts} turnTextsRaw={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTextsRaw} conversationId={(item as Extract<IMessageVO, { type: 'turn_actions' }>).conversationId} />
+          <TurnActions turnTexts={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTexts} turnTextsRaw={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTextsRaw} conversationId={(item as Extract<IMessageVO, { type: 'turn_actions' }>).conversationId} tokenUsage={(item as Extract<IMessageVO, { type: 'turn_actions' }>).tokenUsage} />
         </div>
       );
     }

--- a/src/renderer/messages/TurnActions.tsx
+++ b/src/renderer/messages/TurnActions.tsx
@@ -103,17 +103,14 @@ const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conve
   const cachedReadTokens = tokenUsage?.cachedReadTokens ? formatTokenCount(tokenUsage.cachedReadTokens) : null;
   const cachedWriteTokens = tokenUsage?.cachedWriteTokens ? formatTokenCount(tokenUsage.cachedWriteTokens) : null;
   const thoughtTokens = tokenUsage?.thoughtTokens ? formatTokenCount(tokenUsage.thoughtTokens) : null;
-  const estimatedSessionTokens = formatTokenCount(tokenUsage?.estimatedSessionTokens);
-  const contextWindowTokens = formatTokenCount(tokenUsage?.contextWindowTokens);
   const usageTooltip = tokenUsage ? (
     <div className='text-12px leading-18px'>
       <div>{t('messages.tokenUsageTotal', { defaultValue: 'Total: {{value}} tokens', value: new Intl.NumberFormat().format(tokenUsage.totalTokens) })}</div>
       {typeof tokenUsage.inputTokens === 'number' && <div>{t('messages.tokenUsageInput', { defaultValue: 'Input: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.inputTokens) })}</div>}
       {typeof tokenUsage.outputTokens === 'number' && <div>{t('messages.tokenUsageOutput', { defaultValue: 'Output: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.outputTokens) })}</div>}
       {typeof tokenUsage.thoughtTokens === 'number' && <div>{t('messages.tokenUsageThought', { defaultValue: 'Reasoning: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.thoughtTokens) })}</div>}
-      {typeof tokenUsage.cachedReadTokens === 'number' && <div>{t('messages.tokenUsageCachedRead', { defaultValue: 'Cache read: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.cachedReadTokens) })}</div>}
-      {typeof tokenUsage.cachedWriteTokens === 'number' && <div>{t('messages.tokenUsageCachedWrite', { defaultValue: 'Cache write: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.cachedWriteTokens) })}</div>}
-      {typeof tokenUsage.estimatedSessionTokens === 'number' && typeof tokenUsage.contextWindowTokens === 'number' && <div>{t('messages.tokenUsageContext', { defaultValue: 'Context: {{used}} / {{limit}}', used: new Intl.NumberFormat().format(tokenUsage.estimatedSessionTokens), limit: new Intl.NumberFormat().format(tokenUsage.contextWindowTokens) })}</div>}
+      {typeof tokenUsage.cachedReadTokens === 'number' && tokenUsage.cachedReadTokens > 0 && <div>{t('messages.tokenUsageCachedRead', { defaultValue: 'Cache read: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.cachedReadTokens) })}</div>}
+      {typeof tokenUsage.cachedWriteTokens === 'number' && tokenUsage.cachedWriteTokens > 0 && <div>{t('messages.tokenUsageCachedWrite', { defaultValue: 'Cache write: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.cachedWriteTokens) })}</div>}
     </div>
   ) : null;
 
@@ -143,7 +140,6 @@ const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conve
               {thoughtTokens ? ` · ${t('messages.tokenUsageReasoningShort', { defaultValue: 'reasoning {{value}}', value: thoughtTokens })}` : ''}
               {cachedReadTokens ? ` · ${t('messages.tokenUsageCacheReadShort', { defaultValue: 'cache {{value}}', value: cachedReadTokens })}` : ''}
               {cachedWriteTokens ? ` · ${t('messages.tokenUsageCacheWriteShort', { defaultValue: 'write {{value}}', value: cachedWriteTokens })}` : ''}
-              {estimatedSessionTokens && contextWindowTokens ? ` · ${estimatedSessionTokens}/${contextWindowTokens}` : ''}
             </div>
           </Tooltip>
         )}

--- a/src/renderer/messages/TurnActions.tsx
+++ b/src/renderer/messages/TurnActions.tsx
@@ -22,6 +22,11 @@ const formatTokenCount = (value?: number | null) => {
   return new Intl.NumberFormat().format(value);
 };
 
+const formatPointCount = (tokens?: number | null) => {
+  if (typeof tokens !== 'number' || !Number.isFinite(tokens)) return null;
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(tokens / 500);
+};
+
 const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conversationId?: string; tokenUsage?: TurnTokenUsage }> = ({ turnTexts, turnTextsRaw, conversationId, tokenUsage }) => {
   const { t } = useTranslation();
   const [showCopyAlert, setShowCopyAlert] = useState(false);
@@ -98,6 +103,7 @@ const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conve
   }, [turnTextsRaw, shareoneInstalled, sharing, t]);
 
   const totalTokens = formatTokenCount(tokenUsage?.totalTokens);
+  const points = formatPointCount(tokenUsage?.totalTokens);
   const inputTokens = formatTokenCount(tokenUsage?.inputTokens);
   const outputTokens = formatTokenCount(tokenUsage?.outputTokens);
   const cachedReadTokens = tokenUsage?.cachedReadTokens ? formatTokenCount(tokenUsage.cachedReadTokens) : null;
@@ -106,6 +112,7 @@ const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conve
   const usageTooltip = tokenUsage ? (
     <div className='text-12px leading-18px'>
       <div>{t('messages.tokenUsageTotal', { defaultValue: 'Total: {{value}} tokens', value: new Intl.NumberFormat().format(tokenUsage.totalTokens) })}</div>
+      {points && <div>{t('messages.tokenUsagePoints', { defaultValue: 'Points: {{value}}', value: points })}</div>}
       {typeof tokenUsage.inputTokens === 'number' && <div>{t('messages.tokenUsageInput', { defaultValue: 'Input: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.inputTokens) })}</div>}
       {typeof tokenUsage.outputTokens === 'number' && <div>{t('messages.tokenUsageOutput', { defaultValue: 'Output: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.outputTokens) })}</div>}
       {typeof tokenUsage.thoughtTokens === 'number' && <div>{t('messages.tokenUsageThought', { defaultValue: 'Reasoning: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.thoughtTokens) })}</div>}
@@ -136,6 +143,7 @@ const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conve
           <Tooltip content={usageTooltip}>
             <div className='ml-4px max-w-full truncate text-11px leading-18px px-6px py-1px rd-4px border border-solid border-[var(--color-border-2)] text-t-secondary bg-[var(--color-fill-1)]'>
               {t('messages.tokenUsageSummary', { defaultValue: '{{total}} tokens', total: totalTokens })}
+              {points ? ` · ${t('messages.tokenUsagePointsShort', { defaultValue: '{{value}} points', value: points })}` : ''}
               {inputTokens && outputTokens ? ` · ${t('messages.tokenUsageInOut', { defaultValue: 'in {{input}} / out {{output}}', input: inputTokens, output: outputTokens })}` : ''}
               {thoughtTokens ? ` · ${t('messages.tokenUsageReasoningShort', { defaultValue: 'reasoning {{value}}', value: thoughtTokens })}` : ''}
               {cachedReadTokens ? ` · ${t('messages.tokenUsageCacheReadShort', { defaultValue: 'cache {{value}}', value: cachedReadTokens })}` : ''}

--- a/src/renderer/messages/TurnActions.tsx
+++ b/src/renderer/messages/TurnActions.tsx
@@ -5,6 +5,7 @@
  */
 
 import { iconColors } from '@/renderer/theme/colors';
+import type { TurnTokenUsage } from '@/common/chatLib';
 import { copyText } from '@/renderer/utils/clipboard';
 import { ipcBridge } from '@/common';
 import { emitter } from '@/renderer/utils/emitter';
@@ -14,7 +15,14 @@ import { Copy, FileWord, ShareOne } from '@icon-park/react';
 import React, { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conversationId?: string }> = ({ turnTexts, turnTextsRaw, conversationId }) => {
+const formatTokenCount = (value?: number | null) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1)}M`;
+  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(value >= 10_000 ? 0 : 1)}K`;
+  return new Intl.NumberFormat().format(value);
+};
+
+const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conversationId?: string; tokenUsage?: TurnTokenUsage }> = ({ turnTexts, turnTextsRaw, conversationId, tokenUsage }) => {
   const { t } = useTranslation();
   const [showCopyAlert, setShowCopyAlert] = useState(false);
   const [converting, setConverting] = useState(false);
@@ -87,11 +95,31 @@ const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conve
     } finally {
       setSharing(false);
     }
-  }, [turnTexts, shareoneInstalled, sharing, t]);
+  }, [turnTextsRaw, shareoneInstalled, sharing, t]);
+
+  const totalTokens = formatTokenCount(tokenUsage?.totalTokens);
+  const inputTokens = formatTokenCount(tokenUsage?.inputTokens);
+  const outputTokens = formatTokenCount(tokenUsage?.outputTokens);
+  const cachedReadTokens = tokenUsage?.cachedReadTokens ? formatTokenCount(tokenUsage.cachedReadTokens) : null;
+  const cachedWriteTokens = tokenUsage?.cachedWriteTokens ? formatTokenCount(tokenUsage.cachedWriteTokens) : null;
+  const thoughtTokens = tokenUsage?.thoughtTokens ? formatTokenCount(tokenUsage.thoughtTokens) : null;
+  const estimatedSessionTokens = formatTokenCount(tokenUsage?.estimatedSessionTokens);
+  const contextWindowTokens = formatTokenCount(tokenUsage?.contextWindowTokens);
+  const usageTooltip = tokenUsage ? (
+    <div className='text-12px leading-18px'>
+      <div>{t('messages.tokenUsageTotal', { defaultValue: 'Total: {{value}} tokens', value: new Intl.NumberFormat().format(tokenUsage.totalTokens) })}</div>
+      {typeof tokenUsage.inputTokens === 'number' && <div>{t('messages.tokenUsageInput', { defaultValue: 'Input: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.inputTokens) })}</div>}
+      {typeof tokenUsage.outputTokens === 'number' && <div>{t('messages.tokenUsageOutput', { defaultValue: 'Output: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.outputTokens) })}</div>}
+      {typeof tokenUsage.thoughtTokens === 'number' && <div>{t('messages.tokenUsageThought', { defaultValue: 'Reasoning: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.thoughtTokens) })}</div>}
+      {typeof tokenUsage.cachedReadTokens === 'number' && <div>{t('messages.tokenUsageCachedRead', { defaultValue: 'Cache read: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.cachedReadTokens) })}</div>}
+      {typeof tokenUsage.cachedWriteTokens === 'number' && <div>{t('messages.tokenUsageCachedWrite', { defaultValue: 'Cache write: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.cachedWriteTokens) })}</div>}
+      {typeof tokenUsage.estimatedSessionTokens === 'number' && typeof tokenUsage.contextWindowTokens === 'number' && <div>{t('messages.tokenUsageContext', { defaultValue: 'Context: {{used}} / {{limit}}', used: new Intl.NumberFormat().format(tokenUsage.estimatedSessionTokens), limit: new Intl.NumberFormat().format(tokenUsage.contextWindowTokens) })}</div>}
+    </div>
+  ) : null;
 
   return (
     <>
-      <div className='flex items-center h-28px gap-4px pl-48px'>
+      <div className='flex items-center min-h-28px gap-4px pl-48px flex-wrap'>
         <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
           <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors' onClick={handleCopy} style={{ lineHeight: 0 }}>
             <Copy theme='outline' size='16' fill={iconColors.secondary} />
@@ -107,6 +135,18 @@ const TurnActions: React.FC<{ turnTexts: string[]; turnTextsRaw: string[]; conve
             <ShareOne theme='outline' size='16' fill={sharing ? iconColors.disabled : iconColors.secondary} />
           </div>
         </Tooltip>
+        {totalTokens && (
+          <Tooltip content={usageTooltip}>
+            <div className='ml-4px max-w-full truncate text-11px leading-18px px-6px py-1px rd-4px border border-solid border-[var(--color-border-2)] text-t-secondary bg-[var(--color-fill-1)]'>
+              {t('messages.tokenUsageSummary', { defaultValue: '{{total}} tokens', total: totalTokens })}
+              {inputTokens && outputTokens ? ` · ${t('messages.tokenUsageInOut', { defaultValue: 'in {{input}} / out {{output}}', input: inputTokens, output: outputTokens })}` : ''}
+              {thoughtTokens ? ` · ${t('messages.tokenUsageReasoningShort', { defaultValue: 'reasoning {{value}}', value: thoughtTokens })}` : ''}
+              {cachedReadTokens ? ` · ${t('messages.tokenUsageCacheReadShort', { defaultValue: 'cache {{value}}', value: cachedReadTokens })}` : ''}
+              {cachedWriteTokens ? ` · ${t('messages.tokenUsageCacheWriteShort', { defaultValue: 'write {{value}}', value: cachedWriteTokens })}` : ''}
+              {estimatedSessionTokens && contextWindowTokens ? ` · ${estimatedSessionTokens}/${contextWindowTokens}` : ''}
+            </div>
+          </Tooltip>
+        )}
       </div>
       {showCopyAlert && <Alert type='success' content={t('messages.copySuccess')} showIcon className='fixed top-20px left-50% transform -translate-x-50% z-9999 w-max max-w-[80%]' style={{ boxShadow: 'var(--shadow-md)' }} closable={false} />}
     </>

--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -168,6 +168,7 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
           ...existingMsg,
           content: {
             ...existingMsg.content,
+            ...message.content,
             content: existingMsg.content.content + message.content.content,
           },
         };


### PR DESCRIPTION
## Summary
- attach ACP per-turn token usage to assistant text messages
- render total tokens, points, input/output, and non-zero cache/reasoning details below assistant turns
- document the token usage display flow

## Validation
- bun run type:check
- bunx eslint --quiet src/common/chatLib.ts src/process/task/AcpAgent.ts src/renderer/messages/hooks.ts src/renderer/messages/MessageList.tsx src/renderer/messages/TurnActions.tsx docs/plans/2026-06-02-turn-token-usage-display.md
- manually verified scode conversation token badge in Electron dev app