### PR TITLE
feat: SUDOWORK_REUSE_DAEMONS env var for client-only second instance

### DIFF
--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -8,6 +8,7 @@ import { app } from 'electron';
 import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { isReuseDaemonsMode } from '@process/utils';
 import { processSupervisor } from '@process/ProcessSupervisor';
 import { extractTarGzWithProgress, extractZipWithProgress } from '../archiveProgress';
 import runtimeVersions from '@/shared/runtime-versions.json';
@@ -351,6 +352,25 @@ class DynamicNexusVfsService {
   async start(): Promise<void> {
     if (this._running) return;
 
+    // Client-only / reuse mode: attach to the primary instance's nexus-vfs
+    // daemon on the fixed gRPC port. Critically, this skips the
+    // forceKillProcessesOnPort path below, which would otherwise kill the
+    // primary instance's daemon.
+    if (isReuseDaemonsMode()) {
+      this._port = NEXUS_VFS_DEFAULT_PORT;
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        if (await this.isPortInUse(this._port)) {
+          this.process = null;
+          this._running = true;
+          mainLog('NexusVfs', `Reuse mode: attached to existing nexus-vfs on ${NEXUS_VFS_BIND_HOST}:${this._port}`);
+          this.emit('ready', `Reusing shared nexus-vfs on ${NEXUS_VFS_BIND_HOST}:${this._port}`);
+          return;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 500));
+      }
+      throw new Error('SUDOWORK_REUSE_DAEMONS=1 but no nexus-vfs on 12022; start a primary instance first.');
+    }
+
     this._port = NEXUS_VFS_DEFAULT_PORT;
     this._running = false;
 
@@ -408,6 +428,12 @@ class DynamicNexusVfsService {
 
   async stop(): Promise<void> {
     this._running = false;
+    // Reuse mode never owns the daemon process — just drop local state, never
+    // signal or force-kill the shared nexus-vfs daemon.
+    if (isReuseDaemonsMode()) {
+      this.process = null;
+      return;
+    }
     const proc = this.process;
     if (proc && proc.exitCode === null && !proc.killed) {
       await new Promise<void>((resolve) => {

--- a/src/process/services/nexus/DynamicNexusService.ts
+++ b/src/process/services/nexus/DynamicNexusService.ts
@@ -7,7 +7,7 @@ import { app } from 'electron';
 import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import * as net from 'net';
-import { getDataPath } from '@process/utils';
+import { getDataPath, isReuseDaemonsMode } from '@process/utils';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { processSupervisor } from '@process/ProcessSupervisor';
 import { extractTarGzWithProgress, extractZipWithProgress, listTarGzEntries, listZipEntries } from '../archiveProgress';
@@ -725,6 +725,23 @@ class DynamicNexusService {
   async start(): Promise<void> {
     if (this._running) return;
 
+    // Client-only / reuse mode: a secondary instance attaches to the primary
+    // instance's nexusd on the fixed port instead of spawning or killing one.
+    if (isReuseDaemonsMode()) {
+      this._port = NEXUS_DEFAULT_PORT;
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        if (await this.isHealthyNexusServer(this._port)) {
+          this.process = null;
+          this._running = true;
+          mainLog('Nexus', `Reuse mode: attached to existing nexusd on http://127.0.0.1:${this._port}`);
+          this.emitSetup('ready', `Reusing shared Nexus on http://127.0.0.1:${this._port}`);
+          return;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 500));
+      }
+      throw new Error('SUDOWORK_REUSE_DAEMONS=1 but no healthy nexusd on 12012; start a primary instance first.');
+    }
+
     // 使用固定端口 12012
     this._port = NEXUS_DEFAULT_PORT;
     this._running = false;
@@ -811,6 +828,12 @@ class DynamicNexusService {
    */
   async stop(): Promise<void> {
     this._running = false;
+    // Reuse mode never owns the daemon process — just drop local state, never
+    // signal the shared nexusd to stop.
+    if (isReuseDaemonsMode()) {
+      this.process = null;
+      return;
+    }
     const stopped = await this.stopManagedPidFromFile('on stop');
     if (!stopped) {
       mainWarn('Nexus', 'nexusd.pid not found or does not reference a managed nexusd process, skipping Nexus stop');

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as path from 'node:path';
 import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
+import { isReuseDaemonsMode } from '@process/utils';
 import { initStatusManager } from '../initStatus';
 import { isSudoclawHealthPayload, SUDOCLAW_HEALTH_TIMEOUT_MS, type SudoclawHealthPayload } from '../sudoclaw/sudoclawHealth';
 import { AdbResultSidechannel } from '../sudoclaw/AdbResultSidechannel';
@@ -197,6 +198,14 @@ export class ServiceManager {
   private async startNexusWithRetries(): Promise<void> {
     const { dynamicNexusService } = await import('../nexus/DynamicNexusService');
 
+    if (isReuseDaemonsMode()) {
+      // Reuse mode: never kill the shared daemon and never retry. The
+      // service-level start() probe attaches to the primary's Nexus if it is
+      // healthy, otherwise throws a clear "start a primary instance first" error.
+      await this.startNexusOnce();
+      return;
+    }
+
     const startAttempts = async (attempts: number, phase: 'normal' | 'reinstall'): Promise<void> => {
       let lastError: unknown;
 
@@ -364,6 +373,20 @@ export class ServiceManager {
       mainWarn('ServiceManager', 'Skipping Sudoclaw start because shutdown is in progress');
       return;
     }
+    // Client-only / reuse mode: never spawn or kill a gateway. Attach to the
+    // primary instance's gateway on the fixed port; agents connect over
+    // ws://127.0.0.1:17863 just like normal.
+    if (isReuseDaemonsMode()) {
+      if (this.sudoclawStartPromise) {
+        await this.sudoclawStartPromise;
+        return;
+      }
+      this.sudoclawStartPromise = this.attachToSharedSudoclaw().finally(() => {
+        this.sudoclawStartPromise = null;
+      });
+      await this.sudoclawStartPromise;
+      return;
+    }
     if (this.sudoclawStartPromise) {
       await this.sudoclawStartPromise;
       return;
@@ -373,6 +396,35 @@ export class ServiceManager {
       this.sudoclawStartPromise = null;
     });
     await this.sudoclawStartPromise;
+  }
+
+  /**
+   * Reuse-mode counterpart to startSudoclawWithRetries: verify the primary
+   * instance's gateway is healthy on the fixed port and resolve the gateway
+   * readiness promise so agents can connect. Never spawns a gateway, starts a
+   * sidechannel, or touches the port. `this.gateway` stays null — getGateway()
+   * returns null, which only disables this instance's hot-reload path (safe).
+   */
+  private async attachToSharedSudoclaw(): Promise<void> {
+    const { SUDOCLAW_DEFAULT_PORT } = await import('../sudoclaw/SudoclawInstallService');
+    this.gatewayReadyPromise = new Promise<{ host: string; port: number } | null>((resolve) => {
+      this.gatewayReadyResolve = resolve;
+    });
+    initStatusManager.setStepState('sudoclaw', 'active', '正在连接已有 Sudoclaw 服务...');
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const health = await this.checkSudoclawHealth(SUDOCLAW_DEFAULT_PORT);
+      if (health.healthy) {
+        initStatusManager.setStepProgress('sudoclaw', 100, 'Sudoclaw 服务已就绪');
+        mainLog('ServiceManager', `Reuse mode: attached to shared Sudoclaw gateway on 127.0.0.1:${SUDOCLAW_DEFAULT_PORT}`);
+        this.gatewayReadyResolve?.({ host: 'localhost', port: SUDOCLAW_DEFAULT_PORT });
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    this.gatewayReadyResolve?.(null);
+    throw new Error('SUDOWORK_REUSE_DAEMONS=1 but no healthy Sudoclaw gateway on 17863; start a primary instance first.');
   }
 
   private async startSudoclawWithRetries(): Promise<void> {
@@ -759,6 +811,13 @@ export class ServiceManager {
   }
 
   private async preparePortForStart(port: number, label: 'Sudoclaw' | 'Nexus'): Promise<void> {
+    // Reuse mode: the daemon on this port is owned by the primary instance.
+    // This helper must never kill anything — the service-level start() reuse
+    // probe decides whether a healthy primary daemon is present.
+    if (isReuseDaemonsMode()) {
+      mainLog('ServiceManager', `Reuse mode: ${label} not preparing port ${port} (never kills shared daemons)`);
+      return;
+    }
     const occupied = await this.isPortOccupied(port);
     if (!occupied) {
       return;

--- a/src/process/utils.ts
+++ b/src/process/utils.ts
@@ -17,6 +17,17 @@ export const getTempPath = () => {
 };
 
 /**
+ * "Client-only" / daemon-reuse mode. When SUDOWORK_REUSE_DAEMONS=1 this Electron
+ * instance is a secondary instance that connects to the shared daemons (Nexus
+ * 12012, nexus-vfs 12022, Sudoclaw 17863) already started by a primary instance,
+ * instead of spawning or killing them. The renderer/HTTP clients keep hitting the
+ * same fixed ports — they just talk to the primary's daemons.
+ */
+export const isReuseDaemonsMode = (): boolean => {
+  return process.env.SUDOWORK_REUSE_DAEMONS === '1';
+};
+
+/**
  * Ensure CLI-safe symlink exists and return the symlink path.
  * On macOS, creates a symlink in home directory to avoid spaces in paths.
  * CLI tools like Qwen can't handle spaces in paths properly.


### PR DESCRIPTION
## Summary

Adds a `SUDOWORK_REUSE_DAEMONS=1` env var that turns a second concurrent Electron instance into a **client-only** instance: it attaches to the shared backend daemons already started by a primary instance instead of spawning or killing them.

The three managed daemons run on fixed ports and are shared:
- **Nexus** (HTTP, `12012`)
- **nexus-vfs** (gRPC, `12022`)
- **Sudoclaw gateway** (WebSocket, `17863`)

Renderer/HTTP clients are unchanged — they keep hitting the same fixed ports, now serviced by the primary's daemons.

## The problem this fixes

Without this flag, launching a second instance is destructive. Each service's startup reclaims its port by force-killing whatever holds it. The clearest example is `DynamicNexusVfsService` (`forceKillProcessesOnPort` in `start()`), and `ServiceManager.preparePortForStart` / the Nexus retry loop (`killProcessesOnPort(12012)`). A second instance therefore tears down the **primary** instance's daemons. There was no way to run two instances side by side.

## Design / env-var seam

A single helper `isReuseDaemonsMode()` (reads `SUDOWORK_REUSE_DAEMONS === '1'`) gates all new behavior. In reuse mode each service:
- in `start()`: probes for an already-healthy primary daemon (reusing the service's own health check) with a short retry budget; on detect it sets running state, emits ready, and returns **without spawning or killing**; on no-detect it throws a clear `...start a primary instance first` error (never silently spawns).
- in `stop()`: clears local state only — never terminates the shared daemon.

Port-prep and retry paths that used to kill are made no-ops in reuse mode, so the primary's daemons are never touched. Normal mode (no env var) is byte-for-byte unchanged because every branch is gated at the top of the method.

## Touched files

1. **`src/process/utils.ts`** — new `isReuseDaemonsMode()` helper (single source of truth for the flag).
2. **`src/process/services/nexus/DynamicNexusService.ts`** — reuse branch in `start()` (attach via `isHealthyNexusServer`), guard in `stop()`.
3. **`src/process/services/nexus-vfs/DynamicNexusVfsService.ts`** — reuse branch in `start()` (attach via `isPortInUse`, skipping `forceKillProcessesOnPort`), guard in `stop()`.
4. **`src/process/services/serviceManager/ServiceManager.ts`** — `preparePortForStart` no-op in reuse mode; `startNexusWithRetries` short-circuits (no kill, no retry); `startSudoclaw` attaches via new `attachToSharedSudoclaw()` (health-probe only, never spawns/kills a gateway).

## Verification

- `bunx tsc --noEmit` — clean.
- `bunx eslint` on the 4 touched files — clean (4 pre-existing `no-empty` warnings in `DynamicNexusVfsService.ts` are on `dev` already, not from this change).
- **Live two-instance run.** Primary instance up with `nexus-vfs` on 12022 (real daemon); stand-in `/health` servers on 12012 and 17863 acting as the primary's Nexus/Sudoclaw. Launched a second instance with `SUDOWORK_REUSE_DAEMONS=1` and a separate `--user-data-dir`:
  - `[Nexus] Reuse mode: attached to existing nexusd on http://127.0.0.1:12012`
  - `[NexusVfs] Reuse mode: attached to existing nexus-vfs on 127.0.0.1:12022`
  - `[Process] Initialization complete in 369ms` (no retry/kill loops)
  - **Zero** `Force-killed` / `killProcessesOnPort` markers in the second instance log.
  - All primary daemon PIDs unchanged after second-instance startup AND after its shutdown.
  - Second window rendered fully (Vite auto-picked 5174, CDP 9231, reached `http://localhost:5174/#/login`) while the primary stayed on 5173 / CDP 9230.
  - Graceful close of the second instance left every primary daemon alive.
  - Note: `startSudoclaw()` is lazy (fires on first agent task, not in headless startup), so its attach path wasn't exercised in this headless run; it is structurally identical to the Nexus attach and the stub served the exact `{"ok":true,"status":"live"}` contract `checkSudoclawHealth` requires.
  - Normal mode is not separately re-launched here because doing so reclaims (kills) the shared fixed ports by design, which would disrupt the running primary; the no-regression guarantee rests on every change being gated behind `isReuseDaemonsMode()`.

## Launch recipe

```sh
# Primary instance (normal):
bun run start

# Secondary client-only instance (reuses the primary's daemons):
SUDOWORK_REUSE_DAEMONS=1 node scripts/launch-dev.js start --user-data-dir=/tmp/sudowork-second-userdata
```

(Vite + CDP ports auto-pick; only the three daemon ports are shared.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)