### PR TITLE
feat(scode): add auto sudorouter model option

### DIFF
--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -26,6 +26,8 @@ export type ScodeCustomModelProvider = {
 const SUDOROUTER_PROVIDER_ID = 'sudorouter';
 const OPENAI_COMPAT_API = 'openai-completions';
 const OPENAI_RESPONSES_API = 'openai-responses';
+export const SCODE_AUTO_MODEL_ALIAS = 'auto';
+export const SCODE_AUTO_ROUTER_MODEL_ID = 'claude-opus-4-8';
 
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
@@ -53,10 +55,7 @@ function getCustomApiType(modelId: string, api?: string): string {
   return modelApi || OPENAI_COMPAT_API;
 }
 
-function resolveDefaultModelAlias(
-  existingDefaultModel: string | undefined,
-  models: Record<string, ScodeModelEntry>
-): string | undefined {
+function resolveDefaultModelAlias(existingDefaultModel: string | undefined, models: Record<string, ScodeModelEntry>): string | undefined {
   const defaultModel = existingDefaultModel?.trim();
   if (!defaultModel) return undefined;
   if (models[defaultModel]) return defaultModel;
@@ -72,15 +71,20 @@ function isCustomApiKeyModelEntry(entry: ScodeModelEntry | undefined, providerId
   return entry?.providers?.['api-key']?.provider === providerId;
 }
 
-function buildSudorouterModelEntry(modelId: string): ScodeModelEntry {
+function buildSudorouterModelEntry(modelId: string, alias = modelId): ScodeModelEntry {
   return {
-    alias: modelId,
-    name: modelId,
+    alias,
+    name: alias,
     input: modelInputForModelId(modelId),
     providers: {
       proxy: { provider: SUDOROUTER_PROVIDER_ID, model: modelId, api: OPENAI_COMPAT_API },
     },
   };
+}
+
+export function addScodeAutoModel(models: Record<string, ScodeModelEntry>): Record<string, ScodeModelEntry> {
+  models[SCODE_AUTO_MODEL_ALIAS] = buildSudorouterModelEntry(SCODE_AUTO_ROUTER_MODEL_ID, SCODE_AUTO_MODEL_ALIAS);
+  return models;
 }
 
 function buildCustomApiKeyModelEntry(providerId: string, model: ScodeCustomModelProvider['models'][number], alias: string): ScodeModelEntry {
@@ -211,6 +215,7 @@ export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | un
     }
   }
 
+  addScodeAutoModel(nextModels);
   for (const modelId of modelIds) {
     nextModels[normalizeModelAlias(modelId)] = buildSudorouterModelEntry(modelId);
   }

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -14,12 +14,7 @@
 import { ipcBridge } from '@/common';
 import { modelInputForModelId } from '@/common/imageUtils';
 import type { ScodeModelEntry } from '@/common/ipcBridge';
-import {
-  extractCustomProvidersFromScodeConfig,
-  mergeCustomProvidersIntoScodeConfig,
-  normalizeCustomApiKeyModelsInScodeConfig,
-  type ScodeCustomModelProvider,
-} from '@/common/scodeConfig';
+import { addScodeAutoModel, extractCustomProvidersFromScodeConfig, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, type ScodeCustomModelProvider } from '@/common/scodeConfig';
 import { SCODE_DIR, isScodeInstalled, getScodeVersionState, ensureScodeInstalled } from '@process/services/scode/ScodeInstallService';
 import { readSettings, removeDisabledMcpServersFromSettings, writeSettings } from '@process/services/mcpServices/agents/ScodeMcpAgent';
 import { getDatabase } from '@process/database';
@@ -145,6 +140,7 @@ export async function syncScodeModelsFromPricing(): Promise<void> {
     }
   }
 
+  addScodeAutoModel(models);
   for (const modelId of modelIds) {
     models[modelId] = {
       alias: modelId,

--- a/tests/unit/scodeConfig.test.ts
+++ b/tests/unit/scodeConfig.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  buildScodeConfigFromLoginPayload,
-  extractCustomProvidersFromScodeConfig,
-  mergeCustomProviderIntoScodeConfig,
-  mergeCustomProvidersIntoScodeConfig,
-  normalizeCustomApiKeyModelsInScodeConfig,
-  removeCustomProviderFromScodeConfig,
-} from '@/common/scodeConfig';
+import { buildScodeConfigFromLoginPayload, extractCustomProvidersFromScodeConfig, mergeCustomProviderIntoScodeConfig, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, removeCustomProviderFromScodeConfig, SCODE_AUTO_MODEL_ALIAS, SCODE_AUTO_ROUTER_MODEL_ID } from '@/common/scodeConfig';
 
 describe('scodeConfig', () => {
   it('preserves custom api-key providers and models when login refreshes sudorouter models', () => {
@@ -54,6 +47,17 @@ describe('scodeConfig', () => {
     });
     expect(next.models?.['legacy-router-model']).toBeUndefined();
     expect(next.models?.['gemini-3-flash-preview']?.providers?.proxy?.provider).toBe('sudorouter');
+    expect(next.models?.[SCODE_AUTO_MODEL_ALIAS]).toMatchObject({
+      alias: SCODE_AUTO_MODEL_ALIAS,
+      name: SCODE_AUTO_MODEL_ALIAS,
+      providers: {
+        proxy: { provider: 'sudorouter', model: SCODE_AUTO_ROUTER_MODEL_ID, api: 'openai-completions' },
+      },
+    });
+    const sudorouterModelAliases = Object.entries(next.models || {})
+      .filter(([, model]) => model.providers?.proxy?.provider === 'sudorouter')
+      .map(([alias]) => alias);
+    expect(sudorouterModelAliases).toEqual([SCODE_AUTO_MODEL_ALIAS, 'gemini-3-flash-preview']);
     expect(next.models?.['custom-openai/gpt-4o']?.providers?.['api-key']).toEqual({
       provider: 'custom-openai',
       model: 'gpt-4o',


### PR DESCRIPTION
## Summary
- add an `auto` scode model alias routed through SudoRouter to `claude-opus-4-8`
- inject the alias for both login/initial config generation and live specific_pricing refreshes
- keep `auto` first within the SudoRouter model group

## Verification
- `bunx vitest run tests/unit/scodeConfig.test.ts tests/unit/scodeProxyModels.test.ts`
- `./node_modules/.bin/eslint --quiet src/common/scodeConfig.ts src/process/bridge/scodeBridge.ts tests/unit/scodeConfig.test.ts`
- `./node_modules/.bin/prettier --check src/common/scodeConfig.ts src/process/bridge/scodeBridge.ts tests/unit/scodeConfig.test.ts`
- `bun run start`

Note: full `bunx tsc --noEmit` currently fails on `dev` at `src/process/bridge/managedAgentBridge.ts:16` because `DynamicNexusService` has no `grpcPort` property; unrelated to this change.
