### PR TITLE
feat: display usage points from cost units

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -39,6 +39,7 @@ interface PendingRequest<T = unknown> {
 }
 
 const numberOrUndefined = (value: unknown): number | undefined => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
+const stringOrUndefined = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
 
 function formatAcpErrorMessage(error: AcpResponse['error']): string {
   const message = error?.message || 'Unknown ACP error';
@@ -135,9 +136,7 @@ export class AcpConnection {
         onClose: (info) => {
           if (!this.isSetupComplete) {
             const stderr = transport.getStderr();
-            let errMsg = stderr
-              ? `${backend} ACP process exited during startup (code: ${info.code}):\n${stderr}`
-              : `${backend} ACP process exited during startup (code: ${info.code}, signal: ${info.signal})`;
+            let errMsg = stderr ? `${backend} ACP process exited during startup (code: ${info.code}):\n${stderr}` : `${backend} ACP process exited during startup (code: ${info.code}, signal: ${info.signal})`;
             if (info.code !== 0 && /not recognized|not found|No such file|command not found|ENOENT/i.test(stderr + (setupError?.message ?? ''))) {
               errMsg = `'${this.backend ?? backend}' CLI not found. Please install it or update the CLI path in Settings.\n${stderr}`;
             }
@@ -552,15 +551,23 @@ export class AcpConnection {
             // Extract PromptResponse.usage (per-turn token data from codex-acp / PR #167)
             if (promptResult.usage && typeof promptResult.usage === 'object') {
               const usage = promptResult.usage as AcpPromptResponseUsage;
+              const { costUnits: _directCostUnits, costCurrency: _directCostCurrency, ...usageWithoutCost } = usage;
               const meta = promptResult._meta as Record<string, unknown> | undefined;
               const sudocodeMeta = meta?.sudocode as Record<string, unknown> | undefined;
               const contextWindowTokens = numberOrUndefined(sudocodeMeta?.contextWindowTokens);
               const estimatedSessionTokens = numberOrUndefined(sudocodeMeta?.estimatedSessionTokens);
+              const usageRecord = usage as unknown as Record<string, unknown>;
+              const costUnitsSource = sudocodeMeta && 'costUnits' in sudocodeMeta ? sudocodeMeta.costUnits : usageRecord.costUnits;
+              const costCurrencySource = sudocodeMeta && 'costCurrency' in sudocodeMeta ? sudocodeMeta.costCurrency : usageRecord.costCurrency;
+              const costUnits = numberOrUndefined(costUnitsSource);
+              const costCurrency = stringOrUndefined(costCurrencySource);
               if (typeof usage.totalTokens === 'number') {
                 this.onPromptUsage({
-                  ...usage,
+                  ...usageWithoutCost,
                   ...(contextWindowTokens !== undefined && { contextWindowTokens }),
                   ...(estimatedSessionTokens !== undefined && { estimatedSessionTokens }),
+                  ...(costUnits !== undefined && { costUnits }),
+                  ...(costCurrency !== undefined && { costCurrency }),
                 });
               }
             }

--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -106,6 +106,8 @@ export interface TurnTokenUsage {
   thoughtTokens?: number | null;
   contextWindowTokens?: number | null;
   estimatedSessionTokens?: number | null;
+  costUnits?: number | null;
+  costCurrency?: string | null;
 }
 
 export type IMessageText = IMessage<'text', { content: string; cronMeta?: CronMessageMeta; skills?: string[]; tokenUsage?: TurnTokenUsage }>;

--- a/src/common/tokenUsage.ts
+++ b/src/common/tokenUsage.ts
@@ -14,7 +14,24 @@ export const tokensToUsagePoints = (tokens?: number | null): number | null => {
 
 export const costToUsagePoints = (cost?: number | null): number | null => {
   if (typeof cost !== 'number' || !Number.isFinite(cost)) return null;
-  return Math.round(cost / COST_UNITS_PER_USAGE_POINT);
+  return cost / COST_UNITS_PER_USAGE_POINT;
+};
+
+type UsagePointInput = {
+  totalTokens?: number | null;
+  costUnits?: number | null;
+  costCurrency?: string | null;
+};
+
+export const resolveUsagePoints = (usage?: UsagePointInput | null): number | null => {
+  if (!usage) return null;
+
+  if (usage.costCurrency === 'sudo_point') {
+    const costPoints = costToUsagePoints(usage.costUnits);
+    if (costPoints !== null) return costPoints;
+  }
+
+  return tokensToUsagePoints(usage.totalTokens);
 };
 
 export const usagePointsFromTokensOrFallback = (tokens?: number | null, fallbackPoints?: number | null): number => {

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -137,6 +137,8 @@ function normalizePromptUsageForMessage(usage: AcpPromptResponseUsage): TurnToke
     ...(usage.thoughtTokens !== undefined && { thoughtTokens: usage.thoughtTokens }),
     ...(usage.contextWindowTokens !== undefined && { contextWindowTokens: usage.contextWindowTokens }),
     ...(usage.estimatedSessionTokens !== undefined && { estimatedSessionTokens: usage.estimatedSessionTokens }),
+    ...(usage.costUnits !== undefined && { costUnits: usage.costUnits }),
+    ...(usage.costCurrency !== undefined && { costCurrency: usage.costCurrency }),
   };
 }
 

--- a/src/renderer/messages/TurnActions.tsx
+++ b/src/renderer/messages/TurnActions.tsx
@@ -6,7 +6,7 @@
 
 import { iconColors } from '@/renderer/theme/colors';
 import type { TurnTokenUsage } from '@/common/chatLib';
-import { formatUsagePoints, tokensToUsagePoints } from '@/common/tokenUsage';
+import { costToUsagePoints, formatUsagePoints, resolveUsagePoints } from '@/common/tokenUsage';
 import { copyText } from '@/renderer/utils/clipboard';
 import { ipcBridge } from '@/common';
 import { emitter } from '@/renderer/utils/emitter';
@@ -107,7 +107,14 @@ const TurnActions: React.FC<TurnActionsProps> = ({ turnTexts, turnTextsRaw, conv
   }, [turnTextsRaw, shareoneInstalled, sharing, t]);
 
   const totalTokens = formatTokenCount(tokenUsage?.totalTokens);
-  const points = formatUsagePoints(tokensToUsagePoints(tokenUsage?.totalTokens));
+  const points = formatUsagePoints(resolveUsagePoints(tokenUsage));
+  const hasExactUsagePoints = tokenUsage?.costCurrency === 'sudo_point' && costToUsagePoints(tokenUsage.costUnits) !== null;
+  const pointsTooltipLabel = points
+    ? t(hasExactUsagePoints ? 'messages.tokenUsagePointsExact' : 'messages.tokenUsagePointsEstimated', {
+        defaultValue: hasExactUsagePoints ? 'Points: {{value}} (exact)' : 'Points: {{value}} (estimated)',
+        value: points,
+      })
+    : null;
   const inputTokens = formatTokenCount(tokenUsage?.inputTokens);
   const outputTokens = formatTokenCount(tokenUsage?.outputTokens);
   const cachedReadTokens = tokenUsage?.cachedReadTokens ? formatTokenCount(tokenUsage.cachedReadTokens) : null;
@@ -116,7 +123,7 @@ const TurnActions: React.FC<TurnActionsProps> = ({ turnTexts, turnTextsRaw, conv
   const usageTooltip = tokenUsage ? (
     <div className='text-12px leading-18px'>
       <div>{t('messages.tokenUsageTotal', { defaultValue: 'Total: {{value}} tokens', value: new Intl.NumberFormat().format(tokenUsage.totalTokens) })}</div>
-      {points && <div>{t('messages.tokenUsagePoints', { defaultValue: 'Points: {{value}}', value: points })}</div>}
+      {pointsTooltipLabel && <div>{pointsTooltipLabel}</div>}
       {typeof tokenUsage.inputTokens === 'number' && <div>{t('messages.tokenUsageInput', { defaultValue: 'Input: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.inputTokens) })}</div>}
       {typeof tokenUsage.outputTokens === 'number' && <div>{t('messages.tokenUsageOutput', { defaultValue: 'Output: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.outputTokens) })}</div>}
       {typeof tokenUsage.thoughtTokens === 'number' && <div>{t('messages.tokenUsageThought', { defaultValue: 'Reasoning: {{value}}', value: new Intl.NumberFormat().format(tokenUsage.thoughtTokens) })}</div>}

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -827,6 +827,10 @@ export interface AcpPromptResponseUsage {
   contextWindowTokens?: number | null;
   /** Estimated tokens currently held in the model runtime context */
   estimatedSessionTokens?: number | null;
+  /** Aggregated server billing units for this prompt, supplied by Sudocode metadata when available */
+  costUnits?: number | null;
+  /** Billing currency for costUnits, supplied by Sudocode metadata when available */
+  costCurrency?: string | null;
 }
 
 // ===== ACP Models types (unstable API) =====

--- a/tests/unit/acpConnectionResponseOrder.test.ts
+++ b/tests/unit/acpConnectionResponseOrder.test.ts
@@ -135,6 +135,8 @@ describe('AcpConnection prompt response ordering', () => {
           sudocode: {
             contextWindowTokens: 1048576,
             estimatedSessionTokens: 42000,
+            costUnits: 43700,
+            costCurrency: 'sudo_point',
           },
         },
       },
@@ -146,6 +148,8 @@ describe('AcpConnection prompt response ordering', () => {
       totalTokens: 15,
       contextWindowTokens: 1048576,
       estimatedSessionTokens: 42000,
+      costUnits: 43700,
+      costCurrency: 'sudo_point',
     });
   });
 
@@ -225,6 +229,7 @@ describe('AcpConnection prompt response ordering', () => {
     const connection = new AcpConnection();
     const harness = connection as unknown as AcpConnectionTestHarness & {
       child: { killed: boolean } | null;
+      transport: { send: (message: object) => void; close: () => Promise<void>; connected: boolean } | null;
       sessionId: string | null;
       sendMessage: (message: unknown) => void;
       disconnect: () => Promise<void>;
@@ -233,6 +238,7 @@ describe('AcpConnection prompt response ordering', () => {
     const disconnectSpy = vi.fn().mockResolvedValue(undefined);
 
     harness.child = { killed: false };
+    harness.transport = { send: vi.fn(), close: vi.fn().mockResolvedValue(undefined), connected: true };
     harness.sessionId = 'session-1';
     harness.sendMessage = vi.fn();
     harness.disconnect = disconnectSpy;

--- a/tests/unit/tokenUsage.test.ts
+++ b/tests/unit/tokenUsage.test.ts
@@ -1,4 +1,4 @@
-import { COST_UNITS_PER_USAGE_POINT, TOKENS_PER_USAGE_POINT, costToUsagePoints, formatUsagePoints, tokensToUsagePoints, usagePointsFromTokensOrFallback } from '@/common/tokenUsage';
+import { COST_UNITS_PER_USAGE_POINT, TOKENS_PER_USAGE_POINT, costToUsagePoints, formatUsagePoints, resolveUsagePoints, tokensToUsagePoints, usagePointsFromTokensOrFallback } from '@/common/tokenUsage';
 
 describe('token usage point helpers', () => {
   it('converts tokens to usage points with the shared ratio', () => {
@@ -19,11 +19,28 @@ describe('token usage point helpers', () => {
     expect(usagePointsFromTokensOrFallback(undefined, undefined)).toBe(0);
   });
 
-  it('converts cost units to rounded usage points', () => {
+  it('converts cost units to exact usage points', () => {
     expect(COST_UNITS_PER_USAGE_POINT).toBe(500);
-    expect(costToUsagePoints(702237)).toBe(1404);
-    expect(costToUsagePoints(2785)).toBe(6);
+    expect(costToUsagePoints(43700)).toBe(87.4);
+    expect(costToUsagePoints(702237)).toBe(1404.474);
+    expect(costToUsagePoints(2785)).toBe(5.57);
     expect(costToUsagePoints(undefined)).toBeNull();
+  });
+
+  it('resolves exact server cost points before token estimates', () => {
+    expect(resolveUsagePoints({ totalTokens: 1000, costUnits: 43700, costCurrency: 'sudo_point' })).toBe(87.4);
+  });
+
+  it('falls back to token estimates when server cost is missing', () => {
+    expect(resolveUsagePoints({ totalTokens: 1000 })).toBe(2);
+  });
+
+  it('falls back to token estimates for unsupported cost currencies', () => {
+    expect(resolveUsagePoints({ totalTokens: 1000, costUnits: 43700, costCurrency: 'usd' })).toBe(2);
+  });
+
+  it('treats zero sudo_point cost as exact usage points', () => {
+    expect(resolveUsagePoints({ totalTokens: 1000, costUnits: 0, costCurrency: 'sudo_point' })).toBe(0);
   });
 
   it('formats usage points with one decimal place by default', () => {


### PR DESCRIPTION
## Summary
- parse ACP _meta.sudocode.costUnits/costCurrency into turn token usage
- prefer exact sudo_point cost for points display using costUnits / 500
- fall back to token-based estimates when exact cost is unavailable
- update tests for cost parsing, zero-cost handling, and fallback behavior

## Tests
- bun run test -- tests/unit/tokenUsage.test.ts tests/unit/acpConnectionResponseOrder.test.ts
- git diff --check

Note: bunx tsc --noEmit still reports an existing unrelated error in src/common/utils/workspaceSkillSync.ts(49,7).