### PR TITLE
fix(renderer): polish code and modal layouts

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -140,7 +140,7 @@ function CodeBlock(props: any) {
     const diffLines = isDiff ? formattedContent.split('\n') : [];
 
     return (
-      <div style={{ width: '100%', minWidth: 0, maxWidth: '100%', overflowX: 'auto', ...(props.codeStyle || {}) }}>
+      <div style={{ width: '100%', minWidth: 0, maxWidth: '100%', ...(props.codeStyle || {}) }}>
         <div
           style={{
             width: '100%',
@@ -149,7 +149,6 @@ function CodeBlock(props: any) {
             border: '1px solid var(--bg-3)',
             borderRadius: '0.3rem',
             overflow: 'hidden',
-            overflowX: 'auto',
           }}
         >
           <div
@@ -200,41 +199,37 @@ function CodeBlock(props: any) {
           {logicRender(
             !fold,
             <>
-              <SyntaxHighlighter
-                children={formattedContent}
-                language={language}
-                style={codeTheme}
-                PreTag='div'
-                wrapLines={isDiff}
-                lineProps={
-                  isDiff
-                    ? (lineNumber: number) => ({
-                        style: { display: 'block', ...getDiffLineStyle(diffLines[lineNumber - 1] || '', currentTheme === 'dark') },
-                      })
-                    : undefined
-                }
-                customStyle={{
-                  width: '100%',
-                  minWidth: 0,
-                  marginTop: '0',
-                  margin: '0',
-                  borderTopLeftRadius: '0',
-                  borderTopRightRadius: '0',
-                  borderBottomLeftRadius: '0',
-                  borderBottomRightRadius: '0',
-                  border: 'none',
-                  background: 'transparent',
-                  color: 'var(--text-primary)',
-                  overflowX: 'auto',
-                  maxWidth: '100%',
-                  whiteSpace: 'pre',
-                }}
-                codeTagProps={{
-                  style: {
+              <div style={{ width: '100%', minWidth: 0, maxWidth: '100%', overflowX: 'auto' }}>
+                <SyntaxHighlighter
+                  children={formattedContent}
+                  language={language}
+                  style={codeTheme}
+                  PreTag='div'
+                  wrapLines={isDiff}
+                  lineProps={
+                    isDiff
+                      ? (lineNumber: number) => ({
+                          style: { display: 'block', ...getDiffLineStyle(diffLines[lineNumber - 1] || '', currentTheme === 'dark') },
+                        })
+                      : undefined
+                  }
+                  customStyle={{
+                    width: 'max-content',
+                    minWidth: '100%',
+                    margin: '0',
+                    border: 'none',
+                    background: 'transparent',
                     color: 'var(--text-primary)',
-                  },
-                }}
-              />
+                    overflowX: 'visible',
+                    whiteSpace: 'pre',
+                  }}
+                  codeTagProps={{
+                    style: {
+                      color: 'var(--text-primary)',
+                    },
+                  }}
+                />
+              </div>
               <div
                 style={{
                   display: 'flex',

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -180,7 +180,6 @@ const SkillCard: React.FC<{
   loadingVersion?: boolean;
 }> = ({ skill, isInstalled, hasVersion, installing, installProgress, onInstall, onClick, hasUpdate, onUpdate, updating, latestVersion, loadingVersion }) => {
   const { t } = useTranslation();
-
   return (
     <div className='settings-library-card group bg-fill-1 rd-12px cursor-pointer hover:bg-fill-2 transition-colors border border-line p-12px flex items-start gap-12px relative overflow-hidden' onClick={onClick}>
       {/* Icon */}
@@ -542,11 +541,8 @@ const SkillDetailModal: React.FC<{
                   </Button>
                 </Tooltip>
                 <Tooltip content={t('common.download', { defaultValue: '下载' })}>
-                  <Button size='large' onClick={onDownload} loading={downloading} disabled={installing}>
-                    <span className='flex items-center gap-6px justify-center'>
-                      <Download size='15' />
-                      {t('common.download', { defaultValue: '下载' })}
-                    </span>
+                  <Button size='large' icon={<Download size='15' />} loading={downloading} loadingFixedWidth onClick={onDownload} disabled={installing}>
+                    {t('common.download', { defaultValue: '下载' })}
                   </Button>
                 </Tooltip>
               </>

--- a/src/renderer/pages/conversation/right-panel/DeliverablesPanel.tsx
+++ b/src/renderer/pages/conversation/right-panel/DeliverablesPanel.tsx
@@ -71,12 +71,12 @@ const DeliverablesPanel: React.FC<DeliverablesPanelProps> = ({ conversationId })
   const grouped = useMemo(() => groupByDay(entries, t), [entries, t]);
 
   return (
-    <div className='flex flex-col h-full min-h-0 overflow-y-auto px-12px py-10px gap-12px'>
+    <div className='flex flex-1 flex-col h-full min-h-0 overflow-y-auto px-12px py-10px gap-12px'>
       {entries.length === 0 ? (
         <EmptyState loading={loading} />
       ) : (
         grouped.map((group) => (
-          <div key={group.label} className='flex flex-col gap-6px'>
+          <div key={group.label} className='flex flex-col gap-6px w-fit'>
             <div className='text-11px text-t-secondary opacity-70 uppercase tracking-wider'>{group.label}</div>
             <div className='flex flex-col gap-6px'>
               {group.entries.map((entry) => (


### PR DESCRIPTION
# Pull Request

## 说明

这个 PR 合入了 3 个前端修复：

- 交付物 tab 空状态改为在可用高度内居中，且有交付物时内容不再占满整行。
- 技能详情 modal 的下载按钮 loading 状态修复，避免 loading icon 下方溢出。
- 会话界面代码框横向滚动条修复，确保只有代码内容区域出现横向滚动条，header/footer 不再产生额外空白和滚动。

## 测试

- 未执行自动化测试（仅做了定向 UI 修复）。
