### PR TITLE
fix(theme): apply default theme on first launch

### DIFF
--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -117,9 +117,14 @@ const Layout: React.FC<{
 
       let effectiveCss = decision.effectiveCss;
 
-      // If the active theme resolved to empty CSS and there IS a saved activeThemeId
-      // (but it no longer matches any known theme), fall back to default and persist.
-      if (!effectiveCss && activeThemeId && activeThemeId !== DEFAULT_THEME_ID) {
+      // First launch (nothing saved yet) vs. a saved activeThemeId that no longer
+      // maps to a known theme: in both cases the resolved CSS is empty. Fall back to
+      // the Default theme and persist it, mirroring what CssThemeSettings does on
+      // mount. Without this, a fresh install renders with NO theme variables until
+      // the user opens Settings → Display, which left some surfaces (notably the
+      // terminal) using unreadable fallback colors.
+      const isFirstLaunch = !savedCssRaw && !activeThemeId;
+      if (!effectiveCss && (isFirstLaunch || (activeThemeId && activeThemeId !== DEFAULT_THEME_ID))) {
         const defaultCss = resolveCssByActiveTheme(DEFAULT_THEME_ID, (savedThemes || []) as ICssTheme[]);
         effectiveCss = defaultCss;
         // Persist the fallback so Layout doesn't keep retrying


### PR DESCRIPTION
## 问题

全新安装首次进入应用、未打开过「设置 → 显示」时，终端（交付物/工作空间 区域）显示为发白、灰字看不清；只要进入一次显示设置、任意主题生效后就恢复正常，且之后永久正常。

## 根因

终端配色依赖一组主题 CSS 变量（`--color-bg-1`、`--color-text-1` 等），这些变量由「显示主题」的 CSS 提供。

`src/renderer/layout.tsx` 的 `loadAndHealCustomCss` 在启动时读取已保存的 `customCss` 与 `css.activeThemeId`：

- 全新安装时两者均为空。原逻辑只有在 `activeThemeId` **非空**（且指向已失效主题）时才回退默认主题；首次启动 `activeThemeId` 为空，该分支不触发，`effectiveCss` 返回空字符串 —— **未注入任何主题 CSS**，终端只能用兜底色，发白看不清。
- 打开 设置→显示 后，`CssThemeSettings.loadThemes` 会把 `activeThemeId` 写为 `DEFAULT_THEME_ID` 并持久化默认主题 CSS，因此之后恒正常 —— 与现象一致。

## 修复

在 `layout.tsx` 中把首次启动也纳入「回退默认主题」逻辑（与 `CssThemeSettings` 行为一致），并持久化，使全新安装首次进入即应用默认主题，无需先逛设置页。

## 验证

清除本地 `customCss` / `css.activeThemeId`（模拟全新安装）后启动，直接打开终端 tab 即为正常配色。

🤖 Generated with [Claude Code](https://claude.com/claude-code)