### PR TITLE
fix(guid): clear input draft on reset and send button to prevent stale text

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -309,6 +309,7 @@ const GuidPage: React.FC = () => {
 
   // Listen for guid.reset event to reset agent/mention state only
   const handleGuidReset = useCallback(() => {
+    setGuidDraft({ input: '' });
     agentSelection.resetSelection();
     setCursorPosition(0);
     mention.setMentionOpen(false);
@@ -538,9 +539,7 @@ const GuidPage: React.FC = () => {
       loading={guidInput.loading}
       isButtonDisabled={send.isButtonDisabled}
       onSend={() => {
-        send.handleSend().catch((error) => {
-          console.error('Failed to send message:', error);
-        });
+        send.sendMessageHandler();
       }}
     />
   );


### PR DESCRIPTION
## 问题

在 B 端（企业端）remote agent 对话中，新建会话时 Guid 页面输入框默认填写了上一个会话的第一条消息内容。

## 根因

1. `guid.reset` 事件处理函数 `handleGuidReset` 只重置了 agent/mention 状态，没有清理输入草稿（`guidDraftStore`）
2. 发送按钮直接调用 `handleSend().catch(...)` 跳过了 `sendMessageHandler` 中的 `setInput('')` 草稿清理

## 修复

- 在 `handleGuidReset` 中增加 `setGuidDraft({ input: '' })` 清除输入草稿
- 发送按钮改用 `sendMessageHandler()` 与 Enter 键路径保持一致

## 影响范围

B 端和 C 端共享 Guid 页面，两处修复对 B/C 端均正向生效，无副作用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)