### PR TITLE
feat(nexus-vfs): extract vault plugin signature alongside dylib

### DIFF
--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -128,6 +128,22 @@ function getVaultDylibName(platform = process.platform) {
   return null;
 }
 
+/**
+ * Detached-signature filename for a given dylib. Convention is defined by
+ * `nexus_plugin_abi::signing::SIGNATURE_FILE_SUFFIX` in nexus-vfs — `.sig`
+ * appended to the dylib filename verbatim. The kernel's PluginLoader reads
+ * this file alongside the dylib and Ed25519-verifies before any dlopen.
+ *
+ * Vault releases starting at v0.1.2 ship the `.sig` inside the archive; the
+ * v0.1.1 archive predates signing and lacks it (extraction is permissive
+ * here so this script keeps working against an old archive — the cluster's
+ * own verify path is the binding gate).
+ */
+function getVaultSigName(platform = process.platform) {
+  const dylib = getVaultDylibName(platform);
+  return dylib ? `${dylib}.sig` : null;
+}
+
 function sha256OfFile(filePath) {
   const hash = crypto.createHash('sha256');
   hash.update(fs.readFileSync(filePath));
@@ -398,6 +414,27 @@ async function installVaultPlugin(platform, arch, force) {
   fs.copyFileSync(extractedDylib, installedDylib);
   if (!isWindows) {
     fs.chmodSync(installedDylib, 0o755);
+  }
+
+  // Plugin signature: present in v0.1.2+ archives, absent in v0.1.1. When
+  // present, copy it alongside the dylib so the kernel's PluginLoader can
+  // Ed25519-verify before dlopen. When absent, the cluster's verify path
+  // will reject the dylib at load — that failure surfaces clearly enough
+  // that an extra error here would just duplicate it.
+  const sigName = getVaultSigName(platform);
+  const installedSig = path.join(PLUGIN_DIR, sigName);
+  const extractedSig = findBinaryInDir(extractDir, sigName);
+  if (extractedSig) {
+    fs.copyFileSync(extractedSig, installedSig);
+    console.log(`Installed vault plugin signature: ${installedSig}`);
+  } else {
+    // Best-effort cleanup so an older signed install doesn't shadow a
+    // newer unsigned one (and vice versa) across version downgrades.
+    try { fs.unlinkSync(installedSig); } catch {}
+    console.warn(
+      `⚠️  Archive ${artifact} contains no ${sigName}. Cluster signature ` +
+      'verification will reject this plugin — bump vault to v0.1.2+ to fix.',
+    );
   }
 
   fs.writeFileSync(VAULT_READY_MARKER, VAULT_VERSION);


### PR DESCRIPTION
Half 3 of the cross-repo plugin-signing 0→1.

- Half 1 — kernel verify: https://github.com/nexi-lab/nexus-vfs/pull/52
- Half 2 — release CI signing: https://github.com/nexi-lab/nexus/pull/4366
- Half 3 — sudowork download script: this PR

## What this PR does

Extends `installVaultPlugin` in `scripts/download-nexus-vfs.js` to also pull the detached Ed25519 signature out of the release archive and place it alongside the dylib in `~/.nexus-vfs/plugins/`. The kernel's `PluginLoader::load` reads both files in tandem and verifies before any `dlopen`.

## Permissive on missing .sig

- vault v0.1.1 (current `runtime-versions.json` pin) doesn't ship a `.sig` — the archive predates signing. The script logs a warning and continues; the cluster verifies path will reject the unsigned plugin at load. Duplicating that error here would just be noise.
- vault v0.1.2 (first signed release, comes from the matching nexus PR) ships the `.sig`. The script copies it and the cluster boots normally.
- Best-effort `unlinkSync` on the destination `.sig` covers downgrades — switching back from a signed install to an unsigned one shouldn't leave a stale sig behind.

## Signature file naming

`<dylib>.sig` (suffix appended verbatim). The convention is the SSOT defined in `nexus_plugin_abi::signing::SIGNATURE_FILE_SUFFIX` over in nexus-vfs.

## Coordinated rollout

This PR is safe to merge before vault v0.1.2 ships — the permissive behaviour keeps the current install path working. The actual activation happens in a follow-up PR that bumps `runtime-versions.json` to vault v0.1.2 + updates SHA256SUMS, scheduled to land after https://github.com/nexi-lab/nexus/pull/4366 merges + the `vault-v0.1.2` tag publishes signed archives to COS.

E2E verification is the next step in the same thread (replicate the EthanAI-connector Step 3 with the full signed flow).