### PR TITLE
fix(cron): make agent-facing [CRON_LIST] list tasks globally

### DIFF
--- a/skills/_builtin/cron/SKILL.md
+++ b/skills/_builtin/cron/SKILL.md
@@ -9,10 +9,10 @@ You can manage scheduled tasks to automatically execute operations at specified 
 
 ## IMPORTANT RULES
 
-1. **ONE task per conversation** - Each conversation can only have ONE scheduled task
-2. **Query and WAIT for result** - Before creating a task, output `[CRON_LIST]` and WAIT for the system to return the result
+1. **Tasks are user-global** - `[CRON_LIST]` returns ALL of the user's scheduled tasks, across every conversation. A new task delivers into the conversation that created it.
+2. **NO duplicate tasks** - Before creating a task, output `[CRON_LIST]` and WAIT for the result. If a similar task already exists (even one created in another conversation), do NOT create another without asking the user.
 3. **NEVER combine commands** - Do NOT output `[CRON_LIST]` and `[CRON_CREATE]` in the same message. Query first, wait for result, then decide.
-4. **ASK before delete** - If a task exists, you MUST ask the user whether to replace it or keep it. NEVER delete without user's explicit confirmation.
+4. **ASK before delete** - If a similar task exists, you MUST ask the user whether to replace it or keep it. NEVER delete without user's explicit confirmation.
 5. **ALWAYS include closing tags** - `[CRON_CREATE]` MUST end with `[/CRON_CREATE]`
 6. **Output commands directly** - Do NOT wrap commands in markdown code blocks
 
@@ -21,26 +21,28 @@ You can manage scheduled tasks to automatically execute operations at specified 
 **CRITICAL: This is a multi-turn workflow. Do NOT skip steps or combine them.**
 
 **Step 1: Query existing tasks (STOP and wait)**
-Output ONLY `[CRON_LIST]` and nothing else. The system will return the current task status.
+Output ONLY `[CRON_LIST]` and nothing else. The system will return the user's tasks across all conversations.
 DO NOT proceed to Step 2 until you see the system response.
 
 **Step 2: Review the result and ask user (STOP and wait for user response)**
 After receiving the `[CRON_LIST]` result:
 
 - If "No scheduled tasks" → proceed to Step 3
-- If a task already exists → **You MUST ask the user** what they want to do:
+- If a similar task already exists (same purpose, possibly created in another conversation) → **You MUST ask the user** what they want to do:
   - Option A: Delete the existing task and create a new one
   - Option B: Keep the existing task and cancel creating a new one
+  - Option C: Keep the existing task AND create this one too (only if the user explicitly wants both)
   - **NEVER delete the existing task without explicit user confirmation**
   - Wait for the user's response before proceeding
+- If existing tasks are unrelated to the one being created → proceed to Step 3
 
 **Step 3: Execute user's decision**
 
 - If user chose to replace: First delete the old task with `[CRON_DELETE: <job-id>]`, wait for confirmation, then create new task
 - If user chose to keep: Do NOT create a new task, inform user the existing task is retained
 
-**Step 4: Create the new task (only if no task exists or user confirmed deletion)**
-Only after confirming no task exists (or after successfully deleting), output the `[CRON_CREATE]` block.
+**Step 4: Create the new task (only if no similar task exists or user confirmed)**
+Only after confirming no similar task exists (or after the user's explicit decision), output the `[CRON_CREATE]` block.
 
 ## Create Scheduled Task
 
@@ -113,6 +115,6 @@ Replace `<actual-job-id>` with the real job ID (e.g., `cron_abc123`).
 
 ## Notes
 
-- Scheduled tasks are bound to the current conversation
-- When triggered, the message will be sent to this conversation
+- `[CRON_LIST]` shows ALL of the user's scheduled tasks; entries created by the current conversation are marked `[created in this conversation]`
+- When a task triggers, its message is delivered to the conversation that created it
 - **CRITICAL**: `[CRON_LIST]` is an async query. You MUST wait for the system response before proceeding with `[CRON_CREATE]` or `[CRON_DELETE]`. Never output multiple commands in one message.

--- a/src/process/task/MessageMiddleware.ts
+++ b/src/process/task/MessageMiddleware.ts
@@ -201,18 +201,23 @@ async function handleCronCommands(conversationId: string, agentType: AcpBackendA
         }
 
         case 'list': {
-          const jobs = await cronService.listJobsByConversation(conversationId);
+          // Scheduled tasks are user-global: list everything, not just jobs
+          // created by this conversation. A per-conversation list made every
+          // new chat report "no tasks" while the cron UI showed them, and
+          // defeated the skill's query-before-create duplicate check (#835).
+          const jobs = await cronService.listJobs();
           if (jobs.length === 0) {
-            responses.push('📋 No scheduled tasks in this conversation.');
+            responses.push('📋 No scheduled tasks.');
           } else {
             const jobList = jobs
               .map((j) => {
                 const scheduleStr = j.schedule.kind === 'cron' ? j.schedule.expr : j.schedule.kind;
                 const status = j.enabled ? '✓' : '✗';
-                return `- [${status}] ${j.name} (${scheduleStr}) - ID: ${j.id}`;
+                const origin = j.metadata.conversationId === conversationId ? ' [created in this conversation]' : '';
+                return `- [${status}] ${j.name} (${scheduleStr}) - ID: ${j.id}${origin}`;
               })
               .join('\n');
-            responses.push(`📋 Scheduled tasks:\n${jobList}`);
+            responses.push(`📋 Scheduled tasks (across all conversations):\n${jobList}`);
           }
           break;
         }

--- a/tests/unit/cronCommandListScope.test.ts
+++ b/tests/unit/cronCommandListScope.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for issue #835: the agent-facing [CRON_LIST] command must
+ * list the user's scheduled tasks globally, not just the ones created by the
+ * current conversation — a per-conversation list made every new chat report
+ * "no tasks" (while the cron UI showed them) and defeated the skill's
+ * query-before-create duplicate check.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listJobsMock = vi.fn(async () => [] as unknown[]);
+const listJobsByConversationMock = vi.fn(async () => [] as unknown[]);
+
+vi.mock('@process/services/cron/CronService', () => ({
+  cronService: {
+    listJobs: () => listJobsMock(),
+    listJobsByConversation: (conversationId: string) => listJobsByConversationMock(conversationId),
+    addJob: vi.fn(),
+    removeJob: vi.fn(),
+  },
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    cron: {
+      onJobCreated: { emit: vi.fn() },
+      onJobRemoved: { emit: vi.fn() },
+    },
+  },
+}));
+
+function cronJob(overrides: { id: string; name: string; conversationId: string }) {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    enabled: true,
+    schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Every day at 9:00 AM' },
+    target: { payload: { kind: 'message', text: 'reminder' } },
+    metadata: {
+      conversationId: overrides.conversationId,
+      agentType: 'scode',
+      createdBy: 'agent',
+      createdAt: 0,
+      updatedAt: 0,
+    },
+    state: { runCount: 0 },
+  };
+}
+
+function finishedMessage(text: string) {
+  return {
+    id: 'msg-1',
+    conversation_id: 'conv-b',
+    type: 'content',
+    status: 'finish',
+    content: { content: text },
+  } as never;
+}
+
+describe('[CRON_LIST] scope (issue #835)', () => {
+  beforeEach(() => {
+    listJobsMock.mockReset();
+    listJobsMock.mockResolvedValue([]);
+    listJobsByConversationMock.mockReset();
+  });
+
+  it('lists jobs created by other conversations', async () => {
+    listJobsMock.mockResolvedValue([cronJob({ id: 'cron_1', name: 'Weather reminder', conversationId: 'conv-a' })]);
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-b', 'scode', finishedMessage('[CRON_LIST]'));
+
+    expect(listJobsMock).toHaveBeenCalled();
+    expect(listJobsByConversationMock).not.toHaveBeenCalled();
+    expect(result.systemResponses.join('\n')).toContain('Weather reminder');
+    expect(result.systemResponses.join('\n')).toContain('cron_1');
+  });
+
+  it('marks jobs created by the current conversation', async () => {
+    listJobsMock.mockResolvedValue([cronJob({ id: 'cron_mine', name: 'Mine', conversationId: 'conv-b' }), cronJob({ id: 'cron_other', name: 'Other', conversationId: 'conv-a' })]);
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-b', 'scode', finishedMessage('[CRON_LIST]'));
+
+    const text = result.systemResponses.join('\n');
+    const mineLine = text.split('\n').find((line) => line.includes('cron_mine'));
+    const otherLine = text.split('\n').find((line) => line.includes('cron_other'));
+    expect(mineLine).toContain('[created in this conversation]');
+    expect(otherLine).not.toContain('[created in this conversation]');
+  });
+
+  it('reports no tasks only when the user has none anywhere', async () => {
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-b', 'scode', finishedMessage('[CRON_LIST]'));
+
+    expect(result.systemResponses.join('\n')).toContain('No scheduled tasks');
+  });
+});


### PR DESCRIPTION
Closes #835

## Problem

定时任务"跨会话无效"：a scheduled task created by the agent in one conversation is invisible from any other conversation. Asking "现在都有哪些定时任务" in a new chat returns `crons: []` even though the cron UI panel shows the task.

Root cause: the `[CRON_LIST]` sidechannel command resolved to `cronService.listJobsByConversation(currentConversationId)` — jobs are stored globally but tagged with the conversation that created them, and the agent-facing list only showed jobs born in the *current* chat. Two aggravating inconsistencies:

- The skill's query-before-create duplicate check always saw an empty list in a new conversation, so each chat could create another copy of the same task (e.g. three daily 9:00 weather reminders).
- `[CRON_DELETE]` was already global by job ID, so list and delete disagreed about scoping.

## Changes

- **MessageMiddleware**: `[CRON_LIST]` now uses the global `listJobs()`. The response is labeled "across all conversations" and jobs created by the current conversation carry a `[created in this conversation]` marker so the agent can still reason about ownership.
- **skills/_builtin/cron/SKILL.md**: replaced the "ONE task per conversation" rule with the actual intent — tasks are user-global; before creating, check for a similar existing task (from any conversation) and ask the user whether to replace, keep, or explicitly create both. Delivery semantics unchanged: a task's message still goes to the conversation that created it. Builtin skills force-sync on app start, so no version bump is required.
- **Tests**: new `tests/unit/cronCommandListScope.test.ts` covering cross-conversation visibility (the exact #835 repro), the ownership marker, and the empty case.

Not changed: the renderer's per-conversation cron panel still uses `listJobsByConversation` — that is deliberate UI scoping.

## Test plan

- 3 new regression tests pass.
- `tsc`, eslint, prettier clean on touched files.
- Manual repro per issue screenshots: create a task in conversation A, ask "现在都有哪些定时任务" in conversation B → the task is listed instead of `crons: []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)