### PR TITLE
ci: handle dev→main release sync + large-diff PR review

### DIFF
--- a/.github/actions/gather-pr-diff/action.yml
+++ b/.github/actions/gather-pr-diff/action.yml
@@ -54,13 +54,36 @@ runs:
 
           core.setOutput('pr_number', String(prNumber));
 
-          // Fetch diff (returns raw text when using diff media type)
-          const { data: diff } = await github.rest.pulls.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number: prNumber,
-            mediaType: { format: 'diff' },
-          });
+          // Fetch diff (returns raw text when using diff media type).
+          // GitHub returns 406 when the PR has more than 300 changed files;
+          // in that case fall back to synthesizing an approximate diff from
+          // the paginated listFiles patches.
+          let diff;
+          let fallbackFiles = null;
+          try {
+            const { data } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              mediaType: { format: 'diff' },
+            });
+            diff = data;
+          } catch (e) {
+            if (e.status === 406) {
+              fallbackFiles = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              diff = fallbackFiles
+                .map(f => `--- a/${f.filename}\n+++ b/${f.filename}\n${f.patch || '[patch omitted: file too large]'}`)
+                .join('\n');
+              core.warning(`PR has ${fallbackFiles.length} files; fell back to listFiles API (full diff too large for /pulls/{n}.diff)`);
+            } else {
+              throw e;
+            }
+          }
 
           if (!diff || String(diff).trim().length === 0) {
             core.warning('PR has an empty diff, skipping');
@@ -68,20 +91,26 @@ runs:
             return;
           }
 
-          // Fetch all changed files (paginated)
-          const allFiles = [];
-          let page = 1;
-          while (true) {
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 100,
-              page,
-            });
-            allFiles.push(...files);
-            if (files.length < 100) break;
-            page++;
+          // Fetch all changed files (paginated). Reuse fallbackFiles if the
+          // 406 fallback already fetched them above, to avoid duplicate API calls.
+          let allFiles;
+          if (fallbackFiles) {
+            allFiles = fallbackFiles;
+          } else {
+            allFiles = [];
+            let page = 1;
+            while (true) {
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+                page,
+              });
+              allFiles.push(...files);
+              if (files.length < 100) break;
+              page++;
+            }
           }
 
           const additions = allFiles.reduce((s, f) => s + f.additions, 0);

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,15 +19,19 @@ env:
 
 jobs:
   # Job 0: Reject PRs targeting main — all PRs should target dev
+  # Exception: release sync PRs from 'dev' to 'main' are allowed.
   check-base-branch:
     name: Check PR Base Branch
-    if: github.event.pull_request.base.ref == 'main'
+    if: >
+      github.event.pull_request.base.ref == 'main'
+      && github.event.pull_request.head.ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - name: Reject PR to main
         run: |
           echo "::error::PRs should target 'dev', not 'main'. Please change the base branch."
           echo "To fix: gh pr edit ${{ github.event.pull_request.number }} --base dev"
+          echo "(Note: release sync PRs from 'dev' to 'main' are exempt.)"
           exit 1
 
   # Job 1: Skipped code quality checks (ESLint removed per requirement)


### PR DESCRIPTION
## Summary
- Exempt `dev → main` release sync PRs from the "no PRs to main" check
  (was rejecting legitimate release PRs like #795)
- Make `gather-pr-diff` fall back to paginated `listFiles` when the
  diff endpoint returns HTTP 406 (300-file limit), unblocking AI review
  on large PRs

## Background
PR #795 (1012 changed files) tripped two real failures:
1. `Check PR Base Branch` rejected it because base was `main` — but
   release sync from `dev` is the intended path to merge into `main`.
2. `AI Review / gather-pr-diff` died with `HTTP 406: diff exceeded 300
   files`. Action had no fallback, AI review never ran.

## Test plan
- [x] YAML parses (both files)
- [x] Fallback path mock test (13/13 asserts): 406 → paginate listFiles
      → synthesized diff with \`--- a/F / +++ b/F / [patch omitted]\`
      markers; outputs preserved
- [x] Happy path mock test (7/7 asserts): non-406 keeps raw diff,
      \`paginate\` not called, no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)