### PR TITLE
fix(acp): preserve requested log deliverables

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -44,7 +44,7 @@ import { injectSkillsDirectoryHint, prepareFirstMessageWithSkillsIndex } from '.
 import { AcpSkillManager } from './AcpSkillManager';
 import { archiveTurnFiles, cleanupIntermediateFiles, cleanupTrackedDraftsOnCancel, type TrackedTurnFile } from './draftsCleanup';
 import { detectBashDraftRestoreCommand, FileIntentClassifier, type BashDraftRestoreDetection, type FileIntentSource, type FileOperationIntent } from './FileIntentClassifier';
-import { SCODE_COMPLETION_REMINDER, shouldSkipAcpWorkspaceTrackingPath } from './acpWorkspaceTracking';
+import { SCODE_COMPLETION_REMINDER, shouldRunCurrentTurnPostCleanup, shouldSkipAcpWorkspaceTrackingPath } from './acpWorkspaceTracking';
 import { mergeScodeProxyModelInfo, isModelVisionCapable, getScodeProxyModelInfoSync } from '@process/services/scode/scodeProxyModels';
 import { installWorkspaceSkillsFromTrackedFiles } from './workspaceSkillInstaller';
 import { appendGeneratedFilesMarker, extractExtension, mimeForExtension, type GeneratedFileEntry } from '@/common/generatedFiles';
@@ -216,6 +216,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
   // Turn-level file tracking for precise cleanup on cancel
   private currentTurnFiles: Map<string, TrackedTurnFile> = new Map();
   private currentTurnProtectedFinalPaths = new Set<string>();
+  private pendingCurrentTurnPostCleanup = false;
   private readonly fileIntentClassifier = new FileIntentClassifier();
 
   // Extra config passed to connection
@@ -714,6 +715,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
     // 重置 Turn 级别文件追踪，开始新的 Turn
     this.currentTurnFiles.clear();
     this.currentTurnProtectedFinalPaths.clear();
+    this.pendingCurrentTurnPostCleanup = false;
     this.workspaceFileSnapshot = this.getWorkspaceFiles();
     this.customSkillsSnapshot = this.getCustomSkillNames();
     mainLog('[AcpAgent]', `[TURN-START] Reset file tracking, snapshot size: ${this.workspaceFileSnapshot.size}`);
@@ -1531,6 +1533,7 @@ This identity statement takes priority over the default identity in USER.md.
     const removedCount = await cleanupTrackedDraftsOnCancel(this.workspace, this.currentTurnFiles);
     this.currentTurnFiles.clear();
     this.currentTurnProtectedFinalPaths.clear();
+    this.pendingCurrentTurnPostCleanup = false;
 
     if (removedCount > 0) {
       mainLog('[AcpAgent]', `[CLEANUP] Total current-turn draft files removed: ${removedCount}`);
@@ -1545,6 +1548,7 @@ This identity statement takes priority over the default identity in USER.md.
     }
 
     this.currentTurnProtectedFinalPaths = this.getCurrentTurnFinalRootPaths();
+    this.pendingCurrentTurnPostCleanup = true;
     await archiveTurnFiles(this.workspace, this.currentTurnFiles);
     this.currentTurnFiles.clear();
     mainLog('[AcpAgent]', '[TURN-ARCHIVE] Archived currentTurnFiles and cleared tracking');
@@ -3201,14 +3205,18 @@ This identity statement takes priority over the default identity in USER.md.
       });
 
       // Post-cleanup: move intermediate files from workspace root to .drafts/
-      if (this.workspace) {
+      if (this.workspace && shouldRunCurrentTurnPostCleanup(this.pendingCurrentTurnPostCleanup)) {
         cleanupIntermediateFiles(this.workspace, { protectedFinalPaths: this.currentTurnProtectedFinalPaths })
           .catch((err) => {
             mainError('AcpAgent', 'Post-cleanup failed:', err);
           })
           .finally(() => {
             this.currentTurnProtectedFinalPaths.clear();
+            this.pendingCurrentTurnPostCleanup = false;
           });
+      } else {
+        this.currentTurnProtectedFinalPaths.clear();
+        this.pendingCurrentTurnPostCleanup = false;
       }
     }
 

--- a/src/process/task/FileIntentClassifier.ts
+++ b/src/process/task/FileIntentClassifier.ts
@@ -101,6 +101,7 @@ const TARGET_TYPE_EXTENSIONS: Array<{ pattern: RegExp; extensions: string[] }> =
   { pattern: /\b(xlsx|excel|execl|spreadsheet)\b|表格/i, extensions: ['.xlsx'] },
   { pattern: /\b(csv)\b/i, extensions: ['.csv'] },
   { pattern: /\b(json)\b/i, extensions: ['.json'] },
+  { pattern: /\b(log|logs)\b|日志/i, extensions: ['.log'] },
   { pattern: /\b(html|webpage|website)\b|网页/i, extensions: ['.html', '.htm'] },
   { pattern: /\b(markdown|md)\b|Markdown/i, extensions: ['.md', '.markdown'] },
   { pattern: /\b(png|image|picture|photo)\b|图片|图像/i, extensions: ['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg'] },

--- a/src/process/task/acpWorkspaceTracking.ts
+++ b/src/process/task/acpWorkspaceTracking.ts
@@ -10,6 +10,10 @@ export const SCODE_COMPLETION_REMINDER = `<system-reminder>
 
 `;
 
+export function shouldRunCurrentTurnPostCleanup(pendingCurrentTurnPostCleanup: boolean): boolean {
+  return pendingCurrentTurnPostCleanup;
+}
+
 export function shouldSkipAcpWorkspaceTrackingPath(relativePath: string): boolean {
   const normalizedPath = relativePath.replace(/\\/g, '/');
   if (!normalizedPath || normalizedPath.startsWith('..') || nodePath.isAbsolute(normalizedPath)) return true;

--- a/tests/unit/acpWorkspaceTracking.test.ts
+++ b/tests/unit/acpWorkspaceTracking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { SCODE_COMPLETION_REMINDER, shouldSkipAcpWorkspaceTrackingPath } from '@/process/task/acpWorkspaceTracking';
+import { SCODE_COMPLETION_REMINDER, shouldRunCurrentTurnPostCleanup, shouldSkipAcpWorkspaceTrackingPath } from '@/process/task/acpWorkspaceTracking';
 
 describe('acpWorkspaceTracking', () => {
   test('skips sandbox runtime side effects', () => {
@@ -15,5 +15,10 @@ describe('acpWorkspaceTracking', () => {
   test('scode completion reminder asks for the user language', () => {
     expect(SCODE_COMPLETION_REMINDER).toContain('用户提问的语言');
     expect(SCODE_COMPLETION_REMINDER).toContain('不要只以工具调用结束');
+  });
+
+  test('runs post-cleanup only when the current turn produced tracked files', () => {
+    expect(shouldRunCurrentTurnPostCleanup(true)).toBe(true);
+    expect(shouldRunCurrentTurnPostCleanup(false)).toBe(false);
   });
 });

--- a/tests/unit/fileIntentClassifier.test.ts
+++ b/tests/unit/fileIntentClassifier.test.ts
@@ -59,6 +59,29 @@ describe('FileIntentClassifier — BASH_DELIVERABLE_EXTENSIONS no longer auto-fi
   });
 });
 
+describe('FileIntentClassifier — requested log deliverables', () => {
+  it('marks a bash-written LOG file as final when the user explicitly requests LOG format', () => {
+    const result = classify({
+      filePath: '/workspace/20260610_AI智能体协作趋势.log',
+      requestedPath: '20260610_AI智能体协作趋势.log',
+      source: 'bash-generated',
+      userMessage: '根据AI智能体协作的发展趋势生成 9 种格式文件（PDF, WORD, Excel, PPT, txt, MD, Python, JS, LOG），文件名称以20260610_为前缀',
+    });
+    expect(result.intent).toBe('final');
+    expect(result.reason).toContain('target type .log');
+  });
+
+  it('keeps an unrequested bash-written LOG file as draft', () => {
+    const result = classify({
+      filePath: '/workspace/debug.log',
+      requestedPath: 'debug.log',
+      source: 'bash-generated',
+      userMessage: '生成一份季度销售报告',
+    });
+    expect(result.intent).toBe('draft');
+  });
+});
+
 describe('FileIntentClassifier — workspace-root deliverables untouched', () => {
   it('leaves workspace-root markdown without directory hint as final', () => {
     const result = classify({ filePath: '/workspace/notes.md', requestedPath: 'notes.md', source: 'write', userMessage: '帮我记一些笔记' });


### PR DESCRIPTION
## Summary
- Treat requested LOG files as final deliverables when the user explicitly asks for LOG output
- Gate finish-time intermediate cleanup so shutdown/reopen does not rescan historical workspace files
- Add unit coverage for requested .log deliverables and current-turn cleanup gating

## Tests
- bunx vitest tests/unit/acpWorkspaceTracking.test.ts tests/unit/fileIntentClassifier.test.ts tests/unit/generatedFiles.test.ts --run
- git diff --check -- src/process/task/AcpAgent.ts src/process/task/acpWorkspaceTracking.ts src/process/task/FileIntentClassifier.ts tests/unit/acpWorkspaceTracking.test.ts tests/unit/fileIntentClassifier.test.ts

## Notes
- lint was skipped per request
- bunx tsc --noEmit still fails on pre-existing unrelated errors in src/common/utils/workspaceSkillSync.ts and src/process/bridge/secretBridge.ts