### PR TITLE
feat(messages): 优化会话区正在思考状态展示

### DIFF
--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -17,9 +17,6 @@ import MessageAcpToolCall from '@renderer/messages/acp/MessageAcpToolCall';
 import MessageAgentStatus from '@renderer/messages/MessageAgentStatus';
 import classNames from 'classnames';
 import React, { createContext, useEffect, useMemo } from 'react';
-import sudoclawProDark from '@/renderer/assets/sudoclaw_transparent_large.png';
-import sudoclawProWhite from '@/renderer/assets/sudoclaw_transparent_large.png';
-import sudoworkIconDark from '@/renderer/assets/sudowork-icon-dark.svg';
 import { useTranslation } from 'react-i18next';
 import { Virtuoso } from 'react-virtuoso';
 import { uuid } from '../utils/common';
@@ -64,52 +61,34 @@ type IMessageVO =
 // Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
 
-// Helper to detect current theme
-const isDarkMode = () => {
-  if (typeof document === 'undefined') return false;
-  return document.documentElement.getAttribute('data-theme') === 'dark';
-};
-
 const isUserFacingAcpToolCall = (message: IMessageAcpToolCall): boolean => {
   const title = message.content?.update?.title;
   return title === 'AskUserQuestion' || title === 'SendUserMessage';
 };
 
-const MessageItem: React.FC<{ message: TMessage; isStreaming?: boolean }> = React.memo(
+const MessageItem: React.FC<{ message: TMessage; isStreaming?: boolean; footer?: React.ReactNode }> = React.memo(
   HOC((props) => {
-    const { message, isStreaming } = props as { message: TMessage; isStreaming?: boolean };
+    const { message } = props as { message: TMessage; footer?: React.ReactNode };
     const isAiMessage = message.position === 'left';
-    const [darkMode, setDarkMode] = React.useState(() => isDarkMode());
-
-    React.useEffect(() => {
-      const observer = new MutationObserver(() => {
-        setDarkMode(isDarkMode());
-      });
-      observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
-      return () => observer.disconnect();
-    }, []);
-
-    const streamingAvatar = darkMode ? sudoclawProDark : sudoclawProWhite;
-    const staticAvatar = sudoworkIconDark;
 
     return (
       <div
         data-message-id={message.id}
-        className={classNames('min-w-0 flex w-full items-start box-border message-item [&>div]:max-w-full m-t-10px max-w-full md:max-w-800px mx-auto group', message.type, {
+        className={classNames('min-w-0 flex w-full box-border message-item [&>div]:max-w-full m-t-10px max-w-full md:max-w-800px mx-auto group', message.type, {
+          'items-start': !isAiMessage,
           'justify-center': message.position === 'center',
           'justify-end': message.position === 'right',
           'justify-start': message.position === 'left',
         })}
       >
-        {isAiMessage ? <div className='flex-shrink-0 mr-4px mt-4px w-40px h-40px relative'>{isStreaming ? <img src={streamingAvatar} alt='AI Avatar' className='absolute top-1/2 left-1/2 w-40px h-40px max-w-none -translate-x-1/2 -translate-y-1/2 object-contain' /> : message.type === 'text' ? <img src={staticAvatar} alt='AI Avatar' className='absolute top-1/2 left-1/2 w-24px h-24px max-w-none -translate-x-1/2 -translate-y-1/2 object-contain' /> : null}</div> : <div className='flex-shrink-0 mr-8px mt-4px w-40px h-40px' aria-hidden='true' />}
-        <div className={classNames('min-w-0', isAiMessage ? 'flex flex-1 justify-start' : 'flex-none w-fit')}>{props.children}</div>
+        <div className={classNames('min-w-0', isAiMessage ? 'w-full' : 'flex-none w-fit')}>{props.children}</div>
       </div>
     );
-  })(({ message, isStreaming }) => {
+  })(({ message, isStreaming, footer }) => {
     const { t } = useTranslation();
     switch (message.type) {
       case 'text':
-        return <MessageText message={message} isStreaming={isStreaming}></MessageText>;
+        return <MessageText message={message} isStreaming={isStreaming} footer={footer}></MessageText>;
       case 'tips':
         return <MessageTips message={message}></MessageTips>;
       case 'tool_call':
@@ -404,7 +383,7 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
       }
     }
 
-    const shouldShowLoading = aiProcessing && list.length > 0 && list[list.length - 1].position === 'right';
+    const shouldShowLoading = aiProcessing && list.length > 0;
     if (shouldShowLoading) {
       withTimeSeparators.push({
         type: 'loading_indicator',
@@ -461,6 +440,9 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
   };
 
   const renderItem = (_index: number, item: (typeof processedList)[0]) => {
+    const nextItem = processedList[_index + 1];
+    const turnActionsNode = 'type' in item && nextItem?.type === 'turn_actions' ? <TurnActions turnTexts={nextItem.turnTexts} turnTextsRaw={nextItem.turnTextsRaw} conversationId={nextItem.conversationId} tokenUsage={nextItem.tokenUsage} showTokenUsageBadge={showTokenUsageBadges} /> : undefined;
+
     if ('type' in item && item.type === 'loading_indicator') {
       return <MessageLoadingIndicator key={item.id} />;
     }
@@ -469,53 +451,50 @@ const MessageList: React.FC<MessageListProps> = ({ className, aiProcessing = fal
       return <MessageTimeSeparator key={item.id} timestamp={(item as { type: 'time_separator'; id: string; timestamp: number }).timestamp} />;
     }
     if ('type' in item && ['file_summary', 'tool_summary'].includes(item.type)) {
-      const isLastItemSummary = _index >= processedList.length - 2;
-      const isStreamingForSummary = item.type === 'tool_summary' && (item.messages.some((m) => m.id === lastAiMessageId) || (aiProcessing && isLastItemSummary));
       return (
-        <div key={item.id} data-message-id={item.id} className={'min-w-0 flex w-full items-start box-border message-item m-t-10px max-w-full md:max-w-800px mx-auto ' + item.type}>
-          <div className='flex-shrink-0 mr-4px mt-4px w-40px h-40px relative'>{isStreamingForSummary && <img src={isDarkMode() ? sudoclawProDark : sudoclawProWhite} alt='AI Avatar' className='absolute top-1/2 left-1/2 w-40px h-40px max-w-none -translate-x-1/2 -translate-y-1/2 object-contain' />}</div>
-          <div className='flex flex-1 min-w-0 justify-start'>
-            {item.type === 'file_summary' && <MessageFileChanges diffsChanges={item.diffs} />}
-            {item.type === 'tool_summary' &&
-              (() => {
-                // Check if this summary is part of the ongoing AI response
-                // 检查这个汇总是否是当前正在进行的 AI 响应的一部分
-                const isLastItem = _index >= processedList.length - 2; // last or second to last (actions)
-                const isStreaming = item.messages.some((m) => m.id === lastAiMessageId) || (aiProcessing && isLastItem);
+        <div key={item.id} data-message-id={item.id} className={'min-w-0 flex w-full flex-col items-start box-border message-item m-t-10px max-w-full md:max-w-800px mx-auto ' + item.type}>
+          <div className='w-full min-w-0 flex flex-col items-start'>
+            <div className='flex w-full min-w-0 justify-start'>
+              {item.type === 'file_summary' && <MessageFileChanges diffsChanges={item.diffs} />}
+              {item.type === 'tool_summary' &&
+                (() => {
+                  // Check if this summary is part of the ongoing AI response
+                  // 检查这个汇总是否是当前正在进行的 AI 响应的一部分
+                  const isLastItem = _index >= processedList.length - 2; // last or second to last (actions)
+                  const isStreaming = item.messages.some((m) => m.id === lastAiMessageId) || (aiProcessing && isLastItem);
 
-                return (
-                  <MessageToolGroupSummary
-                    messages={item.messages}
-                    summaryId={item.id}
-                    // While AI is processing/streaming this block, it MUST be expanded.
-                    // 当 AI 正在处理或流式传输此块时，它必须展开。
-                    isExpanded={isStreamingForSummary ? true : (toolSummaryStates[item.id] ?? false)}
-                    onToggle={(id) => {
-                      // Only allow toggling if it's NOT streaming
-                      if (!isStreamingForSummary) {
-                        setToolSummaryStates((prev) => ({ ...prev, [id]: !prev[id] }));
-                      }
-                    }}
-                    isStreaming={isStreaming}
-                  />
-                );
-              })()}
+                  return (
+                    <MessageToolGroupSummary
+                      messages={item.messages}
+                      summaryId={item.id}
+                      // While AI is processing/streaming this block, it MUST be expanded.
+                      // 当 AI 正在处理或流式传输此块时，它必须展开。
+                      isExpanded={isStreaming ? true : (toolSummaryStates[item.id] ?? false)}
+                      onToggle={(id) => {
+                        // Only allow toggling if it's NOT streaming
+                        if (!isStreaming) {
+                          setToolSummaryStates((prev) => ({ ...prev, [id]: !prev[id] }));
+                        }
+                      }}
+                      isStreaming={isStreaming}
+                    />
+                  );
+                })()}
+            </div>
+            {turnActionsNode && <div className='mt-4px w-full max-w-full'>{turnActionsNode}</div>}
           </div>
         </div>
       );
     }
     if ('type' in item && item.type === 'turn_actions') {
-      return (
-        <div key={item.id} className='group min-w-0 message-item w-full box-border max-w-full md:max-w-800px mx-auto'>
-          <TurnActions turnTexts={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTexts} turnTextsRaw={(item as Extract<IMessageVO, { type: 'turn_actions' }>).turnTextsRaw} conversationId={(item as Extract<IMessageVO, { type: 'turn_actions' }>).conversationId} tokenUsage={(item as Extract<IMessageVO, { type: 'turn_actions' }>).tokenUsage} showTokenUsageBadge={showTokenUsageBadges} />
-        </div>
-      );
+      return null;
     }
-    return <MessageItem message={item as TMessage} key={(item as TMessage).id} isStreaming={(item as TMessage).id === lastAiMessageId}></MessageItem>;
+    const message = item as TMessage;
+    return <MessageItem message={message} key={message.id} isStreaming={message.id === lastAiMessageId} footer={turnActionsNode}></MessageItem>;
   };
 
   return (
-    <div className='relative flex-1 h-full' onContextMenu={handleContextMenu}>
+    <div className={classNames('relative flex-1 h-full', className)} onContextMenu={handleContextMenu}>
       {/* Context Menu Rendering */}
       {contextMenu && <ContextMenu x={contextMenu.x} y={contextMenu.y} items={contextMenu.items} onClose={() => setContextMenu(null)} />}
       {/* Use PreviewGroup to wrap all messages for cross-message image preview */}

--- a/src/renderer/messages/MessageLoadingIndicator.tsx
+++ b/src/renderer/messages/MessageLoadingIndicator.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import classNames from 'classnames';
 import sudoclawProDark from '@/renderer/assets/sudoclaw_transparent_large.png';
-import sudoclawProWhite from '@/renderer/assets/sudoclaw_transparent_large.png';
+import { useTranslation } from 'react-i18next';
 
-// Helper to detect current theme
+const sudoclawProWhite = sudoclawProDark;
+
 const isDarkMode = () => {
   if (typeof document === 'undefined') return false;
   return document.documentElement.getAttribute('data-theme') === 'dark';
 };
 
 const MessageLoadingIndicator: React.FC = () => {
+  const { t } = useTranslation();
   const [darkMode, setDarkMode] = React.useState(() => isDarkMode());
 
   React.useEffect(() => {
@@ -21,13 +23,16 @@ const MessageLoadingIndicator: React.FC = () => {
   }, []);
 
   const streamingAvatar = darkMode ? sudoclawProDark : sudoclawProWhite;
+  const thinkingLabel = t('codex.thinking.processing', { defaultValue: '正在思考...' })
+    .replace(/^🤔\s*/u, '')
+    .replace(/^Codex\s*/u, '');
 
   return (
-    <div className={classNames('min-w-0 flex w-full items-start message-item [&>div]:max-w-full m-t-10px max-w-full md:max-w-800px mx-auto group', 'justify-start')}>
-      <div className='flex-shrink-0 mr-4px mt-4px w-40px h-40px relative'>
-        <img src={streamingAvatar} alt='AI Loading Avatar' className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-40px h-40px max-w-none object-contain' />
+    <div className={classNames('min-w-0 flex w-full message-item [&>div]:max-w-full m-t-10px max-w-full md:max-w-800px mx-auto group justify-start')}>
+      <div className='flex items-center gap-8px text-t-secondary'>
+        <img src={streamingAvatar} alt='AI Loading Avatar' className='loading w-40px h-40px max-w-none object-contain' />
+        <span className='text-13px leading-20px'>{thinkingLabel}</span>
       </div>
-      {/* Intentionally left empty - we do NOT want a message bubble, just the pulsing avatar */}
     </div>
   );
 };

--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -57,7 +57,7 @@ const useFormatContent = (content: string) => {
   }, [content]);
 };
 
-const MessageText: React.FC<{ message: IMessageText; isStreaming?: boolean }> = ({ message, isStreaming = false }) => {
+const MessageText: React.FC<{ message: IMessageText; isStreaming?: boolean; footer?: React.ReactNode }> = ({ message, isStreaming = false, footer }) => {
   // Filter think tags from content before rendering
   // 在渲染前过滤 think 标签
   const contentToRender = useMemo(() => {
@@ -140,6 +140,8 @@ const MessageText: React.FC<{ message: IMessageText; isStreaming?: boolean }> = 
 
   const cronMeta = message.content.cronMeta;
 
+  const showFooter = Boolean(footer) && !isUserMessage;
+
   return (
     <>
       <div className={classNames('min-w-0 flex max-w-full flex-col', isUserMessage ? 'items-end' : 'items-start', !isUserMessage && hasCodeLikeContent && 'w-full')}>
@@ -191,6 +193,7 @@ const MessageText: React.FC<{ message: IMessageText; isStreaming?: boolean }> = 
             <GeneratedFileCards entries={generated.files} />
           </div>
         )}
+        {showFooter && <div className='mt-4px w-full max-w-full'>{footer}</div>}
         {/* Skill tags - displayed below user message content */}
         {skills.length > 0 && isUserMessage && (
           <div className={classNames('mt-6px mb-6px', { 'self-end': isUserMessage })}>

--- a/src/renderer/messages/TurnActions.tsx
+++ b/src/renderer/messages/TurnActions.tsx
@@ -127,7 +127,7 @@ const TurnActions: React.FC<TurnActionsProps> = ({ turnTexts, turnTextsRaw, conv
 
   return (
     <>
-      <div className='flex items-center min-h-28px gap-4px pl-48px flex-wrap'>
+      <div className='flex items-center min-h-28px gap-4px flex-wrap'>
         <Tooltip content={t('common.copy', { defaultValue: 'Copy' })}>
           <div className='p-4px rd-4px cursor-pointer hover:bg-3 transition-colors' onClick={handleCopy} style={{ lineHeight: 0 }}>
             <Copy theme='outline' size='16' fill={iconColors.secondary} />


### PR DESCRIPTION
## 修改内容\n- 将会话区的 AI 动态状态调整为底部思考状态条，显示“正在思考...”\n- 去掉静态 AI logo 和 emoji，仅保留动态状态展示\n- 让 turn actions 作为 AI 消息的 footer 渲染，减少独立空行\n- 调整消息列表与加载状态的布局对齐，贴近 cowork 风格