### PR TITLE
test(vault): CI integration test for signed-plugin download layout

### DIFF
--- a/.github/workflows/pr-integration-smoke.yml
+++ b/.github/workflows/pr-integration-smoke.yml
@@ -37,3 +37,30 @@ jobs:
         env:
           DISPLAY: ':99'
           PYTHONPATH: ${{ github.workspace }}/vendor/ai-dev-browser
+
+  vault-signed-download:
+    name: Vault Signed Download
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Run vault signed-download integration test
+        # Real download from the live COS mirror. Test plan + scope:
+        # tests/integration/vault-signed-download.integration.test.ts.
+        run: bunx vitest run tests/integration/vault-signed-download.integration.test.ts

--- a/tests/integration/vault-signed-download.integration.test.ts
+++ b/tests/integration/vault-signed-download.integration.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration test: vault plugin signed-download regression gate.
+ *
+ * Runs the real `scripts/download-nexus-vfs.js` against the live COS mirror
+ * and asserts the produced filesystem layout includes both the dylib and
+ * its detached Ed25519 signature. Catches the regressions this PR cluster
+ * has hit during development:
+ *
+ *   1. `runtime-versions.json` bumped without regenerating SHA256SUMS in
+ *      the download script — script aborts on hash mismatch, the dylib
+ *      never reaches plugin-dir, and this test fails on the missing file.
+ *   2. Archive published to COS without the `.sig` (release CI pipeline
+ *      forgets the sign step) — `.sig` assertion fails.
+ *   3. Future `getVaultDylibName` drift versus the archive's actual
+ *      filename — dylib assertion fails.
+ *
+ * Does NOT cover signature *verification* — the cluster's
+ * `PluginLoader::load` does that at runtime and is exhaustively unit-tested
+ * in nexus-vfs (parse_pubkey_file, verify_signature_against, missing-sig,
+ * wrong-length-sig, etc.). Re-verifying here would duplicate the kernel
+ * test surface; the binding gate for signature correctness is the local
+ * kernel-team E2E run before tagging a new vault release.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const NEXUS_VFS_HOME = path.join(os.homedir(), '.nexus-vfs');
+const PLUGIN_DIR = path.join(NEXUS_VFS_HOME, 'plugins');
+
+// Platform-specific dylib name. Mirrors `getVaultDylibName` in
+// scripts/download-nexus-vfs.js — drift here means a silent test pass, so
+// keep this match the script.
+function dylibName(): string {
+  switch (process.platform) {
+    case 'linux':
+      return 'libnexus_vault.so';
+    case 'darwin':
+      return 'libnexus_vault.dylib';
+    case 'win32':
+      return 'nexus_vault.dll';
+    default:
+      throw new Error(`unsupported test platform: ${process.platform}`);
+  }
+}
+
+describe('vault signed download', () => {
+  beforeAll(() => {
+    // Cold start: nuke any existing install so the script's full path
+    // (download + SHA verify + extract + place files) actually runs. If
+    // `~/.nexus-vfs/bin/.nexus-vfs-bin-ready` already has the pinned
+    // version, the script skips everything and we'd be testing nothing.
+    if (fs.existsSync(NEXUS_VFS_HOME)) {
+      fs.rmSync(NEXUS_VFS_HOME, { recursive: true, force: true });
+    }
+    execSync(
+      `node "${path.join(REPO_ROOT, 'scripts', 'download-nexus-vfs.js')}" --force`,
+      { stdio: 'inherit', timeout: 180_000 },
+    );
+  }, 240_000);
+
+  it('places the vault dylib in plugin-dir', () => {
+    const dylibPath = path.join(PLUGIN_DIR, dylibName());
+    expect(fs.existsSync(dylibPath)).toBe(true);
+
+    // A plausibly-sized dylib (vault is ~2-5 MiB per platform). Catches an
+    // accidental empty-file or wrong-extracted-entry case where existsSync
+    // is true but the file is junk.
+    const size = fs.statSync(dylibPath).size;
+    expect(size).toBeGreaterThan(1_000_000);
+  });
+
+  it('places the detached signature next to the dylib', () => {
+    const sigPath = path.join(PLUGIN_DIR, `${dylibName()}.sig`);
+    expect(fs.existsSync(sigPath)).toBe(true);
+
+    // Ed25519 raw signature length is exactly 64 bytes — pinned in
+    // `nexus_plugin_abi::signing::SIGNATURE_LENGTH` over in nexus-vfs and
+    // produced by `scripts/sign_plugin.py` in nexus. A non-64 sig here
+    // means one of those two sides has silently drifted.
+    expect(fs.statSync(sigPath).size).toBe(64);
+  });
+});


### PR DESCRIPTION
Regression gate for the cross-repo plugin-signing 0→1 (nexi-lab/nexus-vfs#52 + nexi-lab/nexus#4366 + #829 + #836).

## What this PR adds

- **`tests/integration/vault-signed-download.integration.test.ts`** — a vitest integration test that runs the real `scripts/download-nexus-vfs.js` against the live COS mirror, then asserts:
  1. The vault dylib (platform-specific name) is in `~/.nexus-vfs/plugins/` and looks plausibly-sized
  2. The detached signature is next to the dylib and is **exactly** 64 raw bytes (Ed25519 sig length, pinned in `nexus_plugin_abi::signing::SIGNATURE_LENGTH` over in nexus-vfs)
- A new `vault-signed-download` job in the existing `PR Integration Smoke` workflow that runs the test on every PR.

## What it catches

The exact failure modes hit during the 0→1 development cycle:

| Regression | Test failure |
|---|---|
| `runtime-versions.json` bumped without updating SHA256SUMS in the download script | `existsSync(dylib)` fails — script aborted on hash mismatch, nothing extracted |
| Release CI publishes an archive without the `.sig` | `existsSync(sig)` fails |
| `getVaultDylibName` mapping drifts from actual archive content | `existsSync(dylib)` fails |
| Sign step drops a non-64-byte signature | sig size assertion fails (catches SSOT drift across the format constant in plugin-abi / sign_plugin.py / verify in kernel) |

## What it does NOT cover

Signature **verification** — that's the cluster's job, and is exhaustively unit-tested in nexus-vfs (`parse_pubkey_file`, `verify_signature_against` round-trip with a fresh test keypair, missing-sig fail-loud, wrong-length-sig fail-loud). Re-verifying in sudowork CI would duplicate the kernel test surface without adding signal. The binding gate for signature correctness is the kernel-team's local E2E run before tagging a new vault release — which has already passed for v0.1.2 (cluster log: `plugin signature verified` for the CI-produced dylib against the embedded `trusted_keys/nexus-team.pub`).

## Test plan

- [ ] CI on this PR runs the new test and goes green for the current v0.1.2 archive on COS
- [ ] Manual negative-case spot check: bump SHA256SUMS to garbage on a throwaway branch, observe red CI (defer)