### PR TITLE
fix(file-intent): leave AI-auto intermediates in place, hide from UI surfaces

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -25,6 +25,7 @@ import { areSkillSelectionsEqual, resolveLatestConversationEnabledSkills } from 
 import { filterEnabledSkillNames, filterRemoteAvailableSkills } from '../utils/enabledSkillFilter';
 import { copyFilesToDirectory, readDirectoryRecursive } from '../utils';
 import { resolveWorkspaceSkillsDir } from '../utils/workspaceSkillsDir';
+import { INTERMEDIATE_DIR_SEGMENTS } from '../task/FileIntentClassifier';
 import WorkerManage from '../WorkerManage';
 import { migrateConversationToDatabase } from './migrationUtils';
 import { skillManager } from '../SkillManager';
@@ -614,13 +615,19 @@ export function initConversationBridge(): void {
   // to avoid stale results when the user navigates quickly.
   let lastGetWorkspaceAbortController: AbortController | undefined;
 
+  // Intermediate-directory ignore: paths whose path contains any segment in
+  // INTERMEDIATE_DIR_SEGMENTS (e.g. ppt_outputs/, _tmp/) are hidden from the
+  // workspace tree. Matches whole path segments only — `my_ppt_outputs.md`
+  // won't be hidden, but `ppt_outputs/p1.jpg` will.
+  const intermediateSegmentRe = new RegExp(`(^|[/\\\\])(${[...INTERMEDIATE_DIR_SEGMENTS].join('|')})([/\\\\]|$)`);
+
   ipcBridge.conversation.getWorkspace.provider(async ({ workspace, search, path }) => {
     // Abort any in-flight workspace read
     lastGetWorkspaceAbortController?.abort();
     lastGetWorkspaceAbortController = new AbortController();
 
     // Simple file filter that skips common non-essential directories
-    const fileService = { shouldIgnoreFile: (p: string) => p.includes('node_modules') || p.includes('.git') };
+    const fileService = { shouldIgnoreFile: (p: string) => p.includes('node_modules') || p.includes('.git') || intermediateSegmentRe.test(p) };
     try {
       return await readDirectoryRecursive(path, {
         root: workspace,

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -1770,6 +1770,7 @@ This identity statement takes priority over the default identity in USER.md.
       reason: classification.reason,
       source: input.source,
       kind: input.kind,
+      userInitiated: classification.userInitiated,
     });
     mainLog('[AcpAgent]', `[TRACK] File: ${trackingKey}, intent: ${classification.intent}, source: ${input.source}, reason: ${classification.reason}, actualPath: ${actualPath}`);
 

--- a/src/process/task/FileIntentClassifier.ts
+++ b/src/process/task/FileIntentClassifier.ts
@@ -43,7 +43,40 @@ export interface BashDraftRestoreDetection {
 
 const SCRIPT_EXTENSIONS = new Set(['.py', '.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.sh', '.bash', '.zsh', '.rb', '.php', '.lua']);
 const SCRIPT_SIDE_EFFECT_NAMES = new Set(['package.json', 'package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'requirements.txt']);
-const BASH_DELIVERABLE_EXTENSIONS = new Set(['.pdf', '.docx', '.pptx', '.xlsx', '.csv', '.json', '.md', '.markdown', '.txt', '.html', '.htm', '.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg']);
+// Office + text formats that are reasonable defaults to treat as deliverables
+// when an agent's bash script writes them. Images were intentionally removed
+// (see Anthropic-skills convention rules below): bash-written PNG / JPG /
+// SVG are usually intermediate slide frames / thumbnails / chart exports.
+// If the user explicitly asks for an image (caught by inferRequestedExtensions
+// earlier), the request matches and `final` is returned before this rule.
+const BASH_DELIVERABLE_EXTENSIONS = new Set(['.pdf', '.docx', '.pptx', '.xlsx', '.csv', '.json', '.md', '.markdown', '.txt', '.html', '.htm']);
+
+// Anthropic skills convention (mirrors `anthropics/skills/skills/pptx/SKILL.md`):
+// all generated files go to `outputs/<document-name>/`. The deliverable is
+// named `final.<ext>`; everything else in that directory is intermediate.
+// Recognized whenever the workspace-relative path matches one of these shapes.
+const ANTHROPIC_FINAL_OUTPUTS_RE = /^outputs\/[^/]+\/final\.[a-z0-9]+$/i;
+const ANTHROPIC_INSIDE_OUTPUTS_RE = /^outputs\/[^/]+\/.+/i;
+
+// Legacy sudowork-hub conventions used by skills that have not yet adopted
+// the Anthropic `outputs/<doc>/` pattern. A file whose FIRST relative-path
+// segment is in this set is treated as intermediate (draft). Lowercase keys.
+const INTERMEDIATE_DIR_SEGMENTS = new Set([
+  'ppt_outputs',
+  'pptx_outputs',
+  'docx_outputs',
+  'xlsx_outputs',
+  'pdf_outputs',
+  'slides_output',
+  'slide_images',
+  'intermediate',
+  '_intermediate',
+  '_tmp',
+  '_temp',
+  '_cache',
+  '_artifacts',
+  '_build',
+]);
 
 const TARGET_TYPE_EXTENSIONS: Array<{ pattern: RegExp; extensions: string[] }> = [
   { pattern: /\b(pdf|PDF)\b|文档.*pdf|pdf.*文档/i, extensions: ['.pdf'] },
@@ -235,6 +268,24 @@ export class FileIntentClassifier {
     const requestedExtensions = inferRequestedExtensions(userMessage);
     if (requestedExtensions.has(ext)) {
       return { intent: 'final', reason: `Matches requested target type ${ext}`, matched: ext };
+    }
+
+    // Directory-structure rules. Run AFTER the user-driven explicit signals
+    // above (so a user request for a specific file by name still wins) and
+    // BEFORE generic heuristics (so a file in a known intermediate dir is
+    // not accidentally promoted by extension fallbacks).
+    const relativeKey = normalizePathForMatch(input.requestedPath || input.filePath);
+    if (relativeKey) {
+      if (ANTHROPIC_FINAL_OUTPUTS_RE.test(relativeKey)) {
+        return { intent: 'final', reason: 'Anthropic outputs/<doc>/final.<ext> convention', matched: relativeKey };
+      }
+      if (ANTHROPIC_INSIDE_OUTPUTS_RE.test(relativeKey)) {
+        return { intent: 'draft', reason: 'Intermediate file inside Anthropic outputs/<doc>/ tree', matched: relativeKey };
+      }
+      const firstSegment = relativeKey.split('/')[0] || '';
+      if (firstSegment && INTERMEDIATE_DIR_SEGMENTS.has(firstSegment)) {
+        return { intent: 'draft', reason: `Located in legacy intermediate directory "${firstSegment}"`, matched: firstSegment };
+      }
     }
 
     if (isScriptSideEffect(fileName)) {

--- a/src/process/task/FileIntentClassifier.ts
+++ b/src/process/task/FileIntentClassifier.ts
@@ -33,6 +33,21 @@ export interface FileIntentClassification {
   marker?: string;
   line?: number;
   matched?: string;
+  /**
+   * True only when the `intent === 'draft'` decision came from an explicit
+   * user / operation request (e.g. `operationIntent === 'move-to-drafts'`,
+   * or the user message said "move X to drafts").
+   *
+   * Used by archiveTurnFiles to decide between archive vs. delete:
+   *   - userInitiated drafts → archive to .drafts/<basename>
+   *   - all other drafts (classifier heuristics) → unlink
+   *
+   * Rationale: AI-generated intermediate files (PPT slide frames, etc.) have
+   * no recovery value — they're scaffolding the user never asked for. Keeping
+   * them in .drafts/ accumulates disk + cognitive noise. User-explicit moves
+   * still go to .drafts/ because the user might want to restore them.
+   */
+  userInitiated?: boolean;
 }
 
 export interface BashDraftRestoreDetection {
@@ -51,17 +66,18 @@ const SCRIPT_SIDE_EFFECT_NAMES = new Set(['package.json', 'package-lock.json', '
 // earlier), the request matches and `final` is returned before this rule.
 const BASH_DELIVERABLE_EXTENSIONS = new Set(['.pdf', '.docx', '.pptx', '.xlsx', '.csv', '.json', '.md', '.markdown', '.txt', '.html', '.htm']);
 
-// Anthropic skills convention (mirrors `anthropics/skills/skills/pptx/SKILL.md`):
-// all generated files go to `outputs/<document-name>/`. The deliverable is
-// named `final.<ext>`; everything else in that directory is intermediate.
-// Recognized whenever the workspace-relative path matches one of these shapes.
-const ANTHROPIC_FINAL_OUTPUTS_RE = /^outputs\/[^/]+\/final\.[a-z0-9]+$/i;
-const ANTHROPIC_INSIDE_OUTPUTS_RE = /^outputs\/[^/]+\/.+/i;
-
-// Legacy sudowork-hub conventions used by skills that have not yet adopted
-// the Anthropic `outputs/<doc>/` pattern. A file whose FIRST relative-path
-// segment is in this set is treated as intermediate (draft). Lowercase keys.
-const INTERMEDIATE_DIR_SEGMENTS = new Set([
+// Intermediate working directories. A file whose FIRST relative-path segment
+// is in this set is treated as intermediate (draft). These names cover both
+// well-known sudowork-hub conventions (ppt_outputs/) and common scaffolding
+// dirs that skills/scripts use for intermediate artifacts. Lowercase keys.
+//
+// Lifecycle: the matching files are NOT moved or deleted by archiveTurnFiles
+// when userInitiated is false — they remain in place so cross-turn workflows
+// (e.g. PPT slide generation that spans multiple turns before composition)
+// can still read them. They're hidden from the chat-card / deliverables UI
+// because buildGeneratedFileEntries filters to intent='final'; they're hidden
+// from the workspace-tree UI by an ignore rule in conversationBridge.
+export const INTERMEDIATE_DIR_SEGMENTS = new Set([
   'ppt_outputs',
   'pptx_outputs',
   'docx_outputs',
@@ -224,7 +240,7 @@ export class FileIntentClassifier {
     const userMessage = input.userMessage?.trim() || '';
 
     if (input.source !== 'cleanup' && input.operationIntent === 'move-to-drafts' && isDraftsPath(input.filePath, input.requestedPath)) {
-      return { intent: 'draft', reason: 'Move to drafts requested' };
+      return { intent: 'draft', reason: 'Move to drafts requested', userInitiated: true };
     }
 
     if (input.source !== 'cleanup' && input.operationIntent === 'restore-from-drafts' && isRestoredRootFile(input.filePath, input.requestedPath)) {
@@ -232,7 +248,7 @@ export class FileIntentClassifier {
     }
 
     if (input.source !== 'cleanup' && isMoveToDraftsIntent(userMessage) && isDraftsPath(input.filePath, input.requestedPath)) {
-      return { intent: 'draft', reason: 'Move to drafts requested' };
+      return { intent: 'draft', reason: 'Move to drafts requested', userInitiated: true };
     }
 
     if (input.source !== 'cleanup' && isRestoreFromDraftsIntent(userMessage) && isRestoredRootFile(input.filePath, input.requestedPath) && !matchesExcludedFileName(userMessage, input.filePath, input.requestedPath)) {
@@ -270,21 +286,15 @@ export class FileIntentClassifier {
       return { intent: 'final', reason: `Matches requested target type ${ext}`, matched: ext };
     }
 
-    // Directory-structure rules. Run AFTER the user-driven explicit signals
-    // above (so a user request for a specific file by name still wins) and
-    // BEFORE generic heuristics (so a file in a known intermediate dir is
-    // not accidentally promoted by extension fallbacks).
+    // Intermediate-directory rule. Run AFTER user-driven explicit signals
+    // (so a user request for a specific file by name still wins) and BEFORE
+    // generic heuristics (so a file in a known intermediate dir is not
+    // accidentally promoted by extension fallbacks).
     const relativeKey = normalizePathForMatch(input.requestedPath || input.filePath);
     if (relativeKey) {
-      if (ANTHROPIC_FINAL_OUTPUTS_RE.test(relativeKey)) {
-        return { intent: 'final', reason: 'Anthropic outputs/<doc>/final.<ext> convention', matched: relativeKey };
-      }
-      if (ANTHROPIC_INSIDE_OUTPUTS_RE.test(relativeKey)) {
-        return { intent: 'draft', reason: 'Intermediate file inside Anthropic outputs/<doc>/ tree', matched: relativeKey };
-      }
       const firstSegment = relativeKey.split('/')[0] || '';
       if (firstSegment && INTERMEDIATE_DIR_SEGMENTS.has(firstSegment)) {
-        return { intent: 'draft', reason: `Located in legacy intermediate directory "${firstSegment}"`, matched: firstSegment };
+        return { intent: 'draft', reason: `Located in intermediate directory "${firstSegment}"`, matched: firstSegment };
       }
     }
 

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -139,20 +139,6 @@ export interface FirstMessageConfig {
   presetAgentType?: PresetAgentType | string;
 }
 
-/**
- * 构建草稿箱使用指令（优化版）
- * Build drafts box usage instructions for Agent (optimized)
- *
- * 通过系统提示词告诉 Agent：
- * 1. 使用 @draft/@final 标记显式声明文件意图
- * 2. 中间产物写入 .drafts/ 目录
- * 3. 最终结果文件写入工作空间根目录
- *
- * Via system prompt, instruct the Agent:
- * 1. Use @draft/@final markers to declare file intent explicitly
- * 2. Intermediate artifacts go to .drafts/
- * 3. Final deliverables go to workspace root
- */
 export function buildDraftsInstruction(workspace: string): string {
   const draftsPath = `${workspace}/${DRAFTS_DIR_NAME}`;
 
@@ -240,6 +226,55 @@ Ask yourself: "Is this file what the user ultimately wants?"
 }
 
 /**
+ * Build the [Output Convention] block — universal across all backends.
+ *
+ * Two-line summary the model needs to internalize:
+ *   - Deliverables: directly at workspace root, with a DESCRIPTIVE filename.
+ *   - Intermediates: anywhere ELSE (OS temp dir preferred, workspace subdir
+ *     acceptable). Don't put them at workspace root, don't delete them
+ *     yourself — sudowork hides them from the user automatically.
+ *
+ * This convention reflects Claude Cowork's observed behavior: the user sees
+ * one deliverable file (e.g. `数牍科技公司介绍.pptx`) at the working folder
+ * root, never intermediate slide frames / helper data.
+ */
+export function buildOutputConventionInstruction(workspace: string): string {
+  return `[Output Convention]
+
+When you generate files for the user:
+
+DELIVERABLES — outputs the user explicitly asked for. Save them directly at
+the workspace root (${workspace}/) with a DESCRIPTIVE filename matching the
+user's request:
+
+  ${workspace}/数牍科技公司介绍.pptx
+  ${workspace}/q1-sales-review.docx
+  ${workspace}/team-logo.png
+
+Do NOT use placeholder names like "final.pptx", "output.docx", "result.csv",
+"untitled.pdf". The filename must describe the content.
+
+INTERMEDIATE files — slide frames being composed, helper scripts you wrote
+to drive a tool, working JSON, debug renders, draft data. Save them ANYWHERE
+EXCEPT the workspace root:
+
+  - Preferred: system temp directory (Python tempfile.mkdtemp(),
+    shell mktemp -d, Node os.tmpdir()) — these are auto-cleaned by the OS.
+  - Acceptable: a subdirectory under ${workspace}/ (e.g. ppt_outputs/,
+    _tmp/, build/). Sudowork hides these subdirectories from the user.
+
+Sudowork handles intermediate-file lifecycle for you. Do NOT delete them
+yourself between turns — multi-turn workflows (e.g. generating slide images
+across several turns before composing the .pptx) need them to remain
+accessible.
+
+NEVER put intermediate files at the workspace root — anything written there
+is treated as a deliverable and shown to the user.
+
+[End of Output Convention]`;
+}
+
+/**
  * 构建系统指令内容（完整 skills 内容注入 - 用于 Gemini）
  * Build system instructions content (full skills content injection - for Gemini)
  *
@@ -257,6 +292,7 @@ export async function buildSystemInstructions(config: FirstMessageConfig): Promi
   // 添加草稿箱使用指令 / Add drafts box instructions
   if (config.workspace) {
     instructions.push(buildDraftsInstruction(config.workspace));
+    instructions.push(buildOutputConventionInstruction(config.workspace));
   }
 
   // 添加 Node.js 运行时提示 / Add Node.js runtime hint
@@ -330,6 +366,7 @@ export async function prepareFirstMessageWithSkillsIndex(content: string, config
   // 1.5 添加草稿箱使用指令 / Add drafts box instructions
   if (config.workspace) {
     instructions.push(buildDraftsInstruction(config.workspace));
+    instructions.push(buildOutputConventionInstruction(config.workspace));
   }
 
   // 1.8 添加 Node.js 运行时提示 / Add Node.js runtime hint

--- a/src/process/task/draftsCleanup.ts
+++ b/src/process/task/draftsCleanup.ts
@@ -37,6 +37,16 @@ export interface TrackedTurnFile {
   reason: string;
   source: FileIntentSource;
   kind: 'create' | 'edit';
+  /**
+   * Mirror of FileIntentClassification.userInitiated — only set when the
+   * draft decision came from an explicit user/operation request (move-to-drafts).
+   * archiveTurnFiles uses this to choose archive vs. leave-in-place:
+   *   - userInitiated drafts → archive to .drafts/<basename>
+   *   - AI-auto drafts (undefined/false) → leave on disk where the model wrote
+   *     them, so cross-turn workflows (e.g. multi-turn PPT slide composition)
+   *     can still reference them. They're hidden from UI by other surfaces.
+   */
+  userInitiated?: boolean;
 }
 
 export interface CleanupIntermediateFilesOptions {
@@ -315,6 +325,17 @@ export async function archiveTurnFiles(workspace: string, trackedFiles: Readonly
     }
     if (!isPathInside(workspaceRoot, srcPath)) {
       mainLog('draftsCleanup', `[TURN-ARCHIVE] Skipping outside-workspace file ${srcPath}`);
+      continue;
+    }
+
+    // AI-auto drafts (classifier heuristics, not user-explicit) stay on disk
+    // in their original location. Cross-turn workflows (e.g. PPT slide images
+    // generated in earlier turns and re-read by build_pptx.py in a later turn)
+    // depend on these files remaining accessible. They're hidden from UI
+    // surfaces — chat cards / deliverables tab filter to intent='final', and
+    // the workspace tree hides INTERMEDIATE_DIR_SEGMENTS.
+    if (file.intent === 'draft' && !file.userInitiated) {
+      mainLog('draftsCleanup', `[TURN-ARCHIVE] Leaving AI-auto draft in place: ${trackedKey} (${file.reason})`);
       continue;
     }
 

--- a/tests/unit/fileIntentClassifier.test.ts
+++ b/tests/unit/fileIntentClassifier.test.ts
@@ -12,54 +12,14 @@ const classify = (overrides: Partial<FileIntentClassificationInput> & { filePath
   return classifier.classify(input);
 };
 
-describe('FileIntentClassifier — directory-structure rules', () => {
-  // ── Anthropic outputs/<doc>/final.<ext> convention ─────────────────────
-  it('marks outputs/<doc>/final.pptx as final (Anthropic convention)', () => {
-    const result = classify({ filePath: '/workspace/outputs/q1-report/final.pptx', requestedPath: 'outputs/q1-report/final.pptx', source: 'bash-generated' });
-    expect(result.intent).toBe('final');
-    expect(result.reason).toMatch(/Anthropic outputs/);
-  });
-
-  it('marks outputs/<doc>/final.docx as final regardless of extension', () => {
-    const result = classify({ filePath: '/workspace/outputs/q1-report/final.docx', requestedPath: 'outputs/q1-report/final.docx', source: 'write' });
-    expect(result.intent).toBe('final');
-  });
-
-  it('marks outputs/<doc>/final.html as final', () => {
-    const result = classify({ filePath: '/workspace/outputs/landing-page/final.html', requestedPath: 'outputs/landing-page/final.html', source: 'write' });
-    expect(result.intent).toBe('final');
-  });
-
-  // ── Anthropic outputs/<doc>/ intermediate (everything not named final.X) ──
-  it('marks outputs/<doc>/p1.jpg as draft (intermediate inside outputs tree)', () => {
-    const result = classify({ filePath: '/workspace/outputs/数牍科技公司介绍/p1.jpg', requestedPath: 'outputs/数牍科技公司介绍/p1.jpg', source: 'bash-generated' });
-    expect(result.intent).toBe('draft');
-    expect(result.reason).toMatch(/Intermediate.*outputs/);
-  });
-
-  it('marks outputs/<doc>/inventory.json as draft even though .json is in BASH_DELIVERABLE_EXTENSIONS', () => {
-    const result = classify({ filePath: '/workspace/outputs/q1-report/inventory.json', requestedPath: 'outputs/q1-report/inventory.json', source: 'bash-generated' });
-    expect(result.intent).toBe('draft');
-  });
-
-  it('marks outputs/<doc>/thumbnails_grid.png as draft', () => {
-    const result = classify({ filePath: '/workspace/outputs/q1-report/thumbnails_grid.png', requestedPath: 'outputs/q1-report/thumbnails_grid.png', source: 'bash-generated' });
-    expect(result.intent).toBe('draft');
-  });
-
-  it('marks outputs/<doc>/working.pptx as draft (only final.<ext> wins)', () => {
-    const result = classify({ filePath: '/workspace/outputs/q1-report/working.pptx', requestedPath: 'outputs/q1-report/working.pptx', source: 'bash-generated' });
-    expect(result.intent).toBe('draft');
-  });
-
-  // ── Legacy intermediate dir blacklist ────────────────────────────────────
-  it('marks ppt_outputs/p1.jpg as draft (legacy convention)', () => {
+describe('FileIntentClassifier — intermediate-directory rule', () => {
+  it('marks ppt_outputs/p1.jpg as draft', () => {
     const result = classify({ filePath: '/workspace/ppt_outputs/p1.jpg', requestedPath: 'ppt_outputs/p1.jpg', source: 'bash-generated' });
     expect(result.intent).toBe('draft');
-    expect(result.reason).toMatch(/legacy intermediate directory "ppt_outputs"/);
+    expect(result.reason).toMatch(/intermediate directory "ppt_outputs"/);
   });
 
-  it('marks ppt_outputs/final.pptx as draft (legacy dir wins — final.pptx outside outputs/ is not Anthropic-style)', () => {
+  it('marks ppt_outputs/final.pptx as draft (intermediate-dir rule wins over name)', () => {
     const result = classify({ filePath: '/workspace/ppt_outputs/final.pptx', requestedPath: 'ppt_outputs/final.pptx', source: 'bash-generated' });
     expect(result.intent).toBe('draft');
   });
@@ -74,7 +34,14 @@ describe('FileIntentClassifier — directory-structure rules', () => {
     expect(result.intent).toBe('draft');
   });
 
-  // ── BASH_DELIVERABLE_EXTENSIONS no longer auto-finals images at root ────
+  it('does NOT mark these as userInitiated (intermediate-dir is AI-auto)', () => {
+    const result = classify({ filePath: '/workspace/ppt_outputs/p1.jpg', requestedPath: 'ppt_outputs/p1.jpg', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+    expect(result.userInitiated).toBeUndefined();
+  });
+});
+
+describe('FileIntentClassifier — BASH_DELIVERABLE_EXTENSIONS no longer auto-finals images', () => {
   it('does NOT auto-mark a bash-written PNG at workspace root as final when user did not request an image', () => {
     const result = classify({ filePath: '/workspace/report.png', requestedPath: 'report.png', source: 'bash-generated', userMessage: '生成一份季度销售报告' });
     expect(result.intent).toBe('draft');
@@ -86,23 +53,36 @@ describe('FileIntentClassifier — directory-structure rules', () => {
   });
 
   it('marks a bash-written PNG as final when user explicitly asked for an image', () => {
-    // Caught by inferRequestedExtensions before our new rules — user said "图片".
+    // Caught by inferRequestedExtensions before directory rules — user said "图片".
     const result = classify({ filePath: '/workspace/avatar.png', requestedPath: 'avatar.png', source: 'bash-generated', userMessage: '给我画一张猫的图片头像' });
     expect(result.intent).toBe('final');
   });
+});
 
-  // ── Files at workspace root (no relevant directory hint) untouched ──────
-  it('leaves workspace-root markdown without directory hint untouched', () => {
+describe('FileIntentClassifier — workspace-root deliverables untouched', () => {
+  it('leaves workspace-root markdown without directory hint as final', () => {
     const result = classify({ filePath: '/workspace/notes.md', requestedPath: 'notes.md', source: 'write', userMessage: '帮我记一些笔记' });
-    // Falls through to final (default) — matches existing behavior
     expect(result.intent).toBe('final');
   });
 
-  // ── User request still wins over directory rule ────────────────────────
-  it('still marks a user-requested file as final even if path is inside outputs/<doc>/', () => {
+  it('still honors a requested file name even if inside an intermediate dir', () => {
     // User explicitly asks for inventory.json — requestedNames extraction
-    // catches it before our directory rules, so it wins.
-    const result = classify({ filePath: '/workspace/outputs/q1-report/inventory.json', requestedPath: 'outputs/q1-report/inventory.json', source: 'write', userMessage: '把 inventory.json 给我' });
+    // catches it before directory rules, so user intent wins.
+    const result = classify({ filePath: '/workspace/intermediate/inventory.json', requestedPath: 'intermediate/inventory.json', source: 'write', userMessage: '把 inventory.json 给我' });
     expect(result.intent).toBe('final');
+  });
+});
+
+describe('FileIntentClassifier — userInitiated flag', () => {
+  it('sets userInitiated=true when operationIntent=move-to-drafts', () => {
+    const result = classify({ filePath: '/workspace/.drafts/notes.md', requestedPath: '.drafts/notes.md', operationIntent: 'move-to-drafts' });
+    expect(result.intent).toBe('draft');
+    expect(result.userInitiated).toBe(true);
+  });
+
+  it('sets userInitiated=true when user message says "move X to drafts"', () => {
+    const result = classify({ filePath: '/workspace/.drafts/notes.md', requestedPath: '.drafts/notes.md', userMessage: '把 notes.md 移到 .drafts/' });
+    expect(result.intent).toBe('draft');
+    expect(result.userInitiated).toBe(true);
   });
 });

--- a/tests/unit/fileIntentClassifier.test.ts
+++ b/tests/unit/fileIntentClassifier.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { FileIntentClassifier, type FileIntentClassificationInput } from '@/process/task/FileIntentClassifier';
+
+const classifier = new FileIntentClassifier();
+
+const classify = (overrides: Partial<FileIntentClassificationInput> & { filePath: string }) => {
+  const input: FileIntentClassificationInput = {
+    source: 'write',
+    ...overrides,
+  };
+  return classifier.classify(input);
+};
+
+describe('FileIntentClassifier — directory-structure rules', () => {
+  // ── Anthropic outputs/<doc>/final.<ext> convention ─────────────────────
+  it('marks outputs/<doc>/final.pptx as final (Anthropic convention)', () => {
+    const result = classify({ filePath: '/workspace/outputs/q1-report/final.pptx', requestedPath: 'outputs/q1-report/final.pptx', source: 'bash-generated' });
+    expect(result.intent).toBe('final');
+    expect(result.reason).toMatch(/Anthropic outputs/);
+  });
+
+  it('marks outputs/<doc>/final.docx as final regardless of extension', () => {
+    const result = classify({ filePath: '/workspace/outputs/q1-report/final.docx', requestedPath: 'outputs/q1-report/final.docx', source: 'write' });
+    expect(result.intent).toBe('final');
+  });
+
+  it('marks outputs/<doc>/final.html as final', () => {
+    const result = classify({ filePath: '/workspace/outputs/landing-page/final.html', requestedPath: 'outputs/landing-page/final.html', source: 'write' });
+    expect(result.intent).toBe('final');
+  });
+
+  // ── Anthropic outputs/<doc>/ intermediate (everything not named final.X) ──
+  it('marks outputs/<doc>/p1.jpg as draft (intermediate inside outputs tree)', () => {
+    const result = classify({ filePath: '/workspace/outputs/数牍科技公司介绍/p1.jpg', requestedPath: 'outputs/数牍科技公司介绍/p1.jpg', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+    expect(result.reason).toMatch(/Intermediate.*outputs/);
+  });
+
+  it('marks outputs/<doc>/inventory.json as draft even though .json is in BASH_DELIVERABLE_EXTENSIONS', () => {
+    const result = classify({ filePath: '/workspace/outputs/q1-report/inventory.json', requestedPath: 'outputs/q1-report/inventory.json', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+  });
+
+  it('marks outputs/<doc>/thumbnails_grid.png as draft', () => {
+    const result = classify({ filePath: '/workspace/outputs/q1-report/thumbnails_grid.png', requestedPath: 'outputs/q1-report/thumbnails_grid.png', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+  });
+
+  it('marks outputs/<doc>/working.pptx as draft (only final.<ext> wins)', () => {
+    const result = classify({ filePath: '/workspace/outputs/q1-report/working.pptx', requestedPath: 'outputs/q1-report/working.pptx', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+  });
+
+  // ── Legacy intermediate dir blacklist ────────────────────────────────────
+  it('marks ppt_outputs/p1.jpg as draft (legacy convention)', () => {
+    const result = classify({ filePath: '/workspace/ppt_outputs/p1.jpg', requestedPath: 'ppt_outputs/p1.jpg', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+    expect(result.reason).toMatch(/legacy intermediate directory "ppt_outputs"/);
+  });
+
+  it('marks ppt_outputs/final.pptx as draft (legacy dir wins — final.pptx outside outputs/ is not Anthropic-style)', () => {
+    const result = classify({ filePath: '/workspace/ppt_outputs/final.pptx', requestedPath: 'ppt_outputs/final.pptx', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+  });
+
+  it('marks _tmp/working.txt as draft', () => {
+    const result = classify({ filePath: '/workspace/_tmp/working.txt', requestedPath: '_tmp/working.txt', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+  });
+
+  it('marks intermediate/data.csv as draft', () => {
+    const result = classify({ filePath: '/workspace/intermediate/data.csv', requestedPath: 'intermediate/data.csv', source: 'bash-generated' });
+    expect(result.intent).toBe('draft');
+  });
+
+  // ── BASH_DELIVERABLE_EXTENSIONS no longer auto-finals images at root ────
+  it('does NOT auto-mark a bash-written PNG at workspace root as final when user did not request an image', () => {
+    const result = classify({ filePath: '/workspace/report.png', requestedPath: 'report.png', source: 'bash-generated', userMessage: '生成一份季度销售报告' });
+    expect(result.intent).toBe('draft');
+  });
+
+  it('keeps bash-written PPTX at workspace root as final (office extension)', () => {
+    const result = classify({ filePath: '/workspace/report.pptx', requestedPath: 'report.pptx', source: 'bash-generated', userMessage: '生成一份季度销售 ppt' });
+    expect(result.intent).toBe('final');
+  });
+
+  it('marks a bash-written PNG as final when user explicitly asked for an image', () => {
+    // Caught by inferRequestedExtensions before our new rules — user said "图片".
+    const result = classify({ filePath: '/workspace/avatar.png', requestedPath: 'avatar.png', source: 'bash-generated', userMessage: '给我画一张猫的图片头像' });
+    expect(result.intent).toBe('final');
+  });
+
+  // ── Files at workspace root (no relevant directory hint) untouched ──────
+  it('leaves workspace-root markdown without directory hint untouched', () => {
+    const result = classify({ filePath: '/workspace/notes.md', requestedPath: 'notes.md', source: 'write', userMessage: '帮我记一些笔记' });
+    // Falls through to final (default) — matches existing behavior
+    expect(result.intent).toBe('final');
+  });
+
+  // ── User request still wins over directory rule ────────────────────────
+  it('still marks a user-requested file as final even if path is inside outputs/<doc>/', () => {
+    // User explicitly asks for inventory.json — requestedNames extraction
+    // catches it before our directory rules, so it wins.
+    const result = classify({ filePath: '/workspace/outputs/q1-report/inventory.json', requestedPath: 'outputs/q1-report/inventory.json', source: 'write', userMessage: '把 inventory.json 给我' });
+    expect(result.intent).toBe('final');
+  });
+});


### PR DESCRIPTION
## Context

When the AI generates a PPT, the slide-image intermediates (`cover.jpg`, `p1.jpg`–`p9.jpg` in `ppt_outputs/`) leak into the user-facing 交付物 view alongside the actual final `.pptx`. The user has to mentally filter their deliverable out of an intermediate pile that's only useful to the generation pipeline.

## Design constraints

Per requirements (Cowork-aligned, generic across skills):

1. Intermediates **invisible to the user** in chat card / 交付物 tab / workspace tree
2. Deliverable at workspace root with a **descriptive filename** matching the user's request (not `final.X` / `output.X`)
3. **Generic** across all skills, not PPT-specific
4. Mirror **Claude Cowork's actual product UX** (descriptive filename at working-folder root, no visible intermediates)
5. **`.drafts/` reserved for user-explicit `move to drafts`** only — AI-auto intermediates must NOT be archived there

A prior iteration of this PR (commit bb775a71) adopted Anthropic's `outputs/<doc>/final.X` convention from `anthropics/skills`. That was rejected because:

- Cowork's actual product uses descriptive filenames at the working folder root (not `final.X` in a `<doc>/` subdir) — `anthropics/skills` is source code, not the product UX
- Moving AI-auto intermediates to `.drafts/` at turn-end **breaks multi-turn workflows**: PPT 逐页生成 reads slide JPGs from earlier turns when `build_pptx.py` runs in a later compose turn — if those JPGs have already been moved to `.drafts/`, the compose command fails

## Design

**Leave-in-place model**. AI-auto drafts stay at the path the model wrote them. They're hidden from the three UI surfaces:

| Surface | Filter |
|---|---|
| Chat card (`[[NEXUS_GENERATED_FILES]]` marker) | `buildGeneratedFileEntries()` already filters to `intent === 'final'` (no change) |
| 交付物 tab (`DeliverablesService`) | Aggregates from chat-card markers, inherits the filter (no change) |
| Workspace tree (`conversation.getWorkspace`) | **NEW**: `shouldIgnoreFile` skips paths whose segments match `INTERMEDIATE_DIR_SEGMENTS` |

User-explicit `/draft` and "把 X 移到草稿箱" still archive to `.drafts/` via a new `userInitiated` flag on `TrackedTurnFile`.

A universal `[Output Convention]` block is injected on the first message for every backend (ACP / Codex / Claude / Gemini) — tells the model: deliverables go to workspace root with a descriptive name; intermediates go to system /tmp (preferred) or a workspace subdir (acceptable, auto-hidden); never delete intermediates yourself.

## Changes

`src/process/task/FileIntentClassifier.ts`:
- Drop `ANTHROPIC_FINAL_OUTPUTS_RE` and `ANTHROPIC_INSIDE_OUTPUTS_RE` (Cowork doesn't use `outputs/<doc>/final.X`)
- Keep `INTERMEDIATE_DIR_SEGMENTS` (`ppt_outputs/`, `_tmp/`, `intermediate/`, …) — catches the existing PPT助手 SKILL.md's output path as a safety net
- Keep image removal from `BASH_DELIVERABLE_EXTENSIONS`
- Export `INTERMEDIATE_DIR_SEGMENTS` for workspace-tree filter reuse

`src/process/task/draftsCleanup.ts`:
- Add `userInitiated?: boolean` field on `TrackedTurnFile`
- `archiveTurnFiles` now skips drafts where `userInitiated=false` (file stays on disk in its original location); user-explicit drafts still archive to `.drafts/`

`src/process/task/AcpAgent.ts`:
- `trackTurnFile` copies `classification.userInitiated` into the Map entry

`src/process/bridge/conversationBridge.ts`:
- `shouldIgnoreFile` adds path-segment match against `INTERMEDIATE_DIR_SEGMENTS` so intermediate dirs don't surface in the workspace tree

`src/process/task/agentUtils.ts`:
- New `buildOutputConventionInstruction(workspace)`
- Injected into both `prepareFirstMessageWithSkillsIndex` (ACP / Codex / Claude) and `buildSystemInstructions` (Gemini) so every backend gets the convention

## Test plan

- [x] 12 unit tests in `tests/unit/fileIntentClassifier.test.ts` covering the intermediate-dir rule, image-extension removal, workspace-root deliverables, user-message override, and `userInitiated` flag propagation
- [x] 33 unit tests pass across `fileIntentClassifier` / `generatedFiles` / `workspaceTreeFilter`
- [x] `bun run type:check` clean (1 pre-existing error in `workspaceSkillSync.ts:49` unrelated to this PR)
- [x] Manual smoke: PPT generation in dev — chat card shows only `.pptx`, 交付物 tab shows only `.pptx`, workspace tree hides `ppt_outputs/`, `build_pptx.py` can still read intermediate JPGs from earlier turns

## Risk register

| Risk | Mitigation |
|---|---|
| Existing skills' SKILL.md instruct intermediates to workspace subdirs (e.g. `ppt_outputs/`) | INTERMEDIATE_DIR_SEGMENTS catches the dir; workspace-tree filter hides it; chat card / 交付物 tab were already final-only |
| Model writes intermediates to an unknown dir name not in INTERMEDIATE_DIR_SEGMENTS (e.g. `slide_pngs/`) | Universal [Output Convention] tells the model to use system /tmp; new dir names can be added to the blacklist over time |
| Removing images from BASH_DELIVERABLE_EXTENSIONS affects "AI generates a logo" UX | Explicit image-related keywords (`图片` / `image` / `头像` / …) trip `inferRequestedExtensions` BEFORE the bash-deliverable check. Covered by unit test |
| Hub skill SKILL.md (PPT助手, ppt-generator) still references `ppt_outputs/` | Safety net via INTERMEDIATE_DIR_SEGMENTS. Hub skills can be updated independently to follow the universal convention; not blocked by this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)