### PR TITLE
fix(enterprise): resolve icon URLs and MCP installed status

### DIFF
--- a/src/renderer/components/SettingsModal/contents/secrets/EnterpriseSecretSection.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/EnterpriseSecretSection.tsx
@@ -14,22 +14,25 @@ import { useTranslation } from 'react-i18next';
 import PreferenceRow from './PreferenceRow';
 import type { TenantConfigItem } from './types';
 
-function resolveIconUrl(iconUrl: string | null): string {
+function resolveIconUrl(iconUrl: string | null, baseUrl?: string): string {
   if (!iconUrl) return configItemDefaultIcon;
   if (iconUrl.startsWith('data:') || iconUrl.startsWith('http://') || iconUrl.startsWith('https://')) {
     return iconUrl;
   }
+  if (baseUrl) {
+    return `${baseUrl.replace(/\/+$/, '')}${iconUrl.startsWith('/') ? iconUrl : `/${iconUrl}`}`;
+  }
   return configItemDefaultIcon;
 }
 
-const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string }> = ({ iconUrl, name }) => {
-  const [useDefault, setUseDefault] = React.useState(false);
+const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string; baseUrl?: string }> = ({ iconUrl, name, baseUrl }) => {
+  const [useDefault, setUseDefault] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setUseDefault(false);
   }, [iconUrl]);
 
-  const src = useDefault ? configItemDefaultIcon : resolveIconUrl(iconUrl ?? null);
+  const src = useDefault ? configItemDefaultIcon : resolveIconUrl(iconUrl ?? null, baseUrl);
   return <img src={src} alt={name} className='w-16px h-16px object-contain shrink-0' onError={() => setUseDefault(true)} />;
 };
 
@@ -40,12 +43,16 @@ export const EnterpriseSecretSection: React.FC = () => {
   const { ensureValidToken, user } = useAuth();
   const [items, setItems] = useState<TenantConfigItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [iconBaseUrl, setIconBaseUrl] = useState<string | undefined>(undefined);
 
   const loadItems = useCallback(async () => {
     if (!user?.id) return;
     try {
       const token = await ensureValidToken();
       const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+      if (typeof serverUrl === 'string') {
+        setIconBaseUrl(serverUrl);
+      }
       const headers = { Authorization: `Bearer ${token}` };
 
       // 1. Get authorized system config IDs
@@ -91,7 +98,7 @@ export const EnterpriseSecretSection: React.FC = () => {
                     <Right theme='outline' size='14' className='transition-transform' />
                   </span>
                   <div className='flex h-28px w-28px items-center justify-center rd-7px bg-fill-1'>
-                    <ConfigItemIcon iconUrl={item.icon_url} name={item.name} />
+                    <ConfigItemIcon iconUrl={item.icon_url} name={item.name} baseUrl={iconBaseUrl} />
                   </div>
                   <span className='min-w-0 flex-1 truncate text-14px font-600 text-t-primary'>{item.name}</span>
                 </div>

--- a/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
@@ -7,28 +7,53 @@
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
 import { Button, Collapse, Input, Message, Switch } from '@arco-design/web-react';
 import configItemDefaultIcon from '@/renderer/assets/config-item-default.svg';
+import { ConfigStorage } from '@/common/storage';
+import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { Right } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import PreferenceRow from './PreferenceRow';
 import type { TenantConfigItem, TenantConfigValues } from './types';
 
-function resolveIconUrl(iconUrl: string | null): string {
+function resolveIconUrl(iconUrl: string | null, baseUrl?: string): string {
   if (!iconUrl) return configItemDefaultIcon;
   if (iconUrl.startsWith('data:') || iconUrl.startsWith('http://') || iconUrl.startsWith('https://')) {
     return iconUrl;
+  }
+  if (baseUrl) {
+    return `${baseUrl.replace(/\/+$/, '')}${iconUrl.startsWith('/') ? iconUrl : `/${iconUrl}`}`;
   }
   return `${SUDOWORK_SERVER_BASE_URL}${iconUrl}`;
 }
 
 const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string }> = ({ iconUrl, name }) => {
   const [useDefault, setUseDefault] = useState(false);
+  const { isEnterprise } = useAppMode();
+  const [baseUrl, setBaseUrl] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     setUseDefault(false);
   }, [iconUrl]);
 
-  const src = useDefault ? configItemDefaultIcon : resolveIconUrl(iconUrl ?? null);
+  useEffect(() => {
+    if (!isEnterprise) return;
+    let mounted = true;
+    void (async () => {
+      try {
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        if (mounted && typeof serverUrl === 'string') {
+          setBaseUrl(serverUrl);
+        }
+      } catch {
+        // silent
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [isEnterprise]);
+
+  const src = useDefault ? configItemDefaultIcon : resolveIconUrl(iconUrl ?? null, baseUrl);
 
   return <img src={src} alt={name} className='w-16px h-16px object-contain shrink-0' onError={() => setUseDefault(true)} />;
 };

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/__prototype__/mockData.ts
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/__prototype__/mockData.ts
@@ -24,6 +24,7 @@ export const MOCK_ENTERPRISE_SERVERS: EnterpriseMcpServerDto[] = [
     allow_user_disable: true,
     enabled: true,
     status: 'enabled',
+    template_id: null,
     user_disabled: false,
   },
   {
@@ -44,6 +45,7 @@ export const MOCK_ENTERPRISE_SERVERS: EnterpriseMcpServerDto[] = [
     allow_user_disable: true,
     enabled: true,
     status: 'enabled',
+    template_id: null,
     user_disabled: false,
   },
   {
@@ -64,6 +66,7 @@ export const MOCK_ENTERPRISE_SERVERS: EnterpriseMcpServerDto[] = [
     allow_user_disable: false,
     enabled: false,
     status: 'disabled',
+    template_id: null,
     user_disabled: false,
   },
 ];
@@ -87,6 +90,7 @@ export const MOCK_PERSONAL_SERVERS: EnterpriseMcpServerDto[] = [
     allow_user_disable: true,
     enabled: true,
     status: 'enabled',
+    template_id: 'tpl-001',
     user_disabled: false,
   },
   {
@@ -107,6 +111,7 @@ export const MOCK_PERSONAL_SERVERS: EnterpriseMcpServerDto[] = [
     allow_user_disable: true,
     enabled: false,
     status: 'disabled',
+    template_id: null,
     user_disabled: true,
   },
 ];

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/components/McpIcon.tsx
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/components/McpIcon.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Connection } from '@icon-park/react';
+import { ConfigStorage } from '@/common/storage';
 
 interface McpIconProps {
   icon: string | null | undefined;
@@ -7,16 +8,38 @@ interface McpIconProps {
   className?: string;
 }
 
-/** Allow `data:` and `http(s):` URLs straight through; everything else gets fallback. */
-function resolveIconUrl(icon: string | null | undefined): string | null {
+/** Allow `data:` and `http(s):` URLs straight through; relative paths resolved via baseUrl. */
+function resolveIconUrl(icon: string | null | undefined, baseUrl?: string): string | null {
   if (!icon) return null;
   if (icon.startsWith('data:') || icon.startsWith('http://') || icon.startsWith('https://')) return icon;
+  if (baseUrl) {
+    return `${baseUrl.replace(/\/+$/, '')}${icon.startsWith('/') ? icon : `/${icon}`}`;
+  }
   return null;
 }
 
 const McpIcon: React.FC<McpIconProps> = ({ icon, size = 36, className = '' }) => {
   const [errored, setErrored] = useState(false);
-  const url = resolveIconUrl(icon);
+  const [baseUrl, setBaseUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let mounted = true;
+    void (async () => {
+      try {
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        if (mounted && typeof serverUrl === 'string') {
+          setBaseUrl(serverUrl);
+        }
+      } catch {
+        // silent
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const url = resolveIconUrl(icon, baseUrl);
   const showImage = url && !errored;
 
   return (

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/index.tsx
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/index.tsx
@@ -50,14 +50,8 @@ const EnterpriseMcpSettings: React.FC = () => {
 
   const templates = templatesPage?.data ?? [];
 
-  // Server DTO has no template_id. On install, the backend mints server.name as
-  // `<template.name>-<random-suffix>` (e.g., template "github-mcp" → server
-  // "github-mcp-3a8f1cde") to allow multiple installs of the same template.
-  // Match by exact equality (no suffix) or by `template.name + '-'` prefix.
-  // Use longest-prefix wins so a server never double-counts when template names
-  // overlap (e.g., "github" vs "github-mcp").
-  // 同一份匹配结果同时派生 installedTemplateIds（给 MCP 库展示已安装态）
-  // 和 serverHasUserConfig（给"我的 MCP"决定是否显示"修改配置"按钮）。
+  // Derive installed template IDs and user-config availability from server.template_id.
+  // Only user-scope servers are considered — MCP library installs are always personal.
   const { installedTemplateIds, serverHasUserConfig } = useMemo<{
     installedTemplateIds: Set<string>;
     serverHasUserConfig: Map<string, boolean>;
@@ -67,14 +61,14 @@ const EnterpriseMcpSettings: React.FC = () => {
     if (servers.length === 0 || templates.length === 0) {
       return { installedTemplateIds: ids, serverHasUserConfig: hasConfigMap };
     }
-    const sortedTpls = [...templates].sort((a, b) => b.name.length - a.name.length);
+    const tplMap = new Map(templates.map((t) => [t.id, t]));
     for (const s of servers) {
-      const matched = sortedTpls.find((t) => s.name === t.name || s.name.startsWith(`${t.name}-`));
-      if (matched) {
-        ids.add(matched.id);
-        hasConfigMap.set(s.id, (matched.user_config_items?.length ?? 0) > 0);
+      if (s.scope !== 'user' || !s.template_id) continue;
+      const tpl = tplMap.get(s.template_id);
+      if (tpl) {
+        ids.add(tpl.id);
+        hasConfigMap.set(s.id, (tpl.user_config_items?.length ?? 0) > 0);
       }
-      // 未匹配到模板的 server 在 Map 中缺省，调用方按 false 处理（保守策略：不显示"修改配置"）
     }
     return { installedTemplateIds: ids, serverHasUserConfig: hasConfigMap };
   }, [servers, templates]);

--- a/src/renderer/pages/settings/EnterpriseMcpSettings/types.ts
+++ b/src/renderer/pages/settings/EnterpriseMcpSettings/types.ts
@@ -29,6 +29,7 @@ export interface EnterpriseMcpServerDto {
   allow_user_disable: boolean;
   enabled: boolean;
   status: EnterpriseMcpStatus;
+  template_id: string | null;
   user_disabled: boolean;
   _requires_approval?: boolean;
 }


### PR DESCRIPTION
## 修复内容

### 1. E端图标相对路径拼接
E端三个接口返回的图标字段（icon_url / icon）可能为相对路径，当前前端对相对路径处理有误：
- TenantConfigItemGroup：拼接了 C端地址
- EnterpriseSecretSection：直接返回默认图标
- McpIcon：直接丢弃

修复：resolveIconUrl 增加 baseUrl 参数，E端获取 eeclaw.serverUrl 拼接相对路径。C端行为不变。

### 2. MCP 库已安装判断
原逻辑按 server name 前缀匹配，会误匹配企业级 MCP。改为 scope === user + template_id 精确匹配。

🤖 Generated with [Claude Code](https://claude.com/claude-code)