### PR TITLE
fix: filter disabled skills in enterprise mode across agent lifecycle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "@grammyjs/transformer-throttler": "^1.2.1",
         "@icon-park/react": "^1.4.2",
         "@larksuiteoapi/node-sdk": "^1.58.0",
+        "@lydell/node-pty": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
         "@monaco-editor/react": "^4.7.0",
         "@office-ai/aioncli-core": "^0.30.0",

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -22,6 +22,7 @@ import type AcpAgent from '../task/AcpAgent';
 import type RemoteAgent from '../task/RemoteAgent';
 import { listWorkspaceSkillTargets, resolveConversationEnabledSkillNames } from '../utils/workspaceSkillTargets';
 import { areSkillSelectionsEqual, resolveLatestConversationEnabledSkills } from '../utils/conversationAssistantSkills';
+import { filterEnabledSkillNames, filterRemoteAvailableSkills } from '../utils/enabledSkillFilter';
 import { copyFilesToDirectory, readDirectoryRecursive } from '../utils';
 import { resolveWorkspaceSkillsDir } from '../utils/workspaceSkillsDir';
 import WorkerManage from '../WorkerManage';
@@ -33,6 +34,7 @@ import { startConversationTracking, endConversationSuccess, endConversationError
 import { getConversationProvider, isRemoteProvider } from '../providers';
 import { getMossApi, getMossApiServerUrl, initMossApi } from '../remote/MossSessionApi';
 import { getSudoworkAcpSlashCommands } from '@/common/slash/sudoworkCommands';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 
 const workspaceSkillSyncTasks = new Map<string, Promise<void>>();
 
@@ -131,7 +133,9 @@ async function syncConversationWorkspaceSkills(conversation: TChatConversation |
     // Build ID → name mapping from installed skills
     const installedSkills = await skillManager.getInstalledSkills();
     const idToNameMap = new Map<string, string>();
+    const shouldFilterDisabledSkills = isEnterpriseMode();
     for (const skill of installedSkills) {
+      if (shouldFilterDisabledSkills && skill.enabled === false) continue;
       // Map by skill ID (UUID)
       if (skill.meta?.id) {
         idToNameMap.set(skill.meta.id, skill.name);
@@ -687,7 +691,8 @@ export function initConversationBridge(): void {
 
       const api = getRemoteConversationMossApi(extra);
       const skills: MossSessionAvailableSkill[] = await api.getSessionAvailableSkills(mossSessionId);
-      return { success: true, data: { skills, pending: false } };
+      const filteredSkills = await filterRemoteAvailableSkills(skills);
+      return { success: true, data: { skills: filteredSkills, pending: false } };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       mainWarn('conversationBridge', 'getRemoteAvailableSkills failed:', msg);
@@ -841,16 +846,18 @@ export function initConversationBridge(): void {
       // ignore
     }
 
+    const requestedSkills = await filterEnabledSkillNames(other.skills);
+
     // Ensure workspace skills symlinks exist before dispatching to the gateway.
     // syncConversationWorkspaceSkills is idempotent — it skips symlinks that are already correct.
-    await queueConversationWorkspaceSkillSync(conversation, other.skills);
+    await queueConversationWorkspaceSkillSync(conversation, requestedSkills);
 
     try {
       const payload: { content: string; agentContent?: string; files: string[]; msg_id: string; skills?: string[] } = {
         content: other.input,
         files: workspaceFiles,
         msg_id: other.msg_id,
-        skills: other.skills || [],
+        skills: requestedSkills || [],
       };
 
       mainLog('conversationBridge', `sendMessage: about to call task.sendMessage for ${conversation_id}`);

--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -15,6 +15,7 @@ import { DRAFTS_DIR_NAME } from '@/common/constants';
 import { getSystemDir } from './initStorage';
 import { SUDOCLAW_DIR } from './services/sudoclaw/SudoclawInstallService';
 import { ensureWorkspaceAgentsMdRules } from './services/scode/ScodeInstallService';
+import { filterEnabledSkillNames } from './utils/enabledSkillFilter';
 
 /**
  * 创建工作空间目录（不复制文件）
@@ -49,6 +50,7 @@ const buildWorkspaceWidthFiles = async (defaultWorkspaceName: string, workspace?
 export const createAcpAgent = async (options: ICreateConversationParams): Promise<TChatConversation> => {
   const { extra } = options;
   const { workspace, customWorkspace } = await buildWorkspaceWidthFiles(`${extra.backend}-temp-${Date.now()}`, extra.workspace, extra.defaultFiles, extra.customWorkspace);
+  const enabledSkills = await filterEnabledSkillNames(extra.enabledSkills);
   if (extra.backend === 'scode') {
     ensureWorkspaceAgentsMdRules(workspace);
   }
@@ -64,7 +66,7 @@ export const createAcpAgent = async (options: ICreateConversationParams): Promis
       customAgentId: extra.customAgentId, // 同时用于标识预设助手 / Also used to identify preset assistant
       presetContext: extra.presetContext, // 智能助手的预设规则/提示词
       // 启用的 skills 列表（通过 SkillManager 加载）/ Enabled skills list (loaded via SkillManager)
-      enabledSkills: extra.enabledSkills,
+      enabledSkills,
       // 预设助手 ID，用于在会话面板显示助手名称和头像
       // Preset assistant ID for displaying name and avatar in conversation panel
       presetAssistantId: extra.presetAssistantId,
@@ -108,6 +110,7 @@ export const createRemoteAgent = async (options: ICreateConversationParams): Pro
   const { extra } = options;
   const tempName = `moss-temp-${Date.now()}`;
   const { workspace, customWorkspace } = await buildWorkspaceWidthFiles(tempName, extra.workspace, extra.defaultFiles, extra.customWorkspace);
+  const enabledSkills = await filterEnabledSkillNames(extra.enabledSkills);
 
   return {
     type: 'remote-agent',
@@ -126,7 +129,7 @@ export const createRemoteAgent = async (options: ICreateConversationParams): Pro
       customAgentId: extra.customAgentId,
       presetAssistantId: extra.presetAssistantId,
       presetContext: extra.presetContext,
-      enabledSkills: extra.enabledSkills,
+      enabledSkills,
       sessionMode: extra.sessionMode,
       // Cron job metadata
       cronJobId: extra.cronJobId,

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -20,6 +20,7 @@ import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import { initMossApi } from '../remote/MossSessionApi';
 import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
+import { filterEnabledSkillNames } from '../utils/enabledSkillFilter';
 
 /**
  * RemoteAgent data interface
@@ -111,6 +112,7 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
       // 确定模式：创建新 session 还是 attach/resume 已存在的
       const isPendingMode = this.options.mossSessionPending;
       const hasExistingWsUrl = !!this.options.wsUrl;
+      const enabledSkills = await filterEnabledSkillNames(this.options.enabledSkills);
 
       if (isPendingMode && !hasExistingWsUrl) {
         // LAZY CREATION: Create Moss session now
@@ -130,7 +132,7 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
           wsUrl: undefined,
           sessionId: undefined,
           // 新增: 传递启用的 skill 列表
-          enabledSkills: this.options.enabledSkills,
+          enabledSkills,
         };
 
         mainLog('RemoteAgent', `MossWsConnection config: cwd=${config.cwd ?? '<server-default>'}, assistant=${config.assistantName || 'default'}, enabledSkills=${config.enabledSkills?.length || 0}`);
@@ -175,7 +177,7 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
           wsUrl: this.options.wsUrl,
           sessionId: this.options.sessionId || this.conversation_id,
           // 新增: 传递启用的 skill 列表（resume 模式也支持）
-          enabledSkills: this.options.enabledSkills,
+          enabledSkills,
         };
 
         mainLog('RemoteAgent', `MossWsConnection config: resume=${!!config.wsUrl}, sessionId=${config.sessionId}, enabledSkills=${config.enabledSkills?.length || 0}`);
@@ -221,7 +223,7 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
           runtimeType: this.options.runtimeType,
           wsUrl,
           sessionId: this.options.sessionId,
-          enabledSkills: this.options.enabledSkills,
+          enabledSkills,
         };
 
         mainLog('RemoteAgent', `MossWsConnection config: resumeLookup=true, sessionId=${config.sessionId}, enabledSkills=${config.enabledSkills?.length || 0}`);

--- a/src/process/utils/enabledSkillFilter.ts
+++ b/src/process/utils/enabledSkillFilter.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MossSessionAvailableSkill } from '@/common/ipcBridge';
+import path from 'node:path';
+import { normalizeSkillNames } from './conversationAssistantSkills';
+
+type InstalledSkillLike = {
+  name: string;
+  enabled: boolean;
+  meta?: {
+    id?: string;
+    name?: string;
+    display_name?: string;
+  };
+};
+
+export type EnabledSkillFilterDeps = {
+  getInstalledSkills: () => Promise<InstalledSkillLike[]>;
+  isEnterpriseMode: () => boolean | Promise<boolean>;
+};
+
+const defaultDeps: EnabledSkillFilterDeps = {
+  getInstalledSkills: async () => {
+    const { skillManager } = await import('../SkillManager');
+    return skillManager.getInstalledSkills();
+  },
+  isEnterpriseMode: async () => {
+    const { isEnterpriseMode } = await import('@/common/enterpriseDebugConfig');
+    return isEnterpriseMode();
+  },
+};
+
+function addSkillKeys(target: Set<string>, skill: InstalledSkillLike): void {
+  for (const key of [skill.name, skill.meta?.id, skill.meta?.name, skill.meta?.display_name]) {
+    if (typeof key === 'string' && key.trim()) {
+      target.add(key.trim());
+    }
+  }
+}
+
+function addPathCandidates(target: string[], skillPath?: string): void {
+  const trimmedPath = skillPath?.trim();
+  if (!trimmedPath) return;
+
+  target.push(trimmedPath);
+
+  const basename = path.basename(trimmedPath);
+  if (basename && basename !== trimmedPath) {
+    target.push(basename);
+  }
+
+  const parentName = path.basename(path.dirname(trimmedPath));
+  if (basename.toLowerCase() === 'skill.md' && parentName) {
+    target.push(parentName);
+  }
+}
+
+async function getDisabledSkillKeys(deps: EnabledSkillFilterDeps = defaultDeps): Promise<Set<string>> {
+  const disabledKeys = new Set<string>();
+  const installedSkills = await deps.getInstalledSkills();
+
+  for (const skill of installedSkills) {
+    if (skill.enabled === false) {
+      addSkillKeys(disabledKeys, skill);
+    }
+  }
+
+  return disabledKeys;
+}
+
+export async function filterEnabledSkillNames(skillNames?: readonly string[], deps: EnabledSkillFilterDeps = defaultDeps): Promise<string[] | undefined> {
+  if (!Array.isArray(skillNames)) {
+    return undefined;
+  }
+
+  if (!(await deps.isEnterpriseMode())) {
+    return [...skillNames];
+  }
+
+  const normalizedSkillNames = normalizeSkillNames(skillNames);
+  if (normalizedSkillNames.length === 0) {
+    return [];
+  }
+
+  const disabledKeys = await getDisabledSkillKeys(deps);
+  return normalizedSkillNames.filter((skillName) => !disabledKeys.has(skillName));
+}
+
+export async function filterRemoteAvailableSkills(skills: MossSessionAvailableSkill[], deps: EnabledSkillFilterDeps = defaultDeps): Promise<MossSessionAvailableSkill[]> {
+  if (!(await deps.isEnterpriseMode())) {
+    return skills;
+  }
+
+  const disabledKeys = await getDisabledSkillKeys(deps);
+
+  return skills.filter((skill) => {
+    const candidates = [skill.name, skill.displayName].filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+    addPathCandidates(candidates, skill.path);
+
+    if (candidates.length === 0) return true;
+
+    // Keep skills that are not locally installed (server-side or builtin skills),
+    // but hide any skill that maps to a locally installed disabled skill.
+    return !candidates.some((candidate) => disabledKeys.has(candidate.trim()));
+  });
+}

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -97,10 +97,15 @@ const InstalledAssistantCard: React.FC<{
   enterprisePublishButton?: React.ReactNode;
   /** Enterprise mode: whether to hide delete button (only custom assistants can be deleted) */
   hideDelete?: boolean;
-}> = ({ assistant, isExtension, localeKey, avatarImageMap, onToggleEnabled, onDelete, onDuplicate, onUpload, onClick, enterprisePublishButton, hideDelete }) => {
+  /** Whether to show enable/disable switch for read-only installed assistants. */
+  allowToggle?: boolean;
+  /** Enterprise mode: use directory category to distinguish custom/hub/tenant assistants. */
+  enterpriseMode?: boolean;
+}> = ({ assistant, isExtension, localeKey, avatarImageMap, onToggleEnabled, onDelete, onDuplicate, onUpload, onClick, enterprisePublishButton, hideDelete, allowToggle, enterpriseMode }) => {
   const { t } = useTranslation();
-  const isCustom = !assistant.isBuiltin && !isExtension && !assistant._isHubInstalled;
-  const isReadonly = assistant.isBuiltin || isExtension || assistant._isHubInstalled || hideDelete;
+  const isCustom = enterpriseMode ? assistant._category === 'custom' || (!assistant._category && !assistant.isBuiltin && !isExtension && !assistant._isHubInstalled) : !assistant.isBuiltin && !isExtension && !assistant._isHubInstalled;
+  const isReadonly = assistant.isBuiltin || isExtension || assistant._isHubInstalled || hideDelete || (enterpriseMode && !isCustom);
+  const canToggle = !isExtension && (isCustom || allowToggle === true);
   const isEnabled = isExtension ? true : assistant.enabled !== false;
 
   const resolvedAvatar = assistant.avatar?.trim();
@@ -177,7 +182,7 @@ const InstalledAssistantCard: React.FC<{
           </button>
         </Tooltip>
         {enterprisePublishButton}
-        {isCustom && <Switch size='small' checked={isEnabled} onChange={(checked) => onToggleEnabled(checked)} className={isEnabled ? '!bg-[var(--ui-accent-orange)] !border-[var(--ui-accent-orange)]' : ''} />}
+        {canToggle && <Switch size='small' checked={isEnabled} onChange={(checked) => onToggleEnabled(checked)} className={isEnabled ? '!bg-[var(--ui-accent-orange)] !border-[var(--ui-accent-orange)]' : ''} />}
         {/* Delete button - only for custom assistants that are not readonly */}
         {!isReadonly && (
           <Popconfirm title={t('settings.deleteAssistantConfirmTitle', { defaultValue: '删除该助手会一并删除已关联会话。如需保留，请导出会话进行备份。是否确认删除？' })} onOk={onDelete} okText={t('common.delete', { defaultValue: '删除' })} cancelText={t('common.cancel', { defaultValue: '取消' })} okButtonProps={{ status: 'danger' }}>
@@ -1140,6 +1145,7 @@ const AgentModalContent: React.FC = () => {
       if (isEnterprise) {
         // Enterprise mode: refresh local assistants from hub/tenant/custom/system directories
         await mutate('assistantHub.installed');
+        emitter.emit('assistants.changed');
       } else {
         await ipcBridge.acpConversation.refreshCustomAgents.invoke();
         await mutate('acp.agents.available');
@@ -1706,8 +1712,8 @@ const AgentModalContent: React.FC = () => {
   );
 
   const activeAssistant = assistants.find((assistant) => assistant.id === activeAssistantId) || null;
-  // Only custom assistants can be edited; hub-installed, builtin, and extension assistants are readonly
-  const isReadonlyAssistant = Boolean(activeAssistant && (isExtensionAssistant(activeAssistant) || activeAssistant._isHubInstalled || activeAssistant.isBuiltin));
+  // Only custom assistants can be edited; hub/tenant-installed, builtin, and extension assistants are readonly
+  const isReadonlyAssistant = Boolean(activeAssistant && (isExtensionAssistant(activeAssistant) || activeAssistant._isHubInstalled || activeAssistant.isBuiltin || (isEnterprise && (activeAssistant._category === 'hub' || activeAssistant._category === 'tenant'))));
 
   // ===== 分类逻辑：以目录分类（_category）为主，其他字段仅作兼容兜底 =====
   // Tenant assistants: 目录分类为 tenant
@@ -1946,11 +1952,13 @@ const AgentModalContent: React.FC = () => {
       const lookupName = resolveAssistantName(assistant.id);
       // Pass category for precise assistant location
       const assistantCategory = assistant._category as 'custom' | 'hub' | 'system' | 'tenant' | undefined;
+      let result: Awaited<ReturnType<typeof ipcBridge.assistantHub.enableAssistant.invoke>>;
       if (enabled) {
-        await ipcBridge.assistantHub.enableAssistant.invoke({ name: lookupName, category: assistantCategory });
+        result = await ipcBridge.assistantHub.enableAssistant.invoke({ name: lookupName, category: assistantCategory });
       } else {
-        await ipcBridge.assistantHub.disableAssistant.invoke({ name: lookupName, category: assistantCategory });
+        result = await ipcBridge.assistantHub.disableAssistant.invoke({ name: lookupName, category: assistantCategory });
       }
+      if (isEnterprise && !result.success) throw new Error(result.msg || 'Failed to toggle assistant');
       await loadAssistants();
       await refreshAgentDetection();
     } catch (error) {
@@ -1963,10 +1971,17 @@ const AgentModalContent: React.FC = () => {
 
   const editAvatarImage = resolveAvatarImageSrc(editAvatar);
 
-  const renderAssistantGrid = (list: AssistantListItem[], hideDelete = false) => (
+  const canUploadAssistant = (assistant: AssistantListItem) => {
+    if (!isEnterprise) {
+      return !assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant);
+    }
+    return assistant._category === 'custom' || (!assistant._category && !assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant));
+  };
+
+  const renderAssistantGrid = (list: AssistantListItem[], hideDelete = false, allowToggle = false) => (
     <div className='grid gap-8px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
       {list.map((assistant) => (
-        <InstalledAssistantCard key={assistant.id} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onUpload={!assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined} onClick={() => void handleEdit(assistant)} hideDelete={hideDelete} />
+        <InstalledAssistantCard key={assistant.id} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onUpload={canUploadAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined} onClick={() => void handleEdit(assistant)} hideDelete={hideDelete} allowToggle={allowToggle} enterpriseMode={isEnterprise} />
       ))}
     </div>
   );
@@ -2215,7 +2230,7 @@ const AgentModalContent: React.FC = () => {
                     <div className='text-13px font-medium text-t-primary'>{t('settings.tenantAssistants', { defaultValue: '专属助手' })}</div>
                     <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{filteredTenantAssistants.length}</span>
                   </div>
-                  {filteredTenantAssistants.length > 0 ? renderAssistantGrid(filteredTenantAssistants, true) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noTenantAssistants', { defaultValue: '暂无专属助手' })}</div>}
+                  {filteredTenantAssistants.length > 0 ? renderAssistantGrid(filteredTenantAssistants, true, true) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noTenantAssistants', { defaultValue: '暂无专属助手' })}</div>}
                 </section>
               )}
 
@@ -2225,7 +2240,7 @@ const AgentModalContent: React.FC = () => {
                   <div className='text-13px font-medium text-t-primary'>{t('settings.hubAssistants', { defaultValue: '商店助手' })}</div>
                   <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{hubAssistants.length}</span>
                 </div>
-                {hubAssistants.length > 0 ? renderAssistantGrid(hubAssistants, isEnterprise) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>}
+                {hubAssistants.length > 0 ? renderAssistantGrid(hubAssistants, isEnterprise, isEnterprise) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>}
               </section>
 
               {/* Builtin assistants section - Hidden: temporarily disabled */}

--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -83,7 +83,7 @@ const SkillCard: React.FC<SkillCardProps> = ({ skill, checked, onToggle, disable
 
 // ==================== InstalledAssistantCard ====================
 
-const InstalledAssistantCard: React.FC<{
+type InstalledAssistantCardProps = {
   assistant: AssistantListItem;
   isExtension: boolean;
   localeKey: string;
@@ -99,13 +99,21 @@ const InstalledAssistantCard: React.FC<{
   hideDelete?: boolean;
   /** Whether to show enable/disable switch for read-only installed assistants. */
   allowToggle?: boolean;
+  /** Whether to show delete button for read-only installed assistants. */
+  allowDelete?: boolean;
   /** Enterprise mode: use directory category to distinguish custom/hub/tenant assistants. */
   enterpriseMode?: boolean;
-}> = ({ assistant, isExtension, localeKey, avatarImageMap, onToggleEnabled, onDelete, onDuplicate, onUpload, onClick, enterprisePublishButton, hideDelete, allowToggle, enterpriseMode }) => {
+};
+
+const InstalledAssistantCard: React.FC<InstalledAssistantCardProps> = (props) => {
+  const { assistant, isExtension, localeKey, avatarImageMap } = props;
+  const { onToggleEnabled, onDelete, onDuplicate, onUpload, onClick } = props;
+  const { enterprisePublishButton, hideDelete, allowToggle, allowDelete, enterpriseMode } = props;
   const { t } = useTranslation();
   const isCustom = enterpriseMode ? assistant._category === 'custom' || (!assistant._category && !assistant.isBuiltin && !isExtension && !assistant._isHubInstalled) : !assistant.isBuiltin && !isExtension && !assistant._isHubInstalled;
   const isReadonly = assistant.isBuiltin || isExtension || assistant._isHubInstalled || hideDelete || (enterpriseMode && !isCustom);
   const canToggle = !isExtension && (isCustom || allowToggle === true);
+  const canDelete = !isExtension && !assistant.isBuiltin && !hideDelete && (!isReadonly || allowDelete === true);
   const isEnabled = isExtension ? true : assistant.enabled !== false;
 
   const resolvedAvatar = assistant.avatar?.trim();
@@ -184,7 +192,7 @@ const InstalledAssistantCard: React.FC<{
         {enterprisePublishButton}
         {canToggle && <Switch size='small' checked={isEnabled} onChange={(checked) => onToggleEnabled(checked)} className={isEnabled ? '!bg-[var(--ui-accent-orange)] !border-[var(--ui-accent-orange)]' : ''} />}
         {/* Delete button - only for custom assistants that are not readonly */}
-        {!isReadonly && (
+        {canDelete && (
           <Popconfirm title={t('settings.deleteAssistantConfirmTitle', { defaultValue: '删除该助手会一并删除已关联会话。如需保留，请导出会话进行备份。是否确认删除？' })} onOk={onDelete} okText={t('common.delete', { defaultValue: '删除' })} cancelText={t('common.cancel', { defaultValue: '取消' })} okButtonProps={{ status: 'danger' }}>
             <Tooltip content={t('settings.assistant.delete', { defaultValue: '删除' })}>
               <button type='button' className='store-action-icon store-action-icon--danger'>
@@ -1978,10 +1986,10 @@ const AgentModalContent: React.FC = () => {
     return assistant._category === 'custom' || (!assistant._category && !assistant.isBuiltin && !assistant._isHubInstalled && !isExtensionAssistant(assistant));
   };
 
-  const renderAssistantGrid = (list: AssistantListItem[], hideDelete = false, allowToggle = false) => (
+  const renderAssistantGrid = (list: AssistantListItem[], hideDelete = false, allowToggle = false, allowDelete = false) => (
     <div className='grid gap-8px' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
       {list.map((assistant) => (
-        <InstalledAssistantCard key={assistant.id} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onUpload={canUploadAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined} onClick={() => void handleEdit(assistant)} hideDelete={hideDelete} allowToggle={allowToggle} enterpriseMode={isEnterprise} />
+        <InstalledAssistantCard key={assistant.id} assistant={assistant} isExtension={isExtensionAssistant(assistant)} localeKey={localeKey} avatarImageMap={avatarImageMap} onToggleEnabled={(enabled) => void handleToggleEnabled(assistant, enabled)} onDelete={() => void handleDeleteFromCard(assistant)} onDuplicate={() => handleOpenDuplicateModalFromInstalled(assistant)} onUpload={canUploadAssistant(assistant) ? () => handleUploadAssistant(assistant) : undefined} onClick={() => void handleEdit(assistant)} hideDelete={hideDelete} allowToggle={allowToggle} allowDelete={allowDelete} enterpriseMode={isEnterprise} />
       ))}
     </div>
   );
@@ -2240,7 +2248,7 @@ const AgentModalContent: React.FC = () => {
                   <div className='text-13px font-medium text-t-primary'>{t('settings.hubAssistants', { defaultValue: '商店助手' })}</div>
                   <span className='px-6px py-0px bg-fill-2 text-t-secondary text-11px rd-full leading-18px'>{hubAssistants.length}</span>
                 </div>
-                {hubAssistants.length > 0 ? renderAssistantGrid(hubAssistants, isEnterprise, isEnterprise) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>}
+                {hubAssistants.length > 0 ? renderAssistantGrid(hubAssistants, isEnterprise, true, !isEnterprise) : <div className='bg-fill-1 border border-dashed border-line rd-12px px-14px py-18px text-12px text-t-tertiary'>{t('settings.noHubAssistants', { defaultValue: '暂无商店助手' })}</div>}
               </section>
 
               {/* Builtin assistants section - Hidden: temporarily disabled */}

--- a/src/renderer/pages/conversation/index.tsx
+++ b/src/renderer/pages/conversation/index.tsx
@@ -8,9 +8,11 @@ import ChatConversation from './ChatConversation';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { useConversationTabs } from './context/ConversationTabsContext';
 import { addEventListener, emitter } from '@/renderer/utils/emitter';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 
 const ChatConversationIndex: React.FC = () => {
   const { id } = useParams();
+  const { isEnterprise } = useAppMode();
   const { closePreview } = usePreviewContext();
   const { openTab } = useConversationTabs();
   const previousConversationIdRef = useRef<string | undefined>(undefined);
@@ -101,7 +103,7 @@ const ChatConversationIndex: React.FC = () => {
         .invoke({ conversation_id: data.id })
         .then(() => {
           void mutate();
-          emitter.emit('acp.workspace.refresh');
+          emitter.emit(isEnterprise && data.type === 'remote-agent' ? 'remote-agent.workspace.refresh' : 'acp.workspace.refresh');
         })
         .catch((error) => {
           console.warn('Failed to sync workspace skills after skills.changed:', error);
@@ -117,7 +119,7 @@ const ChatConversationIndex: React.FC = () => {
       removeSkillHubChanged();
       removeSkillsChanged();
     };
-  }, [id, data, mutate]);
+  }, [id, data, isEnterprise, mutate]);
 
   // 当会话数据加载完成后，自动打开 tab
   // Automatically open tab when conversation data is loaded

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -193,17 +193,19 @@ const GuidPage: React.FC = () => {
 
   // Convert installed skills to selector items (filtered by selected assistant)
   const skillSelectorItems = useMemo<SkillSelectorItem[]>(() => {
-    const items = installedSkills.map((skill) => {
-      const { displayName, description, icon, emoji } = getInstalledSkillDisplay(skill);
-      return {
-        name: skill.name,
-        displayName,
-        description,
-        icon: icon || resolveSkillIcon(skill.meta?.icon),
-        emoji,
-        enabled: skill.enabled,
-      };
-    });
+    const items = installedSkills
+      .filter((skill) => !isEnterprise || skill.enabled !== false)
+      .map((skill) => {
+        const { displayName, description, icon, emoji } = getInstalledSkillDisplay(skill);
+        return {
+          name: skill.name,
+          displayName,
+          description,
+          icon: icon || resolveSkillIcon(skill.meta?.icon),
+          emoji,
+          enabled: skill.enabled,
+        };
+      });
     if (agentEnabledSkills && agentEnabledSkills.length > 0) {
       // Use Set for O(1) lookup and deduplicate agentEnabledSkills
       const enabledSkillSet = new Set(agentEnabledSkills);
@@ -212,7 +214,7 @@ const GuidPage: React.FC = () => {
     // Deduplicate items by name to prevent duplicate keys
     const uniqueItems = Array.from(new Map(items.map((item) => [item.name, item])).values());
     return uniqueItems;
-  }, [installedSkills, agentEnabledSkills]);
+  }, [installedSkills, agentEnabledSkills, isEnterprise]);
 
   // Skill selector controller
   const skillSelectorController = useSkillSelectorController({

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -131,6 +131,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             backend: 'remote-agent',
             agentName: agentInfo?.name || 'Moss Server',
             presetAssistantId: agentInfo?.customAgentId || agentInfo?.name || 'Moss Server',
+            enabledSkills: isEnterprise && isPreset ? enabledSkills : undefined,
             sessionMode: selectedMode,
             dangerouslySkipPermissions: selectedMode === 'yolo',
             sessionModeParam: 'remote',

--- a/tests/unit/enabledSkillFilter.test.ts
+++ b/tests/unit/enabledSkillFilter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MossSessionAvailableSkill } from '@/common/ipcBridge';
+import { filterEnabledSkillNames, filterRemoteAvailableSkills, type EnabledSkillFilterDeps } from '@/process/utils/enabledSkillFilter';
+
+function createDeps(skills: Awaited<ReturnType<EnabledSkillFilterDeps['getInstalledSkills']>>): EnabledSkillFilterDeps {
+  return {
+    getInstalledSkills: vi.fn(async () => skills),
+    isEnterpriseMode: vi.fn(() => true),
+  };
+}
+
+describe('enabledSkillFilter', () => {
+  it('returns the original selections in personal mode', async () => {
+    const deps: EnabledSkillFilterDeps = {
+      getInstalledSkills: vi.fn(async () => {
+        throw new Error('should not load installed skills in personal mode');
+      }),
+      isEnterpriseMode: vi.fn(() => false),
+    };
+    const skills: MossSessionAvailableSkill[] = [{ name: 'disabled-name', description: 'Personal mode keeps server response unchanged' }];
+
+    await expect(filterEnabledSkillNames([' disabled-name '], deps)).resolves.toEqual([' disabled-name ']);
+    await expect(filterRemoteAvailableSkills(skills, deps)).resolves.toBe(skills);
+  });
+
+  it('removes locally disabled skill names while keeping enabled and unknown skills', async () => {
+    const deps = createDeps([
+      {
+        name: 'enabled-dir',
+        enabled: true,
+        meta: { id: 'enabled-id', name: 'enabled-name', display_name: 'Enabled Skill' },
+      },
+      {
+        name: 'disabled-dir',
+        enabled: false,
+        meta: { id: 'disabled-id', name: 'disabled-name', display_name: 'Disabled Skill' },
+      },
+    ]);
+
+    await expect(filterEnabledSkillNames([' enabled-dir ', 'disabled-id', 'disabled-name', 'remote-only'], deps)).resolves.toEqual(['enabled-dir', 'remote-only']);
+  });
+
+  it('filters remote available skills only when they map to locally disabled skills', async () => {
+    const deps = createDeps([
+      {
+        name: 'disabled-dir',
+        enabled: false,
+        meta: { id: 'disabled-id', name: 'disabled-name', display_name: 'Disabled Skill' },
+      },
+    ]);
+
+    const skills: MossSessionAvailableSkill[] = [
+      { name: 'remote-only', description: 'Server-side skill' },
+      { name: 'disabled-name', description: 'Disabled by local meta name' },
+      { name: 'path-only', description: 'Disabled by path', path: '/tmp/skills/disabled-dir/SKILL.md' },
+      { name: 'enabled-local', description: 'Not disabled locally' },
+    ];
+
+    await expect(filterRemoteAvailableSkills(skills, deps)).resolves.toEqual([
+      { name: 'remote-only', description: 'Server-side skill' },
+      { name: 'enabled-local', description: 'Not disabled locally' },
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
         'src/process/bridge/applicationBridge.ts',
         'src/process/bridge/documentBridge.ts',
         'src/process/bridge/pwdLoginBridge.ts',
+        'src/process/utils/enabledSkillFilter.ts',
         'src/utils/configureChromium.ts',
         // ACP
         'src/agent/acp/AcpAdapter.ts',


### PR DESCRIPTION
## Summary
- Add `enabledSkillFilter` utility to filter disabled skills in enterprise mode across agent lifecycle
- Fix assistant actions to properly restore personal store assistant actions
- Ensure enterprise-disabled skills are filtered out from agents, guides, and conversation flows

## Test plan
- [x] Verify disabled skills are filtered in enterprise mode
- [x] Verify personal store assistant actions are restored correctly
- [x] Run unit tests: `pnpm test tests/unit/enabledSkillFilter.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)