### PR TITLE
fix(browser): provision the browser skill's Python runtime on clean machines

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -292,6 +292,12 @@ buildDependenciesFromSource: false
 nodeGypRebuild: false
 
 asarUnpack:
+  # ai-dev-browser Python package must live on the real filesystem (not inside
+  # app.asar) so resolveAiDevBrowserPackageDir() can junction it into the browser
+  # skill dir and Python can import it. Without this it ships packed in app.asar,
+  # the junction never gets created, and `import ai_dev_browser` fails on every
+  # packaged install.
+  - 'vendor/ai-dev-browser/**/*'
   - 'native/nexus-napi/*.node'
   # index.js must sit next to the unpacked .node so that
   # require(app.asar.unpacked/native/nexus-napi) resolves (see nexus-vfs-client.ts)

--- a/src/process/services/python/PythonRuntimeService.ts
+++ b/src/process/services/python/PythonRuntimeService.ts
@@ -25,6 +25,7 @@ import * as http from 'http';
 import * as path from 'path';
 import { app } from 'electron';
 import { promisify } from 'util';
+import { mainWarn } from '@process/utils/mainLogger';
 
 const execFileAsync = promisify(execFile);
 const execAsync = promisify(exec);
@@ -165,18 +166,28 @@ export class PythonRuntimeService {
     return { installed: false };
   }
 
-  getDownloadUrl(): string {
+  /**
+   * Installer download URLs, ordered by preference. The Huawei Cloud mirror
+   * (which mirrors the python.org/ftp tree exactly) is tried first because the
+   * official python.org host is slow or unreachable from mainland China, where
+   * a failed/timed-out download is the most common reason the Python runtime
+   * never gets provisioned — which in turn breaks the browser skill (it shells
+   * out to `python -m ai_dev_browser`). python.org is kept as a fallback.
+   */
+  getDownloadUrls(): string[] {
     const v = PYTHON_VERSION;
     if (process.platform === 'darwin') {
       // Universal installer for macOS (works on both Intel and Apple Silicon)
-      return `https://www.python.org/ftp/python/${v}/python-${v}-macos11.pkg`;
+      const file = `python-${v}-macos11.pkg`;
+      return [`https://mirrors.huaweicloud.com/python/${v}/${file}`, `https://www.python.org/ftp/python/${v}/${file}`];
     } else if (process.platform === 'win32') {
       // Windows installer
       const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
-      return `https://www.python.org/ftp/python/${v}/python-${v}-${arch}.exe`;
+      const file = `python-${v}-${arch}.exe`;
+      return [`https://mirrors.huaweicloud.com/python/${v}/${file}`, `https://www.python.org/ftp/python/${v}/${file}`];
     } else {
       // Linux: use package manager, no direct download
-      return '';
+      return [];
     }
   }
 
@@ -201,12 +212,50 @@ export class PythonRuntimeService {
 
   async install(onProgress: ProgressCallback): Promise<void> {
     if (process.platform === 'darwin') {
-      return this.installMac(onProgress);
+      await this.installMac(onProgress);
     } else if (process.platform === 'win32') {
-      return this.installWindows(onProgress);
+      await this.installWindows(onProgress);
     } else {
-      return this.installLinux(onProgress);
+      await this.installLinux(onProgress);
     }
+
+    // Python alone isn't enough for the browser skill: it shells out to
+    // `python -m ai_dev_browser`, which needs the ai-dev-browser package AND its
+    // runtime deps (websockets, Pillow, ...). The bundled junction only supplies
+    // the package source, not the deps, so pip-install the published package
+    // (which pulls the full dependency tree) into the freshly installed Python.
+    // Best-effort: a failure here leaves Python installed and is logged, not fatal.
+    try {
+      onProgress('configuring');
+      await this.provisionBrowserRuntime();
+    } catch (err) {
+      mainWarn('PythonRuntime', 'Failed to provision ai-dev-browser into installed Python', err);
+    }
+  }
+
+  /**
+   * Install the browser skill's Python runtime (ai-dev-browser + its full
+   * dependency tree) into the freshly provisioned Python, via a China-friendly
+   * PyPI mirror. Mirrors the manual `pip install ai-dev-browser` that gets the
+   * browser skill working end-to-end on a clean machine.
+   */
+  private async provisionBrowserRuntime(): Promise<void> {
+    const status = await this.checkInstalled();
+    if (!status.installed || !status.path) return;
+    const py = status.path;
+    const mirror = 'https://pypi.tuna.tsinghua.edu.cn/simple';
+    // Upgrade pip first — the pip bundled with the installer can be too old for
+    // newer wheels. Non-fatal: fall through to whatever pip shipped.
+    try {
+      await execFileAsync(py, ['-m', 'pip', 'install', '-i', mirror, '--upgrade', 'pip'], { timeout: 120000 });
+    } catch {
+      /* keep going with the bundled pip */
+    }
+    // Require >=0.10.1, the first release with the Windows port-detection fix
+    // (netstat utf-8 decode → stdout=None crash) that breaks auto port discovery
+    // on Chinese-locale Windows. Prefer the China mirror but fall back to PyPI so
+    // a not-yet-synced mirror can't pin users to the buggy 0.10.0.
+    await execFileAsync(py, ['-m', 'pip', 'install', '-i', mirror, '--extra-index-url', 'https://pypi.org/simple', 'ai-dev-browser>=0.10.1'], { timeout: 300000 });
   }
 
   private async installMac(onProgress: ProgressCallback): Promise<void> {
@@ -217,7 +266,7 @@ export class PythonRuntimeService {
       if (fs.existsSync(pkgPath) && fs.statSync(pkgPath).size > 0) {
         onProgress('downloading', 100);
       } else {
-        await this.downloadFile(this.getDownloadUrl(), pkgPath, (percent) => {
+        await this.downloadWithFallback(this.getDownloadUrls(), pkgPath, (percent) => {
           onProgress('downloading', percent);
         });
       }
@@ -248,7 +297,7 @@ export class PythonRuntimeService {
       if (fs.existsSync(exePath) && fs.statSync(exePath).size > 0) {
         onProgress('downloading', 100);
       } else {
-        await this.downloadFile(this.getDownloadUrl(), exePath, (percent) => {
+        await this.downloadWithFallback(this.getDownloadUrls(), exePath, (percent) => {
           onProgress('downloading', percent);
         });
       }
@@ -359,6 +408,19 @@ export class PythonRuntimeService {
     // Clean download cache
     const cacheDir = this.getCacheDir();
     if (fs.existsSync(cacheDir)) fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+
+  private async downloadWithFallback(urls: string[], dest: string, onPercent: (n: number) => void): Promise<void> {
+    let lastError: unknown;
+    for (const url of urls) {
+      try {
+        await this.downloadFile(url, dest, onPercent);
+        return;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error('All Python installer download mirrors failed');
   }
 
   private downloadFile(url: string, dest: string, onPercent: (n: number) => void): Promise<void> {

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -452,6 +452,23 @@ export class ServiceManager {
         patchOpenclawPdfDescription();
         const prevPath = process.env.PATH ?? '';
         sudoworkBinEnv.PATH = prevPath.length > 0 ? `${SUDOCLAW_SUDOWORK_BIN_DIR}${path.delimiter}${prevPath}` : SUDOCLAW_SUDOWORK_BIN_DIR;
+        // The `browser`/`aidb` dispatcher shells out to a bare `python`. A
+        // freshly provisioned Python is added to the *system* PATH by the
+        // installer's PrependPath, but the already-running sudowork process (and
+        // thus this gateway and its exec children) inherited the pre-install
+        // PATH — so `python` stays invisible until a full machine reboot.
+        // Resolve the installed interpreter and surface its directory on the
+        // gateway PATH directly, so the browser skill works immediately after
+        // install without a reboot. Fail-open.
+        try {
+          const { pythonRuntimeService } = await import('../python/PythonRuntimeService');
+          const py = await pythonRuntimeService.checkInstalled();
+          if (py.installed && py.path) {
+            sudoworkBinEnv.PATH = `${path.dirname(py.path)}${path.delimiter}${sudoworkBinEnv.PATH}`;
+          }
+        } catch (err) {
+          mainWarn('ServiceManager', 'Failed to add provisioned Python to gateway PATH', err);
+        }
         // ai-dev-browser v0.5.1 reads AI_DEV_BROWSER_OUTPUT_DIR as the
         // `--path`-omitted default for screenshot / dump tools (falls back
         // to `./screenshots/` under CWD if unset). openclaw's exec tool


### PR DESCRIPTION
## Problem

The browser skill (`browser`/`aidb` → `python -m ai_dev_browser`) is broken on a clean Windows install with no system Python — confirmed on a real user's machine (Windows Server, mainland China). Three independent packaging/provisioning gaps, **none in the skill logic itself** (the workspace skill sync, the `Skill` tool, and scode all work fine):

1. **ai-dev-browser packed in app.asar** — it's in the `files:` list but **not** `asarUnpack`, so `resolveAiDevBrowserPackageDir()` (which looks under `app.asar.unpacked/…` and `resources/…`) finds nothing → the junction into `_builtin/browser/ai_dev_browser` is never created → `import ai_dev_browser` fails. Confirmed: `…/_builtin/browser/ai_dev_browser/__init__.py` **NOT FOUND** on the user's box.
2. **Python downloaded from python.org** — slow/unreachable from mainland China, so `PythonRuntimeService` provisioning silently never completes. Confirmed: **no Python at all** on the user's machine.
3. **PATH not refreshed** — even after install, the already-running sudowork process inherited the pre-install PATH, so the gateway's exec children can't find `python` until a full reboot.

Plus the bundled junction only supplies the package *source*, not its runtime deps (`websockets`, `Pillow`, …), so even with the junction fixed, the import would fail on a missing dependency.

## Fix

- **electron-builder.yml**: `asarUnpack` `vendor/ai-dev-browser/**` so the package lives on the real filesystem where the junction can point at it.
- **PythonRuntimeService**: try a **China mirror** (Huawei Cloud, mirrors the python.org ftp tree) before python.org — `getDownloadUrls()` + `downloadWithFallback()`, matching the existing `LibreOfficeService` pattern.
- **PythonRuntimeService**: after install, **pip-install `ai-dev-browser`** (pulls its full dependency tree) from a China-friendly PyPI mirror. Best-effort + logged.
- **ServiceManager**: resolve the installed interpreter and **prepend its dir to the gateway PATH** so `python` works immediately — no reboot.

## Validation

Reproduced the exact manual sequence this automates — China-mirror Python install + `pip install ai-dev-browser` — on a clean Windows Server box, which made the browser skill work end-to-end (launch Chrome, navigate, screenshot). `eslint` clean on the changed TS.

## Notes / follow-ups
- The ai-dev-browser `get_pid_on_port()` Windows crash (netstat `text=True` decode → `stdout=None`) is a separate upstream fix in the ai-dev-browser repo.
- `ddddocr` (captcha OCR) is worth considering as an optional browser-skill dep for fully-automated logins — not included here to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)