### PR TITLE
feat(cron): respect user agent/model preferences (unify with manual session defaults)

### DIFF
--- a/src/common/acp/defaultAgent.ts
+++ b/src/common/acp/defaultAgent.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_PRESET_AGENT_TYPE } from '@/types/acpTypes';
+
+/**
+ * Resolve the default agent key for a fresh session when the user has
+ * expressed no preference yet. Used by both the renderer (Guid page)
+ * and the main process (CronService) so they agree on "no preference".
+ *
+ * Enterprise mode defaults to the generic 'remote-agent' (Moss Server);
+ * consumer mode defaults to the preset agent type ('scode').
+ */
+export function defaultAgentForMode(isEnterprise: boolean): string {
+  return isEnterprise ? 'remote-agent' : DEFAULT_PRESET_AGENT_TYPE;
+}

--- a/src/process/services/cron/CronService.ts
+++ b/src/process/services/cron/CronService.ts
@@ -10,7 +10,11 @@ import { uuid } from '@/common/utils';
 import { getDatabase } from '@process/database';
 import { ProcessConfig } from '@process/initStorage';
 import { addMessage } from '@process/message';
-import { DEFAULT_PRESET_AGENT_TYPE, resolvePresetAgentBackend, type AcpBackendAll } from '@/types/acpTypes';
+import { ConfigStorage } from '@/common/storage';
+import { resolvePreferredAcpModelId } from '@/common/acp/defaultModels';
+import { defaultAgentForMode } from '@/common/acp/defaultAgent';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { DEFAULT_PRESET_AGENT_TYPE, resolvePresetAgentBackend, type AcpBackend, type AcpBackendAll } from '@/types/acpTypes';
 import { powerSaveBlocker, app } from 'electron';
 import { Cron } from 'croner';
 import WorkerManage from '../../WorkerManage';
@@ -23,6 +27,18 @@ import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRou
 import { cronBusyGuard } from './CronBusyGuard';
 import { cronStore, type CronJob, type CronSchedule } from './CronStore';
 import { createConversation } from '../conversationService';
+
+/**
+ * Map an ACP backend to the conversation `type` field expected by
+ * conversationService.createConversation. 'remote-agent' and
+ * 'openclaw-gateway' have dedicated dispatch paths; everything else
+ * goes through the generic 'acp' path.
+ */
+function convTypeForBackend(backend: AcpBackendAll): string {
+  if (backend === 'openclaw-gateway') return 'openclaw-gateway';
+  if (backend === 'remote-agent') return 'remote-agent';
+  return 'acp';
+}
 
 /**
  * Parameters for creating a new cron job
@@ -386,9 +402,16 @@ class CronService {
       // Normalize stored agentType — legacy jobs may have 'sudoclaw-gateway' which is not a valid conv type
       const storedAgentType = job.metadata.agentType;
       const normalizedAgentType: AcpBackendAll = !storedAgentType || (storedAgentType as string) === 'sudoclaw-gateway' ? 'openclaw-gateway' : storedAgentType;
+
+      // Resolve the runtime agent type. For jobs bound to a specific preset
+      // assistant, the assistant's meta wins. Otherwise we honor the user's
+      // current Guid-page preference so changing it propagates to scheduled
+      // runs (rather than freezing the value at job-creation time).
       let resolvedAgentType: AcpBackendAll = normalizedAgentType;
-      // convType must be 'openclaw-gateway' or 'acp' — preserve openclaw-gateway for legacy stored jobs
-      let convType: string = normalizedAgentType === 'openclaw-gateway' ? 'openclaw-gateway' : 'acp';
+      if (!presetAssistantId) {
+        resolvedAgentType = await this.resolveUserPreferredAgent(normalizedAgentType);
+      }
+      let convType: string = convTypeForBackend(resolvedAgentType);
 
       if (presetAssistantId) {
         try {
@@ -411,13 +434,17 @@ class CronService {
           enabledSkills = meta?.enabledSkills ?? meta?.defaultEnabledSkills;
           presetAgentName = meta?.nameI18n?.['en-US'];
 
-          // 4. Determine correct conversation type from presetAgentType
-          const presetAgentType = meta?.presetAgentType || DEFAULT_PRESET_AGENT_TYPE;
+          // 4. Determine correct conversation type. Preset metadata is the
+          // primary source; when the assistant doesn't pin a presetAgentType
+          // we defer to the user's current preference instead of the
+          // hard-coded scode default, matching manual-session behavior.
+          const metaAgentType = meta?.presetAgentType ?? (await this.readUserPreferredPresetAgentType());
+          const presetAgentType = metaAgentType || DEFAULT_PRESET_AGENT_TYPE;
           const presetBackend = resolvePresetAgentBackend(presetAgentType);
 
           if (presetBackend === 'openclaw-gateway') {
             resolvedAgentType = 'openclaw-gateway';
-            convType = 'openclaw-gateway';
+            convType = convTypeForBackend(resolvedAgentType);
           } else {
             // Check that the ACP backend CLI has actually been detected on this
             // machine. If not (e.g. Doctor wants 'claude' but Claude CLI isn't
@@ -427,11 +454,11 @@ class CronService {
             const hasCli = detected.some((a) => a.backend === presetBackend && !!a.cliPath);
             if (hasCli) {
               resolvedAgentType = presetBackend as AcpBackendAll;
-              convType = 'acp';
+              convType = convTypeForBackend(resolvedAgentType);
             } else {
               mainWarn('CronService', `Preset ${presetAssistantId} requested backend '${presetBackend}' but no CLI was detected; falling back to Sudoclaw gateway`);
               resolvedAgentType = 'openclaw-gateway';
-              convType = 'openclaw-gateway';
+              convType = convTypeForBackend(resolvedAgentType);
             }
           }
         } catch (err) {
@@ -444,11 +471,17 @@ class CronService {
         if (!hasScodeCli) {
           mainWarn('CronService', 'Scode is selected for cron execution but no CLI was detected; falling back to Sudoclaw gateway');
           resolvedAgentType = 'openclaw-gateway';
-          convType = 'openclaw-gateway';
+          convType = convTypeForBackend(resolvedAgentType);
         }
       }
 
       const agentType = resolvedAgentType;
+      // Mirror the manual-session model resolution chain so the cron job
+      // runs against whichever model the user picked in the ACP model
+      // selector. Empty string is the documented "fall through to backend
+      // default" signal in initAgent.ts.
+      const preferredModelId = await this.readUserPreferredModelId(agentType);
+      const resolvedModelId = resolvePreferredAcpModelId({ backend: agentType, preferredModelId }) ?? undefined;
 
       let task;
       let activeConversationId: string;
@@ -464,7 +497,7 @@ class CronService {
         const min = String(runDate.getMinutes()).padStart(2, '0');
         const convName = `${yyyy}/${mm}/${dd} ${hh}:${min} – ${job.name}`;
 
-        mainLog('CronService', `Creating new conversation: name="${convName}" type="${convType}" agentType="${agentType}"`);
+        mainLog('CronService', `Creating new conversation: name="${convName}" type="${convType}" agentType="${agentType}" modelId="${resolvedModelId ?? 'default'}"`);
         const result = await createConversation({
           type: convType as any,
           name: convName,
@@ -476,6 +509,7 @@ class CronService {
             customWorkspace: !!job.metadata.workspace,
             cronJobId: job.id,
             cronJobName: job.name,
+            currentModelId: resolvedModelId,
             ...(presetAssistantId && {
               presetAssistantId,
               customAgentId: presetAssistantId,
@@ -541,6 +575,7 @@ class CronService {
               customWorkspace: !!job.metadata.workspace,
               cronJobId: job.id,
               cronJobName: job.name,
+              currentModelId: resolvedModelId,
               ...(presetAssistantId && {
                 presetAssistantId,
                 customAgentId: presetAssistantId,
@@ -626,6 +661,64 @@ class CronService {
     const updatedJob = cronStore.getById(job.id);
     if (updatedJob) {
       ipcBridge.cron.onJobUpdated.emit(updatedJob);
+    }
+  }
+
+  /**
+   * Read the user's last-selected agent from the Guid page and translate it
+   * into an AcpBackendAll. The fallback chain mirrors useGuidAgentSelection
+   * so cron jobs without a bound preset assistant track UI preference
+   * changes between runs.
+   *
+   * - 'custom:<id>' is ignored here: cron jobs that pointed at a custom
+   *   assistant carry it via presetAssistantId, so this path is reserved
+   *   for jobs created against the Default Assistant.
+   */
+  private async resolveUserPreferredAgent(stored: AcpBackendAll): Promise<AcpBackendAll> {
+    let userPref: string | undefined;
+    try {
+      userPref = await ConfigStorage.get('guid.lastSelectedAgent');
+    } catch (err) {
+      mainWarn('CronService', 'Failed to read guid.lastSelectedAgent, falling back to stored agentType:', err);
+      return stored;
+    }
+    if (userPref && !userPref.startsWith('custom:')) {
+      return userPref as AcpBackendAll;
+    }
+    // No usable preference saved yet — use the mode-aware default rather
+    // than the stored (possibly stale) value that was frozen at job-creation
+    // time. This is what makes the cron "follow user preference".
+    return defaultAgentForMode(isEnterpriseMode()) as AcpBackendAll;
+  }
+
+  /**
+   * Read the user's last-selected agent and return it as a PresetAgentType
+   * when it maps to one (used inside the preset-assistant branch as a
+   * fallback for the hard-coded DEFAULT_PRESET_AGENT_TYPE).
+   */
+  private async readUserPreferredPresetAgentType(): Promise<string | undefined> {
+    try {
+      const userPref = await ConfigStorage.get('guid.lastSelectedAgent');
+      if (userPref && !userPref.startsWith('custom:') && userPref !== 'remote-agent') {
+        return userPref;
+      }
+    } catch {
+      // Silent — the caller already has a hard fallback.
+    }
+    return undefined;
+  }
+
+  /**
+   * Read the per-backend preferred model the user picked in AcpModelSelector.
+   * Returns undefined when no preference is set; the caller pipes this
+   * through resolvePreferredAcpModelId for the full fallback chain.
+   */
+  private async readUserPreferredModelId(backend: AcpBackendAll): Promise<string | undefined> {
+    try {
+      const acpConfig = await ConfigStorage.get('acp.config');
+      return acpConfig?.[backend as AcpBackend]?.preferredModelId;
+    } catch {
+      return undefined;
     }
   }
 

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -6,6 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import { resolvePreferredAcpModelId } from '@/common/acp/defaultModels';
+import { defaultAgentForMode } from '@/common/acp/defaultAgent';
 import { getPresetById } from '@/common/presets/presetResolver';
 import { DEFAULT_CODEX_MODELS } from '@/common/codex/codexModels';
 import type { IProvider } from '@/common/storage';
@@ -107,7 +108,7 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
 
   // Initial selected agent key: enterprise mode defaults to generic 'remote-agent'
   const getInitialAgentKey = useCallback(() => {
-    return isEnterprise ? 'remote-agent' : DEFAULT_PRESET_AGENT_TYPE;
+    return defaultAgentForMode(isEnterprise);
   }, [isEnterprise]);
 
   const [selectedAgentKey, _setSelectedAgentKey] = useState<string>(() => getInitialAgentKey());
@@ -181,9 +182,10 @@ export const useGuidAgentSelection = ({ modelList, isGoogleAuth, localeKey, assi
     } else {
       // Consumer mode: reset to default preset if currently on remote-agent or custom
       if (selectedAgentKeyRef.current === 'remote-agent' || selectedAgentKeyRef.current.startsWith('custom:')) {
-        _setSelectedAgentKey(DEFAULT_PRESET_AGENT_TYPE);
-        selectedAgentKeyRef.current = DEFAULT_PRESET_AGENT_TYPE;
-        ConfigStorage.set('guid.lastSelectedAgent', DEFAULT_PRESET_AGENT_TYPE).catch((error) => {
+        const fallback = defaultAgentForMode(false);
+        _setSelectedAgentKey(fallback);
+        selectedAgentKeyRef.current = fallback;
+        ConfigStorage.set('guid.lastSelectedAgent', fallback).catch((error) => {
           console.error('Failed to save consumer agent:', error);
         });
       }

--- a/tests/unit/defaultAgent.test.ts
+++ b/tests/unit/defaultAgent.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { defaultAgentForMode } from '../../src/common/acp/defaultAgent';
+import { DEFAULT_PRESET_AGENT_TYPE } from '../../src/types/acpTypes';
+
+describe('defaultAgentForMode', () => {
+  it('returns the preset agent default in consumer mode', () => {
+    expect(defaultAgentForMode(false)).toBe(DEFAULT_PRESET_AGENT_TYPE);
+  });
+
+  it("returns 'remote-agent' in enterprise mode", () => {
+    expect(defaultAgentForMode(true)).toBe('remote-agent');
+  });
+});


### PR DESCRIPTION
## Summary

Scheduled tasks (Cron) used to freeze the agent and model selection at job-creation time and ignore later UI changes. A user who picked Claude or a specific scode model in the Guid page would still see cron jobs execute against `scode` with the backend default model.

This PR makes the cron path share the same resolution chain as manual sessions.

## Before

`CronService.executeJob` resolved the runtime agent purely from `job.metadata.agentType` (frozen at creation) plus `meta?.presetAgentType || DEFAULT_PRESET_AGENT_TYPE`, and always passed an empty model (`useModel: ''`). Result: every "Default Assistant" cron job ran as `scode + gemini-3-flash`, regardless of UI preference.

## After

- **Agent resolution (no preset assistant):** `guid.lastSelectedAgent` → `defaultAgentForMode(isEnterprise)`, then the existing CLI-availability fallback.
- **Agent resolution (preset assistant bound):** preset meta wins; when meta omits `presetAgentType`, the same `guid.lastSelectedAgent` lookup is used before falling back to `DEFAULT_PRESET_AGENT_TYPE`.
- **Model resolution:** `acp.config[backend].preferredModelId` → `resolvePreferredAcpModelId` → `getDefaultAcpModelId(backend)`. The resolved id is threaded through `extra.currentModelId` so it lands in `createAcpAgent`.
- **Enterprise dispatch:** introduced `convTypeForBackend` so a `remote-agent` preference routes to the `'remote-agent'` conversation type (previously coerced to `'acp'`).
- **Shared SSOT:** `defaultAgentForMode(isEnterprise)` extracted to `src/common/acp/defaultAgent.ts`; both `useGuidAgentSelection` and `CronService` consume it.

## Changed paths

- `src/common/acp/defaultAgent.ts` (new) — `defaultAgentForMode` shared helper.
- `src/process/services/cron/CronService.ts` — runtime agent/model resolution + `convTypeForBackend` + three private helpers (`resolveUserPreferredAgent`, `readUserPreferredPresetAgentType`, `readUserPreferredModelId`). `currentModelId` is now passed to both `createConversation` calls.
- `src/renderer/pages/guid/hooks/useGuidAgentSelection.ts` — initial selection (`getInitialAgentKey`) and consumer-mode reset now call `defaultAgentForMode` instead of inlining the branch.
- `tests/unit/defaultAgent.test.ts` (new) — covers consumer and enterprise defaults.

## Test coverage

- `tests/unit/defaultAgent.test.ts` — 2 passing tests for the shared helper.
- `bunx tsc --noEmit` — only the pre-existing `tsconfig.json` `baseUrl` deprecation warning; no new TS errors.
- `bunx vitest run` — 31 failures are pre-existing on `dev` (verified by running the same suite against the unmodified base); none touch the files in this PR.
- Manual smoke: not run. The cron execution path requires a live workspace + assistant + ACP CLI to exercise the new resolution, which I couldn't set up in this environment. Worth a reviewer pass before merging.

## Skipped

- **Cron drawer model picker** (Task 3 in the brief, marked "可选，看时间"). `CronJobDrawer.tsx` is the post-creation edit drawer for command/enabled only — adding an `AcpModelSelector` and threading it through the cron job schema is a meaningful UX change with its own surface (creation modal vs. edit drawer, schema migration). Punted for a follow-up.

## Open question for reviewer

The brief asked me to double-check the fallback constants. What I found:

- `DEFAULT_SCODE_MODEL_ID = 'gemini-3-flash'` in `src/common/acp/defaultModels.ts:7` — only used by `getDefaultAcpModelId`, no duplicates.
- `DEFAULT_PRIMARY_MODEL = 'gemini-3-flash-preview'` in `src/common/sudoclawModelConfig.ts:4` — sudorouter primary, used by the sudoclaw runtime config (`sudoclawBridge.ts`, `sudoclawRuntimeSync.ts`, `SudoclawInstallService.ts`, settings UI).
- `DEFAULT_IMAGE_PARSING_MODEL = 'gemini-3-flash-preview'` in `src/common/storage.ts:492` — image parsing.

These are **not** redundant copies of the same constant — `gemini-3-flash` is the public scode ACP model id, `gemini-3-flash-preview` is the sudorouter preview tier. They live at different layers. The brief was expecting `gemini-3.5-flash`, but the repo has moved on; current product-correct values look right to me, but flagging in case the model lineup has shifted again (e.g., sudorouter dropping the `-preview` suffix). **Reviewer decision needed: are both still current?** No code change made.

## Test plan

- [ ] Create a cron job with the Default Assistant. Switch the Guid page agent to Claude. Trigger the cron — confirm the log line `Creating new conversation: ... agentType="claude"` (CLI permitting) instead of `scode`.
- [ ] Create a cron job with the Default Assistant. Pick a non-default scode model in the model selector. Trigger the cron — confirm log line shows `modelId="<picked>"`.
- [ ] Bind a cron job to a preset assistant. Confirm the assistant's `presetAgentType` still wins over the user preference.
- [ ] In enterprise mode with no preset assistant bound, confirm `remote-agent` routes correctly (no `'invalid conversation type'` error).
- [ ] CI: type check + the test cases that touch agent selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
