### PR TITLE
feat(terminal): isolate right-panel terminal per conversation

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -43,13 +43,24 @@ export interface ITerminalResizeParams {
   rows: number;
 }
 
+/** Emitted whenever the active PTY count changes for a conversation.
+ *  Used by the sidebar to render a "running" spinner next to conversations
+ *  that have live terminal processes. */
+export interface ITerminalActiveCountEvent {
+  conversationId: string;
+  count: number;
+}
+
 export const terminal = {
-  create: bridge.buildProvider<IBridgeResponse<ITerminalCreateResult>, { cwd?: string; shell?: string } | undefined>('terminal.create'),
+  create: bridge.buildProvider<IBridgeResponse<ITerminalCreateResult>, { cwd?: string; shell?: string; conversationId?: string } | undefined>('terminal.create'),
   write: bridge.buildProvider<IBridgeResponse<void>, { sessionId: string; data: string }>('terminal.write'),
   resize: bridge.buildProvider<IBridgeResponse<void>, ITerminalResizeParams>('terminal.resize'),
   dispose: bridge.buildProvider<IBridgeResponse<void>, { sessionId: string }>('terminal.dispose'),
+  /** Kill all PTYs whose `conversationId` matches. SIGTERM with a 2s grace then SIGKILL. */
+  closeByConversation: bridge.buildProvider<IBridgeResponse<{ killed: number }>, { conversationId: string }>('terminal.closeByConversation'),
   output: bridge.buildEmitter<ITerminalOutputEvent>('terminal.output'),
   exit: bridge.buildEmitter<ITerminalExitEvent>('terminal.exit'),
+  activeCountChanged: bridge.buildEmitter<ITerminalActiveCountEvent>('terminal.activeCountChanged'),
 };
 
 //通用会话能力

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -28,6 +28,7 @@ import { resolveWorkspaceSkillsDir } from '../utils/workspaceSkillsDir';
 import { INTERMEDIATE_DIR_SEGMENTS } from '../task/FileIntentClassifier';
 import WorkerManage from '../WorkerManage';
 import { migrateConversationToDatabase } from './migrationUtils';
+import { closeTerminalsByConversation } from './terminalBridge';
 import { skillManager } from '../SkillManager';
 import { ConversationManageWithDB } from '../message';
 import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
@@ -458,6 +459,15 @@ export function initConversationBridge(): void {
 
       // Kill the running task if exists
       WorkerManage.kill(id);
+
+      // Reap any right-panel terminals tied to this conversation. Call the
+      // function directly — bridge.invoke from main → main does NOT route to
+      // the local provider (main adapter's emit only broadcasts to renderers).
+      try {
+        closeTerminalsByConversation(id);
+      } catch (err) {
+        mainWarn('conversationBridge', 'closeTerminalsByConversation failed', err);
+      }
 
       // Delete associated cron jobs
       try {

--- a/src/process/bridge/terminalBridge.ts
+++ b/src/process/bridge/terminalBridge.ts
@@ -6,14 +6,115 @@
 
 import { ipcBridge } from '../../common';
 import { getSystemDir } from '../initStorage';
+import { mainLog } from '../utils/mainLogger';
 import os from 'node:os';
+import { execSync } from 'node:child_process';
 import * as pty from '@lydell/node-pty';
 
 type TerminalSession = {
   pty: pty.IPty;
+  /** The conversation this PTY belongs to. Optional for legacy callers; used to
+   *  drive per-conversation cleanup (closeByConversation) and the sidebar
+   *  "running" spinner (activeCountChanged). */
+  conversationId?: string;
+  createdAt: number;
 };
 
 const sessions = new Map<string, TerminalSession>();
+
+/** Hard cap: refuse to create new PTYs once this many are alive globally. Protects
+ *  the host from runaway tab creation. Per-conv cap is enforced in the renderer. */
+const GLOBAL_PTY_HARD_LIMIT = 50;
+
+/** Grace period before escalating SIGTERM → SIGKILL on closeByConversation. */
+const SIGTERM_GRACE_MS = 2000;
+
+/**
+ * Walk the full descendant tree of `rootPid` and return all PIDs (including the
+ * root). Necessary because `process.kill(-pid, signal)` only signals processes
+ * in the PTY's own process group — but zsh's job control puts each `&`
+ * background job into its **own** process group, so a `sleep 600 &` will
+ * survive signaling the PTY's pgroup.
+ *
+ * Uses `ps -A -o pid=,ppid=` (POSIX-portable across macOS and Linux). Returns
+ * descendants leaf-first so callers can kill children before their parents and
+ * avoid a momentary reparent-to-launchd window.
+ */
+function collectDescendants(rootPid: number): number[] {
+  let psOut: string;
+  try {
+    psOut = execSync('ps -A -o pid=,ppid=', { encoding: 'utf-8' });
+  } catch {
+    return [rootPid];
+  }
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of psOut.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length !== 2) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    const arr = childrenByParent.get(ppid);
+    if (arr) arr.push(pid);
+    else childrenByParent.set(ppid, [pid]);
+  }
+  const order: number[] = [];
+  const queue: number[] = [rootPid];
+  while (queue.length > 0) {
+    const pid = queue.shift()!;
+    order.push(pid);
+    const children = childrenByParent.get(pid) ?? [];
+    queue.push(...children);
+  }
+  return order.reverse(); // leaves first
+}
+
+function killTree(rootPid: number, signal: 'SIGTERM' | 'SIGKILL'): void {
+  for (const pid of collectDescendants(rootPid)) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // process already gone
+    }
+  }
+}
+
+/**
+ * Reap all PTYs tied to a conversation. Exported so main-process callers
+ * (e.g. conversationBridge on delete) can invoke directly — `bridge.invoke`
+ * in main does NOT route back to local providers, only renderer → main works.
+ */
+export function closeTerminalsByConversation(conversationId: string): { killed: number } {
+  const toKill: Array<{ sessionId: string; session: TerminalSession }> = [];
+  for (const [sessionId, session] of sessions) {
+    if (session.conversationId === conversationId) {
+      toKill.push({ sessionId, session });
+    }
+  }
+  mainLog('terminalBridge', `closeTerminalsByConversation conv=${conversationId} matched=${toKill.length}/${sessions.size}`);
+  if (toKill.length === 0) return { killed: 0 };
+
+  for (const { session } of toKill) {
+    const descendants = collectDescendants(session.pty.pid);
+    mainLog('terminalBridge', `SIGTERM rootPid=${session.pty.pid} descendants=${JSON.stringify(descendants)}`);
+    killTree(session.pty.pid, 'SIGTERM');
+  }
+
+  setTimeout(() => {
+    for (const { sessionId, session } of toKill) {
+      if (sessions.has(sessionId)) {
+        const descendants = collectDescendants(session.pty.pid);
+        mainLog('terminalBridge', `SIGKILL rootPid=${session.pty.pid} descendants=${JSON.stringify(descendants)}`);
+        killTree(session.pty.pid, 'SIGKILL');
+        sessions.delete(sessionId);
+      }
+    }
+    emitActiveCount(conversationId);
+  }, SIGTERM_GRACE_MS).unref?.();
+
+  emitActiveCount(conversationId);
+  return { killed: toKill.length };
+}
 
 const defaultShell = (): string => {
   if (process.platform === 'win32') {
@@ -22,8 +123,23 @@ const defaultShell = (): string => {
   return process.env.SHELL || '/bin/bash';
 };
 
+/** Count live PTYs for a conversation and broadcast. Cheap enough to call after
+ *  every create/exit/dispose — the Map is in-process and we only emit one event. */
+function emitActiveCount(conversationId: string | undefined): void {
+  if (!conversationId) return;
+  let count = 0;
+  for (const session of sessions.values()) {
+    if (session.conversationId === conversationId) count++;
+  }
+  ipcBridge.terminal.activeCountChanged.emit({ conversationId, count });
+}
+
 export function initTerminalBridge(): void {
-  ipcBridge.terminal.create.provider(async ({ cwd, shell }) => {
+  ipcBridge.terminal.create.provider(async ({ cwd, shell, conversationId } = {}) => {
+    if (sessions.size >= GLOBAL_PTY_HARD_LIMIT) {
+      return { success: false, msg: `Global PTY limit reached (${GLOBAL_PTY_HARD_LIMIT}). Close some terminals and try again.` };
+    }
+
     const sessionId = `terminal_${Date.now()}_${Math.random().toString(16).slice(2)}`;
     const defaultCwd = getSystemDir().workDir || os.homedir();
     const term = pty.spawn(shell || defaultShell(), [], {
@@ -39,10 +155,14 @@ export function initTerminalBridge(): void {
     });
     term.onExit(({ exitCode }) => {
       ipcBridge.terminal.exit.emit({ sessionId, exitCode });
+      const session = sessions.get(sessionId);
       sessions.delete(sessionId);
+      emitActiveCount(session?.conversationId);
     });
 
-    sessions.set(sessionId, { pty: term });
+    sessions.set(sessionId, { pty: term, conversationId, createdAt: Date.now() });
+    mainLog('terminalBridge', `create sessionId=${sessionId} convId=${conversationId} pid=${term.pid}`);
+    emitActiveCount(conversationId);
     return { success: true, data: { sessionId } };
   });
 
@@ -61,7 +181,13 @@ export function initTerminalBridge(): void {
     if (session) {
       session.pty.kill();
       sessions.delete(sessionId);
+      emitActiveCount(session.conversationId);
     }
     return { success: true, data: undefined };
+  });
+
+  ipcBridge.terminal.closeByConversation.provider(async ({ conversationId }) => {
+    const result = closeTerminalsByConversation(conversationId);
+    return { success: true, data: result };
   });
 }

--- a/src/renderer/pages/conversation/ChatSider.tsx
+++ b/src/renderer/pages/conversation/ChatSider.tsx
@@ -104,7 +104,7 @@ const ChatSider: React.FC<{
             <BrowserPanel active={activeTab === 'browser'} />
           </div>
           <div className={`right-panel-stack__pane ${activeTab === 'terminal' ? 'right-panel-stack__pane--active' : ''}`}>
-            <TerminalPanel cwd={workspace} active={activeTab === 'terminal'} />
+            <TerminalPanel cwd={workspace} active={activeTab === 'terminal'} conversationId={conversation?.id} />
           </div>
           <div className={`right-panel-stack__pane ${activeTab === 'deliverables' ? 'right-panel-stack__pane--active' : ''}`}>
             <DeliverablesPanel conversationId={conversation?.id} active={activeTab === 'deliverables'} />

--- a/src/renderer/pages/conversation/right-panel/TerminalPanel.tsx
+++ b/src/renderer/pages/conversation/right-panel/TerminalPanel.tsx
@@ -2,7 +2,7 @@ import { ipcBridge } from '@/common';
 import { FitAddon } from '@xterm/addon-fit';
 import { Tooltip } from '@arco-design/web-react';
 import { Add, Close } from '@icon-park/react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
@@ -12,16 +12,86 @@ type TerminalTab = {
   sessionId: string | null;
 };
 
-type TerminalSessionRuntime = {
+type ConvState = {
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+};
+
+type StoredRuntime = {
   terminal: Terminal;
   fitAddon: FitAddon;
+  ownerConvKey: string;
   cleanup: () => void;
 };
 
 type TerminalPanelProps = {
   cwd?: string;
   active?: boolean;
+  conversationId?: string;
 };
+
+const PER_CONV_TAB_LIMIT = 10;
+const FALLBACK_CONV_KEY = '__global__';
+
+// ── Module-scope state ────────────────────────────────────────────────────────
+//
+// IMPORTANT: ChatSider is remounted by React on every conversation switch
+// (verified via BrowserPanelCDP webview destroy/register logs). So state held
+// in component refs is wiped on every switch. To get the "switch back and still
+// see tabs and history" behavior (Q1 in the design doc), we hoist:
+//   - conversation tab state
+//   - xterm runtimes (and their DOM elements)
+//   - the global terminal.exit listener
+// to module scope. The component is a thin view that reads/writes this state
+// and reattaches xterm DOM elements to fresh containers on every mount.
+
+const moduleStates = new Map<string, ConvState>();
+const moduleRuntimes = new Map<string, StoredRuntime>(); // key: tabId
+const moduleListeners = new Set<() => void>();
+
+function notifyListeners(): void {
+  for (const l of moduleListeners) l();
+}
+
+function getOrCreateConvState(convKey: string): ConvState {
+  let state = moduleStates.get(convKey);
+  if (!state) {
+    state = { tabs: [], activeTabId: null };
+    moduleStates.set(convKey, state);
+  }
+  return state;
+}
+
+/** Look up which tab a sessionId belongs to (across all conversations). */
+function findTabBySessionId(sessionId: string): { convKey: string; tab: TerminalTab } | null {
+  for (const [convKey, state] of moduleStates.entries()) {
+    const tab = state.tabs.find((t) => t.sessionId === sessionId);
+    if (tab) return { convKey, tab };
+  }
+  return null;
+}
+
+// One process-wide listener for terminal.exit so that ConvState stays accurate
+// even while no TerminalPanel is mounted (e.g. user has the workspace tab
+// open instead). Cleanup of xterm/runtime is left to user actions (closeTab)
+// and conversation deletion (handled externally via closeByConversation IPC).
+let exitListenerInstalled = false;
+function ensureExitListener(): void {
+  if (exitListenerInstalled) return;
+  exitListenerInstalled = true;
+  ipcBridge.terminal.exit.on(({ sessionId }) => {
+    const found = findTabBySessionId(sessionId);
+    if (!found) return;
+    // Leave the tab in place — user sees `[exit N]` written by the active
+    // runtime if mounted, and can manually close the tab. We do clear the
+    // sessionId so the panel will spawn a fresh PTY if the user re-attaches.
+    // But that's currently disabled because xterm shows the [exit N] marker,
+    // and respawning would overwrite history. So just no-op here.
+    void found;
+  });
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
 
 const getThemeColor = (name: string, fallback: string): string => {
   if (typeof window === 'undefined') return fallback;
@@ -34,16 +104,38 @@ const createTab = (): TerminalTab => ({
   sessionId: null,
 });
 
-const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false }) => {
-  const { t } = useTranslation();
-  const [tabs, setTabs] = useState<TerminalTab[]>(() => [createTab()]);
-  const [activeTabId, setActiveTabId] = useState<string>(() => tabs[0]?.id || '');
+// ── Component ─────────────────────────────────────────────────────────────────
 
+const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false, conversationId }) => {
+  const { t } = useTranslation();
+
+  ensureExitListener();
+
+  // Subscribe to module-scope state changes so render is triggered when any
+  // tab/state mutates from inside this component (or from another instance,
+  // though only one mounts at a time today).
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    moduleListeners.add(forceUpdate);
+    return () => {
+      moduleListeners.delete(forceUpdate);
+    };
+  }, []);
+
+  const convKey = conversationId ?? FALLBACK_CONV_KEY;
+  const currentState = getOrCreateConvState(convKey);
+  const tabs = currentState.tabs;
+  const activeTabId = currentState.activeTabId ?? '';
+
+  // Container refs are local to this component instance (one ref per render).
+  // We re-attach xterm DOM elements to these containers in useLayoutEffect
+  // below — runtimes themselves live in module scope.
   const terminalContainerRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const terminalScreenRef = useRef<HTMLDivElement | null>(null);
-  const runtimeRefs = useRef<Record<string, TerminalSessionRuntime | undefined>>({});
+
   const activeTabIdRef = useRef(activeTabId);
   const activePanelRef = useRef(active);
+  const convKeyRef = useRef(convKey);
 
   useEffect(() => {
     activeTabIdRef.current = activeTabId;
@@ -53,75 +145,110 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false }) =>
     activePanelRef.current = active;
   }, [active]);
 
+  useEffect(() => {
+    convKeyRef.current = convKey;
+  }, [convKey]);
+
   const patchTab = useCallback((tabId: string, patch: Partial<TerminalTab>) => {
-    setTabs((prev) => prev.map((tab) => (tab.id === tabId ? { ...tab, ...patch } : tab)));
+    for (const state of moduleStates.values()) {
+      const idx = state.tabs.findIndex((t) => t.id === tabId);
+      if (idx === -1) continue;
+      state.tabs = state.tabs.map((tab) => (tab.id === tabId ? { ...tab, ...patch } : tab));
+      notifyListeners();
+      return;
+    }
   }, []);
 
-  const resizeRuntime = useCallback(
-    (tabId: string) => {
-      const runtime = runtimeRefs.current[tabId];
-      const container = terminalContainerRefs.current[tabId];
-      const sessionId = tabs.find((tab) => tab.id === tabId)?.sessionId;
-      if (!runtime || !container || !sessionId) return;
-
-      requestAnimationFrame(() => {
-        try {
-          runtime.fitAddon.fit();
-          void ipcBridge.terminal.resize.invoke({ sessionId, cols: runtime.terminal.cols, rows: runtime.terminal.rows });
-        } catch (error) {
-          console.error('[TerminalPanel] fit:error', error);
-        }
-      });
-    },
-    [tabs]
-  );
-
-  useEffect(() => {
-    for (const runtime of Object.values(runtimeRefs.current)) {
-      if (!runtime) continue;
-      runtime.terminal.options.disableStdin = !active;
-      if (!active) {
-        runtime.terminal.blur();
+  const resizeRuntime = useCallback((tabId: string) => {
+    const runtime = moduleRuntimes.get(tabId);
+    const container = terminalContainerRefs.current[tabId];
+    if (!runtime || !container) return;
+    // Find sessionId by tabId via module state.
+    let sessionId: string | null = null;
+    for (const state of moduleStates.values()) {
+      const tab = state.tabs.find((t) => t.id === tabId);
+      if (tab) {
+        sessionId = tab.sessionId;
+        break;
       }
+    }
+    if (!sessionId) return;
+
+    requestAnimationFrame(() => {
+      try {
+        runtime.fitAddon.fit();
+        void ipcBridge.terminal.resize.invoke({ sessionId, cols: runtime.terminal.cols, rows: runtime.terminal.rows });
+      } catch (error) {
+        console.error('[TerminalPanel] fit:error', error);
+      }
+    });
+  }, []);
+
+  // Disable stdin / blur on all runtimes whenever panel becomes inactive.
+  useEffect(() => {
+    for (const runtime of moduleRuntimes.values()) {
+      runtime.terminal.options.disableStdin = !active;
+      if (!active) runtime.terminal.blur();
     }
   }, [active]);
 
   useEffect(() => {
     if (active) return;
-    const runtime = runtimeRefs.current[activeTabId];
+    const runtime = moduleRuntimes.get(activeTabId);
     runtime?.terminal.blur();
     terminalContainerRefs.current[activeTabId]?.querySelector('textarea')?.blur();
   }, [active, activeTabId]);
 
   useEffect(() => {
     if (!active) return;
-    const timer = window.setTimeout(() => {
-      resizeRuntime(activeTabId);
-    }, 0);
+    if (!activeTabId) return;
+    const timer = window.setTimeout(() => resizeRuntime(activeTabId), 0);
     return () => window.clearTimeout(timer);
   }, [active, activeTabId, resizeRuntime]);
 
   useEffect(() => {
     const screenEl = terminalScreenRef.current;
     if (!screenEl) return;
-
     const observer = new ResizeObserver(() => {
       if (!activePanelRef.current) return;
       resizeRuntime(activeTabIdRef.current);
     });
-
     observer.observe(screenEl);
     return () => observer.disconnect();
   }, [resizeRuntime]);
 
+  useEffect(() => {
+    if (!active) return;
+    if (!activeTabId) return;
+    const timer = window.setTimeout(() => resizeRuntime(activeTabId), 0);
+    return () => window.clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [convKey]);
+
   const attachRuntime = useCallback(
     async (tabId: string) => {
-      const tab = tabs.find((item) => item.id === tabId);
+      const found = (() => {
+        for (const [k, s] of moduleStates.entries()) {
+          const t = s.tabs.find((tab) => tab.id === tabId);
+          if (t) return { ownerConvKey: k, tab: t };
+        }
+        return null;
+      })();
+      if (!found) return;
+      const { ownerConvKey, tab } = found;
       const container = terminalContainerRefs.current[tabId];
-      if (!tab || tab.sessionId || !container) return;
+      if (!container) return;
+      if (tab.sessionId) return; // already attached
+      if (moduleRuntimes.has(tabId)) return; // race guard
 
-      const res = await ipcBridge.terminal.create.invoke({ cwd });
-      if (!res?.success) return;
+      const res = await ipcBridge.terminal.create.invoke({
+        cwd,
+        conversationId: ownerConvKey === FALLBACK_CONV_KEY ? undefined : ownerConvKey,
+      });
+      if (!res?.success) {
+        console.error('[TerminalPanel] create.failed', res?.msg);
+        return;
+      }
 
       const sessionId = res.data.sessionId;
       const terminal = new Terminal({
@@ -141,26 +268,22 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false }) =>
       const fitAddon = new FitAddon();
       terminal.loadAddon(fitAddon);
       terminal.options.disableStdin = !activePanelRef.current;
-      terminal.attachCustomKeyEventHandler(() => activePanelRef.current && tabId === activeTabIdRef.current);
+      terminal.attachCustomKeyEventHandler(() => activePanelRef.current && tabId === activeTabIdRef.current && ownerConvKey === convKeyRef.current);
       terminal.open(container);
 
       const scheduleFit = () => resizeRuntime(tabId);
       const onData = terminal.onData((data: string) => {
         void ipcBridge.terminal.write.invoke({ sessionId, data });
       });
-
       const onOutput = ipcBridge.terminal.output.on((event) => {
         if (event.sessionId !== sessionId) return;
         terminal.write(event.data);
       });
-
       const onExit = ipcBridge.terminal.exit.on((event) => {
         if (event.sessionId !== sessionId) return;
         terminal.write(`\r\n[exit ${event.exitCode}]\r\n`);
       });
-
       const resizeObserver = new ResizeObserver(scheduleFit);
-
       window.addEventListener('resize', scheduleFit);
       resizeObserver.observe(container);
 
@@ -173,52 +296,95 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false }) =>
         terminal.dispose();
       };
 
-      runtimeRefs.current[tabId] = { terminal, fitAddon, cleanup };
+      moduleRuntimes.set(tabId, { terminal, fitAddon, ownerConvKey, cleanup });
       patchTab(tabId, { sessionId });
       scheduleFit();
     },
-    [cwd, patchTab, resizeRuntime, tabs]
+    [cwd, patchTab, resizeRuntime]
   );
 
-  const openTab = () => {
+  const openTab = useCallback(() => {
+    const state = getOrCreateConvState(convKey);
+    if (state.tabs.length >= PER_CONV_TAB_LIMIT) {
+      console.warn(`[TerminalPanel] per-conv tab limit reached (${PER_CONV_TAB_LIMIT})`);
+      return;
+    }
     const nextTab = createTab();
-    setTabs((prev) => [...prev, nextTab]);
-    setActiveTabId(nextTab.id);
-  };
+    state.tabs = [...state.tabs, nextTab];
+    state.activeTabId = nextTab.id;
+    notifyListeners();
+  }, [convKey]);
 
-  const closeTab = (tabId: string) => {
-    let sessionIdToDispose: string | null = null;
-    setTabs((prev) => {
-      if (prev.length <= 1) return prev;
-      const target = prev.find((item) => item.id === tabId);
-      sessionIdToDispose = target?.sessionId || null;
-      const nextTabs = prev.filter((item) => item.id !== tabId);
-      if (activeTabIdRef.current === tabId) {
-        const nextActive = nextTabs[nextTabs.length - 1] || nextTabs[0];
-        if (nextActive) setActiveTabId(nextActive.id);
+  const closeTab = useCallback(
+    (tabId: string) => {
+      const state = getOrCreateConvState(convKey);
+      const target = state.tabs.find((t) => t.id === tabId);
+      const sessionIdToDispose = target?.sessionId || null;
+      const nextTabs = state.tabs.filter((t) => t.id !== tabId);
+      state.tabs = nextTabs;
+      if (state.activeTabId === tabId) {
+        state.activeTabId = nextTabs.length > 0 ? nextTabs[nextTabs.length - 1].id : null;
       }
-      return nextTabs;
-    });
+      notifyListeners();
 
-    const runtime = runtimeRefs.current[tabId];
-    runtime?.cleanup();
-    delete runtimeRefs.current[tabId];
-    delete terminalContainerRefs.current[tabId];
+      const runtime = moduleRuntimes.get(tabId);
+      runtime?.cleanup();
+      moduleRuntimes.delete(tabId);
+      delete terminalContainerRefs.current[tabId];
 
-    if (sessionIdToDispose) {
-      void ipcBridge.terminal.dispose.invoke({ sessionId: sessionIdToDispose });
-    }
-  };
+      if (sessionIdToDispose) {
+        void ipcBridge.terminal.dispose.invoke({ sessionId: sessionIdToDispose });
+      }
+    },
+    [convKey]
+  );
 
+  const setActiveTab = useCallback(
+    (tabId: string) => {
+      const state = getOrCreateConvState(convKey);
+      state.activeTabId = tabId;
+      notifyListeners();
+    },
+    [convKey]
+  );
+
+  // When activeTab needs a runtime (no sessionId yet), spawn one.
   useEffect(() => {
-    const activeTab = tabs.find((tab) => tab.id === activeTabId);
-    if (!activeTab) return;
-
-    void attachRuntime(activeTab.id);
-    if (activeTab.sessionId) {
-      resizeRuntime(activeTab.id);
+    if (!activeTabId) return;
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab) return;
+    if (tab.sessionId || moduleRuntimes.has(activeTabId)) {
+      resizeRuntime(activeTabId);
+      return;
     }
+    void attachRuntime(activeTabId);
   }, [activeTabId, attachRuntime, resizeRuntime, tabs]);
+
+  // Build the list of panes to render. Only render panes belonging to the
+  // current conversation — we don't need to keep other conv panes mounted
+  // because xterm runtimes are in module scope and we re-attach them on mount.
+  const panes = tabs;
+
+  // After every render, ensure each xterm's DOM element is attached to its
+  // current React-rendered container. xterm.open() can only be called once,
+  // but the underlying DOM element can be moved with appendChild — this is
+  // what gives us "switch back and history is preserved" across conversation
+  // switches that remount the entire component.
+  useLayoutEffect(() => {
+    for (const pane of panes) {
+      const runtime = moduleRuntimes.get(pane.id);
+      const container = terminalContainerRefs.current[pane.id];
+      if (!runtime || !container) continue;
+      if (runtime.terminal.element && runtime.terminal.element.parentNode !== container) {
+        container.appendChild(runtime.terminal.element);
+        try {
+          runtime.fitAddon.fit();
+        } catch {
+          // ignore — container may not be visible yet
+        }
+      }
+    }
+  });
 
   return (
     <div className='terminal-root terminal-root--xterm'>
@@ -232,24 +398,22 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false }) =>
               onMouseDown={(event) => {
                 event.preventDefault();
               }}
-              onClick={() => setActiveTabId(tab.id)}
+              onClick={() => setActiveTab(tab.id)}
             >
               <span className='terminal-root__tab-label'>
                 {t('conversation.rightPanel.terminal.tab', { defaultValue: 'Terminal' })} {index + 1}
               </span>
-              {tabs.length > 1 && (
-                <span
-                  role='button'
-                  tabIndex={-1}
-                  className='terminal-root__tab-close'
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    closeTab(tab.id);
-                  }}
-                >
-                  <Close size={11} />
-                </span>
-              )}
+              <span
+                role='button'
+                tabIndex={-1}
+                className='terminal-root__tab-close'
+                onClick={(event) => {
+                  event.stopPropagation();
+                  closeTab(tab.id);
+                }}
+              >
+                <Close size={11} />
+              </span>
             </button>
           ))}
           <Tooltip content={t('conversation.rightPanel.terminal.newTab', { defaultValue: 'New terminal' })} position='bottom'>
@@ -260,7 +424,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false }) =>
         </div>
       </div>
       <div ref={terminalScreenRef} className='terminal-root__screen terminal-root__screen--xterm'>
-        {tabs.map((tab) => (
+        {panes.map((tab) => (
           <div
             key={tab.id}
             ref={(node) => {


### PR DESCRIPTION
## Summary
- 右侧 terminal 之前 tab 列表是全局共享的:切会话会泄漏 session,删会话还会留下 zsh + `sleep 600 &` 等子进程在后台跑。这个 PR 让 terminal 严格按 conversation 隔离,并在删除会话时彻底回收进程树。
- 把 tab 状态和 xterm 运行时 hoist 到 module-scope,按 conversationId 索引;ChatSider 切换造成的 remount 不再丢历史。xterm DOM 在 `useLayoutEffect` 里 `appendChild` 回挂到新容器。
- 主进程 PTY 注册时记 conversationId,删会话时按 conv 反查;子进程通过 `ps -A -o pid=,ppid=` 走描述符树叶优先递归发信号 —— 因为 zsh 把 `&` 后台任务放在独立 process group,只对 PTY 的 pgroup 发信号会漏掉子进程。
- 两阶段关闭:SIGTERM → 2s grace → SIGKILL。
- 关键修正:`bridge.invoke` 在主进程里调用主进程自身 provider 时不会回流,所以 `closeTerminalsByConversation` 抽成普通导出函数,`conversationBridge.ts` 删会话路径直接调用,不走 IPC。
- 增加 `GLOBAL_PTY_HARD_LIMIT=50` 防止 tab 失控创建。
- ChatSider → TerminalPanel 透传 workspace cwd 和 conversationId。

## Test plan
- [x] 切换会话,每个会话的 terminal tabs 独立,切回来历史保留
- [x] 在 terminal 里跑 `sleep 600 &`、`sleep 300 &`、`sleep 100 &`,删除该会话后 `ps aux | grep sleep` 应空 — 验证通过
- [x] 多会话各开 terminal,各自删除互不影响 — 验证通过
- [ ] 跑满 50 个 PTY 后第 51 个 create 返回 fail msg
- [ ] 跨 conv 不互相重启(switch back history preserved)