### PR TITLE
fix(cron): enforce enterprise client_cron_enabled in the main process (re-target to dev)

### DIFF
--- a/skills/_builtin/cron/SKILL.md
+++ b/skills/_builtin/cron/SKILL.md
@@ -117,4 +117,5 @@ Replace `<actual-job-id>` with the real job ID (e.g., `cron_abc123`).
 
 - `[CRON_LIST]` shows ALL of the user's scheduled tasks; entries created by the current conversation are marked `[created in this conversation]`
 - When a task triggers, its message is delivered to the conversation that created it
+- Scheduled tasks are subject to organization policy. If the system responds that scheduled tasks are disabled by the organization, relay that to the user and do NOT retry the command — only an administrator can enable the feature.
 - **CRITICAL**: `[CRON_LIST]` is an async query. You MUST wait for the system response before proceeding with `[CRON_CREATE]` or `[CRON_DELETE]`. Never output multiple commands in one message.

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -201,6 +201,8 @@ export interface IConfigStorageRefer {
   'eeclaw.localModeAvailable'?: boolean;
   // Enterprise auth token for main process (no user field, unlike localStorage eeclaw_auth_v1)
   'eeclaw.authStorage'?: { access_token: string; refresh_token: string; expires_at: number; device_id: string; session_type?: 'password' | 'api_key' | 'oauth2' };
+  // Last resolved tenant config (main-process offline fallback for policy flags like client_cron_enabled)
+  'eeclaw.tenantConfig'?: { client_cron_enabled?: boolean; [key: string]: unknown };
   // Consumer (personal) mode user info for telemetry / 个人模式用户信息（用于遥测）
   'consumer.userInfo'?: { id: string; nickname?: string; phone?: string; tenant_id?: string };
 }

--- a/src/process/services/cron/CronService.ts
+++ b/src/process/services/cron/CronService.ts
@@ -22,6 +22,7 @@ import { assistantManager } from '@/process/AssistantManager';
 import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
 import { cronBusyGuard } from './CronBusyGuard';
 import { cronStore, type CronJob, type CronSchedule } from './CronStore';
+import { assertClientCronEnabled, getClientCronEnabled } from './cronPolicy';
 import { createConversation } from '../conversationService';
 
 /**
@@ -80,6 +81,10 @@ class CronService {
    * Add a new cron job. Multiple jobs may bind the same conversation.
    */
   async addJob(params: CreateCronJobParams): Promise<CronJob> {
+    // Org policy gate (enterprise client_cron_enabled, issue #854) — enforced
+    // here, at the deepest choke point, so every creation path (agent text
+    // commands, IPC/webui, channels) is covered.
+    await assertClientCronEnabled();
     // Multiple scheduled tasks are allowed to bind the same conversation — each
     // job appears as its own group in the sidebar, and a shared conversation
     // shows up under every group it is bound to.
@@ -139,6 +144,8 @@ class CronService {
    * Update an existing cron job
    */
   async updateJob(jobId: string, updates: Partial<CronJob>): Promise<CronJob> {
+    // Org policy gate (issue #854)
+    await assertClientCronEnabled();
     const existing = cronStore.getById(jobId);
     if (!existing) {
       throw new Error(`Job not found: ${jobId}`);
@@ -182,6 +189,9 @@ class CronService {
    * Remove a cron job
    */
   async removeJob(jobId: string): Promise<void> {
+    // Org policy gate (issue #854) — jobs are paused (not deleted) while the
+    // org has cron disabled, so everything is intact when it is re-enabled.
+    await assertClientCronEnabled();
     // Stop timer
     this.stopTimer(jobId);
 
@@ -217,6 +227,8 @@ class CronService {
    * button) can show a toast instead of silently updating the job row.
    */
   async triggerJob(jobId: string): Promise<void> {
+    // Org policy gate (issue #854)
+    await assertClientCronEnabled();
     const job = cronStore.getById(jobId);
     if (!job) {
       throw new Error(`Job ${jobId} not found`);
@@ -337,6 +349,20 @@ class CronService {
    * Execute a job - send message to conversation
    */
   private async executeJob(job: CronJob): Promise<void> {
+    // Org policy: while client_cron_enabled=false, scheduled fires are skipped
+    // (recorded, schedule advanced) rather than torn down, so jobs resume
+    // cleanly when the org re-enables cron. Checked at fire time so an admin
+    // toggle takes effect without restarting timers. (issue #854)
+    if (!(await getClientCronEnabled())) {
+      job.state.lastStatus = 'skipped';
+      job.state.lastError = 'Skipped: scheduled tasks are disabled by your organization';
+      this.updateNextRunTime(job);
+      cronStore.update(job.id, { state: job.state });
+      ipcBridge.cron.onJobUpdated.emit(job);
+      mainLog('CronService', `executeJob SKIPPED (org policy): id=${job.id} name="${job.name}"`);
+      return;
+    }
+
     const { conversationId } = job.metadata;
     const conversationMode = job.metadata.conversationMode ?? 'new';
 

--- a/src/process/services/cron/cronPolicy.ts
+++ b/src/process/services/cron/cronPolicy.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { resolveTenantConfig } from '@/common/types/tenantConfig';
+import { ProcessConfig } from '@process/initStorage';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+
+/**
+ * Main-process enforcement of the Moss-managed `client_cron_enabled` tenant
+ * flag (issue #854). The renderer's `useCronEnabled` only hides UI; every
+ * mutation/execution path must check this policy at the moment of use —
+ * transcripts can teach agents the cron commands forever, so advertisement is
+ * eventually-consistent while execution stays authoritative.
+ *
+ * The flag is fetched from the enterprise server with a short TTL so admin
+ * toggles propagate without re-login; the last resolved value is persisted as
+ * the offline fallback. Consumer mode is always enabled.
+ */
+
+const TENANT_CONFIG_TTL_MS = 60_000;
+
+let cache: { enabled: boolean; fetchedAt: number } | null = null;
+
+export class CronDisabledError extends Error {
+  constructor() {
+    super('Scheduled tasks are disabled by your organization');
+    this.name = 'CronDisabledError';
+  }
+}
+
+/** Test hook: drop the in-memory cache. */
+export function resetCronPolicyCache(): void {
+  cache = null;
+}
+
+export async function getClientCronEnabled(): Promise<boolean> {
+  if (!isEnterpriseMode()) {
+    return true;
+  }
+
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < TENANT_CONFIG_TTL_MS) {
+    return cache.enabled;
+  }
+
+  const serverUrl = readServerUrl();
+  if (serverUrl) {
+    try {
+      const response = await fetch(`${serverUrl}/api/v1/tenant/config`, { signal: AbortSignal.timeout(10000) });
+      if (response.ok) {
+        const json = (await response.json()) as { success?: boolean; data?: Record<string, unknown> };
+        const resolved = resolveTenantConfig(json?.data ?? null);
+        cache = { enabled: resolved.client_cron_enabled !== false, fetchedAt: now };
+        // Persist for offline fallback; failure to persist must not block policy resolution.
+        ProcessConfig.set('eeclaw.tenantConfig', resolved).catch(() => {});
+        return cache.enabled;
+      }
+      mainWarn('CronPolicy', `tenant config fetch returned ${response.status}, using fallback`);
+    } catch (error) {
+      mainWarn('CronPolicy', `tenant config fetch failed (${error instanceof Error ? error.message : String(error)}), using fallback`);
+    }
+  }
+
+  // Offline fallback: last persisted resolved config; default enabled to match
+  // resolveTenantConfig semantics (only an explicit false disables).
+  let enabled = true;
+  try {
+    const persisted = ProcessConfig.getSync('eeclaw.tenantConfig');
+    enabled = persisted?.client_cron_enabled !== false;
+  } catch {
+    /* ignore */
+  }
+  cache = { enabled, fetchedAt: now };
+  return enabled;
+}
+
+/**
+ * Throw CronDisabledError when the org has disabled client cron. Call this at
+ * every client-side cron mutation/execution entry point.
+ */
+export async function assertClientCronEnabled(): Promise<void> {
+  if (!(await getClientCronEnabled())) {
+    mainLog('CronPolicy', 'Cron action refused: client_cron_enabled=false');
+    throw new CronDisabledError();
+  }
+}
+
+function readServerUrl(): string | null {
+  try {
+    const url = ProcessConfig.getSync('eeclaw.serverUrl');
+    return url ? url.trim().replace(/\/+$/, '') : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/process/task/MessageMiddleware.ts
+++ b/src/process/task/MessageMiddleware.ts
@@ -8,6 +8,7 @@ import type { TMessage } from '@/common/chatLib';
 import { ipcBridge } from '@/common';
 import type { AcpBackendAll } from '@/types/acpTypes';
 import { cronService } from '@process/services/cron/CronService';
+import { getClientCronEnabled } from '@process/services/cron/cronPolicy';
 import { detectCronCommands, stripCronCommands, type CronCommand } from './CronCommandDetector';
 import { hasThinkTags, stripThinkTags } from './ThinkTagDetector';
 
@@ -180,6 +181,14 @@ export async function processCronInMessage(conversationId: string, agentType: Ac
  * Handle detected cron commands
  */
 async function handleCronCommands(conversationId: string, agentType: AcpBackendAll, commands: CronCommand[]): Promise<string[]> {
+  // Org policy gate (issue #854): conversations whose transcripts already
+  // teach the cron commands will keep emitting them after an admin disables
+  // the feature — refuse here with an explicit response so the agent relays
+  // an honest answer instead of hallucinating success.
+  if (!(await getClientCronEnabled())) {
+    return ['⛔ Scheduled tasks are disabled by your organization. Tell the user that an administrator must enable them, and do not retry the command.'];
+  }
+
   const responses: string[] = [];
 
   for (const cmd of commands) {

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -398,7 +398,9 @@ When a user request matches a skill's description, you MUST read that skill's SK
 
 For example:
 - Builtin "browser" skill: ${systemSkillsDir}/browser/SKILL.md
-- Builtin "cron" skill: ${systemSkillsDir}/cron/SKILL.md`;
+- Builtin "cron" skill: ${systemSkillsDir}/cron/SKILL.md
+
+Skill capabilities are subject to organization policy: if the system refuses a skill command as disabled by the organization, relay the refusal to the user and do not retry.`;
 
     instructions.push(skillsInstruction);
   }

--- a/tests/unit/cronCommandListScope.test.ts
+++ b/tests/unit/cronCommandListScope.test.ts
@@ -28,6 +28,10 @@ vi.mock('@/common', () => ({
   },
 }));
 
+vi.mock('@process/services/cron/cronPolicy', () => ({
+  getClientCronEnabled: vi.fn(async () => true),
+}));
+
 function cronJob(overrides: { id: string; name: string; conversationId: string }) {
   return {
     id: overrides.id,

--- a/tests/unit/cronPolicyGate.test.ts
+++ b/tests/unit/cronPolicyGate.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for issue #854: main-process enforcement of the enterprise
+ * client_cron_enabled tenant flag. Covers the policy resolver (TTL cache,
+ * offline fallback, consumer-mode bypass) and the agent-facing refusal in
+ * handleCronCommands.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isEnterpriseModeMock = vi.fn(() => true);
+const getSyncMock = vi.fn((key: string): unknown => (key === 'eeclaw.serverUrl' ? 'http://moss.example' : undefined));
+const setMock = vi.fn(async () => undefined);
+
+vi.mock('@/common/enterpriseDebugConfig', () => ({
+  isEnterpriseMode: () => isEnterpriseModeMock(),
+}));
+
+vi.mock('@process/initStorage', () => ({
+  ProcessConfig: {
+    getSync: (key: string) => getSyncMock(key),
+    set: (key: string, value: unknown) => setMock(),
+  },
+}));
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainError: vi.fn(),
+  mainWarn: vi.fn(),
+}));
+
+function tenantResponse(cronEnabled: boolean | null) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ success: true, data: { client_cron_enabled: cronEnabled } }),
+  };
+}
+
+describe('cronPolicy.getClientCronEnabled (issue #854)', () => {
+  beforeEach(async () => {
+    const { resetCronPolicyCache } = await import('@/process/services/cron/cronPolicy');
+    resetCronPolicyCache();
+    isEnterpriseModeMock.mockReturnValue(true);
+    getSyncMock.mockImplementation((key: string) => (key === 'eeclaw.serverUrl' ? 'http://moss.example' : undefined));
+    setMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('always enabled in consumer mode, without fetching', async () => {
+    isEnterpriseModeMock.mockReturnValue(false);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
+    expect(await getClientCronEnabled()).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reads the flag from the tenant config and persists it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => tenantResponse(false))
+    );
+
+    const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
+    expect(await getClientCronEnabled()).toBe(false);
+    expect(setMock).toHaveBeenCalled();
+  });
+
+  it('caches the result within the TTL', async () => {
+    const fetchMock = vi.fn(async () => tenantResponse(true));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
+    await getClientCronEnabled();
+    await getClientCronEnabled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the last persisted value when the server is unreachable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      })
+    );
+    getSyncMock.mockImplementation((key: string) => {
+      if (key === 'eeclaw.serverUrl') return 'http://moss.example';
+      if (key === 'eeclaw.tenantConfig') return { client_cron_enabled: false };
+      return undefined;
+    });
+
+    const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
+    expect(await getClientCronEnabled()).toBe(false);
+  });
+
+  it('defaults to enabled when unreachable with nothing persisted', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      })
+    );
+
+    const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
+    expect(await getClientCronEnabled()).toBe(true);
+  });
+});
+
+describe('handleCronCommands org-policy refusal (issue #854)', () => {
+  it('refuses all cron commands with an explicit message when disabled', async () => {
+    vi.resetModules();
+    const addJobMock = vi.fn();
+    vi.doMock('@process/services/cron/CronService', () => ({
+      cronService: { addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() },
+    }));
+    vi.doMock('@process/services/cron/cronPolicy', () => ({
+      getClientCronEnabled: vi.fn(async () => false),
+    }));
+    vi.doMock('@/common', () => ({
+      ipcBridge: { cron: { onJobCreated: { emit: vi.fn() }, onJobRemoved: { emit: vi.fn() } } },
+    }));
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const message = {
+      id: 'msg-1',
+      conversation_id: 'conv-1',
+      type: 'content',
+      status: 'finish',
+      content: { content: '[CRON_CREATE]\nname: T\nschedule: 0 9 * * *\nschedule_description: daily\nmessage: hi\n[/CRON_CREATE]' },
+    } as never;
+
+    const result = await processAgentResponse('conv-1', 'scode', message);
+
+    expect(result.systemResponses.join('\n')).toContain('disabled by your organization');
+    expect(addJobMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Delivers #854 to dev. Re-opened because #855 was merged into its stacked base branch (`y-zhu/fix/835-cron-list-global`) after #853 had already landed in dev without deleting that branch — so GitHub never retargeted #855 and the gating commit (02165bd5) never reached dev. dev already contains the #835 commit, so this PR's diff is exactly the gating change. See #855 for the original review.

## Summary (same content as #855)

- **`cronPolicy.ts` (new)** — main-process resolver for the tenant flag: consumer mode always enabled; enterprise fetches `/api/v1/tenant/config` with 60s TTL, persists the resolved config as offline fallback.
- **`CronService`** — `addJob`/`updateJob`/`removeJob`/`triggerJob` throw `CronDisabledError` when the org has cron disabled (deepest choke point: agent commands, IPC/webui, channels).
- **`executeJob`** — fire-time skip: runs recorded as skipped (org policy), schedule keeps advancing; jobs pause while disabled and resume on re-enable.
- **`handleCronCommands`** — explicit "disabled by your organization" refusal fed back to the agent.
- **Skill advertisement unconditional** with a policy caveat; execution stays authoritative across flag toggles.

Companion server-side enforcement: sudoprivacy/moss#84.

## Test plan

Same as #855: `tests/unit/cronPolicyGate.test.ts` (6 tests) + updated `cronCommandListScope.test.ts`, all passing; tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)