### PR TITLE
修复主题设置与侧边栏样式

### DIFF
--- a/src/renderer/components/CssThemeSettings/index.tsx
+++ b/src/renderer/components/CssThemeSettings/index.tsx
@@ -9,8 +9,8 @@ import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
 import { useThemeContext } from '@/renderer/context/ThemeContext';
 import { resolveCssByActiveTheme, setExtensionThemesCache } from '@/renderer/utils/themeCssSync';
-import { Button, Message, Modal } from '@arco-design/web-react';
-import { EditTwo, Plus, CheckOne } from '@icon-park/react';
+import { Message, Modal } from '@arco-design/web-react';
+import { EditTwo, CheckOne } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CssThemeModal from './CssThemeModal';
@@ -357,14 +357,6 @@ const CssThemeSettings: React.FC = () => {
   );
 
   /**
-   * 打开添加主题弹窗 / Open add theme modal
-   */
-  const handleAddTheme = useCallback(() => {
-    setEditingTheme(null);
-    setModalVisible(true);
-  }, []);
-
-  /**
    * 打开编辑主题弹窗 / Open edit theme modal
    */
   const handleEditTheme = useCallback((theme: ICssTheme, e: React.MouseEvent) => {
@@ -454,9 +446,6 @@ const CssThemeSettings: React.FC = () => {
       {/* 标题栏 / Header */}
       <div className='flex items-start md:items-center justify-between gap-8px flex-wrap'>
         <span className='text-14px text-t-secondary leading-22px'>{t('settings.cssTheme.selectOrCustomize')}</span>
-        <Button type='outline' size='small' className='rd-18px h-34px px-14px !m-0' icon={<Plus theme='outline' size='14' />} onClick={handleAddTheme}>
-          {t('settings.cssTheme.addManually')}
-        </Button>
       </div>
 
       {/* 主题卡片列表 / Theme card list */}

--- a/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
@@ -15,7 +15,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
-import { ThemeSwitcher } from '@/renderer/components/ThemeSwitcher';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useSettingsViewMode } from '../settingsViewContext';
 
@@ -314,7 +313,6 @@ const SystemModalContent: React.FC = () => {
   // 偏好设置项配置 / Preference items configuration
   const preferenceItems = [
     { key: 'language', label: t('settings.language'), component: <LanguageSwitcher /> },
-    { key: 'theme', label: t('settings.theme'), component: <ThemeSwitcher /> },
     {
       key: 'closeToTray',
       label: t('settings.closeToTray'),

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -83,9 +83,9 @@
   "agent_name": "Agent Name",
   "rule_content": "Rule Content / Instructions",
   "delete_preset_confirm": "Are you sure you want to delete this preset?",
-  "cssSettings": "CSS Settings",
+  "cssSettings": "Theme Settings",
   "cssTheme": {
-    "selectOrCustomize": "Select preset theme or custom CSS",
+    "selectOrCustomize": "Select a preset theme or custom theme",
     "addManually": "Add Manually",
     "default": "Default",
     "addToPreset": "Add Theme",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -83,9 +83,9 @@
   "agent_name": "智能体名称",
   "rule_content": "规则内容 / 指令",
   "delete_preset_confirm": "确定要删除该预设吗？",
-  "cssSettings": "CSS设置",
+  "cssSettings": "主题设置",
   "cssTheme": {
-    "selectOrCustomize": "选择预设主题或自定义 CSS",
+    "selectOrCustomize": "选择预设主题或自定义主题",
     "addManually": "手动添加",
     "default": "默认",
     "addToPreset": "添加主题",

--- a/src/renderer/layout.tsx
+++ b/src/renderer/layout.tsx
@@ -294,7 +294,7 @@ const Layout: React.FC<{
             collapsedWidth={isMobile ? 0 : 64}
             collapsed={collapsed}
             width={siderWidth}
-            className={classNames('!bg-2 layout-sider', {
+            className={classNames('layout-sider', {
               collapsed: collapsed,
             })}
             style={
@@ -303,6 +303,7 @@ const Layout: React.FC<{
                     position: 'fixed',
                     left: 0,
                     zIndex: 100,
+                    background: 'var(--bg-2)',
                     transform: collapsed ? 'translateX(-100%)' : 'translateX(0)',
                     pointerEvents: collapsed ? 'none' : 'auto',
                   }

--- a/src/renderer/styles/themes/base.css
+++ b/src/renderer/styles/themes/base.css
@@ -760,12 +760,13 @@ body,
   overflow-x: hidden;
   box-shadow: none !important;
   border-right: 1px solid var(--border-base);
-  background: color-mix(in srgb, var(--color-fill-1) 72%, var(--color-bg-1)) !important;
+  background-color: var(--bg-2);
   /* 侧边栏收起展开动画优化 / Sidebar collapse/expand animation */
   transition:
     width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  will-change: width, transform;
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 0.2s ease;
+  will-change: width, transform, background-color;
 }
 
 .sidebar-nav-item {


### PR DESCRIPTION
## 修改内容
- 隐藏主题设置页的“手动添加”按钮
- 统一系统设置页中与主题相关的重复入口
- 调整中英文主题设置文案，统一为“主题设置”
- 优化侧边栏背景与折叠动画样式
