### PR TITLE
fix(i18n): 定时任务标签页空状态文案修正

### DIFF
--- a/src/renderer/i18n/i18n-keys.d.ts
+++ b/src/renderer/i18n/i18n-keys.d.ts
@@ -329,6 +329,7 @@ export type I18nKey =
   | 'conversation.history.exportTargetFolder'
   | 'conversation.history.exporting'
   | 'conversation.history.noHistory'
+  | 'conversation.history.noScheduledTask'
   | 'conversation.history.pin'
   | 'conversation.history.pinFailed'
   | 'conversation.history.pinned'

--- a/src/renderer/i18n/locales/en-US/conversation.json
+++ b/src/renderer/i18n/locales/en-US/conversation.json
@@ -27,6 +27,7 @@
     "recent7Days": "Last 7 Days",
     "earlier": "Earlier",
     "noHistory": "No chat history",
+    "noScheduledTask": "No execution records",
     "actionNewConversation": "New Conversation",
     "deleteTitle": "Delete",
     "deleteConfirm": "Are you sure you want to delete this chat?",

--- a/src/renderer/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/i18n/locales/ja-JP/conversation.json
@@ -27,6 +27,7 @@
     "recent7Days": "過去7日間",
     "earlier": "それ以前",
     "noHistory": "チャット履歴はありません",
+    "noScheduledTask": "実行記録はありません",
     "actionNewConversation": "新しい会話",
     "deleteTitle": "削除",
     "deleteConfirm": "このチャットを削除してもよろしいですか？",

--- a/src/renderer/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/i18n/locales/ko-KR/conversation.json
@@ -27,6 +27,7 @@
     "recent7Days": "최근 7일",
     "earlier": "이전",
     "noHistory": "채팅 기록 없음",
+    "noScheduledTask": "실행 기록 없음",
     "actionNewConversation": "새 대화",
     "deleteTitle": "삭제",
     "deleteConfirm": "이 채팅을 삭제하시겠습니까?",

--- a/src/renderer/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/i18n/locales/tr-TR/conversation.json
@@ -27,6 +27,7 @@
     "recent7Days": "Son 7 Gün",
     "earlier": "Daha Önce",
     "noHistory": "Sohbet geçmişi yok",
+    "noScheduledTask": "Yürütme kaydı yok",
     "deleteTitle": "Sil",
     "deleteConfirm": "Bu sohbeti silmek istediğinizden emin misiniz?",
     "deleteWorkspaceOption": "Çalışma alanı klasörünü de sil",

--- a/src/renderer/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/i18n/locales/zh-CN/conversation.json
@@ -27,6 +27,7 @@
     "recent7Days": "最近7天",
     "earlier": "更早",
     "noHistory": "暂无对话历史",
+    "noScheduledTask": "暂无执行记录",
     "actionNewConversation": "新会话",
     "deleteTitle": "删除",
     "deleteConfirm": "确定删除该对话吗？",

--- a/src/renderer/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/i18n/locales/zh-TW/conversation.json
@@ -27,6 +27,7 @@
     "recent7Days": "近7天",
     "earlier": "更早",
     "noHistory": "暫無對話記錄",
+    "noScheduledTask": "暫無執行記錄",
     "deleteTitle": "刪除",
     "deleteConfirm": "確定要刪除此對話嗎？",
     "deleteWorkspaceOption": "同時刪除工作區資料夾",

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -264,7 +264,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({ onSes
     return (
       <FlexFullContainer>
         <div className='flex-center'>
-          <Empty description={t('conversation.history.noHistory')} />
+          <Empty description={t('conversation.history.noScheduledTask')} />
         </div>
       </FlexFullContainer>
     );


### PR DESCRIPTION
## 问题
定时任务标签页在没有任何执行记录时，错误地显示「暂无对话历史」文案，与对话历史标签页混淆。

## 修复
新增 i18n key `conversation.history.noScheduledTask`，定时任务标签页空状态文案改为：
- zh-CN: 暂无执行记录
- zh-TW: 暫無執行記錄  
- en-US: No execution records
- ja-JP: 実行記録はありません
- ko-KR: 실행 기록 없음
- tr-TR: Yürütme kaydı yok

## 改动文件
- 6 个语言文件：各新增一条 `noScheduledTask` 翻译
- `i18n-keys.d.ts`：新增类型声明
- `grouped-history/index.tsx`：scheduled tab 空状态使用新 key