### PR TITLE
fix(vault): bump vault plugin to v0.1.1 + update SHA256 checksums

### DIFF
--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -61,11 +61,11 @@ const SHA256SUMS = {
   'nexusd-cluster-macos-x86_64.tar.gz': '5d44d7ea5e18a4d2fe71d88342fd1adcff0fd84d09e1782eb0fd409f50668589',
   'nexusd-cluster-windows-aarch64.zip': '5c8b33210161c7d094ebe0ddca3eddefcf8ceabe0bfba7b24f0e0d232be64a92',
   'nexusd-cluster-windows-x86_64.zip': '86a6f47d0755a27af4d6509eb7d2aed83e9d5e1d47ba2ed7944094f419f15e88',
-  // vault plugin v0.1.0
-  'nexus-vault-linux-x86_64.tar.gz': '88fc1436045ebd7a92e55527462bd823ed46b2d19b5acf1303be2f647ca4af13',
-  'nexus-vault-macos-arm64.tar.gz': '2b65a754ebdfaf9b447bc0359f24c7c8a45f58a5452f0b4eb383d5bb93c466d8',
-  'nexus-vault-macos-x86_64.tar.gz': 'e869399f031b7fc31a0b4a5bc92d73ddac25994ddd64d196d7f9db6d4b9c21a2',
-  'nexus-vault-windows-x86_64.zip': '1c34bea1543e2e285fa6bb7a65be9bfde88d983ea734d9efd011c590a907f746',
+  // vault plugin v0.1.1
+  'nexus-vault-linux-x86_64.tar.gz': '9d7d87fd64e2ab16f76f384df4f91252d25c795a6a1f21e8a7c134030f8573fb',
+  'nexus-vault-macos-arm64.tar.gz': 'f185068d23a309589e8b10646d0055bba59d4c491dd86396c8adf95a9a212f56',
+  'nexus-vault-macos-x86_64.tar.gz': '85fc3c67b05884fe32d0464602a80b1962a29dbfa888148a532884d60851d547',
+  'nexus-vault-windows-x86_64.zip': '134b95ba6693eb08b74581b07071519af4219fcaac4766d5610b4e77a0fbca75',
 };
 
 

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -1,7 +1,7 @@
 {
   "nexus": "0.9.43",
   "nexus-vfs": "0.2.0",
-  "nexus-vault": "0.1.0",
+  "nexus-vault": "0.1.1",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
   "scode": "0.1.10"
 }


### PR DESCRIPTION
## Summary
- Bump `nexus-vault` version from 0.1.0 to 0.1.1 in `runtime-versions.json`
- Update all 4 platform SHA256 checksums in `download-nexus-vfs.js`

## Context
Vault v0.1.1 released by 梁 with generic secrets dispatch fix (nexus#4357 merged). COS download + full E2E verified:
- `download-nexus-vfs.js --force` → SHA256 pass
- Zentao "测试并连接" → 已连接
- 重启后凭据持久化 → 已启用

## Test plan
- [x] `node scripts/download-nexus-vfs.js --force` downloads v0.1.1, SHA256 verified
- [x] Electron startup loads vault plugin successfully
- [x] Zentao credentials persisted across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)