### PR TITLE
chore(deps): bump github-actions to latest majors

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -107,7 +107,7 @@ jobs:
           echo "ai-dev-browser package present: $count .py files under $pkg"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -117,7 +117,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -127,7 +127,7 @@ jobs:
       # Restore Electron/Electron-Builder caches before any build-related install
       - name: Cache Electron artifacts
         id: electron-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ runner.temp }}/.cache/electron
@@ -144,7 +144,7 @@ jobs:
         run: echo "electron-cache-hit=${{ steps.electron-cache.outputs.cache-hit }}"
 
       - name: Install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -193,7 +193,7 @@ jobs:
       - name: Install MSVC ARM64 toolchain (Windows ARM64 only)
         if: matrix.platform == 'windows-arm64'
         continue-on-error: true
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 20
           max_attempts: 3
@@ -527,7 +527,7 @@ jobs:
       # Linux: 标准构建，无特殊错误处理
       - name: Build with electron-builder (Linux)
         if: matrix.platform == 'linux'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 60
           max_attempts: 2
@@ -610,7 +610,7 @@ jobs:
       # - macOS: 公证超时但有产物（已在构建步骤中处理）
       # - Windows: 仅当 windows-build 步骤成功
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: >-
           success() &&
           (!startsWith(matrix.platform, 'windows') || steps.windows-build.outputs.result == 'success')

--- a/.github/workflows/candidate-promotion.yml
+++ b/.github/workflows/candidate-promotion.yml
@@ -101,7 +101,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/download-resources.yml
+++ b/.github/workflows/download-resources.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -69,7 +69,7 @@ jobs:
         run: ls -lh resources/*.tgz
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bundles-${{ matrix.platform }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -91,7 +91,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -124,7 +124,7 @@ jobs:
       # Restore Electron/Electron-Builder caches before install-app-deps
       - name: Cache Electron artifacts
         id: electron-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ runner.temp }}/.cache/electron

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload E2E report (self-contained with screenshots & traces)
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-report-linux-pr
           path: |


### PR DESCRIPTION
## Summary
Consolidates the five dependabot github-actions PRs (#799–#803) into a single change so they build and merge together:

| Action | From | To |
|---|---|---|
| `actions/setup-node` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v6 | v7 |
| `nick-fields/retry` | v3 | v4 |

All 16 usages across `_build-reusable.yml`, `pr-checks.yml`, `candidate-promotion.yml`, `download-resources.yml`, and `pr-e2e-artifacts.yml` were updated. Diff is exactly the union of the 5 dependabot diffs.

## Why one PR
These are CI-only bumps that share the same build matrix; reviewing/merging them as one avoids 5 separate full build runs and 5 merge cycles.

## Test plan
- [ ] `pr-checks` (build-test) green.
- [ ] After merge, close dependabot PRs #799–#803 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)