### PR TITLE
refactor(#4259): bump nexus-napi sudocode rev

### DIFF
--- a/native/nexus-napi/Cargo.lock
+++ b/native/nexus-napi/Cargo.lock
@@ -574,8 +574,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9b#0686ed9bb1b55674d9b298615e212cecb7e8579a"
+version = "0.1.10"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=869d571#869d5718c1f7f8b2af8d17ea8160a005514d48b9"
 dependencies = [
  "prost",
  "protoc-bin-vendored",

--- a/native/nexus-napi/Cargo.toml
+++ b/native/nexus-napi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3", features = ["napi9"] }
 napi-derive = "3"
-nexus-vfs-client = { git = "https://github.com/sudoprivacy/sudocode", rev = "0686ed9b" }
+nexus-vfs-client = { git = "https://github.com/sudoprivacy/sudocode", rev = "869d571" }
 
 [build-dependencies]
 napi-build = "2"


### PR DESCRIPTION
## Summary
- Bump `nexus-vfs-client` rev in `native/nexus-napi/Cargo.toml` to the Phase 3 merge commit (`869d571`)
- Ensures nexus-napi uses the updated nexus-vfs-client with synced proto

Part of nexus-vfs repo extraction (#4259). Follows PR #716 (merged).

## Test plan
- [x] `cargo check` passes in native/nexus-napi
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)