### PR TITLE
feat: mirror sudocode runtime download from COS

### DIFF
--- a/scripts/download-scode.js
+++ b/scripts/download-scode.js
@@ -3,7 +3,14 @@
  * Download Scode binary for bundling with the app.
  * Run during build process: bun run scode:download
  *
- * Downloads Scode from: https://github.com/sudoprivacy/sudocode/releases/download/v{version}/
+ * Downloads Scode from the Tencent COS mirror (rolling "latest"):
+ *   https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/
+ * The mirror is rolling-latest only (no versioned directories). The scode entry
+ * in runtime-versions.json is informational; integrity is enforced via the
+ * SHA256SUMS.txt published alongside the artifacts.
+ * Override the base with SCODE_DOWNLOAD_BASE_URL. GitHub Releases are NOT used by
+ * default; set SUDOWORK_USE_GITHUB_FALLBACK=1 to add GitHub as a fallback source.
+ *
  * Saves with versioned filename:
  * - Windows: resources/v{version}-scode-windows-{arch}.zip
  * - macOS: resources/v{version}-scode-macos-{arch}.tar.gz
@@ -15,6 +22,7 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+const crypto = require('crypto');
 const runtimeVersions = require('../src/shared/runtime-versions.json');
 
 const RESOURCES_DIR = path.join(__dirname, '..', 'resources');
@@ -40,7 +48,13 @@ function createFallbackPlaceholder(platform) {
   return outputFile;
 }
 
-const BASE_URL = `https://github.com/sudoprivacy/sudocode/releases/download/v${SCODE_VERSION}`;
+// Tencent COS mirror is the default source. The mirror is rolling-latest only
+// (no versioned dirs). Override with SCODE_DOWNLOAD_BASE_URL (trailing slash optional).
+const COS_BASE_URL = (process.env.SCODE_DOWNLOAD_BASE_URL || 'https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest').replace(/\/+$/, '');
+
+// GitHub is opt-in only, gated behind SUDOWORK_USE_GITHUB_FALLBACK=1.
+const GITHUB_BASE_URL = `https://github.com/sudoprivacy/sudocode/releases/download/v${SCODE_VERSION}`;
+const USE_GITHUB_FALLBACK = process.env.SUDOWORK_USE_GITHUB_FALLBACK === '1';
 
 // Platform mappings: archive downloads (.tar.gz for macOS, .zip for Windows)
 const PLATFORMS = {
@@ -64,10 +78,90 @@ function getOutputFile(platform) {
   return path.join(RESOURCES_DIR, getVersionedFileName(platform));
 }
 
-function getDownloadUrl(platform) {
+/**
+ * Ordered list of download URLs to try for the given platform.
+ * COS first; GitHub only when SUDOWORK_USE_GITHUB_FALLBACK=1.
+ */
+function getDownloadUrls(platform) {
   const config = PLATFORMS[platform];
   if (!config) throw new Error(`Unknown platform: ${platform}`);
-  return `${BASE_URL}/${config.name}`;
+  const urls = [`${COS_BASE_URL}/${config.name}`];
+  if (USE_GITHUB_FALLBACK) urls.push(`${GITHUB_BASE_URL}/${config.name}`);
+  return urls;
+}
+
+/** Fetch a small text resource (SHA256SUMS.txt), following redirects. */
+function fetchText(url) {
+  return new Promise((resolve, reject) => {
+    let redirects = 0;
+    const request = (urlStr) => {
+      if (redirects++ > 10) {
+        reject(new Error('Too many redirects'));
+        return;
+      }
+      https
+        .get(urlStr, (response) => {
+          if ([301, 302, 307, 308].includes(response.statusCode) && response.headers.location) {
+            request(response.headers.location);
+            return;
+          }
+          if (response.statusCode !== 200) {
+            reject(new Error(`HTTP ${response.statusCode}`));
+            return;
+          }
+          let data = '';
+          response.setEncoding('utf8');
+          response.on('data', (chunk) => {
+            data += chunk;
+          });
+          response.on('end', () => resolve(data));
+        })
+        .on('error', reject);
+    };
+    request(url);
+  });
+}
+
+/** Parse a SHA256SUMS.txt body and return the lowercase hex hash for `filename`. */
+function expectedHashFor(sumsText, filename) {
+  for (const line of sumsText.split('\n')) {
+    const match = line.trim().match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+    if (match && match[2].trim() === filename) return match[1].toLowerCase();
+  }
+  return null;
+}
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+/**
+ * Verify a downloaded artifact against the SHA256SUMS.txt next to it.
+ * Throws an Error tagged with code 'INTEGRITY' on any verification failure.
+ */
+async function verifyIntegrity(artifactUrl, filePath, filename) {
+  const sumsUrl = artifactUrl.replace(/[^/]+$/, 'SHA256SUMS.txt');
+  let sumsText;
+  try {
+    sumsText = await fetchText(sumsUrl);
+  } catch (err) {
+    const e = new Error(`Could not fetch SHA256SUMS.txt from ${sumsUrl}: ${err.message}`);
+    e.code = 'INTEGRITY';
+    throw e;
+  }
+  const expected = expectedHashFor(sumsText, filename);
+  if (!expected) {
+    const e = new Error(`No SHA256 entry for ${filename} in ${sumsUrl}`);
+    e.code = 'INTEGRITY';
+    throw e;
+  }
+  const actual = sha256File(filePath);
+  if (actual !== expected) {
+    const e = new Error(`SHA256 mismatch for ${filename}: expected ${expected}, got ${actual}`);
+    e.code = 'INTEGRITY';
+    throw e;
+  }
+  console.log(`SHA256 verified: ${filename}`);
 }
 
 function downloadFile(url, dest) {
@@ -153,31 +247,39 @@ async function downloadScode(platform, force = false) {
   // Ensure resources directory exists
   fs.mkdirSync(RESOURCES_DIR, { recursive: true });
 
-  // Download
-  const url = getDownloadUrl(platform);
+  // Try each source in order (COS, then optional GitHub fallback).
+  const config = PLATFORMS[platform];
+  const urls = getDownloadUrls(platform);
+  let lastErr = null;
 
-  try {
-    await downloadFile(url, outputFile);
-
-    console.log(`Saved to: ${outputFile}`);
-    return true;
-  } catch (err) {
-    // Clean up partial download
+  for (const url of urls) {
     try {
-      fs.unlinkSync(outputFile);
-    } catch {}
-
-    if (err.message === 'NOT_FOUND') {
-      console.warn(`\n⚠️  Scode binary not available for platform ${platform}`);
-      console.warn('   Creating empty placeholder file.');
-      console.warn('   Users can install Scode manually from the About page.');
-      // Create empty placeholder file so electron-builder doesn't fail
-      fs.writeFileSync(outputFile, Buffer.alloc(0));
-      return false;
+      await downloadFile(url, outputFile);
+      await verifyIntegrity(url, outputFile, config.name);
+      console.log(`Saved to: ${outputFile}`);
+      return true;
+    } catch (err) {
+      lastErr = err;
+      // Clean up partial/corrupted download before the next attempt.
+      try {
+        fs.unlinkSync(outputFile);
+      } catch {}
+      console.warn(`Download failed from ${url}: ${err.message}`);
+      // An integrity failure is a hard stop — do not fall back or placeholder.
+      if (err.code === 'INTEGRITY') throw err;
     }
-
-    throw err;
   }
+
+  if (lastErr && lastErr.message === 'NOT_FOUND') {
+    console.warn(`\n⚠️  Scode binary not available for platform ${platform}`);
+    console.warn('   Creating empty placeholder file.');
+    console.warn('   Users can install Scode manually from the About page.');
+    // Create empty placeholder file so electron-builder doesn't fail
+    fs.writeFileSync(outputFile, Buffer.alloc(0));
+    return false;
+  }
+
+  throw lastErr || new Error('Download failed');
 }
 
 async function main() {
@@ -219,6 +321,10 @@ async function main() {
     }
   } catch (err) {
     console.error(`\n❌ Failed to download:`, err.message);
+    if (err.code === 'INTEGRITY') {
+      console.error('   Integrity check failed — refusing to bundle a possibly corrupted or tampered binary.');
+      process.exit(1);
+    }
     console.warn('   Creating empty placeholder file.');
     createFallbackPlaceholder(platform);
     // Exit 0 to allow build to continue

--- a/src/process/services/scode/ScodeInstallService.ts
+++ b/src/process/services/scode/ScodeInstallService.ts
@@ -15,6 +15,7 @@ import { app } from 'electron';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import runtimeVersions from '@/shared/runtime-versions.json';
 import { extractTarGzWithProgress, extractZipWithProgress, listTarGzEntries, listZipEntries } from '../archiveProgress';
@@ -32,7 +33,16 @@ export const SCODE_DIR = path.join(os.homedir(), '.nexus', 'sudocode');
 /** Marker filename to record installed version */
 const SCODE_READY_MARKER = '.scode-bin-ready';
 
-/** GitHub release base URL for scode downloads */
+/**
+ * Tencent COS mirror root for scode downloads (default source). The mirror is
+ * rolling-latest only (no versioned dirs): the "latest" segment and artifact
+ * filename are appended per request. Integrity is enforced against the
+ * SHA256SUMS.txt published alongside the artifacts. Override the full base with
+ * SCODE_DOWNLOAD_BASE_URL.
+ */
+const SCODE_COS_RELEASE_ROOT_URL = 'https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release';
+
+/** GitHub release base URL — opt-in only via SUDOWORK_USE_GITHUB_FALLBACK=1. */
 const SCODE_GITHUB_RELEASE_BASE_URL = 'https://github.com/sudoprivacy/sudocode/releases/download';
 const SCODE_SKILLS_DIR = path.join(SCODE_DIR, 'skills');
 const SCODE_LEGACY_MANAGED_SKILLS_FILE = path.join(SCODE_DIR, '.sudowork-managed-skills.json');
@@ -361,7 +371,82 @@ async function downloadScode(url: string, destPath: string, onProgress?: (percen
   });
 }
 
-/** Get GitHub download URL for scode */
+/** Fetch a small text resource (SHA256SUMS.txt), following redirects. */
+async function fetchText(url: string): Promise<string> {
+  const https = await import('https');
+  const http = await import('http');
+  return new Promise<string>((resolve, reject) => {
+    let redirects = 0;
+    const doRequest = (requestUrl: string): void => {
+      if (redirects > 10) {
+        reject(new Error('Too many redirects'));
+        return;
+      }
+      const mod = requestUrl.startsWith('https') ? https : http;
+      mod
+        .get(requestUrl, (response: import('http').IncomingMessage) => {
+          if ([301, 302, 307, 308].includes(response.statusCode!) && response.headers.location) {
+            redirects++;
+            doRequest(response.headers.location);
+            return;
+          }
+          if (response.statusCode !== 200) {
+            reject(new Error(`HTTP ${response.statusCode}`));
+            return;
+          }
+          let data = '';
+          response.setEncoding('utf8');
+          response.on('data', (chunk: string) => {
+            data += chunk;
+          });
+          response.on('end', () => resolve(data));
+        })
+        .on('error', reject);
+    };
+    doRequest(url);
+  });
+}
+
+/** Parse a SHA256SUMS.txt body and return the lowercase hex hash for `filename`. */
+function expectedHashFor(sumsText: string, filename: string): string | null {
+  for (const line of sumsText.split('\n')) {
+    const match = line.trim().match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+    if (match && match[2].trim() === filename) return match[1].toLowerCase();
+  }
+  return null;
+}
+
+/**
+ * Verify a downloaded archive against the SHA256SUMS.txt next to it.
+ * Throws on any verification failure so the install aborts rather than
+ * installing a corrupted or tampered binary.
+ */
+async function verifyArchiveIntegrity(artifactUrl: string, filePath: string, filename: string): Promise<void> {
+  const sumsUrl = artifactUrl.replace(/[^/]+$/, 'SHA256SUMS.txt');
+  let sumsText: string;
+  try {
+    sumsText = await fetchText(sumsUrl);
+  } catch (err) {
+    throw new Error(`Could not fetch SHA256SUMS.txt from ${sumsUrl}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const expected = expectedHashFor(sumsText, filename);
+  if (!expected) {
+    throw new Error(`No SHA256 entry for ${filename} in ${sumsUrl}`);
+  }
+  const actual = crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  if (actual !== expected) {
+    throw new Error(`SHA256 mismatch for ${filename}: expected ${expected}, got ${actual}`);
+  }
+  mainLog(TAG, `SHA256 verified: ${filename}`);
+}
+
+/** Get COS mirror download URL for scode (default source, rolling-latest). */
+function getCosDownloadUrl(): string {
+  const base = process.env.SCODE_DOWNLOAD_BASE_URL?.replace(/\/+$/, '') || `${SCODE_COS_RELEASE_ROOT_URL}/latest`;
+  return `${base}/${getPlatformArchiveName()}`;
+}
+
+/** Get GitHub download URL for scode (opt-in fallback only). */
 function getGitHubDownloadUrl(): string {
   const version = getScodeVersion();
   return `${SCODE_GITHUB_RELEASE_BASE_URL}/v${version}/${getPlatformArchiveName()}`;
@@ -393,11 +478,14 @@ export async function ensureScodeInstalled(options?: { forceReinstall?: boolean;
     mainLog(TAG, `Using bundled scode archive from ${bundledPath}`);
     options?.onProgress?.(5);
   } else {
-    // Download from GitHub
-    mainLog(TAG, 'Bundled scode not found, attempting download from GitHub...');
+    // Download from the COS mirror (GitHub only when explicitly opted in).
+    mainLog(TAG, 'Bundled scode not found, attempting download from COS mirror...');
     fs.mkdirSync(downloadDir, { recursive: true });
 
-    const downloadAttempts = [{ label: 'GitHub', url: getGitHubDownloadUrl() }];
+    const downloadAttempts = [{ label: 'COS', url: getCosDownloadUrl() }];
+    if (process.env.SUDOWORK_USE_GITHUB_FALLBACK === '1') {
+      downloadAttempts.push({ label: 'GitHub', url: getGitHubDownloadUrl() });
+    }
 
     let lastError: string | null = null;
     for (const attempt of downloadAttempts) {
@@ -407,12 +495,29 @@ export async function ensureScodeInstalled(options?: { forceReinstall?: boolean;
           const mapped = Math.max(5, Math.min(45, Math.round((percent / 100) * 45)));
           options?.onProgress?.(mapped);
         });
-        archivePath = downloadDest;
-        break;
       } catch (err) {
         lastError = err instanceof Error ? err.message : String(err);
         mainWarn(TAG, `${attempt.label} download failed: ${lastError}`);
+        continue;
       }
+
+      // Download succeeded — verify integrity before accepting the archive.
+      // A hash mismatch is a hard stop: refuse to install a corrupted/tampered binary.
+      try {
+        await verifyArchiveIntegrity(attempt.url, downloadDest, getPlatformArchiveName());
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        mainError(TAG, `Integrity verification failed (${attempt.label}): ${msg}`);
+        try {
+          fs.unlinkSync(downloadDest);
+        } catch {
+          /* ignore */
+        }
+        return false;
+      }
+
+      archivePath = downloadDest;
+      break;
     }
 
     if (!archivePath) {


### PR DESCRIPTION
## Summary
Repoint **Sudocode (scode)** runtime downloads from `github.com/sudoprivacy/sudocode` Releases to the Tencent COS mirror. Applies to both download paths:
- `scripts/download-scode.js` — build-time, bundles into `resources/`
- `src/process/services/scode/ScodeInstallService.ts` — runtime install into `~/.nexus/sudocode`

COS is now the **default** source. GitHub is **not** used by default — opt-in only via `SUDOWORK_USE_GITHUB_FALLBACK=1`. The base is overridable via `SCODE_DOWNLOAD_BASE_URL`.

## Mirror model (Option A: rolling-latest)
```
https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/sudocode/release/latest/
  ├── scode-macos-arm64.tar.gz
  ├── scode-macos-x64.tar.gz
  ├── scode-windows-arm64.zip
  ├── scode-windows-x64.zip
  └── SHA256SUMS.txt
```
- The mirror is **rolling-latest only** — no versioned directories.
- The `scode` entry in `runtime-versions.json` is **informational** (used for the local `resources/v{version}-…` filename and version markers); it is **not** part of the COS URL. Left unchanged at `0.1.9`.
- Integrity is pinned via the published **`SHA256SUMS.txt`**, not by the directory version.

## Integrity verification (SHA256SUMS.txt)
On every download, the artifact is hashed and compared against the `SHA256SUMS.txt` sitting next to it (same directory). A mismatch — or a missing/unfetchable sums file, or no entry for the artifact — is a **hard stop**:
- build script (`download-scode.js`) → exits **1** (no placeholder, refuses to bundle)
- runtime service (`ScodeInstallService`) → aborts the install, deletes the temp file, returns `false`

## Why
Faster + more reliable scode downloads inside CN by serving from the COS mirror instead of GitHub Releases, with cryptographic integrity enforcement on download.

## Files changed
- `scripts/download-scode.js` — COS rolling-latest default base; `getDownloadUrls()` (COS, then GitHub iff `SUDOWORK_USE_GITHUB_FALLBACK=1`); `fetchText` / `expectedHashFor` / `verifyIntegrity`; integrity check in the download loop; `exit 1` on integrity failure.
- `src/process/services/scode/ScodeInstallService.ts` — `SCODE_COS_RELEASE_ROOT_URL` (+`/latest`); `getCosDownloadUrl()`; env-gated GitHub fallback; `fetchText` / `expectedHashFor` / `verifyArchiveIntegrity`; integrity gate that aborts install on mismatch.

## Verification (run 2026-06-03, macOS arm64)
| Check | Result |
|---|---|
| `curl -sI …/release/latest/scode-macos-arm64.tar.gz` | **HTTP 200**, Content-Length **8844923** |
| `…/release/latest/SHA256SUMS.txt` | **HTTP 200** (6 entries) |
| `node scripts/download-scode.js --force` (COS only, no fallback) | **HTTP 200** from COS → `SHA256 verified` → saved |
| Downloaded file SHA256 | `8d84b3656308bcd6b734551707f5d3019cc4464c8d34fc0465ddfbea8b24d726` — **matches** SHA256SUMS.txt |
| `scode --version` (extracted) | **`scode 0.1.9`** |
| Negative test (tampered artifact + wrong hash via local server) | `SHA256 mismatch … refusing to bundle` → **exit 1** |

Not run: full `tsc`/eslint — this worktree has no `node_modules` (bun project). The build script uses only Node builtins and passed `node --check`.

## Scope / out of scope
- Nexus is intentionally untouched. The `sudocode/release/latest/` mirror here is unrelated to the separate `nexus-vfs` runtime being added by another worker.
- The `--host` vs `--hostname` spawn-arg bug in `DynamicNexusService.ts` is out of scope (separate PR).

## Test plan
- [ ] Fresh checkout, delete cached binaries, `bun run scode:download` → non-empty `resources/v0.1.9-scode-*` from COS with `SHA256 verified`.
- [ ] Launch app with no bundled scode → `ScodeInstallService` installs from COS into `~/.nexus/sudocode`; `scode --version` → `0.1.9`.
- [ ] Confirm GitHub is NOT contacted by default (only with `SUDOWORK_USE_GITHUB_FALLBACK=1`).
- [ ] Tamper check: serve a bad artifact → install/build aborts on hash mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)