### PR TITLE
fix: Guide page popup positioning by adding forwardRef to ActionChip (#741)

### DIFF
--- a/src/renderer/components/ui/ActionChip.tsx
+++ b/src/renderer/components/ui/ActionChip.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from 'classnames';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 export type ActionChipProps = {
   icon?: React.ReactNode;
@@ -15,15 +15,17 @@ export type ActionChipProps = {
   onClick?: () => void;
   className?: string;
   title?: string;
-};
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'className' | 'title' | 'disabled' | 'onClick'>;
 
-const ActionChip: React.FC<ActionChipProps> = ({ icon, label, active = false, disabled = false, onClick, className, title }) => {
+const ActionChip = forwardRef<HTMLButtonElement, ActionChipProps>(({ icon, label, active = false, disabled = false, onClick, className, title, ...rest }, ref) => {
   return (
-    <button type='button' title={title} disabled={disabled} className={classNames('inline-flex h-34px min-w-0 items-center gap-7px rd-999px border border-solid px-12px text-13px font-500 transition-colors', 'border-[var(--ui-border-strong)] bg-bg-1 text-t-secondary hover:bg-fill-1 hover:text-t-primary', 'disabled:cursor-not-allowed disabled:opacity-55', active && 'border-[rgba(var(--ui-accent-orange-rgb),0.52)] bg-bg-1 text-[var(--ui-accent-orange)]', onClick ? 'cursor-pointer' : 'cursor-default', className)} onClick={onClick}>
+    <button ref={ref} type='button' title={title} disabled={disabled} className={classNames('inline-flex h-34px min-w-0 items-center gap-7px rd-999px border border-solid px-12px text-13px font-500 transition-colors', 'border-[var(--ui-border-strong)] bg-bg-1 text-t-secondary hover:bg-fill-1 hover:text-t-primary', 'disabled:cursor-not-allowed disabled:opacity-55', active && 'border-[rgba(var(--ui-accent-orange-rgb),0.52)] bg-bg-1 text-[var(--ui-accent-orange)]', onClick ? 'cursor-pointer' : 'cursor-default', className)} onClick={onClick} {...rest}>
       {icon && <span className='inline-flex h-16px w-16px shrink-0 items-center justify-center text-inherit'>{icon}</span>}
       <span className='min-w-0 truncate'>{label}</span>
     </button>
   );
-};
+});
+
+ActionChip.displayName = 'ActionChip';
 
 export default ActionChip;

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -602,7 +602,7 @@ const GuidPage: React.FC = () => {
   }, [selectedAssistantConfig, localeKey]);
 
   return (
-    <ConfigProvider getPopupContainer={() => guidContainerRef.current || document.body}>
+    <ConfigProvider getPopupContainer={() => document.body}>
       <div ref={guidContainerRef} className={styles.guidContainer}>
         <div className='absolute top-12px right-16px z-10'>
           <ThemeSwitcher />


### PR DESCRIPTION
Fix the permission default button and model selection button popups on the Guide page incorrectly rendering at the top-left corner.

## Root Cause

`ActionChip` was a plain function component without `forwardRef`. Arco Design's `Trigger` component checks `supportRef()` on its child — when false, it skips setting the ref, so `rootElementRef` stays null. The popup position then falls back to `ReactDOM.findDOMNode()` which is deprecated and unreliable in React 18, causing popups to appear at (0, 0).

Additionally, `ActionChip` did not spread rest props, so event handlers injected by Arco's `cloneElement` were lost.

## Changes

1. `ActionChip`: convert to `forwardRef` + spread rest props to `<button>`
2. `GuidPage`: change `ConfigProvider's` `getPopupContainer` to `document.body`

Closes #741

Generated with [Claude Code](https://claude.ai/code)