### PR TITLE
feat(browser-panel): isolate right-panel browser per conversation

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -578,7 +578,13 @@ export const preview = {
 // the AI writes an HTML file to workspace, and (later) when /browser slash
 // commands or MCP tools request opening a URL in the right-panel browser.
 export const rightPanelBrowser = {
-  open: bridge.buildEmitter<{ url: string; switchTab?: boolean }>('right-panel.browser.open'),
+  open: bridge.buildEmitter<{ url: string; switchTab?: boolean; conversationId?: string }>('right-panel.browser.open'),
+  /**
+   * Broadcast from main when a conversation is deleted so renderer-side
+   * per-conversation BrowserPanel state can drop its entry. Mirrors the
+   * direct cleanup main does via BrowserPanelCdpService.closeTabsByConversation.
+   */
+  convClosed: bridge.buildEmitter<{ conversationId: string }>('right-panel.browser.conv-closed'),
 };
 
 // AI-generated file deliverables for a conversation. The list is built by
@@ -953,10 +959,15 @@ export const browserPanel = {
   // ── Tab registry ────────────────────────────────────────────────────────
   // Renderer reports (tabId ↔ webContentsId) on dom-ready so the main process
   // can target the right webview from agent tool calls.
-  registerTab: bridge.buildProvider<IBridgeResponse<void>, { tabId: string; webContentsId: number }>('browser-panel:register-tab'),
+  // `conversationId` scopes the tab to a single chat conversation so
+  // per-conv BrowserPanel isolation works; absent/empty value falls back to
+  // the global bucket (matches behavior before the per-conv refactor and the
+  // sudowork-browser MCP child's /tab/open path, which doesn't know which
+  // conversation triggered the call).
+  registerTab: bridge.buildProvider<IBridgeResponse<void>, { tabId: string; webContentsId: number; conversationId?: string }>('browser-panel:register-tab'),
   unregisterTab: bridge.buildProvider<IBridgeResponse<void>, { tabId: string }>('browser-panel:unregister-tab'),
-  setActiveTab: bridge.buildProvider<IBridgeResponse<void>, { tabId: string }>('browser-panel:set-active-tab'),
-  listTabs: bridge.buildProvider<IBridgeResponse<Array<{ webContentsId: number; url: string; title: string; attached: boolean }>>, void>('browser-panel:list-tabs'),
+  setActiveTab: bridge.buildProvider<IBridgeResponse<void>, { tabId: string; conversationId?: string }>('browser-panel:set-active-tab'),
+  listTabs: bridge.buildProvider<IBridgeResponse<Array<{ webContentsId: number; url: string; title: string; attached: boolean; conversationId?: string }>>, void>('browser-panel:list-tabs'),
 
   // ── CDP action API ──────────────────────────────────────────────────────
   // Each call resolves the target webview from `tabId` (renderer tab id) or

--- a/src/common/storageKeys.ts
+++ b/src/common/storageKeys.ts
@@ -29,12 +29,6 @@ export const STORAGE_KEYS = {
   /** Last browser URL in the right-side browser panel */
   RIGHT_PANEL_BROWSER_URL: 'aionui_right_panel_browser_url',
 
-  /** Stored browser tabs in the right-side browser panel */
-  RIGHT_PANEL_BROWSER_TABS: 'aionui_right_panel_browser_tabs',
-
-  /** Active browser tab id in the right-side browser panel */
-  RIGHT_PANEL_BROWSER_ACTIVE_TAB: 'aionui_right_panel_browser_active_tab',
-
   /** Conversation panel collapse state / 会话面板折叠状态 */
   CONVERSATION_PANEL_COLLAPSE: 'aionui_conversation_panel_collapsed',
 

--- a/src/process/bridge/browserPanelBridge.ts
+++ b/src/process/bridge/browserPanelBridge.ts
@@ -48,8 +48,8 @@ export function initBrowserPanelBridge(): void {
   });
 
   // ── Tab registry ────────────────────────────────────────────────────────
-  ipcBridge.browserPanel.registerTab.provider(async ({ tabId, webContentsId }) => {
-    browserPanelCdpService.registerTab(tabId, webContentsId);
+  ipcBridge.browserPanel.registerTab.provider(async ({ tabId, webContentsId, conversationId }) => {
+    browserPanelCdpService.registerTab(tabId, webContentsId, conversationId);
     return { success: true };
   });
 
@@ -135,4 +135,25 @@ export function initBrowserPanelBridge(): void {
     browserPanelCdpService.clearBuffers(id);
     return { success: true };
   });
+}
+
+/**
+ * Close every right-panel BrowserPanel tab owned by `conversationId`. Called
+ * by conversationBridge when a conversation is deleted so the conversation's
+ * webviews are torn down alongside its terminals and other per-conv state.
+ * Best-effort: tabs whose webContents is already destroyed are skipped.
+ *
+ * Also broadcasts `rightPanelBrowser.convClosed` so the renderer-side
+ * BrowserPanel can drop the matching entry from its module-level
+ * per-conv state Map.
+ */
+export function closeBrowserTabsByConversation(conversationId: string): number {
+  if (!conversationId) return 0;
+  const closed = browserPanelCdpService.closeTabsByConversation(conversationId);
+  try {
+    ipcBridge.rightPanelBrowser.convClosed.emit({ conversationId });
+  } catch (err) {
+    mainError('BrowserPanel', `convClosed emit failed for ${conversationId}: ${String(err)}`);
+  }
+  return closed;
 }

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -29,6 +29,7 @@ import { INTERMEDIATE_DIR_SEGMENTS } from '../task/FileIntentClassifier';
 import WorkerManage from '../WorkerManage';
 import { migrateConversationToDatabase } from './migrationUtils';
 import { closeTerminalsByConversation } from './terminalBridge';
+import { closeBrowserTabsByConversation } from './browserPanelBridge';
 import { skillManager } from '../SkillManager';
 import { ConversationManageWithDB } from '../message';
 import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
@@ -467,6 +468,17 @@ export function initConversationBridge(): void {
         closeTerminalsByConversation(id);
       } catch (err) {
         mainWarn('conversationBridge', 'closeTerminalsByConversation failed', err);
+      }
+
+      // Reap any right-panel BrowserPanel tabs tied to this conversation.
+      // Same direct-call pattern as closeTerminalsByConversation. The
+      // function also broadcasts rightPanelBrowser.convClosed so the
+      // renderer-side BrowserPanel can drop its module-level state for
+      // this conv.
+      try {
+        closeBrowserTabsByConversation(id);
+      } catch (err) {
+        mainWarn('conversationBridge', 'closeBrowserTabsByConversation failed', err);
       }
 
       // Delete associated cron jobs

--- a/src/process/services/browserPanel/BrowserPanelCdpService.ts
+++ b/src/process/services/browserPanel/BrowserPanelCdpService.ts
@@ -75,6 +75,8 @@ export interface TabInfo {
   url: string;
   title: string;
   attached: boolean;
+  /** Conversation that owns this tab, or undefined for the global bucket. */
+  conversationId?: string;
 }
 
 export interface EvaluateResult {
@@ -174,6 +176,15 @@ interface TabState {
   attached: boolean;
   /** epoch (ms) when CDP attach completed; used as time origin for network startedAt */
   attachOriginMs: number;
+  /**
+   * Conversation that owns this tab, set when the renderer reports
+   * registerTab. Used to drive per-conversation cleanup (close-by-conv on
+   * conversation delete) and per-conv tab-list responses. Empty/absent
+   * means the tab belongs to the global bucket (e.g. opened via the
+   * sudowork-browser MCP child's /tab/open path, which doesn't know
+   * which conversation triggered it).
+   */
+  conversationId?: string;
 }
 
 class BrowserPanelCdpService {
@@ -398,6 +409,7 @@ class BrowserPanelCdpService {
       url: state.contents.isDestroyed() ? '' : state.contents.getURL(),
       title: state.contents.isDestroyed() ? '' : state.contents.getTitle(),
       attached: state.attached,
+      conversationId: state.conversationId,
     }));
   }
 
@@ -451,8 +463,14 @@ class BrowserPanelCdpService {
   //  which webview to target.
   // ─────────────────────────────────────────────────────────────────────────
 
-  registerTab(tabId: string, webContentsId: number): void {
+  registerTab(tabId: string, webContentsId: number, conversationId?: string): void {
     this.tabIdRegistry.set(tabId, webContentsId);
+    // Attach ownership to the corresponding TabState, used by
+    // closeTabsByConversation when the conversation is deleted.
+    const state = this.tabs.get(webContentsId);
+    if (state && conversationId) {
+      state.conversationId = conversationId;
+    }
     // Reconcile a pending active-tab set that arrived before this dom-ready.
     if (this.pendingActiveTabId === tabId) {
       this.activeWebContentsId = webContentsId;
@@ -461,6 +479,34 @@ class BrowserPanelCdpService {
       // No active tab yet at all — use this one as a sensible default.
       this.activeWebContentsId = webContentsId;
     }
+  }
+
+  /**
+   * Close every BrowserPanel tab that belongs to a conversation. Called by
+   * conversationBridge.ts when a conversation is deleted, so the agent's
+   * webview teardown happens alongside the rest of the conversation cleanup
+   * (mirrors closeTerminalsByConversation in terminalBridge).
+   *
+   * Returns the number of tabs that were closed. Best-effort: a tab whose
+   * underlying webContents is already destroyed is skipped; the
+   * `'destroyed'` listener registered in registerWebContents handles the
+   * map cleanup either way.
+   */
+  closeTabsByConversation(conversationId: string): number {
+    if (!conversationId) return 0;
+    let closed = 0;
+    for (const [webContentsId, state] of this.tabs) {
+      if (state.conversationId !== conversationId) continue;
+      try {
+        if (!state.contents.isDestroyed()) {
+          state.contents.close();
+          closed += 1;
+        }
+      } catch (err) {
+        mainWarn('BrowserPanelCDP', `closeTabsByConversation: webContents.close failed for id=${webContentsId}: ${String(err)}`);
+      }
+    }
+    return closed;
   }
 
   unregisterTab(tabId: string): void {

--- a/src/process/services/browserPanel/BrowserPanelHttpServer.ts
+++ b/src/process/services/browserPanel/BrowserPanelHttpServer.ts
@@ -161,9 +161,18 @@ class BrowserPanelHttpServer {
       case '/tab/list':
         return browserPanelCdpService.listTabs();
       case '/tab/open': {
-        const { url: target } = body as { url?: string };
+        const { url: target, conversationId } = body as { url?: string; conversationId?: string };
         if (typeof target !== 'string' || !target) throw new Error('url required');
-        ipcBridge.rightPanelBrowser.open.emit({ url: target, switchTab: true });
+        // conversationId is optional: the sudowork-browser MCP child doesn't
+        // know which chat conversation triggered the call, so it omits the
+        // field. Renderer-side BrowserPanel treats undefined conversationId
+        // as routing to the global bucket — preserves the pre-isolation
+        // behavior for this code path.
+        ipcBridge.rightPanelBrowser.open.emit({
+          url: target,
+          switchTab: true,
+          ...(conversationId ? { conversationId } : {}),
+        });
         return { ok: true };
       }
       case '/tab/navigate': {

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -1792,7 +1792,7 @@ This identity statement takes priority over the default identity in USER.md.
     // tool argument shapes).
     if (classification.intent !== 'draft' && /\.html?$/i.test(actualPath)) {
       try {
-        ipcBridge.rightPanelBrowser.open.emit({ url: `file://${actualPath}`, switchTab: true });
+        ipcBridge.rightPanelBrowser.open.emit({ url: `file://${actualPath}`, switchTab: true, conversationId: this.conversation_id });
         mainLog('[AcpAgent]', `[TRACK] rightPanelBrowser.open fired for ${actualPath}`);
       } catch (err) {
         mainLog('[AcpAgent]', `[TRACK] rightPanelBrowser.open emit failed: ${String(err)}`);
@@ -2441,7 +2441,7 @@ This identity statement takes priority over the default identity in USER.md.
                 // not a network action.
                 if (/\.html?$/i.test(filePath)) {
                   try {
-                    ipcBridge.rightPanelBrowser.open.emit({ url: `file://${filePath}`, switchTab: true });
+                    ipcBridge.rightPanelBrowser.open.emit({ url: `file://${filePath}`, switchTab: true, conversationId: this.conversation_id });
                   } catch (err) {
                     console.log(`[AcpAgent] rightPanelBrowser.open emit failed: ${String(err)}`);
                   }
@@ -3742,7 +3742,7 @@ This identity statement takes priority over the default identity in USER.md.
             if (!rest) {
               emit('Usage: `/browser open <url>`');
             } else {
-              ipcBridge.rightPanelBrowser.open.emit({ url: rest, switchTab: true });
+              ipcBridge.rightPanelBrowser.open.emit({ url: rest, switchTab: true, conversationId: this.conversation_id });
               emit(`Opened ${rest} in the right-panel browser.`);
             }
           } else if (targetId === null) {

--- a/src/renderer/pages/conversation/ChatSider.tsx
+++ b/src/renderer/pages/conversation/ChatSider.tsx
@@ -101,7 +101,7 @@ const ChatSider: React.FC<{
         <div className='right-panel-stack'>
           <div className={`right-panel-stack__pane ${activeTab === 'workspace' ? 'right-panel-stack__pane--active' : ''}`}>{workspaceNode}</div>
           <div className={`right-panel-stack__pane ${activeTab === 'browser' ? 'right-panel-stack__pane--active' : ''}`}>
-            <BrowserPanel active={activeTab === 'browser'} />
+            <BrowserPanel active={activeTab === 'browser'} conversationId={conversation?.id} />
           </div>
           <div className={`right-panel-stack__pane ${activeTab === 'terminal' ? 'right-panel-stack__pane--active' : ''}`}>
             <TerminalPanel cwd={workspace} active={activeTab === 'terminal'} conversationId={conversation?.id} />

--- a/src/renderer/pages/conversation/right-panel/BrowserPanel.tsx
+++ b/src/renderer/pages/conversation/right-panel/BrowserPanel.tsx
@@ -1,11 +1,10 @@
-import { STORAGE_KEYS } from '@/common/storageKeys';
 import { ipcBridge } from '@/common';
 import { BROWSER_PANEL_PARTITION, DEFAULT_BROWSER_PANEL_HOMEPAGE, normalizeBrowserUrl } from '@/common/browserPanelUrl';
 import WebviewHost from '@/renderer/components/WebviewHost';
 import { useAddEventListener } from '@/renderer/utils/emitter';
 import { Message, Modal, Tooltip } from '@arco-design/web-react';
 import { Add, Close, Delete } from '@icon-park/react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type BrowserTab = {
@@ -14,41 +13,84 @@ type BrowserTab = {
   url: string;
 };
 
+type ConvBrowserState = {
+  tabs: BrowserTab[];
+  activeTabId: string;
+};
+
+const FALLBACK_CONV_KEY = '__global__';
+
 const createTab = (url: string, title?: string): BrowserTab => ({
   id: `browser-tab-${Date.now()}-${Math.random().toString(16).slice(2)}`,
   title: title || url,
   url,
 });
 
-const BrowserPanel: React.FC<{ active?: boolean }> = ({ active = false }) => {
+const makeInitialState = (defaultUrl: string): ConvBrowserState => {
+  const tab = createTab(defaultUrl, defaultUrl);
+  return { tabs: [tab], activeTabId: tab.id };
+};
+
+// Module-level per-conversation state. Keyed by `convKey =
+// conversationId ?? '__global__'`. Survives across BrowserPanel unmounts
+// (e.g. when the user switches conversations) so each conv's tab list and
+// active tab return verbatim on re-entry. Same shape as the per-conv
+// terminal store from feat/per-conversation-terminal (commit 76d19d5a).
+const moduleStates = new Map<string, ConvBrowserState>();
+const moduleListeners = new Set<() => void>();
+
+function notifyListeners(): void {
+  for (const l of moduleListeners) l();
+}
+
+function getOrCreateConvState(convKey: string, defaultUrl: string): ConvBrowserState {
+  let state = moduleStates.get(convKey);
+  if (!state) {
+    state = makeInitialState(defaultUrl);
+    moduleStates.set(convKey, state);
+  }
+  return state;
+}
+
+function dropConvBrowserState(convKey: string): void {
+  if (moduleStates.delete(convKey)) {
+    notifyListeners();
+  }
+}
+
+interface BrowserPanelProps {
+  active?: boolean;
+  conversationId?: string;
+}
+
+const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversationId }) => {
   const { t } = useTranslation();
   const panelRef = useRef<HTMLDivElement | null>(null);
-  const [tabs, setTabs] = useState<BrowserTab[]>(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEYS.RIGHT_PANEL_BROWSER_TABS);
-      if (stored) {
-        const parsed = JSON.parse(stored) as BrowserTab[];
-        if (Array.isArray(parsed) && parsed.length > 0) return parsed;
-      }
-    } catch {
-      // ignore
-    }
-    return [createTab(DEFAULT_BROWSER_PANEL_HOMEPAGE, DEFAULT_BROWSER_PANEL_HOMEPAGE)];
-  });
-  const [activeTabId, setActiveTabId] = useState<string>(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEYS.RIGHT_PANEL_BROWSER_ACTIVE_TAB);
-      if (stored) return stored;
-    } catch {
-      // ignore
-    }
-    return tabs[0]?.id || '';
-  });
-  // Default URL used for new-tab and initial first tab — fetched from system settings on mount.
+
+  // Settings — not per-conv. Stay in component-local useState.
   const [defaultUrl, setDefaultUrl] = useState<string>(DEFAULT_BROWSER_PANEL_HOMEPAGE);
   const [reloadEpoch, setReloadEpoch] = useState(0); // bump to force-reload all tabs after cache clear
   const partition = useMemo(() => BROWSER_PANEL_PARTITION, []);
 
+  // Subscribe to the module-level store so this component re-renders when
+  // any conv's state mutates. Keyed by useReducer's incrementing counter
+  // pattern (same as TerminalPanel).
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    moduleListeners.add(forceUpdate);
+    return () => {
+      moduleListeners.delete(forceUpdate);
+    };
+  }, []);
+
+  const convKey = conversationId ?? FALLBACK_CONV_KEY;
+  const currentState = getOrCreateConvState(convKey, defaultUrl);
+  const tabs = currentState.tabs;
+  const activeTabId = currentState.activeTabId;
+
+  // Fetch the user-configured default URL once on mount. Backfill it into
+  // any conv state whose initial tab still points at DEFAULT_BROWSER_PANEL_HOMEPAGE
+  // (avoids the first-tab racing with the settings fetch).
   useEffect(() => {
     let cancelled = false;
     ipcBridge.systemSettings.getBrowserDefaultUrl
@@ -75,26 +117,16 @@ const BrowserPanel: React.FC<{ active?: boolean }> = ({ active = false }) => {
     }
   }, [activeTabId]);
 
+  // Inform main which tab is currently focused for this conversation. Main
+  // uses this for the activeWebContentsId fallback when a tool call doesn't
+  // explicitly pass a tabId.
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEYS.RIGHT_PANEL_BROWSER_TABS, JSON.stringify(tabs));
-    } catch {
-      // ignore
-    }
-  }, [tabs]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEYS.RIGHT_PANEL_BROWSER_ACTIVE_TAB, activeTabId);
-    } catch {
-      // ignore
-    }
     if (activeTabId) {
-      ipcBridge.browserPanel.setActiveTab.invoke({ tabId: activeTabId }).catch(() => {
+      ipcBridge.browserPanel.setActiveTab.invoke({ tabId: activeTabId, conversationId: conversationId || undefined }).catch(() => {
         // ignore — main may not yet have the tab registered (race on first mount)
       });
     }
-  }, [activeTabId]);
+  }, [activeTabId, conversationId]);
 
   useEffect(() => {
     if (!active) return;
@@ -104,22 +136,47 @@ const BrowserPanel: React.FC<{ active?: boolean }> = ({ active = false }) => {
     return () => window.clearTimeout(timer);
   }, [active, activeTabId, focusActiveWebview]);
 
-  const openNewTab = (url: string) => {
-    const normalized = normalizeBrowserUrl(url);
-    if (!normalized) return;
-    const nextTab = createTab(normalized, normalized);
-    setTabs((prev) => [...prev, nextTab]);
-    setActiveTabId(nextTab.id);
-  };
+  const setActiveTabId = useCallback(
+    (tabId: string) => {
+      const state = getOrCreateConvState(convKey, defaultUrl);
+      if (state.activeTabId === tabId) return;
+      state.activeTabId = tabId;
+      notifyListeners();
+    },
+    [convKey, defaultUrl],
+  );
 
-  // Subscribe to "open in right-panel browser" — fired by the main process when
-  // the AI writes an HTML file, and (later) by the /browser slash and MCP tools.
-  // Listen on both the in-renderer emitter (for renderer-side dispatch) and the
-  // IPC emitter (for main-process dispatch), mirroring the preview.open pattern.
-  const handleOpenBrowserUrl = useCallback(({ url }: { url: string; switchTab?: boolean }) => {
-    if (!url) return;
-    openNewTab(url);
-  }, []);
+  const openNewTab = useCallback(
+    (url: string) => {
+      const normalized = normalizeBrowserUrl(url);
+      if (!normalized) return;
+      const state = getOrCreateConvState(convKey, defaultUrl);
+      const nextTab = createTab(normalized, normalized);
+      state.tabs = [...state.tabs, nextTab];
+      state.activeTabId = nextTab.id;
+      notifyListeners();
+    },
+    [convKey, defaultUrl],
+  );
+
+  // Subscribe to "open in right-panel browser". Accept the emit when:
+  //   - it carries no `conversationId` (unscoped — fsBridge file-write,
+  //     /tab/open from sudowork-browser MCP, etc.); the currently mounted
+  //     panel is the user-visible target, so handle it
+  //   - it carries a `conversationId` matching this panel's convKey
+  // Skip when the emit is scoped to a different conversation. This is the
+  // filter that delivers the per-conv isolation: each BrowserPanel only
+  // reacts to navigation emits intended for it.
+  const handleOpenBrowserUrl = useCallback(
+    (payload: { url: string; switchTab?: boolean; conversationId?: string }) => {
+      if (!payload?.url) return;
+      const emitConv = payload.conversationId;
+      const isMatch = !emitConv || emitConv === convKey;
+      if (!isMatch) return;
+      openNewTab(payload.url);
+    },
+    [convKey, openNewTab],
+  );
 
   useAddEventListener('right-panel.browser.open', handleOpenBrowserUrl, [handleOpenBrowserUrl]);
 
@@ -130,24 +187,48 @@ const BrowserPanel: React.FC<{ active?: boolean }> = ({ active = false }) => {
     };
   }, [handleOpenBrowserUrl]);
 
-  const updateTabUrl = useCallback((tabId: string, nextUrl: string) => {
-    setTabs((prev) => prev.map((tab) => (tab.id === tabId ? { ...tab, url: nextUrl, title: nextUrl } : tab)));
+  // Listen for "conversation deleted" cleanup from main (closeBrowserTabsByConversation
+  // → ipcBridge.rightPanelBrowser.convClosed.emit). Drop the matching entry
+  // from the module-level state so its tabs don't reappear if the user later
+  // creates a new conversation that happens to reuse the same id (unlikely
+  // given uuid ids, but cheap to be defensive).
+  useEffect(() => {
+    const unsubscribe = ipcBridge.rightPanelBrowser.convClosed.on((payload) => {
+      if (!payload?.conversationId) return;
+      dropConvBrowserState(payload.conversationId);
+    });
+    return () => {
+      unsubscribe();
+    };
   }, []);
 
-  const closeTab = (tabId: string) => {
-    setTabs((prev) => {
-      if (prev.length <= 1) return prev;
-      const nextTabs = prev.filter((tab) => tab.id !== tabId);
-      if (activeTabId === tabId) {
+  const updateTabUrl = useCallback(
+    (tabId: string, nextUrl: string) => {
+      const state = getOrCreateConvState(convKey, defaultUrl);
+      const idx = state.tabs.findIndex((tab) => tab.id === tabId);
+      if (idx < 0) return;
+      if (state.tabs[idx].url === nextUrl) return;
+      state.tabs = state.tabs.map((tab) => (tab.id === tabId ? { ...tab, url: nextUrl, title: nextUrl } : tab));
+      notifyListeners();
+    },
+    [convKey, defaultUrl],
+  );
+
+  const closeTab = useCallback(
+    (tabId: string) => {
+      const state = getOrCreateConvState(convKey, defaultUrl);
+      if (state.tabs.length <= 1) return;
+      const nextTabs = state.tabs.filter((tab) => tab.id !== tabId);
+      state.tabs = nextTabs;
+      if (state.activeTabId === tabId) {
         const nextActive = nextTabs[nextTabs.length - 1] || nextTabs[0];
-        if (nextActive) {
-          setActiveTabId(nextActive.id);
-        }
+        if (nextActive) state.activeTabId = nextActive.id;
       }
-      return nextTabs;
-    });
-    ipcBridge.browserPanel.unregisterTab.invoke({ tabId }).catch(() => {});
-  };
+      notifyListeners();
+      ipcBridge.browserPanel.unregisterTab.invoke({ tabId }).catch(() => {});
+    },
+    [convKey, defaultUrl],
+  );
 
   const handleClearCache = useCallback(() => {
     Modal.confirm({
@@ -214,7 +295,7 @@ const BrowserPanel: React.FC<{ active?: boolean }> = ({ active = false }) => {
               onUrlChange={(nextUrl) => updateTabUrl(tab.id, nextUrl)}
               defaultZoomFactor={0.9}
               onWebContentsIdReady={(webContentsId) => {
-                ipcBridge.browserPanel.registerTab.invoke({ tabId: tab.id, webContentsId }).catch(() => {
+                ipcBridge.browserPanel.registerTab.invoke({ tabId: tab.id, webContentsId, conversationId: conversationId || undefined }).catch(() => {
                   // Best-effort; the agent tools will fall back to "no tab" semantics.
                 });
               }}


### PR DESCRIPTION
## Why

右侧浏览器面板（BrowserPanel）当前是**全局共享**的：切换会话 A → B 时，A 的 tab 列表和当前激活 webview 会带过来；在 A 关掉一个 tab 等于 B 也关掉。这跟用户对 "每个会话的右侧浏览器应该独立" 的直觉相反。

sudowork 之前为右侧终端做过等价隔离（`76d19d5a feat(terminal): isolate right-panel terminal per conversation`），本 PR 直接照搬那个 pattern 到 BrowserPanel。

## Behavior

实施后：

- 切会话 A → B：显示 B 自己的 tab 列表（或 B 首次打开时的默认 homepage 单 tab）。A 的 tabs 保留在内存里，切回 A 后原样恢复。
- 关 A 的 tab 不影响 B。
- 删 conversation A：reaper 关闭 A 的所有 webview（`webContents.close()`），renderer 端 module-level Map 里也丢掉 A 这一项。
- `sudowork-browser` MCP 子进程 POST `/tab/open` 时不带 `conversationId`（因为子进程没法知道当前哪个会话触发的）—— 渲染端 filter 把这种 unscoped emit 当作 "任何 mounted panel 都处理"，结果是 fall back 到用户当前可见的会话面板。跟改造前的体验一致。

## Implementation

### Renderer

`BrowserPanel.tsx` — `tabs` 和 `activeTabId` 从 `useState + localStorage` 迁到 module-level `Map<convKey, ConvBrowserState>`（`convKey = conversationId ?? '__global__'`）。订阅模式跟 TerminalPanel 一致：`Set<() => void>` listener + `useReducer` 跑 forceUpdate。**不**做 per-conv 持久化（同 terminal 隔离 PR 的取舍：tab 是 ephemeral runtime state）。

事件监听规则：

- `rightPanelBrowser.open.on`: payload 带 `conversationId` 时仅 match 同 conv 的面板；不带则任何 mounted 面板都接受（覆盖 fsBridge HTML write、`/tab/open` HTTP loopback、in-renderer `GeneratedFileCard` 这几条 unscoped 路径）。
- `rightPanelBrowser.convClosed.on`: 删会话信号，drop 对应 module Map 条目。

`ChatSider.tsx` — `<BrowserPanel conversationId={conversation?.id} />`（跟 TerminalPanel 同一行的 prop 形态）。

### Main

`BrowserPanelCdpService.ts`:

- `TabState` / `TabInfo` 加 `conversationId?: string`
- `registerTab(tabId, webContentsId, conversationId?)`: 记录归属
- 新增 `closeTabsByConversation(conversationId)`: 找到匹配的 `tabs` entry，`webContents.close()`，原有的 `'destroyed'` 监听负责 Map 清理

`browserPanelBridge.ts`:

- `registerTab` IPC handler 透传 conversationId
- 新增 export `closeBrowserTabsByConversation(conversationId)`：调 service + emit `rightPanelBrowser.convClosed`，让 renderer Map 也清理

`conversationBridge.ts`: `ipcBridge.conversation.remove.provider` 里 `closeTerminalsByConversation(id)` 之后挂 `closeBrowserTabsByConversation(id)`，同 try/catch shape。

`BrowserPanelHttpServer.ts`: `/tab/open` body 可选 `conversationId`，转发到 emit。今天 sudowork-browser MCP 子进程不传（不知道 chat conv），落 unscoped 分支。

`AcpAgent.ts`: 三处 `rightPanelBrowser.open.emit`（HTML write detect at L1795 / L2444, `/browser open` slash at L3745）都加 `conversationId: this.conversation_id`。

### IPC contract

`ipcBridge.ts`:

- `rightPanelBrowser.open` payload 可选 `conversationId?: string`
- `rightPanelBrowser.convClosed`: 新 emitter（main → renderer，会话删除清理信号）
- `browserPanel.registerTab` / `setActiveTab` / `listTabs` 可选 `conversationId`

### Cleanup

`storageKeys.ts` 删 `RIGHT_PANEL_BROWSER_TABS` / `RIGHT_PANEL_BROWSER_ACTIVE_TAB` 两个 localStorage key（已经没读者了）。

## Verification

- `bunx tsc --noEmit` → 1 error, baseline only（`workspaceSkillSync.ts:49`）, **零新增 TS 错误**
- 本地 `bun start` 重启 OK，主进程 init complete, tray created, 无 panic / IPC handler 报错

## Manual smoke checklist（移交早上人工跑）

- [ ] **A→B 切会话保留各自 tab**：在 conv A 让 AI 打开 URL₁；切到 conv B，让 AI 打开 URL₂；切回 A 看到 URL₁，切回 B 看到 URL₂
- [ ] **关 tab 隔离**：在 A 关 URL₁ tab，切到 B 看 URL₂ 仍在
- [ ] **删会话清理**：删 conv A 后，B 的 BrowserPanel 不动；inspect `BrowserPanelCdpService.tabs` 应该没有 A 残留 webview entry
- [ ] **HTTP loopback unscoped fall-through**：用户当前面板手动 `curl POST /tab/open`（不带 `conversationId`）→ 当前显示会话的面板加载该 URL（保持改造前体验）
- [ ] **AcpAgent emit 严格按 conv**：让 conv A 的 agent 写一个 `.html` 文件；切到 conv B 之前确认右侧 BrowserPanel 已切到那个 file URL（说明 AcpAgent 的 emit 用 `this.conversation_id` 路由正确）

## Out of scope

- Per-conv tab **持久化**（重启后丢）。同 terminal 隔离 PR 的 trade-off。如果后续要持久化，应该放在 main + sqlite，不要回 localStorage。
- `resolveWebContentsId` 没改成 per-conv 严格语义 —— BrowserPanelHttpServer / `/tab/screenshot` 等 MCP tool 调用今天没 conv context，多 conv 同时打开 tab 时 active resolution 仍是"最近 setActiveTab 的那个"（全局）。第一版务实选择；后续如果出现"agent 工具调用打到错的 tab" 报告再扩展 `resolveWebContentsId(tabId?, conversationId?)`。
- `fsBridge.ts` 文件 IO 层 emit 没带 conv id（fsBridge 是抽象层无法持有 conv context）。renderer filter 的 unscoped 分支会处理。

## Reference

- 参考蓝本：commit `76d19d5a feat(terminal): isolate right-panel terminal per conversation`
- Plan file: `/Users/pengwu/.claude/plans/task-notification-task-id-b2c4eknlb-tas-wild-meadow.md`（含三个 follow-up 的完整设计与 trade-off 记录；本 PR 是其中 Step 3。Step 1+2 已发到 #783）