### PR TITLE
fix: SecretCacheImpl.put — use try/catch for sync putSecret

### DIFF
--- a/src/common/nexus/secret-cache.ts
+++ b/src/common/nexus/secret-cache.ts
@@ -105,9 +105,13 @@ class SecretCacheImpl {
     this.cache.set(ref, value);
     this.migrated.add(ref);
 
-    // Fire-and-forget write to Nexus
+    // Fire-and-forget write to Nexus (putSecret is synchronous — use try/catch, not .catch())
     if (this.client) {
-      this.client.putSecret(namespace, key, value).catch((error) => console.error(`[SecretCache] Failed to write secret ${ref} to Nexus:`, error));
+      try {
+        this.client.putSecret(namespace, key, value);
+      } catch (error) {
+        console.error(`[SecretCache] Failed to write secret ${ref} to Nexus:`, error);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- `NexusSecretClient.putSecret()` is synchronous (NAPI `callBinary` blocks)
- `SecretCacheImpl.put()` called `.catch()` on the return value (`SecretMetadata`), not a Promise
- Runtime TypeError when saving credentials via 秘钥管理 UI

## Root Cause
Sync/async contract mismatch — `.catch()` is a Promise method, not available on sync return values.

## Fix
Replace `.catch()` with `try/catch` to match the synchronous contract.

## Test plan
- [x] Verified locally: save ShareOne API key → no more TypeError in logs
- [x] Verified: `listSecrets` returns saved secrets after restart


🤖 Generated with [Claude Code](https://claude.com/claude-code)