### PR TITLE
fix(enterprise): make conversation resume reliable after token invalidation

### DIFF
--- a/src/agent/remote/MossWsConnection.ts
+++ b/src/agent/remote/MossWsConnection.ts
@@ -127,7 +127,20 @@ export class MossWsConnection {
         mainLog('MossWsConnection', `Session created: ${this.sessionId}, workDir: ${this.workDir}`);
       }
 
-      await this.openWebSocket();
+      try {
+        await this.openWebSocket();
+      } catch (wsError) {
+        // A 401 on the WS handshake means the access token went bad between
+        // exchangeToken and the upgrade (expired or revoked server-side).
+        // Force-refresh once and retry before giving up.
+        const message = wsError instanceof Error ? wsError.message : String(wsError);
+        if (!message.includes('401')) {
+          throw wsError;
+        }
+        mainLog('MossWsConnection', 'WS handshake rejected with 401, force refreshing token and retrying');
+        this.accessToken = await this.exchangeToken(true);
+        await this.openWebSocket();
+      }
 
       this.state = 'connected';
       this.reconnectAttempts = 0;
@@ -142,21 +155,28 @@ export class MossWsConnection {
     }
   }
 
-  private async exchangeToken(): Promise<string> {
-    if (this.config.authToken && this.config.authToken.startsWith('eyJ')) {
-      return this.config.authToken;
-    }
+  private async exchangeToken(forceRefresh = false): Promise<string> {
+    const isApiKey = !!this.config.authToken && !this.config.authToken.startsWith('eyJ');
 
-    // Try shared getValidToken which handles refresh with dedup
-    if (!this.config.authToken) {
+    // Enterprise login sessions: always source the freshest token from auth
+    // storage. A JWT pinned in config may be expired or revoked (e.g. captured
+    // before a logout/re-login), so it is only a fallback when auth storage is
+    // unavailable.
+    if (!isApiKey) {
       try {
-        const token = await getValidToken();
+        const token = await getValidToken(forceRefresh);
         if (token) {
-          this.config.authToken = token;
           return token;
         }
       } catch (e) {
         mainError('MossWsConnection', 'Failed to get valid token:', e);
+        if (this.config.authToken?.startsWith('eyJ')) {
+          mainLog('MossWsConnection', 'Falling back to config-provided JWT');
+          return this.config.authToken;
+        }
+        if (!this.config.username && !this.config.password) {
+          throw e instanceof Error ? e : new Error(String(e));
+        }
       }
     }
 
@@ -251,11 +271,13 @@ export class MossWsConnection {
       throw new Error('No ws_url available');
     }
 
-    // Append refresh_token to wsUrl for server-side token refresh on WS upgrade
+    // Append refresh_token to wsUrl for server-side token refresh on WS upgrade.
+    // OAuth2 sessions hold the IdP's refresh token (or none), which moss cannot
+    // verify as a refresh JWT — never put it on the URL.
     let wsUrlWithRefresh = this.wsUrl!;
     try {
       const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
-      if (authStorage?.refresh_token) {
+      if (authStorage?.refresh_token && authStorage.session_type !== 'oauth2') {
         const separator = wsUrlWithRefresh.includes('?') ? '&' : '?';
         wsUrlWithRefresh += `${separator}refresh_token=${encodeURIComponent(authStorage.refresh_token)}`;
       }
@@ -281,6 +303,9 @@ export class MossWsConnection {
       this.ws.on('error', (err) => {
         clearTimeout(timeout);
         this.callbacks.onError?.(err);
+        // Settle the connect promise — a handshake failure (e.g. 401/404)
+        // must fail fast, not strand connect() awaiting forever.
+        reject(err);
       });
       this.ws.on('close', (code, reason) => this.handleClose(code, reason.toString()));
     });

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -2003,6 +2003,8 @@ export const eeclaw = {
   logout: bridge.buildProvider<IBridgeResponse<{}>, void>('eeclaw.logout'),
   /** Emitted when the main process refreshes the enterprise auth token */
   tokenRefreshed: bridge.buildEmitter<{ access_token: string; refresh_token: string; expires_at: number }>('eeclaw.token-refreshed'),
+  /** Emitted when the enterprise token is invalid and cannot be refreshed (e.g. OAuth2 session without a refresh token) — the user must sign in again */
+  authRequired: bridge.buildEmitter<{ reason: 'no_refresh_token' | 'refresh_failed' }>('eeclaw.auth-required'),
   /** Refresh enterprise auth token via main process (single entry point to avoid race conditions) */
   refreshToken: bridge.buildProvider<IBridgeResponse<{ access_token: string; refresh_token?: string; expires_at: number }>, void>('eeclaw.refresh-token'),
   /** Trigger manual sync of remote skills and assistants to local (for Local mode) */

--- a/src/process/WorkerManage.ts
+++ b/src/process/WorkerManage.ts
@@ -67,7 +67,30 @@ const buildConversation = (conversation: TChatConversation, options?: BuildConve
         mainError('WorkerManage', 'Moss Server URL not configured for remote-agent conversation');
         return null;
       }
-      let authToken = extra?.authToken || '';
+
+      // A conversation can only be resumed against the server that owns its
+      // session. Resuming a server1 conversation while logged into server2
+      // would send server2 credentials to server1 — fail explicitly instead
+      // of producing an opaque 401 loop.
+      try {
+        const currentServerUrl = ProcessConfig.getSync('eeclaw.serverUrl');
+        const normalize = (u: string) => u.replace(/\/+$/, '');
+        if (currentServerUrl && normalize(currentServerUrl) !== normalize(mossServerUrl)) {
+          mainError('WorkerManage', `Conversation ${conversation.id} belongs to ${mossServerUrl} but the current enterprise server is ${currentServerUrl}; switch back to resume it`);
+          return null;
+        }
+      } catch {
+        /* ignore — no enterprise config available */
+      }
+
+      // JWTs are never sourced from the conversation record: a token pinned at
+      // creation time outlives logins/logouts and resurfaces revoked (issue
+      // #849). Always read the current auth storage; MossWsConnection
+      // re-validates via getValidToken at connect time anyway. A non-JWT
+      // extra.authToken is an API key and stays — it is a stable credential,
+      // not a session token.
+      const pinnedToken = extra?.authToken || '';
+      let authToken = pinnedToken && !pinnedToken.startsWith('eyJ') ? pinnedToken : '';
       if (!authToken) {
         try {
           const authStorage = ProcessConfig.getSync('eeclaw.authStorage');

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -89,7 +89,10 @@ function getRemoteConversationMossApi(extra: RemoteConversationExtra) {
 
   const currentApi = getMossApi();
   const api = currentApi && getMossApiServerUrl() === serverUrl ? currentApi : initMossApi(serverUrl);
-  if (extra.authToken) {
+  // Seed only non-JWT credentials (API keys). A JWT pinned in the conversation
+  // record may be expired or revoked (issue #849); without an explicit token
+  // the API sources the current one via getValidToken.
+  if (extra.authToken && !extra.authToken.startsWith('eyJ')) {
     api.setAccessToken(extra.authToken);
   }
   return api;

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -12,6 +12,36 @@ import { resetConversationProvider } from '../providers';
 
 let refreshPromise: Promise<string> | null = null;
 
+// Serializes every mutation of eeclaw.authStorage (login, logout, refresh).
+// Without this, a logout/login race can persist an already-revoked token as
+// "current", permanently breaking session resume (see issue #849).
+let authStorageWriteLock: Promise<unknown> = Promise.resolve();
+
+export function withAuthStorageLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run: Promise<T> = authStorageWriteLock.then(
+    (): Promise<T> => fn(),
+    (): Promise<T> => fn()
+  );
+  authStorageWriteLock = run.catch((): undefined => undefined);
+  return run;
+}
+
+// Emitted at most once per window so a burst of 401s doesn't spam the renderer.
+let lastAuthRequiredAt = 0;
+const AUTH_REQUIRED_EMIT_INTERVAL_MS = 30_000;
+
+function emitAuthRequired(reason: 'no_refresh_token' | 'refresh_failed'): void {
+  const now = Date.now();
+  if (now - lastAuthRequiredAt < AUTH_REQUIRED_EMIT_INTERVAL_MS) return;
+  lastAuthRequiredAt = now;
+  mainWarn('eeclawBridge', `Auth required (${reason}) — prompting re-login`);
+  try {
+    ipcBridge.eeclaw.authRequired.emit({ reason });
+  } catch (e) {
+    mainWarn('eeclawBridge', 'Failed to emit authRequired event:', e);
+  }
+}
+
 export async function getValidToken(forceRefresh = false): Promise<string> {
   const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
   const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
@@ -38,14 +68,18 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
     return refreshPromise;
   }
 
-  mainLog('eeclawBridge', `[getValidToken] ${forceRefresh ? 'Force refresh requested' : `Token expired (remaining=${Math.round(remainingMs / 1000)}s)`}, starting refresh (refresh_token=${refresh_token ? refresh_token.slice(0, 20) + '...' : 'NONE'})`);
+  // Non-refreshable session (e.g. OAuth2 where the IdP issued no refresh
+  // token): there is nothing to retry — surface a single re-login prompt
+  // instead of looping on "No refresh token available".
+  if (!refresh_token) {
+    emitAuthRequired('no_refresh_token');
+    throw new Error('AUTH_REQUIRED: session is not refreshable, please sign in again');
+  }
+
+  mainLog('eeclawBridge', `[getValidToken] ${forceRefresh ? 'Force refresh requested' : `Token expired (remaining=${Math.round(remainingMs / 1000)}s)`}, starting refresh (refresh_token=${refresh_token.slice(0, 20)}...)`);
 
   refreshPromise = (async () => {
     try {
-      if (!refresh_token) {
-        throw new Error('No refresh token available');
-      }
-
       // OAuth2 sessions send the provider refresh_token inside a generic `params`
       // dict (moss forwards it to the credential script); other sessions send the
       // moss refresh_token at the top level as before.
@@ -93,7 +127,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
                 session_type: latestAuth.session_type,
               };
               mainLog('eeclawBridge', `[getValidToken] Retry refresh successful! new_expires_at=${newAuthStorage.expires_at}`);
-              await ProcessConfig.set('eeclaw.authStorage', newAuthStorage);
+              await withAuthStorageLock(() => ProcessConfig.set('eeclaw.authStorage', newAuthStorage));
               setCachedAuthToken(retryData.access_token);
               try {
                 ipcBridge.eeclaw.tokenRefreshed.emit({
@@ -112,6 +146,11 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
           }
         }
         mainWarn('eeclawBridge', `[getValidToken] Refresh failed: status=${response.status}, error=${data?.error || 'unknown'}`);
+        // The server definitively rejected the refresh (not a network blip) —
+        // the session is dead and only an interactive re-login can recover it.
+        if (response.status === 401 || data?.error === 'Invalid refresh token') {
+          emitAuthRequired('refresh_failed');
+        }
         throw new Error(data?.error || 'token_refresh_failed');
       }
 
@@ -125,7 +164,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
 
       mainLog('eeclawBridge', `[getValidToken] Refresh successful! new_expires_at=${newAuthStorage.expires_at}, new_refresh_token=${newAuthStorage.refresh_token ? newAuthStorage.refresh_token.slice(0, 20) + '...' : 'NONE'}`);
 
-      await ProcessConfig.set('eeclaw.authStorage', newAuthStorage);
+      await withAuthStorageLock(() => ProcessConfig.set('eeclaw.authStorage', newAuthStorage));
       setCachedAuthToken(data.access_token);
 
       // Notify renderer process about the refreshed token
@@ -255,15 +294,17 @@ export function initEeclawBridge(): void {
       // Save server URL and auth storage to ProcessConfig
       // 将服务器 URL 和认证存储保存到 ProcessConfig
       const sessionType: 'password' | 'api_key' | 'oauth2' = body.grant_type === 'oauth2' ? 'oauth2' : body.grant_type === 'api_key' ? 'api_key' : 'password';
-      await ProcessConfig.set('eeclaw.serverUrl', serverUrl);
-      await ProcessConfig.set('eeclaw.authStorage', {
-        access_token: data.access_token,
-        refresh_token: data.refresh_token,
-        expires_at: Date.now() + (data.expires_in || 3600) * 1000,
-        device_id: deviceId,
-        session_type: sessionType,
+      await withAuthStorageLock(async () => {
+        await ProcessConfig.set('eeclaw.serverUrl', serverUrl);
+        await ProcessConfig.set('eeclaw.authStorage', {
+          access_token: data.access_token,
+          refresh_token: data.refresh_token,
+          expires_at: Date.now() + (data.expires_in || 3600) * 1000,
+          device_id: deviceId,
+          session_type: sessionType,
+        });
+        await ProcessConfig.set('eeclaw.localModeAvailable', localModeAvailable);
       });
-      await ProcessConfig.set('eeclaw.localModeAvailable', localModeAvailable);
 
       // Update enterprise cache for synchronous access
       // 更新企业配置缓存以供同步访问
@@ -420,32 +461,38 @@ export function initEeclawBridge(): void {
   });
 
   ipcBridge.eeclaw.logout.provider(async () => {
-    try {
-      const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
-      const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
+    // The whole revoke-then-clear sequence holds the auth storage lock: the
+    // token snapshot, the server-side revocation and the local clear must not
+    // interleave with a concurrent login/refresh write, otherwise a revoked
+    // token can survive as the persisted "current" token (issue #849).
+    await withAuthStorageLock(async () => {
+      try {
+        const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
+        const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
 
-      if (serverUrl && authStorage?.access_token) {
-        await fetch(`${serverUrl}/api/v1/auth/logout`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${authStorage.access_token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            refresh_token: authStorage.refresh_token || undefined,
-          }),
-          signal: AbortSignal.timeout(5000),
-        }).catch((err) => mainWarn('eeclawBridge', 'Logout request failed:', err));
+        if (serverUrl && authStorage?.access_token) {
+          await fetch(`${serverUrl}/api/v1/auth/logout`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${authStorage.access_token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              refresh_token: authStorage.refresh_token || undefined,
+            }),
+            signal: AbortSignal.timeout(5000),
+          }).catch((err) => mainWarn('eeclawBridge', 'Logout request failed:', err));
+        }
+      } finally {
+        // Always clear local state even if server request fails
+        await ProcessConfig.set('eeclaw.authStorage', null);
+        await ProcessConfig.set('eeclaw.localModeAvailable', null);
+        setCachedAuthToken('');
+        setCachedLocalModeAvailable(null);
+        resetConversationProvider();
+        mainLog('eeclawBridge', 'Logged out, local storage cleared');
       }
-    } finally {
-      // Always clear local state even if server request fails
-      await ProcessConfig.set('eeclaw.authStorage', null);
-      await ProcessConfig.set('eeclaw.localModeAvailable', null);
-      setCachedAuthToken('');
-      setCachedLocalModeAvailable(null);
-      resetConversationProvider();
-      mainLog('eeclawBridge', 'Logged out, local storage cleared');
-    }
+    });
     return { success: true, data: {} };
   });
 

--- a/src/process/initAgent.ts
+++ b/src/process/initAgent.ts
@@ -119,7 +119,10 @@ export const createRemoteAgent = async (options: ICreateConversationParams): Pro
       customWorkspace,
       // Moss Server specific fields
       mossServerUrl: extra.mossServerUrl,
-      authToken: extra.authToken,
+      // Persist only stable credentials (API keys). Session JWTs outlive
+      // logins/logouts and resurface revoked (issue #849) — connections read
+      // the current auth storage instead.
+      authToken: extra.authToken && !extra.authToken.startsWith('eyJ') ? extra.authToken : undefined,
       username: extra.username,
       password: extra.password,
       runtimeType: extra.runtimeType,

--- a/src/process/providers/RemoteConversationProvider.ts
+++ b/src/process/providers/RemoteConversationProvider.ts
@@ -146,7 +146,9 @@ export class RemoteConversationProvider implements IConversationProvider {
         workspace: params.extra?.workspace,
         backend: 'remote-agent',
         mossServerUrl: this.config.mossServerUrl,
-        authToken: this.config.authToken,
+        // Deliberately no authToken here: persisted session tokens outlive
+        // logins and resurface revoked (issue #849). Connections always read
+        // the current auth storage instead.
         runtimeType: this.config.runtimeType,
         agentName: params.extra?.agentName || params.extra?.presetAssistantId,
         presetAssistantId: params.extra?.presetAssistantId,
@@ -382,7 +384,9 @@ export class RemoteConversationProvider implements IConversationProvider {
         ...existingExtra,
         backend: 'remote-agent',
         mossServerUrl: this.config.mossServerUrl,
-        authToken: this.config.authToken,
+        // Scrub any legacy pinned token from existing records — persisted
+        // session tokens outlive logins and resurface revoked (issue #849).
+        authToken: undefined,
         runtimeType: this.config.runtimeType,
         agentName: session.assistantName || session.assistant_name,
         sessionMode: 'remote',

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -384,7 +384,9 @@ export class MossSessionApi {
   private getWsUrlWithRefreshToken(wsUrl: string): string {
     try {
       const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
-      if (authStorage?.refresh_token) {
+      // OAuth2 sessions hold the IdP's refresh token (or none), which moss
+      // cannot verify as a refresh JWT — never put it on the URL.
+      if (authStorage?.refresh_token && authStorage.session_type !== 'oauth2') {
         const separator = wsUrl.includes('?') ? '&' : '?';
         return `${wsUrl}${separator}refresh_token=${encodeURIComponent(authStorage.refresh_token)}`;
       }

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -191,6 +191,25 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
         // 恢复/附加模式：使用已有的 wsUrl
         mainLog('RemoteAgent', 'RESUME/ATTACH MODE: Using existing wsUrl');
 
+        // Re-derive ws_url from the current server before attaching. The
+        // persisted acpWsUrl embeds the advertisedHost from session-creation
+        // time and goes stale when the server address changes; hitting the
+        // resume endpoint also lets the server start respawning a dead
+        // runtime before the WS handshake. Stored wsUrl remains the fallback
+        // so a transient lookup failure doesn't block reattach.
+        let resumeWsUrl = this.options.wsUrl;
+        const resumeSessionId = this.options.sessionId || this.conversation_id;
+        try {
+          const api = initMossApi(this.options.serverUrl);
+          const resumed = await api.resumeSession(resumeSessionId);
+          if (resumed.wsUrl) {
+            resumeWsUrl = resumed.wsUrl;
+            this.options.wsUrl = resumed.wsUrl;
+          }
+        } catch (lookupError) {
+          mainLog('RemoteAgent', `resumeSession lookup failed (${lookupError instanceof Error ? lookupError.message : String(lookupError)}), falling back to stored wsUrl`);
+        }
+
         const config: MossWsConnectionConfig = {
           serverUrl: this.options.serverUrl,
           authToken: this.options.authToken,
@@ -201,8 +220,8 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
           dangerouslySkipPermissions: this.options.dangerouslySkipPermissions ?? this.yoloMode,
           runtimeType: this.options.runtimeType,
           // Resume mode: use existing wsUrl and sessionId
-          wsUrl: this.options.wsUrl,
-          sessionId: this.options.sessionId || this.conversation_id,
+          wsUrl: resumeWsUrl,
+          sessionId: resumeSessionId,
           // 新增: 传递启用的 skill 列表（resume 模式也支持）
           enabledSkills,
         };

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -876,6 +876,22 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     };
   }, []);
 
+  // Main process signals the enterprise token is dead and cannot be refreshed
+  // (e.g. OAuth2 session whose IdP issued no refresh token, or a definitively
+  // rejected refresh). Drop to the login screen — conversations are untouched
+  // and resume after re-login (issue #849).
+  useEffect(() => {
+    const unsubscribe = ipcBridge.eeclaw.authRequired.on(({ reason }) => {
+      console.warn(`[Auth] Enterprise session requires re-login (${reason})`);
+      localStorage.removeItem(EECLAW_AUTH_STORAGE_KEY);
+      setUser(null);
+      setStatus('unauthenticated');
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   const login = useCallback(async ({ phone, code, enterprise_code, invitation_code: _invitation_code, remember: _remember }: LoginParams): Promise<LoginResult> => {
     const deviceId = getDeviceId();
 

--- a/tests/unit/mossWsConnectionResume.test.ts
+++ b/tests/unit/mossWsConnectionResume.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression tests for issue #849: enterprise resume must fail fast (never
+ * hang) on a rejected WS handshake, and must recover from a 401 by force
+ * refreshing the access token once.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Controls how the next MockWebSocket instances behave: each entry is either
+// 'open' or an error message to emit on the handshake.
+const wsScript: Array<'open' | string> = [];
+
+vi.mock('ws', () => {
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = 1;
+    private handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+    constructor() {
+      queueMicrotask(() => {
+        const step = wsScript.shift() ?? 'open';
+        if (step === 'open') {
+          this.emit('open');
+        } else {
+          this.emit('error', new Error(step));
+          this.emit('close', 1006, Buffer.from(''));
+        }
+      });
+    }
+
+    on(event: string, callback: (...args: unknown[]) => void) {
+      (this.handlers[event] ||= []).push(callback);
+      return this;
+    }
+
+    private emit(event: string, ...args: unknown[]) {
+      for (const callback of this.handlers[event] || []) callback(...args);
+    }
+
+    send() {
+      return undefined;
+    }
+
+    close() {
+      return undefined;
+    }
+  }
+
+  return { default: MockWebSocket, WebSocket: MockWebSocket };
+});
+
+const getValidTokenMock = vi.fn(async (_forceRefresh?: boolean) => 'fresh-token');
+
+vi.mock('@/process/bridge/eeclawBridge', () => ({
+  getValidToken: (forceRefresh?: boolean) => getValidTokenMock(forceRefresh),
+}));
+
+vi.mock('@/process/initStorage', () => ({
+  ProcessConfig: {
+    getSync: vi.fn(() => undefined),
+  },
+}));
+
+vi.mock('@/process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainError: vi.fn(),
+}));
+
+function resumeConfig() {
+  return {
+    serverUrl: 'https://moss.example.com',
+    authToken: 'eyJ.pinned-stale-token',
+    wsUrl: 'ws://moss.example/ws/sessions/session-1',
+    sessionId: 'session-1',
+  };
+}
+
+describe('MossWsConnection resume (issue #849)', () => {
+  beforeEach(() => {
+    wsScript.length = 0;
+    getValidTokenMock.mockClear();
+    getValidTokenMock.mockImplementation(async () => 'fresh-token');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('sources the token from auth storage instead of the pinned JWT', async () => {
+    wsScript.push('open');
+    const { MossWsConnection } = await import('@/agent/remote/MossWsConnection');
+    const connection = new MossWsConnection(resumeConfig(), {
+      onMessage: vi.fn(),
+      onPermissionRequest: vi.fn(),
+    });
+
+    await connection.connect();
+
+    expect(getValidTokenMock).toHaveBeenCalled();
+  });
+
+  it('rejects instead of hanging when the WS handshake fails persistently', async () => {
+    wsScript.push('Unexpected server response: 401', 'Unexpected server response: 401');
+    const { MossWsConnection } = await import('@/agent/remote/MossWsConnection');
+    const connection = new MossWsConnection(resumeConfig(), {
+      onMessage: vi.fn(),
+      onPermissionRequest: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    await expect(connection.connect()).rejects.toThrow('401');
+  });
+
+  it('force-refreshes the token and retries once on a 401 handshake', async () => {
+    wsScript.push('Unexpected server response: 401', 'open');
+    const { MossWsConnection } = await import('@/agent/remote/MossWsConnection');
+    const connection = new MossWsConnection(resumeConfig(), {
+      onMessage: vi.fn(),
+      onPermissionRequest: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    await connection.connect();
+
+    expect(getValidTokenMock).toHaveBeenCalledWith(true);
+    expect(connection.isConnected()).toBe(true);
+  });
+
+  it('does not force-refresh on non-auth handshake failures', async () => {
+    wsScript.push('Unexpected server response: 404');
+    const { MossWsConnection } = await import('@/agent/remote/MossWsConnection');
+    const connection = new MossWsConnection(resumeConfig(), {
+      onMessage: vi.fn(),
+      onPermissionRequest: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    await expect(connection.connect()).rejects.toThrow('404');
+    expect(getValidTokenMock).not.toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
Closes #849

## Problem

Resuming an enterprise conversation could break permanently (diagnosed against a live repro on `ruigu_test`):

1. A logout/login race persisted an **already-revoked JWT** as the current token in `eeclaw.authStorage`; with an OAuth2 session whose local `expires_at` was ~116 days out, `getValidToken` kept returning it without question.
2. The resume path preferred the **token pinned in the conversation record** (`extra.authToken`) over current auth storage, so even re-logging-in didn't heal existing conversations.
3. OAuth2 sessions whose IdP issues **no refresh token** (`refresh_token: ''`) had no recovery path — every 401 looped on `"No refresh token available"`.
4. A rejected WS handshake left `connect()` awaiting a promise that **never settles** (the `'error'` handler cleared the timeout but didn't reject), so `RemoteAgent`'s cached bootstrap blocked every subsequent send — the "stuck reconnect".
5. The persisted `acpWsUrl` embeds the server's `advertisedHost` from creation time and breaks resume when the server address changes.

## Changes

- **MossWsConnection**: reject the connect promise on WS handshake error; always source the access token from auth storage via `getValidToken()` (pinned JWT only as fallback when storage is unavailable); on a 401 handshake, force-refresh once and retry.
- **eeclawBridge**: serialize all `eeclaw.authStorage` mutations (login/logout/refresh) behind a write lock so a revoked token can never be persisted as current; sessions without a refresh token are treated as non-refreshable — a single `eeclaw.authRequired` event is emitted (30s dedup) instead of a retry storm, also emitted when the server definitively rejects a refresh.
- **AuthContext**: on `authRequired`, clear renderer auth state and drop to the login screen — conversations are untouched and resume after re-login.
- **RemoteAgent**: RESUME/ATTACH re-derives `ws_url` via `POST /api/v1/sessions/:id/resume` against the current server (also lets moss start respawning a dead runtime before the handshake), falling back to the stored URL on lookup failure.
- **Token pinning removed**: session JWTs are no longer persisted in conversation `extra` (`RemoteConversationProvider`, `initAgent`) nor read back (`WorkerManage`, `conversationBridge`); non-JWT API keys are still honored as stable credentials; legacy pinned tokens are scrubbed on cron sync.
- **Server-mismatch guard** (`WorkerManage`): resuming a conversation owned by a different moss server fails with an explicit log instead of sending wrong-server credentials into a 401 loop.
- **WS URL hygiene**: OAuth2 (IdP) refresh tokens are never appended to the WS URL — moss cannot verify them and the server logs `req.url`.

No moss server changes required: session persistence, `resumeOnMissingRuntime` container respawn with transcript resume, and idle-kill reactivation already cover the server side.

## Test plan

- New `tests/unit/mossWsConnectionResume.test.ts`: handshake failure rejects (no hang), 401 triggers exactly one `getValidToken(true)` retry then connects, non-auth failures don't force-refresh, token sourced from auth storage instead of the pinned JWT.
- Existing module tests pass: `mossWsConnection`, `mossSessionWorkspaceApi`, `remoteConversationProviderSync`, `remoteAgentIdleDetach` (17/17).
- `tsc`, eslint, prettier clean on touched files; full vitest run shows zero new failures vs. the dev baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)