### PR TITLE
修复右侧浏览器和终端页签新增按钮布局

### DIFF
--- a/src/renderer/pages/conversation/right-panel/BrowserPanel.tsx
+++ b/src/renderer/pages/conversation/right-panel/BrowserPanel.tsx
@@ -4,7 +4,7 @@ import WebviewHost from '@/renderer/components/WebviewHost';
 import { useAddEventListener } from '@/renderer/utils/emitter';
 import { Message, Modal, Tooltip } from '@arco-design/web-react';
 import { Add, Close, Delete } from '@icon-park/react';
-import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type BrowserTab = {
@@ -66,10 +66,15 @@ interface BrowserPanelProps {
 const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversationId }) => {
   const { t } = useTranslation();
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const browserTabsScrollerRef = useRef<HTMLDivElement | null>(null);
+  const browserTabsTabsRef = useRef<HTMLDivElement | null>(null);
+  const browserTabsMeasureAddRef = useRef<HTMLButtonElement | null>(null);
+  const browserTabsScrollToEndRef = useRef(false);
 
   // Settings — not per-conv. Stay in component-local useState.
   const [defaultUrl, setDefaultUrl] = useState<string>(DEFAULT_BROWSER_PANEL_HOMEPAGE);
   const [reloadEpoch, setReloadEpoch] = useState(0); // bump to force-reload all tabs after cache clear
+  const [browserTabsOverflowing, setBrowserTabsOverflowing] = useState(false);
   const partition = useMemo(() => BROWSER_PANEL_PARTITION, []);
 
   // Subscribe to the module-level store so this component re-renders when
@@ -143,7 +148,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversatio
       state.activeTabId = tabId;
       notifyListeners();
     },
-    [convKey, defaultUrl],
+    [convKey, defaultUrl]
   );
 
   const openNewTab = useCallback(
@@ -154,9 +159,10 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversatio
       const nextTab = createTab(normalized, normalized);
       state.tabs = [...state.tabs, nextTab];
       state.activeTabId = nextTab.id;
+      browserTabsScrollToEndRef.current = true;
       notifyListeners();
     },
-    [convKey, defaultUrl],
+    [convKey, defaultUrl]
   );
 
   // Subscribe to "open in right-panel browser". Accept the emit when:
@@ -175,7 +181,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversatio
       if (!isMatch) return;
       openNewTab(payload.url);
     },
-    [convKey, openNewTab],
+    [convKey, openNewTab]
   );
 
   useAddEventListener('right-panel.browser.open', handleOpenBrowserUrl, [handleOpenBrowserUrl]);
@@ -211,7 +217,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversatio
       state.tabs = state.tabs.map((tab) => (tab.id === tabId ? { ...tab, url: nextUrl, title: nextUrl } : tab));
       notifyListeners();
     },
-    [convKey, defaultUrl],
+    [convKey, defaultUrl]
   );
 
   const closeTab = useCallback(
@@ -227,7 +233,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversatio
       notifyListeners();
       ipcBridge.browserPanel.unregisterTab.invoke({ tabId }).catch(() => {});
     },
-    [convKey, defaultUrl],
+    [convKey, defaultUrl]
   );
 
   const handleClearCache = useCallback(() => {
@@ -248,39 +254,100 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversatio
     });
   }, [t]);
 
+  useLayoutEffect(() => {
+    if (!active) {
+      setBrowserTabsOverflowing(false);
+      browserTabsScrollToEndRef.current = false;
+      return;
+    }
+
+    const scroller = browserTabsScrollerRef.current;
+    const tabsRow = browserTabsTabsRef.current;
+    const addButtonWidth = browserTabsMeasureAddRef.current?.offsetWidth ?? 0;
+    if (!scroller || !tabsRow) return;
+
+    const measure = () => {
+      const overflowing = tabsRow.scrollWidth + addButtonWidth + 4 > scroller.clientWidth;
+      setBrowserTabsOverflowing((current) => (current === overflowing ? current : overflowing));
+    };
+
+    const rafId = window.requestAnimationFrame(() => {
+      measure();
+    });
+
+    const resizeObserver = new ResizeObserver(() => {
+      measure();
+    });
+
+    resizeObserver.observe(scroller);
+    resizeObserver.observe(tabsRow);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      resizeObserver.disconnect();
+    };
+  }, [active, tabs.length]);
+
+  useLayoutEffect(() => {
+    if (!active || !browserTabsOverflowing || !browserTabsScrollToEndRef.current) return;
+    const scroller = browserTabsScrollerRef.current;
+    if (!scroller) return;
+
+    browserTabsScrollToEndRef.current = false;
+    scroller.scrollTo({ left: scroller.scrollWidth, behavior: 'smooth' });
+  }, [active, activeTabId, browserTabsOverflowing, tabs.length]);
+
   return (
-    <div className='flex h-full min-h-0 flex-1 flex-col'>
+    <div className='flex h-full min-h-0 min-w-0 flex-1 flex-col'>
       <div className='flex flex-col border-b border-[var(--color-border-2)] flex-shrink-0'>
-        <div className='browser-tabs overflow-x-auto'>
-          {tabs.map((tab) => (
-            <button key={tab.id} type='button' className={`browser-tabs__item ${tab.id === activeTabId ? 'browser-tabs__item--active' : ''}`} onClick={() => setActiveTabId(tab.id)}>
-              <span className='max-w-160px truncate'>{tab.title}</span>
-              {tabs.length > 1 && (
-                <span
-                  role='button'
-                  tabIndex={-1}
-                  className='browser-tabs__close'
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    closeTab(tab.id);
-                  }}
-                >
-                  <Close size={12} />
-                </span>
+        <div className='browser-tabs'>
+          <div ref={browserTabsScrollerRef} className='browser-tabs__scroller'>
+            <div ref={browserTabsTabsRef} className='browser-tabs__tabs'>
+              {tabs.map((tab) => (
+                <button key={tab.id} type='button' className={`browser-tabs__item ${tab.id === activeTabId ? 'browser-tabs__item--active' : ''}`} onClick={() => setActiveTabId(tab.id)}>
+                  <span className='max-w-160px truncate'>{tab.title}</span>
+                  {tabs.length > 1 && (
+                    <span
+                      role='button'
+                      tabIndex={-1}
+                      className='browser-tabs__close'
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        closeTab(tab.id);
+                      }}
+                    >
+                      <Close size={12} />
+                    </span>
+                  )}
+                  <span aria-hidden='true' className='browser-tabs__indicator' />
+                </button>
+              ))}
+              {!browserTabsOverflowing && (
+                <Tooltip content={t('conversation.rightPanel.browser.newTab')} position='bottom'>
+                  <button type='button' className='browser-tabs__new-tab browser-tabs__new-tab--inline' onClick={() => openNewTab(defaultUrl)} aria-label={t('conversation.rightPanel.browser.newTab')}>
+                    <Add size={14} />
+                  </button>
+                </Tooltip>
               )}
-              <span aria-hidden='true' className='browser-tabs__indicator' />
-            </button>
-          ))}
-          <Tooltip content={t('conversation.rightPanel.browser.newTab')} position='bottom'>
-            <button type='button' className='browser-tabs__new-tab' onClick={() => openNewTab(defaultUrl)} aria-label={t('conversation.rightPanel.browser.newTab')}>
-              <Add size={14} />
-            </button>
-          </Tooltip>
-          <Tooltip content={t('conversation.rightPanel.browser.clearCache')} position='bottom'>
-            <button type='button' className='browser-tabs__new-tab' onClick={handleClearCache} aria-label={t('conversation.rightPanel.browser.clearCache')}>
-              <Delete size={14} />
-            </button>
-          </Tooltip>
+              <button ref={browserTabsMeasureAddRef} type='button' tabIndex={-1} aria-hidden='true' className='browser-tabs__new-tab browser-tabs__new-tab--measure'>
+                <Add size={14} />
+              </button>
+            </div>
+          </div>
+          <div className='browser-tabs__actions'>
+            {browserTabsOverflowing && (
+              <Tooltip content={t('conversation.rightPanel.browser.newTab')} position='bottom'>
+                <button type='button' className='browser-tabs__new-tab browser-tabs__new-tab--utility' onClick={() => openNewTab(defaultUrl)} aria-label={t('conversation.rightPanel.browser.newTab')}>
+                  <Add size={14} />
+                </button>
+              </Tooltip>
+            )}
+            <Tooltip content={t('conversation.rightPanel.browser.clearCache')} position='bottom'>
+              <button type='button' className='browser-tabs__new-tab browser-tabs__new-tab--utility' onClick={handleClearCache} aria-label={t('conversation.rightPanel.browser.clearCache')}>
+                <Delete size={14} />
+              </button>
+            </Tooltip>
+          </div>
         </div>
       </div>
       <div ref={panelRef} className='flex min-h-0 flex-1 relative overflow-hidden' onMouseDown={focusActiveWebview} onPointerDown={focusActiveWebview}>

--- a/src/renderer/pages/conversation/right-panel/TerminalPanel.tsx
+++ b/src/renderer/pages/conversation/right-panel/TerminalPanel.tsx
@@ -2,7 +2,7 @@ import { ipcBridge } from '@/common';
 import { FitAddon } from '@xterm/addon-fit';
 import { Tooltip } from '@arco-design/web-react';
 import { Add, Close } from '@icon-park/react';
-import React, { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
@@ -126,10 +126,15 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false, conv
   const currentState = getOrCreateConvState(convKey);
   const tabs = currentState.tabs;
   const activeTabId = currentState.activeTabId ?? '';
+  const [terminalTabsOverflowing, setTerminalTabsOverflowing] = useState(false);
 
   // Container refs are local to this component instance (one ref per render).
   // We re-attach xterm DOM elements to these containers in useLayoutEffect
   // below — runtimes themselves live in module scope.
+  const terminalTabsScrollerRef = useRef<HTMLDivElement | null>(null);
+  const terminalTabsListRef = useRef<HTMLDivElement | null>(null);
+  const terminalMeasureAddRef = useRef<HTMLButtonElement | null>(null);
+  const terminalTabsScrollToEndRef = useRef(false);
   const terminalContainerRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const terminalScreenRef = useRef<HTMLDivElement | null>(null);
 
@@ -225,6 +230,49 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false, conv
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [convKey]);
 
+  useLayoutEffect(() => {
+    if (!active) {
+      setTerminalTabsOverflowing(false);
+      terminalTabsScrollToEndRef.current = false;
+      return;
+    }
+
+    const scroller = terminalTabsScrollerRef.current;
+    const tabsList = terminalTabsListRef.current;
+    const addButtonWidth = terminalMeasureAddRef.current?.offsetWidth ?? 0;
+    if (!scroller || !tabsList) return;
+
+    const measure = () => {
+      const overflowing = tabsList.scrollWidth + addButtonWidth + 4 > scroller.clientWidth;
+      setTerminalTabsOverflowing((current) => (current === overflowing ? current : overflowing));
+    };
+
+    const rafId = window.requestAnimationFrame(() => {
+      measure();
+    });
+
+    const resizeObserver = new ResizeObserver(() => {
+      measure();
+    });
+
+    resizeObserver.observe(scroller);
+    resizeObserver.observe(tabsList);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      resizeObserver.disconnect();
+    };
+  }, [active, tabs.length]);
+
+  useLayoutEffect(() => {
+    if (!active || !terminalTabsOverflowing || !terminalTabsScrollToEndRef.current) return;
+    const scroller = terminalTabsScrollerRef.current;
+    if (!scroller) return;
+
+    terminalTabsScrollToEndRef.current = false;
+    scroller.scrollTo({ left: scroller.scrollWidth, behavior: 'smooth' });
+  }, [active, activeTabId, terminalTabsOverflowing, tabs.length]);
+
   const attachRuntime = useCallback(
     async (tabId: string) => {
       const found = (() => {
@@ -312,6 +360,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false, conv
     const nextTab = createTab();
     state.tabs = [...state.tabs, nextTab];
     state.activeTabId = nextTab.id;
+    terminalTabsScrollToEndRef.current = true;
     notifyListeners();
   }, [convKey]);
 
@@ -389,38 +438,54 @@ const TerminalPanel: React.FC<TerminalPanelProps> = ({ cwd, active = false, conv
   return (
     <div className='terminal-root terminal-root--xterm'>
       <div className='terminal-root__header'>
-        <div className='terminal-root__tabs'>
-          {tabs.map((tab, index) => (
-            <button
-              key={tab.id}
-              type='button'
-              className={`terminal-root__tab ${tab.id === activeTabId ? 'terminal-root__tab--active' : ''}`}
-              onMouseDown={(event) => {
-                event.preventDefault();
-              }}
-              onClick={() => setActiveTab(tab.id)}
-            >
-              <span className='terminal-root__tab-label'>
-                {t('conversation.rightPanel.terminal.tab', { defaultValue: 'Terminal' })} {index + 1}
-              </span>
-              <span
-                role='button'
-                tabIndex={-1}
-                className='terminal-root__tab-close'
-                onClick={(event) => {
-                  event.stopPropagation();
-                  closeTab(tab.id);
+        <div ref={terminalTabsScrollerRef} className='terminal-root__tabs'>
+          <div ref={terminalTabsListRef} className='terminal-root__tabs-list'>
+            {tabs.map((tab, index) => (
+              <button
+                key={tab.id}
+                type='button'
+                className={`terminal-root__tab ${tab.id === activeTabId ? 'terminal-root__tab--active' : ''}`}
+                onMouseDown={(event) => {
+                  event.preventDefault();
                 }}
+                onClick={() => setActiveTab(tab.id)}
               >
-                <Close size={11} />
-              </span>
-            </button>
-          ))}
-          <Tooltip content={t('conversation.rightPanel.terminal.newTab', { defaultValue: 'New terminal' })} position='bottom'>
-            <button type='button' className='terminal-root__new-tab' onClick={openTab} aria-label={t('conversation.rightPanel.terminal.newTab', { defaultValue: 'New terminal' })}>
+                <span className='terminal-root__tab-label'>
+                  {t('conversation.rightPanel.terminal.tab', { defaultValue: 'Terminal' })} {index + 1}
+                </span>
+                <span
+                  role='button'
+                  tabIndex={-1}
+                  className='terminal-root__tab-close'
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    closeTab(tab.id);
+                  }}
+                >
+                  <Close size={11} />
+                </span>
+              </button>
+            ))}
+            {!terminalTabsOverflowing && (
+              <Tooltip content={t('conversation.rightPanel.terminal.newTab', { defaultValue: 'New terminal' })} position='bottom'>
+                <button type='button' className='terminal-root__new-tab terminal-root__new-tab--inline' onClick={openTab} aria-label={t('conversation.rightPanel.terminal.newTab', { defaultValue: 'New terminal' })}>
+                  <Add size={14} />
+                </button>
+              </Tooltip>
+            )}
+            <button ref={terminalMeasureAddRef} type='button' tabIndex={-1} aria-hidden='true' className='terminal-root__new-tab terminal-root__new-tab--measure'>
               <Add size={14} />
             </button>
-          </Tooltip>
+          </div>
+        </div>
+        <div className='terminal-root__actions'>
+          {terminalTabsOverflowing && (
+            <Tooltip content={t('conversation.rightPanel.terminal.newTab', { defaultValue: 'New terminal' })} position='bottom'>
+              <button type='button' className='terminal-root__new-tab terminal-root__new-tab--utility' onClick={openTab} aria-label={t('conversation.rightPanel.terminal.newTab', { defaultValue: 'New terminal' })}>
+                <Add size={14} />
+              </button>
+            </Tooltip>
+          )}
         </div>
       </div>
       <div ref={terminalScreenRef} className='terminal-root__screen terminal-root__screen--xterm'>

--- a/src/renderer/pages/conversation/workspace/workspace-card.css
+++ b/src/renderer/pages/conversation/workspace/workspace-card.css
@@ -54,24 +54,74 @@
 }
 
 /* ——— Shared right-panel tab strip ——— */
-.right-panel-tabs,
-.browser-tabs {
+.right-panel-tabs {
   display: flex;
   align-items: flex-end;
   gap: 4px;
+  min-width: 0;
   min-height: 40px;
   padding: 6px 8px 0;
   border-bottom: 1px solid var(--color-border-2);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--color-fill-1) 72%, transparent) 0%, transparent 100%);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-fill-1) 72%, transparent) 0%, transparent 100%);
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
   -ms-overflow-style: none;
 }
 
+.browser-tabs {
+  display: flex;
+  align-items: flex-end;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  min-height: 40px;
+  padding: 6px 8px 0;
+  border-bottom: 1px solid var(--color-border-2);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-fill-1) 72%, transparent) 0%, transparent 100%);
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.browser-tabs__scroller {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 0;
+  box-sizing: border-box;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.browser-tabs__tabs {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  min-width: max-content;
+  width: fit-content;
+}
+
+.browser-tabs__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  padding-left: 4px;
+  margin-left: auto;
+  justify-content: flex-end;
+}
+
 .right-panel-tabs::-webkit-scrollbar,
 .browser-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.browser-tabs__scroller::-webkit-scrollbar {
   display: none;
 }
 
@@ -149,7 +199,6 @@
 }
 
 .browser-tabs__new-tab {
-  margin-left: auto;
   width: 28px;
   height: 28px;
   flex: 0 0 auto;
@@ -165,6 +214,19 @@
     background-color 0.16s ease,
     color 0.16s ease;
   outline: none;
+}
+
+.browser-tabs__new-tab--inline,
+.browser-tabs__new-tab--utility {
+  background: transparent;
+}
+
+.browser-tabs__new-tab--measure {
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .browser-tabs__new-tab:hover {
@@ -203,13 +265,20 @@
 .terminal-root__header {
   display: flex;
   align-items: stretch;
-  justify-content: space-between;
   min-height: 40px;
   padding: 0 12px;
   gap: 12px;
   border-bottom: 1px solid var(--color-border-2);
   background: linear-gradient(180deg, color-mix(in srgb, var(--color-fill-1) 58%, transparent) 0%, transparent 100%);
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, Liberation Mono, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Monaco,
+    Consolas,
+    Liberation Mono,
+    monospace;
 }
 
 .terminal-root__tabs {
@@ -218,10 +287,20 @@
   gap: 4px;
   min-width: 0;
   flex: 1;
+  width: 0;
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
   -ms-overflow-style: none;
+}
+
+.terminal-root__tabs-list {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  min-width: max-content;
+  width: fit-content;
 }
 
 .terminal-root__tabs::-webkit-scrollbar {
@@ -295,7 +374,7 @@
   flex: 0 0 auto;
   width: 28px;
   height: 28px;
-  margin: 2px 0 0;
+  margin: 0;
   border: none;
   border-radius: 8px;
   background: transparent;
@@ -304,6 +383,28 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+}
+
+.terminal-root__new-tab--inline,
+.terminal-root__new-tab--utility {
+  background: transparent;
+}
+
+.terminal-root__new-tab--measure {
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.terminal-root__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  margin-left: auto;
+  justify-content: flex-end;
 }
 
 .terminal-root__new-tab:hover {


### PR DESCRIPTION
## 修改内容
- 调整右侧浏览器页签栏：不溢出时新增按钮跟随最后一个页签，溢出时固定到右侧操作区
- 调整右侧浏览器页签：新增后自动滚动到最右侧，直接显示当前页签
- 调整右侧终端页签栏：新增按钮与浏览器保持一致的布局与溢出行为
- 统一右侧页签区域样式：页签可横向滚动，新增按钮和关闭按钮保持可见

## 说明
- 仅涉及右侧浏览器、终端页签及共享样式调整