### PR TITLE
chore(vault): bump to v0.1.2 — first signed release

### DIFF
--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -61,11 +61,14 @@ const SHA256SUMS = {
   'nexusd-cluster-macos-x86_64.tar.gz': '5d44d7ea5e18a4d2fe71d88342fd1adcff0fd84d09e1782eb0fd409f50668589',
   'nexusd-cluster-windows-aarch64.zip': '5c8b33210161c7d094ebe0ddca3eddefcf8ceabe0bfba7b24f0e0d232be64a92',
   'nexusd-cluster-windows-x86_64.zip': '86a6f47d0755a27af4d6509eb7d2aed83e9d5e1d47ba2ed7944094f419f15e88',
-  // vault plugin v0.1.1
-  'nexus-vault-linux-x86_64.tar.gz': '9d7d87fd64e2ab16f76f384df4f91252d25c795a6a1f21e8a7c134030f8573fb',
-  'nexus-vault-macos-arm64.tar.gz': 'f185068d23a309589e8b10646d0055bba59d4c491dd86396c8adf95a9a212f56',
-  'nexus-vault-macos-x86_64.tar.gz': '85fc3c67b05884fe32d0464602a80b1962a29dbfa888148a532884d60851d547',
-  'nexus-vault-windows-x86_64.zip': '134b95ba6693eb08b74581b07071519af4219fcaac4766d5610b4e77a0fbca75',
+  // vault plugin v0.1.2 — first signed release (Ed25519 detached `.sig`
+  // alongside dylib inside each archive). Hashes regenerate from scratch
+  // because the archive shape changed (now ships sig too); they are
+  // unrelated to v0.1.1 sums.
+  'nexus-vault-linux-x86_64.tar.gz': '484d6c806cb67d9e2360282ad55a7da17764cd959059e2587846e1608fb9ab63',
+  'nexus-vault-macos-arm64.tar.gz': 'a97fbcdc7b178bc3b3dc4e1adb99e8dd40e77ea412354f5d6f4f54b328a583f4',
+  'nexus-vault-macos-x86_64.tar.gz': '27a85d33cdd8adcb84f6a263202b3fb0c4a682174de21b2964efc51e883b0bb0',
+  'nexus-vault-windows-x86_64.zip': 'c80b7453255b5c05f50a2206556402784aef75ae1cf5f272a599193f92856a07',
 };
 
 

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -1,7 +1,7 @@
 {
   "nexus": "0.9.43",
   "nexus-vfs": "0.2.0",
-  "nexus-vault": "0.1.1",
+  "nexus-vault": "0.1.2",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
   "scode": "0.1.10"
 }


### PR DESCRIPTION
Bumps the vault plugin pin from `0.1.1` to `0.1.2` and regenerates SHA256SUMS for the new archives.

## What changed in v0.1.2

First release whose archives ship a detached Ed25519 signature alongside the dylib:

```
nexus-vault-linux-x86_64.tar.gz
├── libnexus_vault.so
└── libnexus_vault.so.sig    ← new (64 raw bytes)
```

The cluster's PluginLoader (nexi-lab/nexus-vfs#52, already merged) reads the sig and verifies against an embedded trusted pubkey before `dlopen`. The script-side `.sig` extraction landed in #829.

## End-to-end verification

Before opening this PR I pulled the v0.1.2 archives straight from the GitHub Release, extracted `libnexus_vault.so` + `libnexus_vault.so.sig`, and verified the signature against `nexus-vfs/rust/kernel/trusted_keys/nexus-team.pub` (the same pubkey that's `include_bytes!`'d into nexusd-cluster):

```
OK: libnexus_vault.so: 2490848 bytes verified by embedded pubkey
```

That closes the sign→ship→verify loop with the actual CI-produced artefact, not just unit tests.

## SHA256SUMS

Regenerated from scratch — the archive shape changed (each now contains the dylib + its `.sig`), so the new sums are unrelated to v0.1.1.

| Archive | SHA256 |
|---|---|
| `nexus-vault-linux-x86_64.tar.gz` | `484d6c80…fb9ab63` |
| `nexus-vault-macos-arm64.tar.gz` | `a97fbcdc…28a583f4` |
| `nexus-vault-macos-x86_64.tar.gz` | `27a85d33…883b0bb0` |
| `nexus-vault-windows-x86_64.zip` | `c80b7453…f92856a07` |

After merge a local E2E (replicating the EthanAI-connector Step 3: download v0.1.2, restart sudowork, vault loads, persisted credentials read back) will be the binding gate before we close the 0→1 thread.