### PR TITLE
fix(channel-detector): 收窄渠道查询意图检测，避免误拦截

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -3570,8 +3570,9 @@ This identity statement takes priority over the default identity in USER.md.
         msg_id: responseMsgId,
         data: result,
       };
+      // 只发送一次，acpConversation.responseStream 和 conversation.responseStream 是同一流
       ipcBridge.acpConversation.responseStream.emit(contentMsg);
-      ipcBridge.conversation.responseStream.emit(contentMsg);
+      // 消息落库
       const tMessage = transformMessage(contentMsg);
       if (tMessage) addOrUpdateMessage(this.conversation_id, tMessage);
     } catch (error) {

--- a/src/process/task/ChannelInfoDetector.ts
+++ b/src/process/task/ChannelInfoDetector.ts
@@ -34,9 +34,95 @@ const CHANNEL_KEYWORDS: Array<{ keyword: string; channelType: string }> = [
 ];
 
 /**
- * 问题关键词（表示用户想查询状态）
+ * 渠道管理语义关键词（必须与渠道词搭配使用才能触发查询）
+ * 这些词明确表示用户在询问渠道的配置/状态等管理信息
  */
-const QUERY_INDICATORS = ['配置', '状态', '连接', '启用', '开通', '设置', '是否', '有没有', '怎么样', '信息', '情况', 'configured', 'status', 'enabled', 'connected'];
+const CHANNEL_MANAGEMENT_KEYWORDS = [
+  '配置',
+  '状态',
+  '连接',
+  '启用',
+  '开通',
+  '设置',
+  '渠道',
+  '机器人',
+  'configured',
+  'status',
+  'enabled',
+  'connected',
+];
+
+/**
+ * 泛查询词（单独使用不应触发，必须与渠道管理关键词搭配）
+ * 例如："有没有配置" 可以，但 "有没有推广机会" 不行
+ */
+const GENERIC_QUERY_WORDS = ['是否', '有没有', '怎么样', '信息', '情况'];
+
+/**
+ * 窗口大小：渠道管理关键词必须出现在渠道词前后此范围内
+ */
+const WINDOW_SIZE = 16;
+
+/**
+ * 检查关键词是否在目标位置的窗口范围内
+ */
+function isWithinWindow(keywordIndex: number, targetIndex: number, windowSize: number): boolean {
+  return Math.abs(keywordIndex - targetIndex) <= windowSize;
+}
+
+/**
+ * 检查句子中是否存在有效的渠道查询语义
+ * 要求：渠道管理关键词必须出现在渠道词附近（前后 WINDOW_SIZE 字符内）
+ */
+function hasValidChannelQuerySemantics(lowerMsg: string, channelKeyword: string): boolean {
+  const keywordLower = channelKeyword.toLowerCase();
+  const keywordIndex = lowerMsg.indexOf(keywordLower);
+
+  if (keywordIndex === -1) return false;
+
+  // 渠道词的结束位置
+  const keywordEndIndex = keywordIndex + keywordLower.length;
+
+  // 方案1: 渠道管理关键词在渠道词附近（如 "微信配置", "飞书状态", "企业微信状态怎么样"）
+  for (const mgmtKeyword of CHANNEL_MANAGEMENT_KEYWORDS) {
+    const mgmtLower = mgmtKeyword.toLowerCase();
+    let searchPos = 0;
+    while ((searchPos = lowerMsg.indexOf(mgmtLower, searchPos)) !== -1) {
+      // 检查管理关键词是否在渠道词前后窗口内
+      if (isWithinWindow(searchPos, keywordIndex, WINDOW_SIZE) || isWithinWindow(searchPos, keywordEndIndex, WINDOW_SIZE)) {
+        return true;
+      }
+      searchPos++;
+    }
+  }
+
+  // 方案2: 泛查询词 + 渠道管理关键词的组合（如 "飞书有没有配置"）
+  // 要求：泛查询词和管理关键词都在渠道词窗口内
+  for (const genericWord of GENERIC_QUERY_WORDS) {
+    const genericLower = genericWord.toLowerCase();
+    const genericIndex = lowerMsg.indexOf(genericLower);
+    if (genericIndex === -1) continue;
+
+    // 泛查询词必须在渠道词窗口内
+    if (!isWithinWindow(genericIndex, keywordIndex, WINDOW_SIZE) && !isWithinWindow(genericIndex, keywordEndIndex, WINDOW_SIZE)) {
+      continue;
+    }
+
+    // 还需要在窗口内找到管理关键词
+    for (const mgmtKeyword of CHANNEL_MANAGEMENT_KEYWORDS) {
+      const mgmtLower = mgmtKeyword.toLowerCase();
+      let searchPos = 0;
+      while ((searchPos = lowerMsg.indexOf(mgmtLower, searchPos)) !== -1) {
+        if (isWithinWindow(searchPos, keywordIndex, WINDOW_SIZE) || isWithinWindow(searchPos, keywordEndIndex, WINDOW_SIZE)) {
+          return true;
+        }
+        searchPos++;
+      }
+    }
+  }
+
+  return false;
+}
 
 /**
  * 排除关键词（避免误拦截）
@@ -74,17 +160,32 @@ export function detectChannelQueryIntent(userMessage: string): ChannelQueryComma
     return { kind: 'list' };
   }
 
-  // 检测特定渠道查询（按优先级顺序）
+  // 检测特定渠道查询
+  // 统计匹配到的不同渠道数量，超过1个则不拦截（避免误拦截多渠道比较）
+  const matchedChannels: Array<{ keyword: string; channelType: string; start: number; end: number }> = [];
+
   for (const { keyword, channelType } of CHANNEL_KEYWORDS) {
-    if (lowerMsg.includes(keyword.toLowerCase())) {
-      // 检查是否有问题关键词
-      const hasQueryIntent = QUERY_INDICATORS.some((indicator) => lowerMsg.includes(indicator.toLowerCase()));
-      if (hasQueryIntent) {
-        return { kind: 'query', channelType };
+    const keywordLower = keyword.toLowerCase();
+    const keywordIndex = lowerMsg.indexOf(keywordLower);
+    if (keywordIndex !== -1) {
+      // 检查是否有有效的渠道查询语义
+      if (hasValidChannelQuerySemantics(lowerMsg, keyword)) {
+        const keywordEnd = keywordIndex + keywordLower.length;
+        const coveredBySpecificKeyword = matchedChannels.some((c) => c.start <= keywordIndex && keywordEnd <= c.end);
+        // 避免重复添加同一渠道类型，也避免 "企业微信" 再被内部的 "微信" 计为第二个渠道。
+        if (!coveredBySpecificKeyword && !matchedChannels.some((c) => c.channelType === channelType)) {
+          matchedChannels.push({ keyword, channelType, start: keywordIndex, end: keywordEnd });
+        }
       }
     }
   }
 
+  // 只有一个渠道匹配时返回查询结果
+  if (matchedChannels.length === 1) {
+    return { kind: 'query', channelType: matchedChannels[0].channelType };
+  }
+
+  // 多个不同渠道匹配时不拦截（用户可能在比较或讨论，不是查询）
   return null;
 }
 

--- a/tests/unit/ChannelInfoDetector.test.ts
+++ b/tests/unit/ChannelInfoDetector.test.ts
@@ -126,6 +126,68 @@ describe('ChannelInfoDetector', () => {
       });
     });
 
+    describe('误拦截修复场景', () => {
+      // 原始长句：包含多个渠道词和泛查询词，但实际是商业讨论
+      it('should return null for long sentence about business opportunity discussion', () => {
+        const longSentence =
+          '所以我觉得包括还有大厂在内的，类似于推出 workbuddy 这样的抢占终端用户，还有类似飞书和钉钉都可以 ai 办公了，我们的 sudowork 你觉得还有没有推广的机会，我觉得海外大模型api 中转站是个更好的机会，再加上我们的 ai 管理平台（sudorouter），你从批判的角度来看，那个更有机会，语言上不要有任何保留，尖锐一点';
+        const result = detectChannelQueryIntent(longSentence);
+        expect(result).toBeNull();
+      });
+
+      // 飞书和钉钉竞品比较讨论 - 不应拦截
+      it('should return null for "飞书和钉钉都可以ai办公了"', () => {
+        const result = detectChannelQueryIntent('飞书和钉钉都可以ai办公了');
+        expect(result).toBeNull();
+      });
+
+      // 单渠道商业讨论 - 不应拦截
+      it('should return null for "飞书这样的办公产品有没有推广机会"', () => {
+        const result = detectChannelQueryIntent('飞书这样的办公产品有没有推广机会');
+        expect(result).toBeNull();
+      });
+
+      // 管理词不在渠道词窗口内 - 不应拦截
+      it('should return null for "飞书这样的产品有没有推广机会，另外我们配置 sudorouter"', () => {
+        const result = detectChannelQueryIntent('飞书这样的产品有没有推广机会，另外我们配置 sudorouter');
+        expect(result).toBeNull();
+      });
+
+      // 只有泛查询词但没有渠道管理语义 - 不应拦截
+      it('should return null for "飞书有没有"', () => {
+        const result = detectChannelQueryIntent('飞书有没有');
+        expect(result).toBeNull();
+      });
+
+      // 渠道词 + 泛查询词 + 渠道管理关键词 - 应该拦截
+      it('should detect "飞书有没有配置"', () => {
+        const result = detectChannelQueryIntent('飞书有没有配置');
+        expect(result).toEqual({ kind: 'query', channelType: 'lark' });
+      });
+
+      it('should detect "钉钉有没有开通"', () => {
+        const result = detectChannelQueryIntent('钉钉有没有开通');
+        expect(result).toEqual({ kind: 'query', channelType: 'dingtalk' });
+      });
+
+      it('should detect "微信连接是否正常"', () => {
+        const result = detectChannelQueryIntent('微信连接是否正常');
+        expect(result).toEqual({ kind: 'query', channelType: 'wechat' });
+      });
+
+      // 多渠道比较 + 泛查询词 + 渠道管理关键词 - 不应拦截（多渠道比较）
+      it('should return null for "飞书和钉钉的配置情况"', () => {
+        const result = detectChannelQueryIntent('飞书和钉钉的配置情况');
+        expect(result).toBeNull();
+      });
+
+      // 明确的列表查询 - 应该返回 list
+      it('should detect "飞书和钉钉所有渠道信息"', () => {
+        const result = detectChannelQueryIntent('飞书和钉钉所有渠道信息');
+        expect(result).toEqual({ kind: 'list' });
+      });
+    });
+
     describe('不匹配场景', () => {
       it('should return null for "[CHANNEL_INFO]" command format', () => {
         const result = detectChannelQueryIntent('[CHANNEL_INFO]');


### PR DESCRIPTION
## Summary

- **拆分关键词检测逻辑**：将 `QUERY_INDICATORS` 拆分为 `CHANNEL_MANAGEMENT_KEYWORDS`（渠道管理语义词）和 `GENERIC_QUERY_WORDS`（泛查询词）
- **新增窗口检测**：管理词必须在渠道词前后 16 字符内，避免 "飞书这样的产品有没有推广机会，另外我们配置 sudorouter" 误判
- **多渠道词匹配优化**：一句话出现多个不同渠道词时返回 `null`，避免竞品比较场景误拦截
- **修复重复 emit**：`handleChannelQueryIntent` 中删除重复的 `conversation.responseStream.emit`，因为 `acpConversation.responseStream` 已是其别名

## Test plan

- [x] 原始长句商业讨论不拦截
- [x] 多渠道竞品比较不拦截
- [x] 单渠道商业讨论无管理词窗口内不拦截
- [x] 管理词不在渠道词窗口内不拦截
- [x] 泛查询词+管理词组合在窗口内正常拦截
- [x] 37 个单测全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)