### PR TITLE
fix(ci): bundle ai-dev-browser into release builds

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -79,6 +79,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+          # ai-dev-browser (browser skill runtime) is a git submodule; without
+          # this the bundle ships no Python implementation and the skill is dead.
+          submodules: recursive
 
       - name: Get commit hash
         id: commit

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -280,6 +280,10 @@ asarUnpack:
   # Required for Homebrew installations where asar paths may have issues
   - 'rules/**/*'
   - 'skills/**/*'
+  # ai-dev-browser Python package must live in app.asar.unpacked: the runtime
+  # resolver (resolveAiDevBrowserPackageDir) only looks under app.asar.unpacked,
+  # and a Python package can't be executed/symlinked from inside the asar.
+  - 'vendor/ai-dev-browser/**/*'
 
 # Compression level: normal for faster builds, maximum for smallest size
 # Note: electron-builder doesn't support YAML template syntax for env vars


### PR DESCRIPTION
## Summary
The **browser** builtin skill shipped **dead** in GitHub releases — the vendored `ai-dev-browser` Python package was missing from the app bundle entirely. Verified against the installed `/Applications/Sudowork.app`: `app.asar` contains **0** `ai_dev_browser` files and no top-level `vendor/`; `app.asar.unpacked/` has only `native/node_modules/skills`.

Two independent root causes, both fixed here:

- **Submodule not checked out (build-time).** `vendor/ai-dev-browser` is a git submodule, but `_build-reusable.yml` (the job that actually runs `electron-builder`) checked out without `submodules`. Only `pr-integration-smoke.yml` and `update-ai-dev-browser.yml` set `submodules: true`. So the submodule was empty at build time and `files: vendor/ai-dev-browser/ai_dev_browser/**/*` matched nothing. → added `submodules: recursive`.
- **Wrong asar layer (config).** Even when present, the package was only listed under `files:` (packed *into* `app.asar`), but the runtime resolver `resolveAiDevBrowserPackageDir` only resolves it from `app.asar.unpacked/` (and a Python package can't be executed/symlinked from inside the asar). → added `vendor/ai-dev-browser/**/*` to `asarUnpack`.

Failure chain: either cause → `resolveAiDevBrowserPackageDir()` returns null → `linkAiDevBrowserIntoSystemSkill` warns and returns → no `ai_dev_browser` symlink under `_system/_builtin/browser/` → skill has no Python implementation → unusable.

All release paths (build-and-release, build-nightly, build-manual, hotfix, candidate-promotion) package through `_build-reusable.yml`, so the single checkout fix covers every release.

## Test plan
- [ ] CI build produces an `app.asar.unpacked/vendor/ai-dev-browser/ai_dev_browser/` directory
- [ ] Installed app creates the `~/.nexus/skills/_system/_builtin/browser/ai_dev_browser` symlink on first launch
- [ ] `browser --list` works inside the browser skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)