### PR TITLE
feat(cron): gate client cron UI on Moss admin flag (enterprise mode)

### DIFF
--- a/src/common/types/tenantConfig.ts
+++ b/src/common/types/tenantConfig.ts
@@ -25,6 +25,13 @@ export interface TenantConfig {
   about_name?: string;
   /** 公司主体名称 - 关于页公司信息 */
   app_company_name?: string;
+  /**
+   * 是否允许企业版客户端使用定时任务（cron）功能。
+   * 由 Moss 管理端控制，仅企业模式生效；null/undefined 视为开启（默认 true）。
+   * Whether the enterprise client may use the cron feature. Controlled by the
+   * Moss admin; enterprise mode only. null/undefined → enabled (default true).
+   */
+  client_cron_enabled?: boolean | null;
 }
 
 /**
@@ -36,7 +43,7 @@ export interface TenantConfigResponse {
   msg?: string;
 }
 
-export type TenantConfigInput = Partial<Record<keyof TenantConfig, string | null | undefined>>;
+export type TenantConfigInput = Partial<Record<keyof TenantConfig, string | boolean | null | undefined>>;
 
 export const TENANT_CONFIG_STORAGE_KEY = 'sudowork_tenant_config';
 
@@ -51,15 +58,18 @@ export const DEFAULT_TENANT_CONFIG: Required<TenantConfig> = {
   login_desp: 'AgentOps | 办公专家',
   about_name: 'SudoWork',
   app_company_name: '北京数牍科技有限公司',
+  client_cron_enabled: true,
 };
 
 export function resolveTenantConfig(config?: TenantConfigInput | null): Required<TenantConfig> {
   return {
-    logo: config?.logo || DEFAULT_TENANT_CONFIG.logo,
-    app_name: config?.app_name || DEFAULT_TENANT_CONFIG.app_name,
-    top_name: config?.top_name || DEFAULT_TENANT_CONFIG.top_name,
-    login_desp: config?.login_desp || DEFAULT_TENANT_CONFIG.login_desp,
-    about_name: config?.about_name || DEFAULT_TENANT_CONFIG.about_name,
-    app_company_name: config?.app_company_name || DEFAULT_TENANT_CONFIG.app_company_name,
+    logo: (config?.logo as string | undefined) || DEFAULT_TENANT_CONFIG.logo,
+    app_name: (config?.app_name as string | undefined) || DEFAULT_TENANT_CONFIG.app_name,
+    top_name: (config?.top_name as string | undefined) || DEFAULT_TENANT_CONFIG.top_name,
+    login_desp: (config?.login_desp as string | undefined) || DEFAULT_TENANT_CONFIG.login_desp,
+    about_name: (config?.about_name as string | undefined) || DEFAULT_TENANT_CONFIG.about_name,
+    app_company_name: (config?.app_company_name as string | undefined) || DEFAULT_TENANT_CONFIG.app_company_name,
+    // Only an explicit `false` disables cron; null/undefined → default on.
+    client_cron_enabled: config?.client_cron_enabled === false ? false : true,
   };
 }

--- a/src/renderer/hooks/useCronEnabled.ts
+++ b/src/renderer/hooks/useCronEnabled.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useAppMode } from '@/renderer/hooks/useAppMode';
+import { useTenantConfig } from '@/renderer/context/TenantConfigContext';
+
+/**
+ * Whether the client-side cron (scheduled task) feature is available.
+ *
+ * - Consumer mode: always enabled.
+ * - Enterprise mode: governed by the Moss-managed `client_cron_enabled` flag
+ *   delivered through the tenant config (admin/super_admin only; read-only on
+ *   the client). A missing/unset value defaults to enabled.
+ */
+export function useCronEnabled(): boolean {
+  const { isEnterprise } = useAppMode();
+  const { config } = useTenantConfig();
+
+  if (!isEnterprise) {
+    return true;
+  }
+  // resolveTenantConfig normalizes this to a boolean (default true).
+  return config.client_cron_enabled !== false;
+}

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -6,6 +6,7 @@
 
 import { resolveLocaleKey } from '@/common/utils';
 import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
+import { useCronEnabled } from '@/renderer/hooks/useCronEnabled';
 import { openExternalUrl, isElectronDesktop, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { useConversationTabs } from '@/renderer/pages/conversation/context/ConversationTabsContext';
 import { ThemeSwitcher } from '@/renderer/components/ThemeSwitcher';
@@ -69,6 +70,7 @@ const GuidPage: React.FC = () => {
   const selectedMenu = searchParams.get('menu');
   const skillParam = searchParams.get('skill');
   const assistantParam = searchParams.get('assistant');
+  const cronEnabled = useCronEnabled();
 
   // Skill selector state
   const [installedSkills, setInstalledSkills] = useState<any[]>([]);
@@ -615,7 +617,7 @@ const GuidPage: React.FC = () => {
             {selectedMenu === 'agent' && <AgentSettings />}
             {selectedMenu === 'security' && <SecuritySettings />}
             {selectedMenu === 'webui' && <WebuiSettings />}
-            {selectedMenu === 'cron' && <CronSettings />}
+            {selectedMenu === 'cron' && cronEnabled && <CronSettings />}
           </div>
         ) : (
           /* Normal/Assistant conversation area */

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Navigate, Route, Routes, useLocation } from 'react-router-d
 import AppLoader from './components/AppLoader';
 import { useAuth } from './context/AuthContext';
 import { useAppMode, isModeResolved } from './hooks/useAppMode';
+import { useCronEnabled } from './hooks/useCronEnabled';
 
 const Conversation = React.lazy(() => import('./pages/conversation'));
 const Guid = React.lazy(() => import('./pages/guid'));
@@ -48,6 +49,7 @@ const SettingsDefaultRoute: React.FC = () => {
 const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
   const { status } = useAuth();
   const { isEnterprise } = useAppMode();
+  const cronEnabled = useCronEnabled();
   const location = useLocation();
 
   if (status === 'checking') {
@@ -66,6 +68,11 @@ const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) =
   // Enterprise mode route guard: restrict access to allowed settings paths
   if (isEnterprise && location.pathname.startsWith('/settings/') && !ENTERPRISE_ALLOWED_PATHS.includes(location.pathname)) {
     return <Navigate to='/settings/enterprise' replace />;
+  }
+
+  // Client cron disabled: the cron settings page is not reachable.
+  if (!cronEnabled && location.pathname === '/settings/cron') {
+    return <Navigate to='/settings/agent' replace />;
   }
 
   return React.cloneElement(layout);

--- a/src/renderer/sider.tsx
+++ b/src/renderer/sider.tsx
@@ -14,6 +14,7 @@ import { useAuth } from './context/AuthContext';
 import { addEventListener, emitter } from './utils/emitter';
 import { ConfigStorage } from '@/common/storage';
 import { useAppMode } from './hooks/useAppMode';
+import { useCronEnabled } from './hooks/useCronEnabled';
 import SidebarNavItem from './components/ui/SidebarNavItem';
 import SidebarSegmentedControl from './components/ui/SidebarSegmentedControl';
 
@@ -48,6 +49,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   const navigate = useNavigate();
   const { logout, user: currentUser } = useAuth();
   const { isEnterprise } = useAppMode();
+  const cronEnabled = useCronEnabled();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
@@ -86,7 +88,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
   };
 
   // 功能菜单项定义 / Function menu items definition
-  const functionMenus = [{ id: 'agent', label: t('common.siderMenu.agent'), icon: Robot, path: '/settings/agent' }, { id: 'skill-store', label: t('common.siderMenu.skillStore'), icon: Lightning, path: '/settings/skill' }, { id: 'security', label: t('common.siderMenu.security'), icon: Shield, path: '/settings/security' }, ...(!isEnterprise ? [{ id: 'webui' as const, label: t('common.siderMenu.webui'), icon: Earth, path: '/settings/webui' }] : []), { id: 'cron', label: t('common.siderMenu.cron'), icon: AlarmClock, path: '/settings/cron' }];
+  const functionMenus = [{ id: 'agent', label: t('common.siderMenu.agent'), icon: Robot, path: '/settings/agent' }, { id: 'skill-store', label: t('common.siderMenu.skillStore'), icon: Lightning, path: '/settings/skill' }, { id: 'security', label: t('common.siderMenu.security'), icon: Shield, path: '/settings/security' }, ...(!isEnterprise ? [{ id: 'webui' as const, label: t('common.siderMenu.webui'), icon: Earth, path: '/settings/webui' }] : []), ...(cronEnabled ? [{ id: 'cron' as const, label: t('common.siderMenu.cron'), icon: AlarmClock, path: '/settings/cron' }] : [])];
 
   // 处理功能菜单点击 — 在 GuidPage 内联显示，通过 query param 传递 menuId
   const handleFunctionMenuClick = (menuId: string) => {
@@ -128,6 +130,9 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     setIsBatchMode((prev) => !prev);
   };
 
+  // With client cron disabled the scheduled tab is hidden, so fall back to the
+  // timeline even if 'scheduled' was previously persisted.
+  const effectiveTab: 'timeline' | 'scheduled' = cronEnabled ? activeTab : 'timeline';
   const workspaceHistoryProps = {
     collapsed,
     tooltipEnabled: collapsed && !isMobile,
@@ -138,7 +143,7 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
     },
     batchMode: isBatchMode,
     onBatchModeChange: setIsBatchMode,
-    activeTab,
+    activeTab: effectiveTab,
   };
   const tooltipEnabled = collapsed && !isMobile;
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
@@ -229,10 +234,13 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
 
             {/* Session history tabs + batch mode button */}
             <div className={classNames('mb-8px px-8px flex items-center', collapsed ? 'justify-center' : 'justify-between')}>
-              {!collapsed && (
+              {/* The scheduled (cron) tab is only meaningful when the client cron
+                  feature is enabled; with it off only the timeline remains, so we
+                  hide the whole switcher. */}
+              {!collapsed && cronEnabled && (
                 <SidebarSegmentedControl
                   className='flex-1'
-                  value={activeTab}
+                  value={effectiveTab}
                   options={[
                     { value: 'timeline', label: t('conversation.history.timeline', { defaultValue: '对话' }) },
                     { value: 'scheduled', label: t('conversation.history.scheduledTab', { defaultValue: '定时任务' }) },


### PR DESCRIPTION
## Summary

Hides the cron (scheduled task) surfaces in the client when a **Moss-managed** flag is off. The flag is **read-only on the client** — only a Moss admin/super_admin can change it — and it only governs **enterprise mode**. Consumer mode always has cron enabled.

The flag arrives through the existing tenant config channel (`GET /api/v1/tenant/config`).

## Changes

- **`src/common/types/tenantConfig.ts`** — add `client_cron_enabled` (default `true`; only an explicit `false` disables).
- **`src/renderer/hooks/useCronEnabled.ts`** — `true` in consumer mode; in enterprise mode reads the flag from `TenantConfigContext`.
- **`src/renderer/sider.tsx`** — hide the cron menu item and the scheduled-tasks tab / run list; `effectiveTab` falls back to `timeline` when disabled.
- **`src/renderer/router.tsx`** — redirect `/settings/cron` → `/settings/agent` when disabled.
- **`src/renderer/pages/guid/GuidPage.tsx`** — gate the inline cron page (`?menu=cron`).

## Related

Server/admin side is in the **moss** repo PR #75 (`feat/client-cron-enterprise-toggle`).

## Test plan

- [ ] Consumer mode: cron menu + scheduled tab visible.
- [ ] Enterprise mode, flag on/unset: cron visible.
- [ ] Enterprise mode, admin sets flag off: cron menu, scheduled tab, inline `?menu=cron`, and `/settings/cron` route all hidden/blocked.
- [ ] Toggling on the Moss side propagates within the tenant-config poll interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)