### PR TITLE
chore(deps): bump electron to 40.8.5 + add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Major bumps are landed manually — they tend to need build/runtime testing.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "cross-env": "^7.0.3",
         "dotenv": "^17.2.1",
-        "electron": "40.8.3",
+        "electron": "40.8.5",
         "electron-builder": "^26.6.0",
         "electron-vite": "^5.0.0",
         "esbuild": "^0.25.11",
@@ -2115,7 +2115,7 @@
 
     "ejs": ["ejs@3.1.10", "https://registry.npmmirror.com/ejs/-/ejs-3.1.10.tgz", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@40.8.3", "https://registry.npmmirror.com/electron/-/electron-40.8.3.tgz", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-MH6LK4xM6VVmmtz0nRE0Fe8l2jTKSYTvH1t0ZfbNLw3o6dlBCVTRqQha6uL8ZQVoMy74JyLguGwK7dU7rCKIhw=="],
+    "electron": ["electron@40.8.5", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A=="],
 
     "electron-builder": ["electron-builder@26.8.1", "https://registry.npmmirror.com/electron-builder/-/electron-builder-26.8.1.tgz", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "cross-env": "^7.0.3",
     "dotenv": "^17.2.1",
-    "electron": "40.8.3",
+    "electron": "40.8.5",
     "electron-builder": "^26.6.0",
     "electron-vite": "^5.0.0",
     "esbuild": "^0.25.11",


### PR DESCRIPTION
## What

- **Bump `electron` `40.8.3` → `40.8.5`** (devDependency) + update `bun.lock`.
- **Add `.github/dependabot.yml`**: weekly, grouped minor/patch version updates (majors ignored) for `npm` + `github-actions`, limit 5 PRs/group.

## Why

electron is the one **direct** dependency where a vuln maps to RCE on the user's machine, so it's the high-value patch. `40.8.5` clears the open Dependabot alerts against the declared version (2 low + 1 medium, all fixed in 40.8.4/40.8.5).

The 116 other open alerts are transitive (in `pnpm-lock.yaml`) and outside a local desktop app's realistic threat model — e.g. the 2 "critical" protobufjs alerts (CVE-2026-41242) require the app to **load attacker-controlled `.proto`/JSON descriptors**, which sudowork never does (schemas are bundled & fixed, data comes from Google/Feishu over TLS). Not chasing those here.

## Notes for the reviewer

- Build uses `bun install --no-frozen-lockfile`, so **`bun.lock` is the real lockfile** and is what's updated here. The electron entry's empty tarball URL matches the 6 existing empty-URL entries already on `dev` (idiomatic; CI fills it on install).
- **`pnpm-lock.yaml` is intentionally left untouched.** It is stale/vestigial (has `electron@37.10.3`, missing `@bufbuild/protobuf` from #733, mismatched overrides) and is **not consumed by the build** — but Dependabot still scans it, which is the source of most of the 119 phantom alerts. Cleaning it up (regenerate to match reality, or stop tracking it since the build is on bun) is a **separate follow-up decision**, deliberately not bundled into this security bump.

## Test plan

- [ ] `bun install` resolves cleanly
- [ ] App builds (`bun run package`) and launches on Electron 40.8.5
- [ ] Smoke-test core flows (agent chat, ACP spawn, browser panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)