### PR TITLE
feat(sidebar): show spinner for conversations with running terminal

### DIFF
--- a/src/process/bridge/terminalBridge.ts
+++ b/src/process/bridge/terminalBridge.ts
@@ -123,18 +123,68 @@ const defaultShell = (): string => {
   return process.env.SHELL || '/bin/bash';
 };
 
-/** Count live PTYs for a conversation and broadcast. Cheap enough to call after
- *  every create/exit/dispose — the Map is in-process and we only emit one event. */
+/** Last emitted "active" count per conversation. We diff against this to skip
+ *  duplicate emits — the 2s tick re-runs ps even when nothing has changed. */
+const lastActiveCount = new Map<string, number>();
+
+/** Build a parent → children PID map once from a single `ps -A` invocation —
+ *  shared by recomputeAndEmitAll so we don't shell out per-session. */
+function buildPidParentMap(): Map<number, number[]> {
+  let psOut: string;
+  try {
+    psOut = execSync('ps -A -o pid=,ppid=', { encoding: 'utf-8' });
+  } catch {
+    return new Map();
+  }
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of psOut.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length !== 2) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    const arr = childrenByParent.get(ppid);
+    if (arr) arr.push(pid);
+    else childrenByParent.set(ppid, [pid]);
+  }
+  return childrenByParent;
+}
+
+/** Recompute per-conversation "active" PTY count and broadcast diffs.
+ *  Active = the PTY's shell has at least one child process. An idle zsh
+ *  sitting at a prompt has no children, so opening a terminal but running
+ *  nothing leaves the conversation's count at 0. */
+function recomputeAndEmitAll(): void {
+  if (sessions.size === 0 && lastActiveCount.size === 0) return;
+  const parents = buildPidParentMap();
+  const next = new Map<string, number>();
+  for (const session of sessions.values()) {
+    if (!session.conversationId) continue;
+    const hasChild = (parents.get(session.pty.pid) ?? []).length > 0;
+    if (hasChild) next.set(session.conversationId, (next.get(session.conversationId) ?? 0) + 1);
+  }
+  const convs = new Set<string>([...lastActiveCount.keys(), ...next.keys()]);
+  for (const conv of convs) {
+    const prev = lastActiveCount.get(conv) ?? 0;
+    const count = next.get(conv) ?? 0;
+    if (prev === count) continue;
+    if (count === 0) lastActiveCount.delete(conv);
+    else lastActiveCount.set(conv, count);
+    ipcBridge.terminal.activeCountChanged.emit({ conversationId: conv, count });
+  }
+}
+
+/** Trigger a recompute (and possible emit) tied to a specific conversation —
+ *  invoked on PTY lifecycle (create/exit/dispose/close) so transitions to/from
+ *  zero are caught without waiting for the 2s tick. */
 function emitActiveCount(conversationId: string | undefined): void {
   if (!conversationId) return;
-  let count = 0;
-  for (const session of sessions.values()) {
-    if (session.conversationId === conversationId) count++;
-  }
-  ipcBridge.terminal.activeCountChanged.emit({ conversationId, count });
+  recomputeAndEmitAll();
 }
 
 export function initTerminalBridge(): void {
+  setInterval(recomputeAndEmitAll, 2000).unref?.();
+
   ipcBridge.terminal.create.provider(async ({ cwd, shell, conversationId } = {}) => {
     if (sessions.size >= GLOBAL_PTY_HARD_LIMIT) {
       return { success: false, msg: `Global PTY limit reached (${GLOBAL_PTY_HARD_LIMIT}). Close some terminals and try again.` };

--- a/src/renderer/hooks/useTerminalActiveCount.ts
+++ b/src/renderer/hooks/useTerminalActiveCount.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ipcBridge } from '@/common';
+import { useEffect, useState } from 'react';
+
+const counts = new Map<string, number>();
+const listeners = new Set<(convId: string, count: number) => void>();
+let installed = false;
+
+function ensureInstalled(): void {
+  if (installed) return;
+  installed = true;
+  ipcBridge.terminal.activeCountChanged.on(({ conversationId, count }) => {
+    if (count > 0) counts.set(conversationId, count);
+    else counts.delete(conversationId);
+    for (const l of listeners) l(conversationId, count);
+  });
+}
+
+/**
+ * Reactive PTY count for a single conversation. Wraps the
+ * `terminal.activeCountChanged` event in a per-component subscription so
+ * sidebar rows can show a spinner whenever the conversation has live PTYs.
+ *
+ * State is module-scope: subscribing late returns the latest known count for
+ * that conversation (PTYs don't survive main-process restart, so on fresh
+ * boot the Map is empty and we don't miss anything).
+ */
+export function useTerminalActiveCount(conversationId: string | undefined): number {
+  ensureInstalled();
+  const [count, setCount] = useState(() => (conversationId ? (counts.get(conversationId) ?? 0) : 0));
+  useEffect(() => {
+    if (!conversationId) {
+      setCount(0);
+      return;
+    }
+    setCount(counts.get(conversationId) ?? 0);
+    const handler = (id: string, c: number): void => {
+      if (id !== conversationId) return;
+      setCount(c);
+    };
+    listeners.add(handler);
+    return () => {
+      listeners.delete(handler);
+    };
+  }, [conversationId]);
+  return count;
+}

--- a/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
+++ b/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
@@ -8,11 +8,12 @@ import type { TChatConversation } from '@/common/storage';
 import { getAgentLogo } from '@/renderer/utils/agentLogo';
 import FlexFullContainer from '@/renderer/components/FlexFullContainer';
 import { usePresetAssistantInfo } from '@/renderer/hooks/usePresetAssistantInfo';
+import { useTerminalActiveCount } from '@/renderer/hooks/useTerminalActiveCount';
 import { CronJobIndicator } from '@/renderer/pages/cron';
 import { cleanupSiderTooltips, getSiderTooltipProps } from '@/renderer/utils/siderTooltip';
 import { useLayoutContext } from '@/renderer/context/LayoutContext';
 import { Checkbox, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
-import { DeleteOne, EditOne, Export, MessageOne, Pushpin } from '@icon-park/react';
+import { DeleteOne, EditOne, Export, Loading, MessageOne, Pushpin } from '@icon-park/react';
 import classNames from 'classnames';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -38,6 +39,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
     ? (conversation as { isPinned?: boolean }).isPinned ?? false
     : isConversationPinned(conversation as TChatConversation);
   const cronStatus = getJobStatus(conversation.id);
+  const ptyActiveCount = useTerminalActiveCount(conversation.id);
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
   const inlineNameTooltipEnabled = !collapsed && !isMobile && !!conversation.name;
 
@@ -102,6 +104,13 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
           </span>
         )}
         {renderLeadingIcon()}
+        {ptyActiveCount > 0 && (
+          <Tooltip mini content={t('conversation.history.terminalRunning', { count: ptyActiveCount, defaultValue: '{{count}} terminal still running' })}>
+            <span className='flex-center ml-6px collapsed-hidden text-[rgb(var(--ui-accent-orange))]'>
+              <Loading theme='outline' size='12' className='animate-spin' />
+            </span>
+          </Tooltip>
+        )}
         <FlexFullContainer className='h-24px min-w-0 flex-1 collapsed-hidden ml-10px'>
           <Tooltip content={conversation.name} disabled={!inlineNameTooltipEnabled} trigger='hover' popupVisible={inlineNameTooltipEnabled ? undefined : false} unmountOnExit popupHoverStay={false} position='top'>
             <div className={classNames('chat-history__item-name overflow-hidden text-ellipsis block w-full text-14px lh-24px whitespace-nowrap min-w-0 group-hover:text-1', selected && !batchMode ? 'text-1 font-medium' : 'text-2')}>{conversation.name}</div>


### PR DESCRIPTION
## Summary
PR #780 把右侧终端按 conversation 隔离开了之后,如果在 A 会话里跑了 `sleep 600 &` 或 `npm install` 之类后台/长时任务,然后切到 B 会话,A 那边的活儿就彻底"看不见"了 — 容易忘。这个 PR 在左侧栏的会话标题旁边加一个橙色小转圈圈,只要该会话的某个 PTY 当前有非 shell 子进程,就转圈;命令结束 spinner 自动消失。

## 关键设计
- "Active" 定义为 **PTY 有非 shell 子进程**。空闲 zsh 坐在 prompt 不算 — 所以"开终端但什么都没跑"不会触发 spinner(第一版我用了 `sessions.size` 当指标,导致开终端就转圈,误导)。
- 主进程 2s 单次共享 `ps -A` 轮询,按 conversation 聚合 count,diff 后只在变化时 emit。生命周期事件(create/exit/dispose/closeByConversation)立即触发一次重算,所以删除会话时 spinner 不会拖 2s 才消失。
- 渲染端 `useTerminalActiveCount(convId)` hook:module-scope 订阅一次 `terminal.activeCountChanged`,所有 ConversationRow 共享。
- ConversationRow 在 leading icon 和标题之间渲染一个 12px Loading 图标 + `animate-spin`,tooltip 显示在跑的 terminal 数。collapsed 模式不显示。

## Test plan
- [x] 开终端不执行命令 → 无 spinner
- [x] 跑 `sleep 60 &` → 2 秒内 spinner 出现;sleep 退出 → 2 秒内 spinner 消失
- [x] 跑前台 `sleep 30` → spinner 出现
- [ ] 跑两个并发 `sleep 60 &; sleep 60 &` → tooltip 显示 "2 terminal still running"
- [ ] 删除会话 → spinner 立刻消失
- [ ] 多个会话同时活跃 → 各自 spinner 独立显示