### PR TITLE
fix(browser): revert SKILL.md + harden browser_helper path resolution

### DIFF
--- a/resources/sudoclaw-bin/browser_helper.py
+++ b/resources/sudoclaw-bin/browser_helper.py
@@ -33,7 +33,9 @@ def _browser_skill_dir() -> pathlib.Path:
     pythonpath = os.environ.get("PYTHONPATH", "")
     for entry in pythonpath.split(os.pathsep):
         candidate = pathlib.Path(entry)
-        if (candidate / "ai_dev_browser").is_dir():
+        # Verify ai_dev_browser/tools/ exists — a stale directory with only
+        # metadata (SKILL.md) but no Python tools package must be skipped.
+        if (candidate / "ai_dev_browser" / "tools").is_dir():
             return candidate
     # Fallback for direct invocation outside sudowork
     try:

--- a/skills/_builtin/browser/SKILL.md
+++ b/skills/_builtin/browser/SKILL.md
@@ -5,30 +5,6 @@ description: "AI-native browser. Explore websites, discover page structure, take
 
 # Browser
 
-## Opening a URL in the right-side panel
-
-When the user asks to open / preview / show a URL in the right-side browser
-panel (e.g. "在右侧浏览器打开 https://example.com", "preview localhost:8769",
-"看一下我刚启动的 dashboard"), run this immediately:
-
-```bash
-browser page_goto --url <URL>
-```
-
-The right-side BrowserPanel auto-syncs to the URL on this command — no extra
-step needed. Do NOT first call `read_file`, `ListMcpResources`, or `ToolSearch`
-to "explore what's available"; that just wastes turns. The dispatcher above is
-the canonical entry point and is the only thing you need for the open-URL
-flow.
-
-Equivalent forms also auto-sync the right panel:
-
-- `aidb tab_new --url=<URL>` (legacy dispatcher alias)
-- `python -m ai_dev_browser.tools.page_goto --url "<URL>"` (raw Python)
-- MCP: `sudowork-browser.browser_open(url=<URL>)` (when reachable as an MCP tool)
-
-## CLI reference
-
 ```bash
 browser --list
 ```


### PR DESCRIPTION
## Summary

Two fixes for browser skill reliability:

1. **Revert SKILL.md** to minimal (`browser --list` only). The "right-side panel" instructions (734bfada) are Sudowork UI details that should be transparent to the agent. Sidebar routing will be handled at the Sudowork/ai-dev-browser infra layer (phase 2).

2. **Harden browser_helper.py path resolution**: verify `ai_dev_browser/tools/` exists, not just `ai_dev_browser/` directory. Stale skill directories from before the `_builtin/` migration match PYTHONPATH but have no tools inside, causing "tools directory not found" that forces agents to write Python scripts instead of using CLI.

## Root cause

邓佳奇 reported agent writing Python scripts instead of using `browser` CLI. Debug trace:
- `browser --list` → `Error: tools directory not found: ~/.nexus/skills/_system/browser/ai_dev_browser/tools`
- Path is `_system/browser/` (missing `_builtin/`), a leftover from pre-migration layout
- `browser_helper.py` matched the stale directory because it only checked `ai_dev_browser/` exists, not `ai_dev_browser/tools/`

## Test plan

- [ ] CI passes (Browser Port Isolation includes `browser --list` check)
- [x] Confirmed: with fix, stale directories are skipped and correct `_builtin/` path is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)