### PR TITLE
fix: include ai-dev-browser in packaged app

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,6 +25,8 @@ files:
   - rules/**/*
   - skills/**/*
   - assistant/**/*
+  # ai-dev-browser Python package (browser skill runtime)
+  - vendor/ai-dev-browser/ai_dev_browser/**/*
   - package.json
   # Rust napi addon (nexus gRPC client)
   - native/nexus-napi/*.node

--- a/tests/integration/browser_port_isolation.py
+++ b/tests/integration/browser_port_isolation.py
@@ -123,6 +123,14 @@ def _cdp_tabs(port: int) -> list[str]:
 
 def run_test(sudowork_port: int = 9230) -> tuple[bool, str]:
     """Run the full port isolation test. Returns (passed, message)."""
+    # 0. Verify browser_helper.py can find ai_dev_browser tools
+    helper = _find_helper()
+    if not os.path.isfile(helper):
+        return False, f"browser_helper.py not found at {helper}"
+    check = _run("--list", timeout=10)
+    if check["exit"] != 0 or "page_goto" not in check["stdout"]:
+        return False, f"browser --list failed (tools not installed): {check['stderr'] or check['stdout']}"
+
     server, test_port = _start_server()
     test_url = f"http://127.0.0.1:{test_port}"
     chrome_port = None


### PR DESCRIPTION
## Summary

Browser skill broken in packaged Sudowork: `vendor/ai-dev-browser/ai_dev_browser/` was not in `electron-builder.yml` files list. The symlink from `~/.nexus/skills/_system/_builtin/browser/ai_dev_browser` to the Python tools package couldn't be created because the target didn't exist in the packaged app.

Agent error: "helper 期望在 ~/.nexus/skills/_system/browser/ai_dev_browser/tools 找工具,但实际只有 _builtin/browser"

## Fix

Add `vendor/ai-dev-browser/ai_dev_browser/**/*` to electron-builder.yml files list.

## Test plan

- [ ] CI passes
- [ ] Packaged app: browser skill works (browser_start + page_goto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)