### PR TITLE
修复 Windows 下 @技能/文件 草稿文件重复显示

### DIFF
--- a/src/renderer/components/SkillSelectorMenu.tsx
+++ b/src/renderer/components/SkillSelectorMenu.tsx
@@ -264,7 +264,7 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({ title, hint, item
             {fileItems.length === 0 && <div className='px-10px py-12px text-13px text-t-secondary'>{searchQuery ? noSearchResultsText : filesEmptyText}</div>}
             {fileItems.map((file, index) => (
               <button
-                key={file.fullPath}
+                key={file.relativePath}
                 type='button'
                 role='option'
                 ref={(node) => {

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -135,7 +135,7 @@ const SendBox: React.FC<{
     return () => {
       setSendBoxHandler(null);
     };
-  }, [setSendBoxHandler]);
+  }, [latestInputRef, setInputRef, setSendBoxHandler]);
 
   // 初始化时获取单行输入框的可用宽度
   // Initialize and get the available width of single-line input
@@ -595,7 +595,7 @@ const SendBox: React.FC<{
               onTabChange={skillSelectorController.setActiveTab}
               fileItems={skillSelectorController.filteredFiles}
               onSelectFile={(file) => {
-                const fileIndex = skillSelectorController.filteredFiles.findIndex((f) => f.fullPath === file.fullPath);
+                const fileIndex = skillSelectorController.filteredFiles.findIndex((f) => f.relativePath === file.relativePath);
                 if (fileIndex >= 0) {
                   skillSelectorController.onSelectByIndex(fileIndex);
                 }

--- a/src/renderer/hooks/useWorkspaceFiles.ts
+++ b/src/renderer/hooks/useWorkspaceFiles.ts
@@ -20,6 +20,7 @@ const HIDDEN_DIR_NAMES = new Set(['.git', '.nexus', '.scode', '.claude', '.sandb
 const BUILD_DIR_NAMES = new Set(['dist', 'build', 'out', '__pycache__', 'venv', 'node_modules']);
 
 const isHiddenOrBuildDir = (name: string): boolean => HIDDEN_DIR_NAMES.has(name) || BUILD_DIR_NAMES.has(name) || (name.startsWith('.') && name !== DRAFTS_DIR_NAME);
+const normalizeUiPath = (value: string): string => value.replace(/\\/g, '/');
 
 /**
  * Flattened workspace file item for @ mention selection
@@ -42,7 +43,7 @@ export interface WorkspaceFileItem {
  */
 function flattenFileTree(nodes: IDirOrFile[], result: WorkspaceFileItem[] = []): WorkspaceFileItem[] {
   for (const node of nodes) {
-    const normalizedPath = node.relativePath.replace(/\\/g, '/');
+    const normalizedPath = normalizeUiPath(node.relativePath);
     const topDir = normalizedPath.split('/')[0];
 
     // Skip hidden/build directories and files inside them (allow .drafts)
@@ -53,7 +54,7 @@ function flattenFileTree(nodes: IDirOrFile[], result: WorkspaceFileItem[] = []):
       result.push({
         name: node.name,
         fullPath: node.fullPath,
-        relativePath: node.relativePath,
+        relativePath: normalizedPath,
         isFile: true,
       });
     }
@@ -93,9 +94,9 @@ export function useWorkspaceFiles(): WorkspaceFileItem[] {
       if (draftsResult?.success && draftsResult.data && draftsResult.data.length > 0) {
         const sep = workspace.includes('\\') ? '\\' : '/';
         const draftsDir = `${workspace}${sep}${DRAFTS_DIR_NAME}`;
-        const fileIndexByRelativePath = new Map(flatList.map((item, index) => [item.relativePath, index] as const));
+        const fileIndexByRelativePath = new Map(flatList.map((item, index) => [normalizeUiPath(item.relativePath), index] as const));
         for (const draft of draftsResult.data) {
-          const relativePath = `${DRAFTS_DIR_NAME}/${draft.name}`;
+          const relativePath = normalizeUiPath(`${DRAFTS_DIR_NAME}/${draft.name}`);
           const existingIndex = fileIndexByRelativePath.get(relativePath);
           if (existingIndex !== undefined) {
             flatList[existingIndex] = {


### PR DESCRIPTION
## 修改内容
- 统一 @ 技能/文件 列表中草稿文件的路径格式，避免 Windows 下 `\\` 和 `/` 造成同一文件重复显示
- 草稿文件去重改为使用归一化后的相对路径
- 文件选择菜单的条目 key 改为逻辑路径，避免重复渲染
- 发送侧按归一化后的相对路径匹配文件，保证选择结果一致

## 说明
- 仅修复会话页面 @ 技能/文件 的草稿文件重复问题