### PR TITLE
fix(enterprise): save workspace from Moss session for Word export

### DIFF
--- a/src/agent/remote/MossWsConnection.ts
+++ b/src/agent/remote/MossWsConnection.ts
@@ -60,6 +60,7 @@ export class MossWsConnection {
   private ws: WebSocket | null = null;
   private sessionId: string | null = null;
   private wsUrl: string | null = null;
+  private workDir: string | null = null;
   private accessToken: string | null = null;
   private state: 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'closed' = 'idle';
   private reconnectAttempts = 0;
@@ -117,12 +118,13 @@ export class MossWsConnection {
         const sessionData = await this.createMossSession();
         this.sessionId = sessionData.session_id;
         this.wsUrl = sessionData.ws_url;
+        this.workDir = sessionData.work_dir;
         // CRITICAL: Persist created session details back to config
         // This ensures reconnects/scheduleReconnect() enter resume mode
         // instead of creating duplicate sessions (the "session storm")
         this.config.wsUrl = sessionData.ws_url;
         this.config.sessionId = sessionData.session_id;
-        mainLog('MossWsConnection', `Session created: ${this.sessionId}`);
+        mainLog('MossWsConnection', `Session created: ${this.sessionId}, workDir: ${this.workDir}`);
       }
 
       await this.openWebSocket();
@@ -886,5 +888,9 @@ export class MossWsConnection {
 
   getWsUrl(): string | null {
     return this.wsUrl;
+  }
+
+  getWorkDir(): string | null {
+    return this.workDir;
   }
 }

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -301,6 +301,10 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
         return;
       }
 
+      // Get workDir from Moss session if available
+      // 从 Moss session 获取 workDir（如果可用）
+      const sessionWorkDir = this.connection?.getWorkDir?.();
+
       const updatedConversation = {
         ...existing.data,
         extra: {
@@ -308,13 +312,16 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
           mossSessionId: this.mossSessionId,
           acpWsUrl: this.mossWsUrl,
           mossSessionPending: false,
+          // Update workspace with Moss session's workDir if available
+          // 使用 Moss session 的 workDir 更新 workspace（如果可用）
+          workspace: sessionWorkDir || existing.data.extra?.workspace,
         },
         status: 'finished',
         modifyTime: Date.now(),
       } as unknown as TChatConversation;
 
       db.updateConversation(this.conversation_id, updatedConversation);
-      mainLog('RemoteAgent', `Updated conversation ${this.conversation_id} with Moss session: ${this.mossSessionId}`);
+      mainLog('RemoteAgent', `Updated conversation ${this.conversation_id} with Moss session: ${this.mossSessionId}, workspace: ${sessionWorkDir || existing.data.extra?.workspace}`);
 
       // Emit refresh event to update sidebar
       // 发送刷新事件更新侧边栏


### PR DESCRIPTION
When creating a Moss session in enterprise mode, the work_dir returned by Moss Server was not saved to the local database. This caused "Convert to Word" feature to fail with "Workspace not found" error.

Changes:
- MossWsConnection: add workDir property and getWorkDir() method
- RemoteAgent: update workspace field when Moss session is created

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to AionUi! 🎉**
