### PR TITLE
fix(settings): 修复技能更新按钮上溢出

### DIFF
--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -499,8 +499,8 @@ const SkillDetailModal: React.FC<{
               <>
                 {hasUpdate ? (
                   <Tooltip content={t('settings.skill.updateTo', { version: latestVersionInfo?.version, defaultValue: `更新至 v${latestVersionInfo?.version || ''}` })}>
-                    <Button type='primary' long size='large' className='flex-1' loading={updating} onClick={onUpdate}>
-                      <span className='flex items-center gap-6px justify-center'>
+                    <Button type='primary' long size='large' className='flex-1' loading={updating} loadingFixedWidth onClick={onUpdate}>
+                      <span className='inline-flex items-center gap-6px justify-center whitespace-nowrap'>
                         <Install size='15' />
                         {t('settings.skill.updateTo', { version: latestVersionInfo?.version, defaultValue: `更新至 v${latestVersionInfo?.version || ''}` })}
                       </span>


### PR DESCRIPTION
## 修改内容\n- 修复 SkillDetailModal 中已安装技能更新状态按钮在 loading/updating 时的内容溢出问题\n- 为更新按钮增加固定宽度的 loading 展示，避免 spinner 和文字挤压导致布局下坠\n- 保持按钮文案单行显示，避免在详情弹窗底部换行撑出边界\n\n## 说明\n- 仅修改技能商店详情页更新按钮的展示，不影响其他技能卡片和安装按钮\n