### PR TITLE
fix(skills): isolate per-skill junction failures in workspace skill sync

### DIFF
--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -200,12 +200,22 @@ async function syncConversationWorkspaceSkills(conversation: TChatConversation |
     }
   }
 
+  let failedCount = 0;
   for (const [skillName, targetDir] of expectedTargets) {
     if (existingNames.has(skillName)) continue;
     const linkPath = path.join(workspaceSkillsDir, skillName);
     const linkType = process.platform === 'win32' ? 'junction' : 'dir';
-    await fs.symlink(targetDir, linkPath, linkType);
-    createdCount++;
+    try {
+      await fs.symlink(targetDir, linkPath, linkType);
+      createdCount++;
+    } catch (error) {
+      // Isolate per-skill failures: a single failed link (e.g. EPERM creating a
+      // Windows junction on a restricted/OneDrive-synced home dir) must not abort
+      // the whole loop and leave the workspace with zero linked skills — which is
+      // what makes builtins like `browser` silently invisible to the agent.
+      failedCount++;
+      mainWarn('ConversationSkillSync', `Failed to link skill "${skillName}" (${linkType}) into workspace`, error);
+    }
   }
 
   mainLog('ConversationSkillSync', 'syncConversationWorkspaceSkills completed', {
@@ -216,6 +226,7 @@ async function syncConversationWorkspaceSkills(conversation: TChatConversation |
     removedCount,
     recreatedCount,
     createdCount,
+    failedCount,
     durationMs: Date.now() - startedAt,
   });
 }


### PR DESCRIPTION
## Problem

`syncConversationWorkspaceSkills` links each expected skill into the per-conversation workspace skills dir (`<workspace>/.nexus/sudocode/skills` for scode, `<workspace>/.claude/skills` for claude) so the agent can discover and read them. The link loop used a bare `await fs.symlink(...)` with **no per-skill error handling**:

```ts
for (const [skillName, targetDir] of expectedTargets) {
  if (existingNames.has(skillName)) continue;
  const linkPath = path.join(workspaceSkillsDir, skillName);
  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
  await fs.symlink(targetDir, linkPath, linkType);  // ← one failure aborts ALL
  createdCount++;
}
```

On Windows, junction creation can fail with `EPERM`/`EACCES` on restricted or OneDrive-synced home directories. A single failure throws out of the loop and aborts the **entire** sync, so the workspace ends up with **zero** linked skills. Auto-injected builtins like `browser` then become silently invisible to the agent — no `Skill` entry, no `SKILL.md` to read — which users report as *"I don't have a browser tool / can't find browser."*

## Fix

Wrap each link in `try/catch`: count and `warn` on failure, but keep linking the remaining skills. A broken link for one skill no longer takes down the others. `failedCount` is added to the completion log for diagnosis.

## Verification
- `eslint` clean on the changed file.
- Reproduced on a current dev build (Windows): junction sync succeeds (6/6), scode's `Skill` tool finds and loads `browser` end-to-end. This change hardens the path for environments where one link fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)