### PR TITLE
优化输入框 Chip 样式并延后会话操作按钮显示

### DIFF
--- a/src/renderer/components/CssThemeSettings/presets/discourse-horizon.css
+++ b/src/renderer/components/CssThemeSettings/presets/discourse-horizon.css
@@ -731,7 +731,7 @@ body {
 .agent-mode-compact-pill,
 .guidContainer .sendbox-model-btn.guid-config-btn {
   border: 1px solid var(--border-base) !important;
-  background: color-mix(in srgb, var(--horizon-surface) 92%, var(--aou-1)) !important;
+  background: color-mix(in srgb, var(--horizon-surface) 90%, var(--fill)) !important;
   color: var(--text-primary) !important;
 }
 
@@ -752,16 +752,16 @@ body {
 [data-theme='dark'] .header-model-btn,
 [data-theme='dark'] .agent-mode-compact-pill,
 [data-theme='dark'] .guidContainer .sendbox-model-btn.guid-config-btn {
-  background: color-mix(in srgb, var(--horizon-surface-soft) 92%, var(--aou-2)) !important;
+  background: color-mix(in srgb, var(--horizon-surface-soft) 90%, var(--fill)) !important;
 }
 
 .guidContainer .actionTools .arco-btn.arco-btn-text {
   border-radius: 999px !important;
-  background: color-mix(in srgb, var(--horizon-surface) 90%, var(--aou-1)) !important;
+  background: color-mix(in srgb, var(--horizon-surface) 90%, var(--fill)) !important;
 }
 
 [data-theme='dark'] .guidContainer .actionTools .arco-btn.arco-btn-text {
-  background: color-mix(in srgb, var(--horizon-surface-soft) 90%, var(--aou-2)) !important;
+  background: color-mix(in srgb, var(--horizon-surface-soft) 90%, var(--fill)) !important;
 }
 
 .guidContainer [data-agent-pill='true'][data-agent-selected='true'] {

--- a/src/renderer/components/ui/ActionChip.tsx
+++ b/src/renderer/components/ui/ActionChip.tsx
@@ -19,7 +19,7 @@ export type ActionChipProps = {
 
 const ActionChip = forwardRef<HTMLButtonElement, ActionChipProps>(({ icon, label, active = false, disabled = false, onClick, className, title, ...rest }, ref) => {
   return (
-    <button ref={ref} type='button' title={title} disabled={disabled} className={classNames('inline-flex h-34px min-w-0 items-center gap-7px rd-999px border border-solid px-12px text-13px font-500 transition-colors', 'border-[var(--ui-border-strong)] bg-bg-1 text-t-secondary hover:bg-fill-1 hover:text-t-primary', 'disabled:cursor-not-allowed disabled:opacity-55', active && 'border-[rgba(var(--ui-accent-orange-rgb),0.52)] bg-bg-1 text-[var(--ui-accent-orange)]', onClick ? 'cursor-pointer' : 'cursor-default', className)} onClick={onClick} {...rest}>
+    <button ref={ref} type='button' title={title} disabled={disabled} className={classNames('inline-flex h-34px min-w-0 items-center gap-7px rd-999px border border-solid px-12px text-13px font-500 transition-colors', 'border-[var(--border-base)] bg-fill-2 text-t-secondary hover:bg-fill-3 hover:text-t-primary', 'disabled:cursor-not-allowed disabled:opacity-55', active && 'border-[rgba(var(--ui-accent-orange-rgb),0.44)] bg-[rgba(var(--ui-accent-orange-rgb),0.12)] text-[var(--ui-accent-orange)] hover:bg-[rgba(var(--ui-accent-orange-rgb),0.16)]', onClick ? 'cursor-pointer' : 'cursor-default', className)} onClick={onClick} {...rest}>
       {icon && <span className='inline-flex h-16px w-16px shrink-0 items-center justify-center text-inherit'>{icon}</span>}
       <span className='min-w-0 truncate'>{label}</span>
     </button>

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -375,8 +375,10 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
       diffsChanges = [];
       result.push(message);
     }
-    // Flush any remaining turn actions at the end
-    flushTurnActions();
+    // Only expose turn actions after the AI stream finishes.
+    if (!aiProcessing) {
+      flushTurnActions();
+    }
 
     // Insert time separators between messages with significant time gaps
     // 在时间间隔较大的消息之间插入时间分隔符

--- a/src/renderer/pages/guid/index.module.css
+++ b/src/renderer/pages/guid/index.module.css
@@ -86,18 +86,18 @@
   min-width: 0;
 }
 
-/* 首页输入框下方「模型 / 模式」按钮：弱化视觉，不抢主输入区 */
+/* 首页输入框下方「模型 / 模式」按钮：跟随主题使用更柔和的填充 */
 .actionTools :global(.sendbox-model-btn) {
-  background-color: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
+  background: color-mix(in srgb, var(--horizon-surface) 90%, var(--fill)) !important;
+  border: 1px solid var(--border-base) !important;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.28) inset !important;
   color: var(--color-text-2) !important;
 }
 
 .actionTools :global(.sendbox-model-btn:hover) {
-  background-color: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
+  background: color-mix(in srgb, var(--horizon-surface) 82%, var(--horizon-selected)) !important;
+  border: 1px solid var(--border-base) !important;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--horizon-focus-ring) 60%, transparent) !important;
   color: var(--color-text-1) !important;
 }
 


### PR DESCRIPTION
## 修改内容
- 调整会话页和 Guide 页输入框中的 chip 按钮颜色，使其跟随深浅色主题，避免浅色下白底过于突兀。
- 调整会话页面 AI 消息底部的复制 / Word / 分享按钮显示时机，改为等流式输出结束后再展示。

## 验证
- `bunx prettier --check src/renderer/components/ui/ActionChip.tsx src/renderer/pages/guid/index.module.css src/renderer/components/CssThemeSettings/presets/discourse-horizon.css src/renderer/messages/MessageList.tsx`
- `bunx eslint src/renderer/messages/MessageList.tsx`（仅有仓库内已有 warning）