### PR TITLE
fix(enterprise): support restart-and-connect for remote-agent sessions

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -19,6 +19,7 @@ import { shouldSyncWorkspaceSkills } from '../../common/utils/workspaceSkillSync
 import { getSkillsDir, ProcessChat } from '../initStorage';
 import { ConversationService } from '../services/conversationService';
 import type AcpAgent from '../task/AcpAgent';
+import type RemoteAgent from '../task/RemoteAgent';
 import { listWorkspaceSkillTargets, resolveConversationEnabledSkillNames } from '../utils/workspaceSkillTargets';
 import { areSkillSelectionsEqual, resolveLatestConversationEnabledSkills } from '../utils/conversationAssistantSkills';
 import { copyFilesToDirectory, readDirectoryRecursive } from '../utils';
@@ -587,12 +588,14 @@ export function initConversationBridge(): void {
   // Disconnects current connection, clears bootstrap, then re-initializes
   ipcBridge.conversation.restartAndConnect.provider(async ({ conversation_id }) => {
     try {
-      const task = WorkerManage.getTaskById(conversation_id) as AcpAgent | undefined;
+      const task = WorkerManage.getTaskById(conversation_id);
       if (!task) return { success: false, msg: 'conversation not found' };
 
-      if (task.type === 'acp') {
-        const acpTask = task as AcpAgent;
-        await acpTask.restartAndConnect();
+      // Both ACP (local) and remote-agent (enterprise/Moss) tasks expose
+      // restartAndConnect to recover a dead connection (e.g. socket hang up
+      // after the laptop wakes from sleep).
+      if (task.type === 'acp' || task.type === 'remote-agent') {
+        await (task as AcpAgent | RemoteAgent).restartAndConnect();
         return { success: true };
       }
 

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -338,6 +338,32 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
   /**
    * Send message
    */
+  /**
+   * Tear down the current Moss connection and reconnect, resuming the same
+   * session. Used by the "重启并连接" action after the WebSocket dies (e.g. the
+   * laptop wakes from a long sleep and the socket has hung up). initAgent is
+   * guarded by `this.bootstrap`, so it would otherwise reuse the dead
+   * connection — clearing bootstrap forces a fresh attach/resume via the
+   * persisted wsUrl/sessionId.
+   */
+  async restartAndConnect(): Promise<void> {
+    mainLog('RemoteAgent', `restartAndConnect for conversation ${this.conversation_id}`);
+    this.emitStatusMessage('connecting');
+    try {
+      this.connection?.disconnect();
+    } catch (error) {
+      mainError('RemoteAgent', `disconnect during restart failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    this.connection = null;
+    // Clear bootstrap so initAgent rebuilds the connection instead of returning
+    // the stale (resolved) one.
+    this.bootstrap = undefined;
+    await this.initAgent();
+    if (!this.connection?.isConnected()) {
+      throw new Error('Connection not ready after restart');
+    }
+  }
+
   async sendMessage(data: { content: string; files?: string[]; msg_id?: string }): Promise<{ success: boolean; msg?: string }> {
     mainLog('RemoteAgent', `sendMessage called for conversation ${this.conversation_id}`);
     mainLog('RemoteAgent', `content length: ${data.content?.length || 0}, files: ${data.files?.length || 0}`);
@@ -357,6 +383,15 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
       mainLog('RemoteAgent', 'Calling initAgent...');
       await this.initAgent();
       mainLog('RemoteAgent', 'initAgent completed');
+
+      // initAgent reuses a cached bootstrap, so a connection that died while
+      // idle (e.g. socket hang up after the laptop slept) won't be rebuilt by
+      // the call above. Detect the dead socket and transparently reconnect once
+      // before failing, so the user's send self-heals instead of erroring.
+      if (!this.connection?.isConnected()) {
+        mainLog('RemoteAgent', 'Connection stale after initAgent; attempting reconnect');
+        await this.restartAndConnect();
+      }
 
       if (!this.connection?.isConnected()) {
         mainError('RemoteAgent', 'Connection not ready after initAgent');


### PR DESCRIPTION
## Problem

After the laptop wakes from a long sleep, the Moss WebSocket hangs up and enterprise (`remote-agent`) conversations break in two ways:

1. **Clicking "重启并连接" shows "unsupported conversation type."** The `restartAndConnect` IPC handler only handled `task.type === 'acp'`, but enterprise conversations are `remote-agent`.
2. **"socket hang up" persists on the next send.** `RemoteAgent.initAgent()` is guarded by `this.bootstrap`; once a session is established that cached promise is reused, so a connection that died while idle is never rebuilt — `sendMessage` throws "Connection not ready" with no recovery.

## Fix

**`src/process/task/RemoteAgent.ts`**
- Add `restartAndConnect()`: disconnect, drop the connection + cached `bootstrap`, then re-run `initAgent()` — which resumes the **same** Moss session via the persisted `wsUrl`/`sessionId`. Mirrors `AcpAgent.restartAndConnect()`.
- `sendMessage()` now **self-heals**: if the connection is dead after `initAgent()`, it reconnects once before failing, so most wake-from-sleep sends recover automatically without the user clicking the button.

**`src/process/bridge/conversationBridge.ts`**
- The `restartAndConnect` handler now accepts both `'acp'` and `'remote-agent'`.
- Added the `RemoteAgent` type import.

## Verification
- `tsc --noEmit` clean; `eslint` clean on both files.
- Logic confirmed against `RemoteAgent`'s resume path (persisted `wsUrl`/`sessionId` drive attach/resume in `initAgent`).
- Manual wake-from-sleep + "重启并连接" testing in the packaged app to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)