### PR TITLE
fix(build): preserve claude-code binary hardlink in CI tgz (-60MB dmg)

### DIFF
--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -164,6 +164,76 @@ function restoreFrameworkSymlinks(fwPath) {
 }
 
 /**
+ * Snapshot every group of hardlinked regular files under `dir`.
+ *
+ * `codesign` writes a temp file and renames over the target, which breaks
+ * hardlinks. For archives like claude-code.tgz that ship the platform binary
+ * twice via a single inode (~210 MB total on disk), the post-sign re-pack
+ * loses dedup and the tgz nearly doubles in size. Pair with restoreHardlinkGroups.
+ *
+ * Symlinks are skipped — codesign follows them and we never want to convert
+ * one back to a hardlink.
+ *
+ * @param {string} dir
+ * @returns {Array<string[]>} groups of 2+ paths that shared an inode pre-sign
+ */
+function snapshotHardlinkGroups(dir) {
+  const groups = new Map(); // "dev:ino" -> string[]
+  function walk(currentDir) {
+    let entries;
+    try { entries = fs.readdirSync(currentDir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) { walk(fullPath); continue; }
+      if (!entry.isFile()) continue;
+      let st;
+      try { st = fs.statSync(fullPath); } catch { continue; }
+      if (st.nlink < 2) continue;
+      const key = `${st.dev}:${st.ino}`;
+      const arr = groups.get(key);
+      if (arr) arr.push(fullPath);
+      else groups.set(key, [fullPath]);
+    }
+  }
+  walk(dir);
+  // Sort each group for deterministic primary selection across runs.
+  return [...groups.values()].filter(arr => arr.length > 1).map(arr => arr.sort());
+}
+
+/**
+ * Re-create hardlinks broken by codesign. For each group, the first path
+ * (alphabetical) is the primary; every other path is unlinked and re-linked
+ * to the primary's inode so they share the signed content again.
+ *
+ * Groups already intact (codesign happened to leave them alone) are skipped.
+ *
+ * @param {Array<string[]>} groups - output of snapshotHardlinkGroups
+ * @returns {number} number of paths re-linked
+ */
+function restoreHardlinkGroups(groups) {
+  let restored = 0;
+  for (const paths of groups) {
+    const [primary, ...rest] = paths;
+    let primarySt;
+    try { primarySt = fs.statSync(primary); } catch { continue; }
+    for (const p of rest) {
+      let pSt;
+      try { pSt = fs.statSync(p); } catch { continue; }
+      if (pSt.dev === primarySt.dev && pSt.ino === primarySt.ino) continue;
+      try {
+        fs.unlinkSync(p);
+        fs.linkSync(primary, p);
+        restored++;
+      } catch (err) {
+        console.warn(`   ⚠️  Could not re-link ${path.relative(process.cwd(), p)}: ${err.message}`);
+      }
+    }
+  }
+  return restored;
+}
+
+/**
  * Sign all binary files recursively in a directory
  * @param {string} dir - Directory to search for binaries
  * @param {string} identity - Code signing identity
@@ -575,9 +645,23 @@ async function signBinariesInArchive(archivePath, identity, isNested = false, en
       console.log(`   🗑  Removed ${removedCount} un-notarizable file(s) from ${archiveName}`);
     }
 
+    // Snapshot hardlink groups before signing — codesign atomically replaces
+    // files, which breaks the inode share that install.cjs sets up between
+    // e.g. @anthropic-ai/claude-code/bin/claude.exe and the platform package's
+    // binary. Without restoring, the re-packed tgz ships the ~210 MB binary
+    // twice (claude-code.tgz: 62 MB → 123 MB; dmg: +60 MB).
+    const hardlinkGroups = snapshotHardlinkGroups(extractedDir);
+
     // Sign binaries in the main extracted content
     const signedCount = signBinariesInDir(extractedDir, identity, entitlementsPath);
     console.log(`   Signed ${signedCount} binaries total`);
+
+    if (hardlinkGroups.length > 0) {
+      const relinked = restoreHardlinkGroups(hardlinkGroups);
+      if (relinked > 0) {
+        console.log(`   🔗 Restored ${relinked} hardlink(s) across ${hardlinkGroups.length} group(s) broken by codesign`);
+      }
+    }
 
     // Re-pack the main archive
     // Original structure preservation:


### PR DESCRIPTION
## Background

Follow-up to #761 ("CI hardlink fix (separate)" item). That PR identified a ~60 MB size delta on the macOS dmg traced to `claude-code.tgz` shipping the ~210 MB Claude binary twice. PR #761 attributed it to "Linux runner GNU tar not preserving hardlinks." Reproducing locally showed the actual root cause is in our own `afterPack.js` codesign step on the **macOS** runner.

## Root cause

`@anthropic-ai/claude-code`'s `install.cjs` postinstall hardlinks the platform binary into the wrapper package:

```
@anthropic-ai/claude-code/bin/claude.exe                       ─┐
                                                                ├─ same inode, link count 2
@anthropic-ai/claude-code-darwin-arm64/claude                  ─┘
```

`scripts/download-claude-code.js` tars the install dir; bsdtar (mac) and GNU tar both encode the second path as a `h` type entry (size 0). Result: **62 MB tgz**.

Then `scripts/afterPack.js:signBinariesInArchive` extracts the tgz, signs every Mach-O it finds, and re-packs. `codesign` writes a temp file and `rename()`s it over the target — atomically replacing the inode, **breaking the hardlink**. The re-pack now sees two separate ~210 MB inodes and emits two full file entries.

Local repro on macOS (Apple Silicon):

| State                              | tgz size  |
|------------------------------------|-----------|
| Out of `download-claude-code.js`   | 62 MB     |
| After `codesign` (hardlink broken) | **122 MB** |
| After fix (hardlink restored)      | 61 MB     |

The 122 MB matches what PR #761 measured in v0.2.7's bundled tgz.

## Fix

In `signBinariesInArchive`, just before the main `signBinariesInDir` call:

1. Walk `extractedDir` and snapshot every group of regular files sharing an inode (`nlink >= 2`).
2. Run codesign as before.
3. For each snapshot group, pick the alphabetically-first path as the primary; for every other path in the group, `unlink` + `linkSync(primary, p)` — but only if codesign actually broke the share (skip otherwise).

`tar` dedupes by inode at pack time, so restoring the share is sufficient — no tar flag changes needed.

The primary's signed content wins; the secondaries discard their own post-sign content. This is safe because both binaries started as byte-identical (the same Mach-O from the platform package), and both get the same signing identity/entitlements — they only differ in the timestamp nonce inside `LC_CODE_SIGNATURE`. Either signature is valid and macOS verifies against file content, not path.

## Risk

- **Wrong file picked as primary, breaks a different bundled archive.** The snapshot scope is `extractedDir` for a single archive at a time, and only groups with link count ≥ 2 inside that archive are touched. For archives without hardlinks (gemini-cli, mcporter, nexus, node) the snapshot is empty and the restore is a no-op.
- **Symlinks getting confused with hardlinks.** Snapshot explicitly skips `entry.isSymbolicLink()`.
- **The signed binary not running.** Verified locally by extracting the re-linked tgz and invoking `node_modules/@anthropic-ai/claude-code/bin/claude.exe --version` — returns `2.1.167 (Claude Code)`.

## Verification (local)

```
$ cd /tmp/verify && tar -xzf .../resources/claude-code.tgz
$ stat claude-code/bin/claude.exe claude-code-darwin-arm64/claude
  # links=2 inode=87436590 (hardlinked)

$ codesign --force --sign - claude-code-darwin-arm64/claude
$ stat claude-code/bin/claude.exe claude-code-darwin-arm64/claude
  # links=1, different inodes (hardlink broken)

$ tar -czf no-restore.tgz . && ls -lh no-restore.tgz
  # 122 MB

$ node -e 'require("./fix").restoreHardlinkGroups([[...two paths...]])'
$ stat ...
  # links=2, same inode (restored)

$ tar -czf with-restore.tgz . && ls -lh with-restore.tgz
  # 61 MB
```

CI verification: the size drop won't show up in artifacts until this is merged and a full build runs. Recommend a reviewer cross-check by triggering `build-and-release` on a tag or via `workflow_dispatch` and confirming `claude-code.tgz` inside the resulting dmg drops back to ~62 MB.

## Out of scope

- `download-claude-code.js` and the `download-resources.yml` workflow are unchanged. They produce the correct 62 MB tgz; the regression is purely in the macOS signing pass.
- Windows runner does not codesign, so no analog fix is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)