### PR TITLE
fix(nexus): run nexusd-cluster (Rust) with correct install + startup protocol

### DIFF
--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -17,7 +17,7 @@ const execAsync = promisify(exec);
 /**
  * nexus-vfs — a third managed runtime, independent of and additive to the
  * existing Nexus (~/.nexus, port 12012) and Sudocode runtimes. It launches the
- * `nexusd-cluster` daemon from the nexus-vfs repo (v0.0.1-rc1) under ~/.nexus-vfs
+ * `nexusd-cluster` daemon from the nexus-vfs repo (version pinned in runtime-versions.json) under ~/.nexus-vfs
  * and binds gRPC on 127.0.0.1:12022.
  *
  * Differences from DynamicNexusService that matter here:
@@ -36,7 +36,7 @@ const NEXUS_VFS_START_TIMEOUT_MS = 30_000;
 /** Marker file recording the installed version inside the bin directory. */
 const NEXUS_VFS_READY_MARKER = '.nexus-vfs-bin-ready';
 
-/** COS mirror that actually hosts the v0.0.1-rc1 artifacts (verified by HEAD probe). */
+/** COS mirror that hosts the nexus-vfs release artifacts (verified by HEAD probe). */
 const NEXUS_VFS_COS_BASE_URL = 'https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/nexus-vfs/release';
 
 /** Node.js process.platform → artifact OS token. */
@@ -44,17 +44,17 @@ const OS_NAME_MAP: Record<string, string> = { darwin: 'macos', win32: 'windows',
 /** Node.js process.arch → artifact arch token (note: arm64 → aarch64). */
 const ARCH_NAME_MAP: Record<string, string> = { arm64: 'aarch64', x64: 'x86_64' };
 
-/** Known-good SHA256 sums for v0.0.1-rc1 (mirrors SHA256SUMS.txt in the bucket). */
+/** Known-good SHA256 sums for v0.1.0 (mirrors SHA256SUMS.txt in the bucket). */
 const NEXUS_VFS_SHA256SUMS: Record<string, string> = {
-  'nexusd-cluster-linux-aarch64.tar.gz': '1dd8d899b6cca4f9f47c6785ac7cd3bf30ff3d9faca1c6b791ec9fc76232af87',
-  'nexusd-cluster-linux-x86_64.tar.gz': '9d4f86780ae4ba59cb3e2fc573d68200bba7a0d45cd4e5d862499012ec46945a',
-  'nexusd-cluster-macos-aarch64.tar.gz': 'eeb5d821cf8940cc97e879707f85b39db0dbb054d42334e2d8c48a4e63cd13ab',
-  'nexusd-cluster-windows-aarch64.zip': 'dc121b622575f781c4ac5efb4190153cae9e783ee635342e325e67a30d1852c8',
-  'nexusd-cluster-windows-x86_64.zip': '4e261d26070994667fee2d98f6b065c0d5e436a903fca2d7dfd198a85a19d81f',
+  'nexusd-cluster-linux-aarch64.tar.gz': '2a7e668db3c90216ea2367ab38fc146a758ba44cd86418a2b0dd67235505409e',
+  'nexusd-cluster-linux-x86_64.tar.gz': '8727ce5fedaf18e0becabf185707fa088dfa9aa5caa4d200a944a0310745f268',
+  'nexusd-cluster-macos-aarch64.tar.gz': '7cc2a1f8d5e351a42d6abc4dacd13a3729cfed4d9cd963a91b1eea1d99ac7c5b',
+  'nexusd-cluster-windows-aarch64.zip': '81167da16a8b480b3c6336077608b22fa5c5d2062362dada0a73e96481730771',
+  'nexusd-cluster-windows-x86_64.zip': 'b7d79bc060d1d598fae7a6c7131e4e7d5d3cb76b14ec7742a6a6d28d2dc57817',
 };
 
 /** Explicit, non-fallback error for the one platform this release does not ship. */
-const INTEL_MAC_UNSUPPORTED = 'nexus-vfs v0.0.1-rc1 has no Intel macOS artifact; use Apple Silicon or wait for a newer release';
+const INTEL_MAC_UNSUPPORTED = 'nexus-vfs v0.1.0 has no Intel macOS artifact; use Apple Silicon or wait for a newer release';
 
 export type NexusVfsStage = 'idle' | 'checking' | 'downloading' | 'installing' | 'starting' | 'ready' | 'error';
 

--- a/src/process/services/nexus/DynamicNexusService.ts
+++ b/src/process/services/nexus/DynamicNexusService.ts
@@ -64,6 +64,14 @@ class DynamicNexusService {
   }
 
   /**
+   * The binary name inside the nexusd-cluster (Rust) archive, before it is
+   * renamed to nexusd. The archive ships `nexusd-cluster[.exe]`.
+   */
+  private getClusterBinaryName(): string {
+    return this.isWindows ? 'nexusd-cluster.exe' : 'nexusd-cluster';
+  }
+
+  /**
    * Get the archive file extension for the current platform.
    * macOS/Linux: .tar.gz, Windows: .zip
    */
@@ -343,8 +351,11 @@ class DynamicNexusService {
         }
       }
 
-      // Verify that nexusd is present at the stripped level
-      if (names.has(nexusdName)) {
+      // Verify that the nexus binary is present at the stripped level. The
+      // v0.9.43 (Python) archive ships it as `nexusd`; the nexusd-cluster
+      // (Rust) archive ships it as `nexusd-cluster` and is renamed to `nexusd`
+      // after extraction (see installFromArchive).
+      if (names.has(nexusdName) || names.has(this.getClusterBinaryName())) {
         return { strip: 1, topLevelNames: names };
       }
     }
@@ -443,6 +454,17 @@ class DynamicNexusService {
         },
         strip
       );
+
+      // The nexusd-cluster (Rust) archive ships the binary as `nexusd-cluster`,
+      // but the rest of the service (start, readiness, install check) expects
+      // `nexusd`. Rename it after extraction so both archive layouts converge on
+      // the same installed path.
+      const nexusdPath = path.join(binDir, this.getNexusdName());
+      const clusterPath = path.join(binDir, this.getClusterBinaryName());
+      if (!fs.existsSync(nexusdPath) && fs.existsSync(clusterPath)) {
+        fs.renameSync(clusterPath, nexusdPath);
+        mainLog('Nexus', `Renamed ${this.getClusterBinaryName()} -> ${this.getNexusdName()}`);
+      }
 
       this.emitSetup('installing', 'Setting permissions...', 85);
 
@@ -626,9 +648,23 @@ class DynamicNexusService {
   private resolveStartCommand(port = NEXUS_DEFAULT_PORT): { command: string; args: string[] } {
     const newPath = this.getInstalledNexusdPath();
     if (fs.existsSync(newPath)) {
+      // nexusd-cluster (Rust runtime) CLI: --hostname / --bind-addr /
+      // --bootstrap-mode / --data-dir / --no-tls. It speaks gRPC only (no HTTP
+      // /health), so readiness is a TCP-connect probe (see waitForHealthyServer).
+      // bootstrap-mode `static` with empty peers brings up a single-node zone.
       return {
         command: newPath,
-        args: ['--host', 'localhost', '--profile=cluster', '--auth-type', 'none', '--port', String(port)],
+        args: [
+          '--hostname',
+          'localhost',
+          '--bind-addr',
+          `127.0.0.1:${port}`,
+          '--bootstrap-mode',
+          'static',
+          '--data-dir',
+          path.join(getDataPath(), 'nexus_data'),
+          '--no-tls',
+        ],
       };
     }
 
@@ -957,15 +993,21 @@ class DynamicNexusService {
   }
 
   private async isHealthyNexusServer(port: number): Promise<boolean> {
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/health`, {
-        signal: AbortSignal.timeout(NEXUS_HEALTHCHECK_TIMEOUT_MS),
+    // nexusd-cluster (Rust) speaks gRPC only — there is no HTTP /health
+    // endpoint — so readiness is a plain TCP-connect probe against the bind port.
+    return new Promise<boolean>((resolve) => {
+      const socket = net.connect(port, '127.0.0.1', () => {
+        socket.destroy();
+        resolve(true);
       });
-      const payload = (await response.json()) as { status?: string };
-      return payload.status === 'healthy';
-    } catch {
-      return false;
-    }
+      socket.setTimeout(NEXUS_HEALTHCHECK_TIMEOUT_MS);
+      const fail = (): void => {
+        socket.destroy();
+        resolve(false);
+      };
+      socket.once('timeout', fail);
+      socket.once('error', fail);
+    });
   }
 
   private async waitForHealthyServer(port: number, timeoutMs?: number): Promise<void> {


### PR DESCRIPTION
## Problem

Fresh installs fail at startup with **`以下组件安装未完成: nexus`**.

**Scope: affects both personal (consumer) and enterprise modes — not enterprise-only.** `serviceManager.startup()` is invoked for any `appMode` (`'c'` or `'e'`; only skipped for brand-new users who haven't picked a mode), and it unconditionally starts the `nexus` runtime. The code comment at `src/process/index.ts` is explicit: *"Both Enterprise and Consumer modes: start local services … Enterprise mode now requires local services for Local session mode support."* So any installed user on the affected build hits this on launch.

## Root cause

The **`nexus` runtime** (`DynamicNexusService`, port 12012) was left **half-migrated** by two PRs that merged into `dev` independently and contradict each other:

- **`930d7acc`** ("rollback nexus to v0.9.43") configured the service for the **old Python `nexus-cluster`** archive: binary named `nexusd`, `--host/--profile=cluster/--auth-type/--port` CLI, HTTP `GET /health` readiness.
- **PR #729** ("align nexus-vfs download") then re-pointed the service's **download URL / version / archive name** to the **new Rust `nexusd-cluster` v0.1.0** artifact (gRPC-only) — **without** updating the matching install / start / health logic.

Net result: the service **downloads and installs a Rust gRPC binary but tries to install and run it as a Python HTTP binary**. The three observed errors are all symptoms of that single mismatch:

| Stage | Gets (Rust v0.1.0) | Code still expects (Python 0.9.43) | Symptom |
|---|---|---|---|
| Install | binary named `nexusd-cluster` | `nexusd` | `Nexus runtime is missing after startup installation` |
| Start | gRPC CLI (`--bind-addr` …) | `--host/--profile=cluster/--auth-type/--port` | `nexusd exited before becoming ready (code=2)` |
| Health | gRPC-only, no HTTP | HTTP `GET /health` | never reports healthy → readiness times out |

Separately (same version-bump class of bug): **`DynamicNexusVfsService`** (port 12022) verified downloads against the **v0.0.1-rc1** SHA256 sums after its version was bumped to **v0.1.0** → `SHA256 mismatch`, nexus-vfs failed to start.

> This is a **code-level protocol mismatch, not a missing/mislocated binary** — no binary placement can bridge a Python-vs-Rust startup contract. Confirmed on Apple Silicon; the logic is platform-independent so it breaks all platforms doing a fresh nexus install.

## Fix

**`DynamicNexusService.ts`** (port 12012) — align with the Rust binary it actually ships:
- Rename `nexusd-cluster` → `nexusd` after extraction; `analyzeArchiveStructure` now also recognizes the cluster binary so the top-level dir is stripped correctly.
- Spawn with the Rust CLI: `--hostname / --bind-addr / --bootstrap-mode static / --data-dir / --no-tls`.
- Replace the HTTP `/health` check with a **TCP-connect readiness probe** on the gRPC bind port.

**`DynamicNexusVfsService.ts`** (port 12022):
- Update `NEXUS_VFS_SHA256SUMS` to the **v0.1.0** values (verified against the bucket's `v0.1.0/SHA256SUMS.txt`); refresh stale `v0.0.1-rc1` comments.

This mirrors how `DynamicNexusVfsService` already runs the same Rust binary correctly.

## Verification
- Ran the packaged app: both **`nexus` (12012)** and **`nexus-vfs` (12022)** reach ready (`Server ready — port=12012`, `nexus-vfs ready`), and `ServiceManager` logs **`All components ready`** — no more `组件安装未完成` / `exited before becoming ready` / `SHA256 mismatch`.
- Ran the binary directly with the new args to confirm it binds the port and forms the raft zone.
- tsc: no new errors (a pre-existing `grpcPort` error in `managedAgentBridge.ts` is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)