### PR TITLE
fix: correct gRPC port + nexus HTTP cleanup

### DIFF
--- a/docs/tech/nexus-integration-architecture.md
+++ b/docs/tech/nexus-integration-architecture.md
@@ -21,7 +21,7 @@ Cross-references:
 │   chat UI, audit viewer,           starts nexusd, manages sessions  │
 │   messenger UI                     via gRPC                          │
 └───────────────────────────────────────┬─────────────────────────────┘
-                                        │ gRPC (localhost:2028)
+                                        │ gRPC (localhost:12022)
                                         ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │              nexusd + sudo-code  (single process, always-on)         │

--- a/native/nexus-napi/index.d.ts
+++ b/native/nexus-napi/index.d.ts
@@ -9,7 +9,7 @@
 export declare class NexusGrpcClient {
   /**
    * Create a new gRPC client targeting the given endpoint
-   * (e.g. "http://localhost:2028").
+   * (e.g. "http://localhost:12022").
    * The TCP connection is lazy — established on first RPC call.
    */
   constructor(endpoint: string)

--- a/native/nexus-napi/src/lib.rs
+++ b/native/nexus-napi/src/lib.rs
@@ -15,7 +15,7 @@ pub struct NexusGrpcClient {
 #[napi]
 impl NexusGrpcClient {
     /// Create a new gRPC client targeting the given endpoint
-    /// (e.g. "http://localhost:2028").
+    /// (e.g. "http://localhost:12022").
     /// The TCP connection is lazy — established on first RPC call.
     #[napi(constructor)]
     pub fn new(endpoint: String) -> Result<Self> {

--- a/src/common/nexus/nexus-vfs-client.ts
+++ b/src/common/nexus/nexus-vfs-client.ts
@@ -7,16 +7,16 @@
 /**
  * Nexus RPC Client
  *
- * File I/O client backed by nexusd-cluster gRPC (port 2028).
+ * File I/O client backed by nexusd-cluster gRPC (port 12022).
  * Uses the nexus-napi native addon for typed Read/Write RPCs and
  * the generic Call RPC for stat/readdir/unlink/mkdir.
  *
- * Migrated from HTTP JSON-RPC (:12012) to gRPC (:2028) — all callers
+ * Migrated from HTTP JSON-RPC (:12012) to gRPC (:12022) — all callers
  * (safety hooks, etc.) keep the same public API.
  */
 
 export interface NexusRpcOptions {
-  /** gRPC endpoint (default: http://localhost:2028) */
+  /** gRPC endpoint (default: http://localhost:12022) */
   endpoint?: string;
   /** Auth token for gRPC calls */
   authToken?: string;
@@ -47,7 +47,7 @@ export class Nexus {
   private readonly authToken: string;
 
   constructor(options?: NexusRpcOptions) {
-    const endpoint = options?.endpoint ?? options?.serverUrl ?? 'http://localhost:2028';
+    const endpoint = options?.endpoint ?? options?.serverUrl ?? 'http://localhost:12022';
     this.authToken = options?.authToken ?? options?.apiKey ?? '';
     const { NexusGrpcClient } = loadNativeBinding();
     this.client = new NexusGrpcClient(endpoint);
@@ -224,7 +224,7 @@ let nexusInstance: Nexus | null = null;
 export function getNexusRpcClient(options?: NexusRpcOptions): Nexus {
   if (!nexusInstance) {
     nexusInstance = new Nexus({
-      endpoint: 'http://localhost:2028',
+      endpoint: 'http://localhost:12022',
       ...options,
     });
   }


### PR DESCRIPTION
## Summary
- Fix gRPC port bug: `nexus-vfs-client.ts` hardcoded port 2028, but `nexusd-cluster` binds on 12022 — broke all gRPC file I/O via `getNexusRpcClient()`
- Fix stale port in napi doc comments and integration architecture diagram

## HTTP cleanup status
`FetchClient` has **2 consumers** — cannot fully delete yet:
1. `SecretStoreClient` → being migrated to vault by parallel-2
2. `pwdLoginService.ts` → password login flow (still needed)

Secret-store HTTP deletion will be a follow-up after parallel-2 vault migration merges.

## Test plan
- [x] Grep confirms zero remaining `localhost:2028` references
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)