### PR TITLE
fix(acp): handle empty scode deliverable turns

### DIFF
--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -701,7 +701,7 @@ export class AionUIDatabase {
             SELECT *
             FROM messages
             WHERE conversation_id = ?
-            ORDER BY created_at ${order} LIMIT ?
+            ORDER BY created_at ${order}, rowid ${order} LIMIT ?
             OFFSET ?
           `
         )

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -190,6 +190,9 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
   private hasReceivedUsageUpdate = false;
   private lastAssistantTextMsgId: string | null = null;
   private turnHadVisibleAssistantContent = false;
+  private turnEventSequence = 0;
+  private lastVisibleAssistantContentSequence = 0;
+  private lastToolCompletionSequence = 0;
   private lastUserMessage: string | null = null;
   private plannedRestartInProgress = false;
   private contextOverflowRecoveryPending = false;
@@ -699,6 +702,9 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
     this.hasReceivedUsageUpdate = false;
     this.lastAssistantTextMsgId = null;
     this.turnHadVisibleAssistantContent = false;
+    this.turnEventSequence = 0;
+    this.lastVisibleAssistantContentSequence = 0;
+    this.lastToolCompletionSequence = 0;
 
     // ★ Reset turn-level file tracking for new turn
     // 重置 Turn 级别文件追踪，开始新的 Turn
@@ -1564,7 +1570,8 @@ This identity statement takes priority over the default identity in USER.md.
   }
 
   private emitFallbackCompletionMessage(finalFiles: Array<{ path: string; reason: string }>): void {
-    if (this.userCancelled || this.turnHadVisibleAssistantContent) {
+    const hasVisibleContentAfterLastTool = this.turnHadVisibleAssistantContent && this.lastVisibleAssistantContentSequence > this.lastToolCompletionSequence;
+    if (this.userCancelled || hasVisibleContentAfterLastTool) {
       return;
     }
 
@@ -1683,6 +1690,7 @@ This identity statement takes priority over the default identity in USER.md.
         }
       }
 
+      let trackedCount = 0;
       for (const changedFile of changedFiles) {
         const file = changedFile.path;
         const relativePath = nodePath.relative(this.workspace, file);
@@ -1703,13 +1711,14 @@ This identity statement takes priority over the default identity in USER.md.
           source: 'bash-generated',
           kind: changedFile.kind,
         });
+        trackedCount++;
       }
 
       // Update snapshot for next comparison
       this.workspaceFileSnapshot = currentSnapshot;
 
-      if (changedFiles.length > 0) {
-        mainLog('[AcpAgent]', `[TRACK-BASH] Total changed files tracked: ${changedFiles.length}`);
+      if (trackedCount > 0) {
+        mainLog('[AcpAgent]', `[TRACK-BASH] Total changed files tracked: ${trackedCount}`);
       }
     } catch (err) {
       mainError('[AcpAgent]', 'Failed to track Bash generated files:', err);
@@ -2169,6 +2178,9 @@ This identity statement takes priority over the default identity in USER.md.
         const statusUpdate = data as ToolCallUpdateStatus;
         const toolCallId = statusUpdate.update?.toolCallId;
         const toolStatus = statusUpdate.update?.status;
+        if (toolStatus === 'completed' || toolStatus === 'failed') {
+          this.lastToolCompletionSequence = ++this.turnEventSequence;
+        }
 
         // Breadcrumb: MCP/tool call result
         if (toolStatus === 'completed' || toolStatus === 'failed') {
@@ -2895,6 +2907,7 @@ This identity statement takes priority over the default identity in USER.md.
 
     if (filteredMessage.type === 'content' && this.hasVisibleAssistantContent(filteredMessage.data)) {
       this.turnHadVisibleAssistantContent = true;
+      this.lastVisibleAssistantContentSequence = ++this.turnEventSequence;
     }
 
     if (filteredMessage.type !== 'thought' && filteredMessage.type !== 'acp_model_info' && filteredMessage.type !== 'acp_context_usage') {

--- a/src/process/task/FileIntentClassifier.ts
+++ b/src/process/task/FileIntentClassifier.ts
@@ -35,6 +35,7 @@ export interface FileIntentClassification {
 
 const SCRIPT_EXTENSIONS = new Set(['.py', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.sh', '.bash', '.zsh', '.rb', '.php', '.lua']);
 const SCRIPT_SIDE_EFFECT_NAMES = new Set(['package.json', 'package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'requirements.txt']);
+const BASH_DELIVERABLE_EXTENSIONS = new Set(['.pdf', '.docx', '.pptx', '.xlsx', '.csv', '.json', '.md', '.markdown', '.txt', '.html', '.htm', '.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg']);
 
 const TARGET_TYPE_EXTENSIONS: Array<{ pattern: RegExp; extensions: string[] }> = [
   { pattern: /\b(pdf|PDF)\b|文档.*pdf|pdf.*文档/i, extensions: ['.pdf'] },
@@ -158,12 +159,16 @@ export class FileIntentClassifier {
       return { intent: 'final', reason: 'Matches final file pattern' };
     }
 
-    if (input.source === 'bash-generated') {
-      return { intent: 'draft', reason: 'Bash-generated file without explicit final signal' };
-    }
-
     if (matchesDraftPattern(fileName)) {
       return { intent: 'draft', reason: 'Matches draft file pattern' };
+    }
+
+    if (input.source === 'bash-generated' && BASH_DELIVERABLE_EXTENSIONS.has(ext)) {
+      return { intent: 'final', reason: `Bash-generated deliverable file type ${ext}`, matched: ext };
+    }
+
+    if (input.source === 'bash-generated') {
+      return { intent: 'draft', reason: 'Bash-generated file without explicit final signal' };
     }
 
     if (isIntermediateScript(fileName, userMessage)) {

--- a/src/process/task/acpWorkspaceTracking.ts
+++ b/src/process/task/acpWorkspaceTracking.ts
@@ -1,6 +1,6 @@
 import * as nodePath from 'node:path';
 
-export const ACP_WORKSPACE_TRACKING_SKIP_DIRS = new Set(['.codex', '.drafts', '.git', '.nexus', '.sandbox-home', '.scode', 'node_modules', '__pycache__', '.venv', 'venv']);
+export const ACP_WORKSPACE_TRACKING_SKIP_DIRS = new Set(['.codex', '.drafts', '.git', '.nexus', '.sandbox-home', '.sandbox-tmp', '.scode', 'node_modules', '__pycache__', '.venv', 'venv']);
 
 export const ACP_WORKSPACE_TRACKING_SKIP_FILES = new Set(['.gitignore', '.env', '.env.local', '.DS_Store', 'Thumbs.db']);
 

--- a/tests/unit/acpWorkspaceTracking.test.ts
+++ b/tests/unit/acpWorkspaceTracking.test.ts
@@ -4,6 +4,8 @@ import { SCODE_COMPLETION_REMINDER, shouldSkipAcpWorkspaceTrackingPath } from '@
 describe('acpWorkspaceTracking', () => {
   test('skips sandbox runtime side effects', () => {
     expect(shouldSkipAcpWorkspaceTrackingPath('.sandbox-home/.rustup/settings.toml')).toBe(true);
+    expect(shouldSkipAcpWorkspaceTrackingPath('.sandbox-tmp/node-compile-cache/v24.13.0-arm64/00bf0630')).toBe(true);
+    expect(shouldSkipAcpWorkspaceTrackingPath('.sandbox-tmp/pip-unpack-abc/lxml-6.1.1.whl')).toBe(true);
   });
 
   test('keeps user deliverables trackable', () => {

--- a/tests/unit/draftsCleanup.test.ts
+++ b/tests/unit/draftsCleanup.test.ts
@@ -85,12 +85,34 @@ describe('FileIntentClassifier', () => {
 
   test('treats bash-generated files as draft by default', () => {
     const result = classifier.classify({
-      filePath: 'analysis.csv',
+      filePath: 'analysis.bin',
       source: 'bash-generated',
     });
 
     expect(result.intent).toBe('draft');
     expect(result.reason).toContain('Bash-generated');
+  });
+
+  test('keeps bash-generated PDF deliverables in workspace root without current user intent', () => {
+    const result = classifier.classify({
+      filePath: '20260604_具身智能发展趋势报告.pdf',
+      userMessage: '?',
+      source: 'bash-generated',
+    });
+
+    expect(result.intent).toBe('final');
+    expect(result.reason).toContain('deliverable file type .pdf');
+  });
+
+  test('keeps draft-named bash-generated PDFs as draft', () => {
+    const result = classifier.classify({
+      filePath: 'temp_report.pdf',
+      userMessage: '?',
+      source: 'bash-generated',
+    });
+
+    expect(result.intent).toBe('draft');
+    expect(result.reason).toContain('draft file pattern');
   });
 
   test('promotes bash-generated file when it matches requested target type', () => {


### PR DESCRIPTION
## Summary
- emit fallback completion only when no visible assistant content appears after the last tool completion
- keep bash-generated deliverable files such as PDFs in the workspace root
- skip sandbox temp runtime files from ACP workspace tracking

## Tests
- bunx vitest run tests/unit/draftsCleanup.test.ts tests/unit/acpWorkspaceTracking.test.ts
- bunx tsc --noEmit (fails on existing unrelated managedAgentBridge grpcPort type error)