### PR TITLE
fix(remote-agent): keep Moss workspace paths remote

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -283,6 +283,8 @@ export type TChatConversation =
           cronJobBoundId?: string;
           /** Cron job name this conversation is pre-bound to */
           cronJobBoundName?: string;
+          /** Moss remote container workspace path (enterprise mode) - stored separately from local workspace */
+          mossWorkDir?: string;
         }
       >,
       'model'
@@ -356,6 +358,8 @@ export type TChatConversation =
           cronJobBoundId?: string;
           /** Cron job name this conversation is pre-bound to */
           cronJobBoundName?: string;
+          /** Moss remote container workspace path (enterprise mode) - stored separately from local workspace */
+          mossWorkDir?: string;
         }
       >,
       'model'

--- a/src/common/utils/workspaceSkillSync.ts
+++ b/src/common/utils/workspaceSkillSync.ts
@@ -1,15 +1,53 @@
 import type { TChatConversation } from '@/common/storage';
 
 /**
+ * Check if a workspace path is a remote container path (Moss/Sudorouter).
+ * Remote paths start with /app/ or contain /data/runtime/sessions/.
+ * These paths exist only in the remote container, not on the local filesystem.
+ */
+export function isRemoteContainerPath(workspace?: string): boolean {
+  if (!workspace) return false;
+  // Moss container paths: /app/data/runtime/sessions/<id>/workspace
+  return workspace.startsWith('/app/') || workspace.includes('/data/runtime/sessions/');
+}
+
+/**
  * Workspace skill linking is supported when the conversation has a workspace and
  * either:
- * 1. the preset assistant explicitly declares enabled skills, or
- * 2. the current message requests ad-hoc skills, or
- * 3. it's a supported ACP backend (claude, scode).
+ * 1. it's an OpenClaw conversation, or
+ * 2. the preset assistant explicitly declares enabled skills, or
+ * 3. the current message requests ad-hoc skills.
+ *
+ * NOTE: Remote-agent conversations are ALWAYS excluded because their workspace
+ * exists in a remote container, not on the local filesystem. The remote container
+ * workDir should be stored in extra.mossWorkDir, not extra.workspace.
+ * Remote-agent workspace skills are managed by Moss Server, not locally.
  */
 export function shouldSyncWorkspaceSkills(conversation?: TChatConversation, requestedSkillNames?: string[]): boolean {
   if (!conversation?.extra?.workspace) {
     return false;
+  }
+
+  // ALWAYS skip remote-agent conversations - their workspace is in a remote container
+  // Remote-agent workspace skills are managed by Moss Server, not locally
+  if (conversation.type === 'remote-agent') {
+    return false;
+  }
+
+  // Defense-in-depth: also skip if workspace is a remote container path
+  // This guards against accidental pollution of extra.workspace with remote paths
+  if (isRemoteContainerPath(conversation.extra.workspace)) {
+    return false;
+  }
+
+  // Also skip if mossWorkDir is present (indicates remote-agent conversation)
+  const extra = conversation.extra as { mossWorkDir?: string };
+  if (extra.mossWorkDir) {
+    return false;
+  }
+
+  if (conversation.type === 'openclaw-gateway') {
+    return true;
   }
 
   if (conversation.type === 'acp' && conversation.extra?.backend === 'claude') {

--- a/src/process/providers/RemoteConversationProvider.ts
+++ b/src/process/providers/RemoteConversationProvider.ts
@@ -15,6 +15,7 @@ import { initMossApi, type MossSessionApi } from '@process/remote/MossSessionApi
 import { mainLog, mainError } from '@process/utils/mainLogger';
 import { uuid } from '@/common/utils';
 import { ProcessConfig } from '@process/initStorage';
+import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
 
 const HIDDEN_CRON_SESSIONS_KEY = 'remote.hiddenCronSessionIds';
 
@@ -369,6 +370,45 @@ export class RemoteConversationProvider implements IConversationProvider {
       const modifyTime = session.lastActiveAt || session.last_active_at || session.updatedAt || session.updated_at || now;
       const createTime = existingConversation?.createTime || session.createdAt || session.created_at || modifyTime;
       const existingExtra = existingConversation?.extra as Record<string, unknown> | undefined;
+
+      // Extract Moss workDir (remote container path)
+      const mossWorkDir = session.workDir || session.work_dir || session.cwd;
+
+      // Check if workDir is a remote container path
+      const isRemotePath = isRemoteContainerPath(mossWorkDir);
+
+      // Build extra - save remote paths to mossWorkDir, preserve existing workspace
+      const extra: Record<string, unknown> = {
+        ...existingExtra,
+        backend: 'remote-agent',
+        mossServerUrl: this.config.mossServerUrl,
+        authToken: this.config.authToken,
+        runtimeType: this.config.runtimeType,
+        agentName: session.assistantName || session.assistant_name,
+        sessionMode: 'remote',
+        mossSessionId,
+        mossSessionPending: false,
+        mossSessionUpdatedAt: modifyTime,
+        cronJobId: cronSource.cronJobId,
+        cronJobName: cronSource.cronJobName,
+        cronRunId: cronSource.cronRunId,
+      };
+
+      if (isRemotePath) {
+        // Remote container path - save to mossWorkDir, preserve existing workspace
+        extra.mossWorkDir = mossWorkDir;
+        // Preserve existing workspace if present
+        if (existingExtra?.workspace) {
+          extra.workspace = existingExtra.workspace;
+        }
+      } else if (mossWorkDir) {
+        // Local path - safe to set as workspace
+        extra.workspace = mossWorkDir;
+      } else if (existingExtra?.workspace) {
+        // No new workDir, preserve existing workspace
+        extra.workspace = existingExtra.workspace;
+      }
+
       const conversation: TChatConversation = {
         id: existingConversation?.id || mossSessionId,
         name: existingConversation?.name || this.formatCronSessionTitle(cronSource.cronJobName, createTime),
@@ -377,22 +417,7 @@ export class RemoteConversationProvider implements IConversationProvider {
         modifyTime,
         status: session.status === 'ended' || session.status === 'terminated' ? 'finished' : 'running',
         source: 'aionui',
-        extra: {
-          ...existingExtra,
-          workspace: session.workDir || session.work_dir || session.cwd,
-          backend: 'remote-agent',
-          mossServerUrl: this.config.mossServerUrl,
-          authToken: this.config.authToken,
-          runtimeType: this.config.runtimeType,
-          agentName: session.assistantName || session.assistant_name,
-          sessionMode: 'remote',
-          mossSessionId,
-          mossSessionPending: false,
-          mossSessionUpdatedAt: modifyTime,
-          cronJobId: cronSource.cronJobId,
-          cronJobName: cronSource.cronJobName,
-          cronRunId: cronSource.cronRunId,
-        },
+        extra,
       };
 
       if (existingConversation) {
@@ -945,19 +970,36 @@ export class RemoteConversationProvider implements IConversationProvider {
         return false;
       }
 
+      // Extract Moss workDir (remote container path)
+      const mossWorkDir = sessionData.workDir || sessionData.work_dir;
+
+      // Check if workDir is a remote container path
+      const isRemotePath = isRemoteContainerPath(mossWorkDir);
+
+      // Build extra update - save remote paths to mossWorkDir, not workspace
+      const extraUpdate: Record<string, unknown> = {
+        ...existing.data.extra,
+        mossSessionId,
+        acpWsUrl: wsUrl,
+        mossSessionPending: false,
+        agentName: sessionData.assistantName || sessionData.assistant_name,
+      };
+
+      if (isRemotePath) {
+        // Remote container path - save to mossWorkDir, preserve existing workspace
+        extraUpdate.mossWorkDir = mossWorkDir;
+        // Do NOT overwrite workspace with remote path
+      } else if (mossWorkDir && !existing.data.extra?.workspace) {
+        // Local path and no existing workspace - safe to set
+        extraUpdate.workspace = mossWorkDir;
+      }
+
       const updatedConversation = {
         ...existing.data,
         // Optionally update ID to Moss session ID (requires special handling)
         // 可选：将 ID 更新为 Moss session ID（需要特殊处理）
         // id: mossSessionId,
-        extra: {
-          ...existing.data.extra,
-          mossSessionId,
-          acpWsUrl: wsUrl,
-          mossSessionPending: false,
-          workspace: sessionData.workDir || sessionData.work_dir,
-          agentName: sessionData.assistantName || sessionData.assistant_name,
-        },
+        extra: extraUpdate,
         status: 'finished',
         modifyTime: Date.now(),
       } as TChatConversation;

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -19,6 +19,7 @@ import { detectFileIntent, matchesDraftPattern } from './draftsCleanup';
 import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import { initMossApi } from '../remote/MossSessionApi';
+import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
 
 /**
  * RemoteAgent data interface
@@ -265,15 +266,33 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
         assistantName?: string;
         assistant_name?: string;
       };
+
+      // Extract Moss workDir (remote container path)
+      const mossWorkDir = session.workDir || session.work_dir;
+
+      // Check if workDir is a remote container path using shared helper
+      const isRemotePath = isRemoteContainerPath(mossWorkDir);
+
+      // Build the extra update - save remote paths to mossWorkDir, not workspace
+      const extraUpdate: Record<string, unknown> = {
+        ...existing.data.extra,
+        mossSessionId,
+        acpWsUrl: wsUrl,
+        mossSessionPending: false,
+        agentName: session.assistantName || session.assistant_name || existing.data.extra?.agentName,
+      };
+
+      if (isRemotePath) {
+        // Remote container path - save to mossWorkDir, preserve existing workspace
+        extraUpdate.mossWorkDir = mossWorkDir;
+        // Do NOT overwrite workspace with remote path
+      } else if (mossWorkDir && !existing.data.extra?.workspace) {
+        // Local path and no existing workspace - safe to set
+        extraUpdate.workspace = mossWorkDir;
+      }
+
       void db.updateConversation(this.conversation_id, {
-        extra: {
-          ...existing.data.extra,
-          mossSessionId,
-          acpWsUrl: wsUrl,
-          mossSessionPending: false,
-          workspace: session.workDir || session.work_dir || existing.data.extra?.workspace,
-          agentName: session.assistantName || session.assistant_name || existing.data.extra?.agentName,
-        },
+        extra: extraUpdate,
         status: 'finished',
         modifyTime: Date.now(),
       } as Partial<TChatConversation>);
@@ -305,23 +324,35 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
       // 从 Moss session 获取 workDir（如果可用）
       const sessionWorkDir = this.connection?.getWorkDir?.();
 
+      // Check if workDir is a remote container path using shared helper
+      const isRemotePath = isRemoteContainerPath(sessionWorkDir);
+
+      // Build the extra update - save remote paths to mossWorkDir, not workspace
+      const extraUpdate: Record<string, unknown> = {
+        ...existing.data.extra,
+        mossSessionId: this.mossSessionId,
+        acpWsUrl: this.mossWsUrl,
+        mossSessionPending: false,
+      };
+
+      if (isRemotePath) {
+        // Remote container path - save to mossWorkDir, preserve existing workspace
+        extraUpdate.mossWorkDir = sessionWorkDir;
+        // Do NOT overwrite workspace with remote path
+      } else if (sessionWorkDir && !existing.data.extra?.workspace) {
+        // Local path and no existing workspace - safe to set
+        extraUpdate.workspace = sessionWorkDir;
+      }
+
       const updatedConversation = {
         ...existing.data,
-        extra: {
-          ...existing.data.extra,
-          mossSessionId: this.mossSessionId,
-          acpWsUrl: this.mossWsUrl,
-          mossSessionPending: false,
-          // Update workspace with Moss session's workDir if available
-          // 使用 Moss session 的 workDir 更新 workspace（如果可用）
-          workspace: sessionWorkDir || existing.data.extra?.workspace,
-        },
+        extra: extraUpdate,
         status: 'finished',
         modifyTime: Date.now(),
       } as unknown as TChatConversation;
 
       db.updateConversation(this.conversation_id, updatedConversation);
-      mainLog('RemoteAgent', `Updated conversation ${this.conversation_id} with Moss session: ${this.mossSessionId}, workspace: ${sessionWorkDir || existing.data.extra?.workspace}`);
+      mainLog('RemoteAgent', `Updated conversation ${this.conversation_id} with Moss session: ${this.mossSessionId}, mossWorkDir: ${isRemotePath ? sessionWorkDir : 'N/A'}, workspace: ${existing.data.extra?.workspace || 'N/A'}`);
 
       // Emit refresh event to update sidebar
       // 发送刷新事件更新侧边栏

--- a/tests/unit/workspaceSkillSync.test.ts
+++ b/tests/unit/workspaceSkillSync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { TChatConversation } from '@/common/storage';
-import { shouldSyncWorkspaceSkills } from '@/common/utils/workspaceSkillSync';
+import { shouldSyncWorkspaceSkills, isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
 
 describe('workspace skill sync gating', () => {
   it('enables workspace skill sync for openclaw conversations with a workspace', () => {
@@ -168,5 +168,213 @@ describe('workspace skill sync gating', () => {
     } as TChatConversation;
 
     expect(shouldSyncWorkspaceSkills(conversation)).toBe(false);
+  });
+
+  // New tests for remote-agent workspace path handling
+  describe('remote-agent workspace path handling', () => {
+    it('detects Moss container paths starting with /app/', () => {
+      expect(isRemoteContainerPath('/app/data/runtime/sessions/abc123/workspace')).toBe(true);
+      expect(isRemoteContainerPath('/app/workspace')).toBe(true);
+      expect(isRemoteContainerPath('/tmp/local/workspace')).toBe(false);
+    });
+
+    it('detects Moss container paths containing /data/runtime/sessions/', () => {
+      expect(isRemoteContainerPath('/var/data/runtime/sessions/xyz/workspace')).toBe(true);
+      expect(isRemoteContainerPath('/home/user/data/runtime/sessions/test')).toBe(true);
+      expect(isRemoteContainerPath('/home/user/workspace')).toBe(false);
+    });
+
+    it('returns false for undefined or empty workspace paths', () => {
+      expect(isRemoteContainerPath(undefined)).toBe(false);
+      expect(isRemoteContainerPath('')).toBe(false);
+    });
+
+    // Tests for remote-agent type (primary check)
+    describe('remote-agent type conversations', () => {
+      it('ALWAYS disables workspace skill sync for remote-agent type conversations', () => {
+        const conversation = {
+          id: 'conv-remote-agent',
+          name: 'Remote Agent',
+          type: 'remote-agent',
+          createTime: Date.now(),
+          modifyTime: Date.now(),
+          extra: {
+            workspace: '/tmp/local-workspace', // Even with local workspace
+            backend: 'remote-agent',
+            enabledSkills: ['pptx'],
+          },
+          model: {
+            id: 'default',
+            platform: 'openai',
+            name: 'default',
+            baseUrl: '',
+            apiKey: '',
+            useModel: 'default',
+          },
+        } as TChatConversation;
+
+        // Should skip because type is remote-agent, regardless of workspace path
+        expect(shouldSyncWorkspaceSkills(conversation)).toBe(false);
+      });
+
+      it('disables workspace skill sync for remote-agent with local workspace and enabled skills', () => {
+        const conversation = {
+          id: 'conv-remote-agent-skills',
+          name: 'Remote Agent with Skills',
+          type: 'remote-agent',
+          createTime: Date.now(),
+          modifyTime: Date.now(),
+          extra: {
+            workspace: '/home/user/project', // Local path
+            backend: 'remote-agent',
+            enabledSkills: ['pptx', 'xlsx', 'pdf'],
+          },
+          model: {
+            id: 'default',
+            platform: 'openai',
+            name: 'default',
+            baseUrl: '',
+            apiKey: '',
+            useModel: 'default',
+          },
+        } as TChatConversation;
+
+        expect(shouldSyncWorkspaceSkills(conversation)).toBe(false);
+      });
+
+      it('disables workspace skill sync for remote-agent when requested skills are provided', () => {
+        const conversation = {
+          id: 'conv-remote-agent-requested',
+          name: 'Remote Agent Requested Skills',
+          type: 'remote-agent',
+          createTime: Date.now(),
+          modifyTime: Date.now(),
+          extra: {
+            workspace: '/home/user/project',
+            backend: 'remote-agent',
+          },
+          model: {
+            id: 'default',
+            platform: 'openai',
+            name: 'default',
+            baseUrl: '',
+            apiKey: '',
+            useModel: 'default',
+          },
+        } as TChatConversation;
+
+        // Should skip even when requested skills are passed
+        expect(shouldSyncWorkspaceSkills(conversation, ['pptx', 'xlsx'])).toBe(false);
+      });
+
+      it('disables workspace skill sync for remote-agent with preset assistant', () => {
+        const conversation = {
+          id: 'conv-remote-agent-preset',
+          name: 'Remote Agent Preset',
+          type: 'remote-agent',
+          createTime: Date.now(),
+          modifyTime: Date.now(),
+          extra: {
+            workspace: '/home/user/project',
+            backend: 'remote-agent',
+            presetAssistantId: 'builtin-cowork',
+          },
+          model: {
+            id: 'default',
+            platform: 'openai',
+            name: 'default',
+            baseUrl: '',
+            apiKey: '',
+            useModel: 'default',
+          },
+        } as TChatConversation;
+
+        expect(shouldSyncWorkspaceSkills(conversation)).toBe(false);
+      });
+    });
+
+    // Defense-in-depth: remote container path detection
+    describe('remote container path detection (defense-in-depth)', () => {
+      it('disables workspace skill sync for acp conversations with Moss container paths', () => {
+        const conversation = {
+          id: 'conv-remote-path',
+          name: 'Remote Path',
+          type: 'acp',
+          createTime: Date.now(),
+          modifyTime: Date.now(),
+          extra: {
+            workspace: '/app/data/runtime/sessions/abc123/workspace',
+            backend: 'claude',
+            enabledSkills: ['pptx'],
+          },
+          model: {
+            id: 'default',
+            platform: 'openai',
+            name: 'default',
+            baseUrl: '',
+            apiKey: '',
+            useModel: 'default',
+          },
+        } as TChatConversation;
+
+        // Should skip even with enabled skills because workspace is remote
+        expect(shouldSyncWorkspaceSkills(conversation)).toBe(false);
+      });
+
+      it('disables workspace skill sync when mossWorkDir field is present', () => {
+        const conversation = {
+          id: 'conv-moss-workdir',
+          name: 'Moss Conversation',
+          type: 'acp',
+          createTime: Date.now(),
+          modifyTime: Date.now(),
+          extra: {
+            workspace: '/tmp/local-workspace', // Local path
+            mossWorkDir: '/app/data/runtime/sessions/abc123/workspace', // Remote container path
+            backend: 'claude',
+            enabledSkills: ['pptx'],
+          },
+          model: {
+            id: 'default',
+            platform: 'openai',
+            name: 'default',
+            baseUrl: '',
+            apiKey: '',
+            useModel: 'default',
+          },
+        } as TChatConversation;
+
+        // Should skip because mossWorkDir indicates remote-agent conversation
+        expect(shouldSyncWorkspaceSkills(conversation)).toBe(false);
+      });
+    });
+
+    // Positive case: local acp conversations should still work
+    describe('local acp conversations', () => {
+      it('enables workspace skill sync for local paths without mossWorkDir', () => {
+        const conversation = {
+          id: 'conv-local',
+          name: 'Local Conversation',
+          type: 'acp',
+          createTime: Date.now(),
+          modifyTime: Date.now(),
+          extra: {
+            workspace: '/tmp/local-workspace',
+            backend: 'claude',
+            enabledSkills: ['pptx'],
+          },
+          model: {
+            id: 'default',
+            platform: 'openai',
+            name: 'default',
+            baseUrl: '',
+            apiKey: '',
+            useModel: 'default',
+          },
+        } as TChatConversation;
+
+        expect(shouldSyncWorkspaceSkills(conversation)).toBe(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- store Moss container workDir values in `extra.mossWorkDir` instead of polluting local `extra.workspace`
- skip local workspace skill sync for `remote-agent` conversations and guard against remote container paths
- update RemoteAgent and RemoteConversationProvider session updates to preserve local workspace paths
- add focused workspace skill sync tests for remote-agent and remote path handling

## Verification
- `npm run test -- tests/unit/workspaceSkillSync.test.ts` passes: 17 tests
- launched dev app from the worktree with main `node_modules` symlink; remote-agent conversation accepted multiple consecutive messages without `/app` ENOENT or workspace-skill-sync errors

## Notes
- `npm run type:check` still fails on existing dev issue: `src/process/bridge/managedAgentBridge.ts(16,62): Property 'grpcPort' does not exist on type 'DynamicNexusService'.`