### PR TITLE
ci: fail build if ai-dev-browser submodule is not bundled

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -88,6 +88,21 @@ jobs:
           echo "short=$SHORT" >> $GITHUB_OUTPUT
           echo "Commit: $SHORT"
 
+      # Guard against shipping a dead browser skill. The ai-dev-browser package
+      # is a git submodule; if checkout forgets `submodules: recursive`, the
+      # electron-builder `files:` glob silently matches nothing and the release
+      # builds green but with no browser runtime. Fail loudly here instead.
+      - name: Verify ai-dev-browser submodule is bundled
+        shell: bash
+        run: |
+          pkg="vendor/ai-dev-browser/ai_dev_browser"
+          count=$(find "$pkg" -name '*.py' 2>/dev/null | wc -l | tr -d ' ')
+          if [ "${count:-0}" -eq 0 ]; then
+            echo "::error::ai-dev-browser package is empty or missing ($pkg has no .py files). The browser builtin skill would ship dead. Ensure checkout uses 'submodules: recursive' and the submodule is initialized."
+            exit 1
+          fi
+          echo "ai-dev-browser package present: $count .py files under $pkg"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
Complementary guard for #758. Adds a build-time assertion in `_build-reusable.yml` (the reusable job that every release path runs through) that **fails the build** if `vendor/ai-dev-browser/ai_dev_browser` has no `.py` files.

### Why
`ai-dev-browser` is a git submodule. When a checkout forgets `submodules: recursive`, electron-builder's `files: vendor/ai-dev-browser/ai_dev_browser/**/*` glob silently matches nothing — the release builds **green** but ships with no browser runtime. That's exactly how the browser builtin skill shipped dead. Today nothing in the chain (submodule → files → asarUnpack → startup symlink → PYTHONPATH → import) validates end-to-end, and every failure is a silent `warn` deferred to tool-invocation time for end users.

This turns that silent shipped-broken into a loud CI red, right after checkout.

### Relationship to #758
- **#758** fixes the actual breakage (adds `submodules: recursive` + `asarUnpack` entry).
- **This PR** prevents regressions. **Merge #758 first** — until the submodule is checked out, this assertion will (correctly) fail any release build, which is the intended behavior.

## Test plan
- [ ] With submodule checked out: step prints `ai-dev-browser package present: N .py files` and passes
- [ ] Without submodule (regression simulation): step fails with the `::error::` annotation
- [ ] Step runs on both macOS and Windows runners (uses `shell: bash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)