### PR TITLE
feat: dogfood-signed plugin installer (vault + local-connector + fuse)

### DIFF
--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -30,6 +30,8 @@ const runtimeVersions = require('../src/shared/runtime-versions.json');
 
 const VERSION = runtimeVersions['nexus-vfs'];
 const VAULT_VERSION = runtimeVersions['nexus-vault'];
+const LOCAL_CONNECTOR_VERSION = runtimeVersions['nexus-local-connector'];
+const FUSE_PLUGIN_VERSION = runtimeVersions['nexus-fuse-plugin'];
 
 // Runtime bucket is primary; legacy bucket stays live as a fallback during deprecation.
 const COS_BASE_URLS = [
@@ -45,6 +47,21 @@ const VAULT_COS_BASE_URLS = [
 
 // GitHub Release fallback for vault plugin (梁 mirrors to COS, but GH is source of truth).
 const VAULT_GITHUB_URL = `https://github.com/nexi-lab/nexus/releases/download/vault-v${VAULT_VERSION}`;
+
+// local-connector + fuse-plugin are released from the nexus repo too. Both
+// signed by kernel-dogfood-v1.pub (in contrast to vault's nexus-team.pub
+// bootstrap key); kernel trust root in nexus-vfs#58 picks up both keys.
+const LOCAL_CONNECTOR_COS_BASE_URLS = [
+  `https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com/nexus-local-connector/release/v${LOCAL_CONNECTOR_VERSION}`,
+  `https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/nexus-local-connector/release/v${LOCAL_CONNECTOR_VERSION}`,
+];
+const LOCAL_CONNECTOR_GITHUB_URL = `https://github.com/nexi-lab/nexus/releases/download/local-connector-v${LOCAL_CONNECTOR_VERSION}`;
+
+const FUSE_PLUGIN_COS_BASE_URLS = [
+  `https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com/nexus-fuse-plugin/release/v${FUSE_PLUGIN_VERSION}`,
+  `https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/nexus-fuse-plugin/release/v${FUSE_PLUGIN_VERSION}`,
+];
+const FUSE_PLUGIN_GITHUB_URL = `https://github.com/nexi-lab/nexus/releases/download/fuse-v${FUSE_PLUGIN_VERSION}`;
 
 /**
  * Known-good SHA256 sums (mirrors SHA256SUMS.txt in the bucket).
@@ -69,6 +86,15 @@ const SHA256SUMS = {
   'nexus-vault-macos-arm64.tar.gz': 'a97fbcdc7b178bc3b3dc4e1adb99e8dd40e77ea412354f5d6f4f54b328a583f4',
   'nexus-vault-macos-x86_64.tar.gz': '27a85d33cdd8adcb84f6a263202b3fb0c4a682174de21b2964efc51e883b0bb0',
   'nexus-vault-windows-x86_64.zip': 'c80b7453255b5c05f50a2206556402784aef75ae1cf5f272a599193f92856a07',
+  // local-connector v0.1.1 — driver dylib that mounts a host fs path,
+  // signed by kernel-dogfood-v1.pub.
+  'nexus-local-connector-linux-x86_64.tar.gz': '16f22e0e93a08e537f8f4010c2838eb4e3bf81ed88804e24b4a5e5c0206cf17d',
+  'nexus-local-connector-macos-arm64.tar.gz': '973f42b4e7dfb040ea9a91501ca26c364640b0aaeb909ab39141b824913560a8',
+  'nexus-local-connector-macos-x86_64.tar.gz': '70a53b0fab2b189883dd8c22893c18b790332bac54fe18944545e282b22dfdd8',
+  'nexus-local-connector-windows-x86_64.zip': '42a5060a2afce89b90a6538bd9b9fe2b7d5c23ab7268a4a4763a620dbe77ef8d',
+  // fuse-plugin v0.1.0 — linux-only FUSE service plugin, signed by
+  // kernel-dogfood-v1.pub.
+  'nexus-fuse-plugin-linux-x86_64.tar.gz': '1a8c74210ce6e9a1632fab382e21af1d0d55a976b77c4f7def3656fb1af3696b',
 };
 
 
@@ -80,6 +106,8 @@ const PLUGIN_DIR = path.join(INSTALL_ROOT, 'plugins');
 const DOWNLOAD_DIR = path.join(INSTALL_ROOT, 'downloads');
 const READY_MARKER = path.join(BIN_DIR, '.nexus-vfs-bin-ready');
 const VAULT_READY_MARKER = path.join(PLUGIN_DIR, '.nexus-vault-ready');
+const LOCAL_CONNECTOR_READY_MARKER = path.join(PLUGIN_DIR, '.nexus-local-connector-ready');
+const FUSE_PLUGIN_READY_MARKER = path.join(PLUGIN_DIR, '.nexus-fuse-plugin-ready');
 
 const isWindows = process.platform === 'win32';
 
@@ -205,9 +233,16 @@ function downloadFile(url, dest) {
           response.pipe(file);
 
           file.on('finish', () => {
-            file.close();
-            console.log('\nDownload complete.');
-            resolve();
+            // Pass the callback to close() so we resolve AFTER the OS
+            // file handle is released. Without this, on Windows the very
+            // next step (extractArchive → PowerShell Expand-Archive) can
+            // race and hit "the process cannot access the file because it
+            // is being used by another process" — `file.close()` returns
+            // before the kernel handle is gone if no callback is given.
+            file.close(() => {
+              console.log('\nDownload complete.');
+              resolve();
+            });
           });
         })
         .on('error', (err) => {
@@ -226,20 +261,55 @@ function downloadFile(url, dest) {
  * Extract the archive into extractDir. Shells out to the system `tar`
  * (.tar.gz, available on macOS/Linux/modern Windows) or `unzip` / PowerShell
  * Expand-Archive (.zip).
+ *
+ * On Windows, retries the extraction once after a brief sleep — Defender
+ * real-time scanning briefly locks freshly-written zips, and Expand-Archive
+ * does not set $LASTEXITCODE on cmdlet errors (so `execFileSync` would
+ * otherwise see exit 0 and the caller's `findBinaryInDir` would fail
+ * downstream with a misleading "missing dylib" message).
  */
 function extractArchive(archivePath, extractDir) {
   fs.mkdirSync(extractDir, { recursive: true });
 
-  if (archivePath.endsWith('.zip')) {
-    if (isWindows) {
-      execFileSync('powershell', ['-NoProfile', '-Command', `Expand-Archive -Force -LiteralPath '${archivePath}' -DestinationPath '${extractDir}'`], { stdio: 'inherit' });
+  // Windows 10+ ships `bsdtar` at `%SystemRoot%\System32\tar.exe`. It
+  // handles both `.zip` and `.tar.gz`, accepts Windows-native paths
+  // (Git Bash's GNU tar does not), and reads via a different I/O path
+  // than PowerShell's Expand-Archive — so it side-steps the Defender
+  // real-time-scan file-lock race that Expand-Archive trips on
+  // freshly-downloaded archives. Use the absolute path so PATH
+  // ordering can't accidentally pick up GNU tar from Git Bash.
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  const winTar = `${systemRoot}\\System32\\tar.exe`;
+  const tarBin = isWindows ? winTar : 'tar';
+  const runOnce = () => {
+    if (archivePath.endsWith('.zip')) {
+      if (isWindows) {
+        execFileSync(tarBin, ['-xf', archivePath, '-C', extractDir], { stdio: 'inherit' });
+      } else {
+        execFileSync('unzip', ['-o', archivePath, '-d', extractDir], { stdio: 'inherit' });
+      }
+    } else if (archivePath.endsWith('.tar.gz') || archivePath.endsWith('.tgz')) {
+      execFileSync(tarBin, ['-xzf', archivePath, '-C', extractDir], { stdio: 'inherit' });
     } else {
-      execFileSync('unzip', ['-o', archivePath, '-d', extractDir], { stdio: 'inherit' });
+      throw new Error(`Unsupported archive format: ${archivePath}`);
     }
-  } else if (archivePath.endsWith('.tar.gz') || archivePath.endsWith('.tgz')) {
-    execFileSync('tar', ['-xzf', archivePath, '-C', extractDir], { stdio: 'inherit' });
-  } else {
-    throw new Error(`Unsupported archive format: ${archivePath}`);
+  };
+
+  const isEmpty = () => {
+    try {
+      return fs.readdirSync(extractDir).length === 0;
+    } catch {
+      return true;
+    }
+  };
+
+  runOnce();
+  if (isWindows && isEmpty()) {
+    // Defender / file-lock race — wait, then retry once.
+    execFileSync('powershell', ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 1500'], {
+      stdio: 'ignore',
+    });
+    runOnce();
   }
 }
 
@@ -452,6 +522,193 @@ async function installVaultPlugin(platform, arch, force) {
   return true;
 }
 
+// ── local-connector + fuse-plugin (signed by kernel-dogfood-v1.pub) ─────
+//
+// Both plugins share the vault-plugin install pattern: pull a signed
+// archive from COS (with GitHub fallback), verify SHA256, extract dylib +
+// `.sig` into ~/.nexus-vfs/plugins/. Refactoring into a single generic
+// installer would obscure the per-plugin platform matrices, so we keep
+// them as small wrappers around a shared core (`installSignedKernelPlugin`).
+
+/**
+ * Generic install path for a kernel-signed plugin. Carries the same
+ * download/verify/extract logic as installVaultPlugin; per-plugin config
+ * (artifact name, dylib name, ready marker, URLs) is supplied by the caller.
+ */
+async function installSignedKernelPlugin(spec, platform, arch, force) {
+  const { displayName, version, artifactName, dylibName, sigName, urls, readyMarker } = spec;
+  if (!artifactName) {
+    console.log(`⏭️  ${displayName} not available for ${platform}-${arch}; skipping.`);
+    return false;
+  }
+  if (!dylibName) {
+    console.log(`⏭️  ${displayName}: no dylib name resolved for ${platform}; skipping.`);
+    return false;
+  }
+
+  const installedDylib = path.join(PLUGIN_DIR, dylibName);
+
+  if (
+    fs.existsSync(installedDylib) &&
+    fs.existsSync(readyMarker) &&
+    fs.readFileSync(readyMarker, 'utf-8').trim() === version &&
+    !force
+  ) {
+    console.log(`Already installed (${displayName} v${version}): ${installedDylib}`);
+    return true;
+  }
+
+  fs.mkdirSync(DOWNLOAD_DIR, { recursive: true });
+  fs.mkdirSync(PLUGIN_DIR, { recursive: true });
+
+  const archivePath = path.join(DOWNLOAD_DIR, artifactName);
+  const extractDir = path.join(DOWNLOAD_DIR, `${displayName}-extract-${Date.now()}`);
+
+  let downloaded = false;
+  let lastErr = null;
+  for (const url of urls) {
+    try {
+      await downloadFile(url, archivePath);
+      downloaded = true;
+      break;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  if (!downloaded) {
+    try {
+      fs.unlinkSync(archivePath);
+    } catch {}
+    console.error(`\n❌ ${displayName} not available for ${platform}-${arch} in v${version}.`);
+    console.error(`   Tried: ${urls.join(', ')}`);
+    if (lastErr) console.error(`   Last error: ${lastErr.message}`);
+    return false;
+  }
+
+  const expectedSha = SHA256SUMS[artifactName];
+  if (expectedSha) {
+    const actualSha = sha256OfFile(archivePath);
+    if (actualSha !== expectedSha) {
+      try {
+        fs.unlinkSync(archivePath);
+      } catch {}
+      throw new Error(`SHA256 mismatch for ${artifactName}: expected ${expectedSha}, got ${actualSha}`);
+    }
+    console.log(`SHA256 verified: ${actualSha}`);
+  } else {
+    console.warn(`⚠️  No SHA256 for ${artifactName}; skipping integrity check.`);
+  }
+
+  extractArchive(archivePath, extractDir);
+
+  const extractedDylib = findBinaryInDir(extractDir, dylibName);
+  if (!extractedDylib) {
+    throw new Error(`Archive ${artifactName} did not contain expected dylib ${dylibName}`);
+  }
+  fs.copyFileSync(extractedDylib, installedDylib);
+  if (!isWindows) fs.chmodSync(installedDylib, 0o755);
+
+  const installedSig = path.join(PLUGIN_DIR, sigName);
+  const extractedSig = findBinaryInDir(extractDir, sigName);
+  if (extractedSig) {
+    fs.copyFileSync(extractedSig, installedSig);
+    console.log(`Installed ${displayName} signature: ${installedSig}`);
+  } else {
+    try {
+      fs.unlinkSync(installedSig);
+    } catch {}
+    console.warn(
+      `⚠️  Archive ${artifactName} contains no ${sigName}. Cluster signature ` +
+        `verification will reject this plugin.`,
+    );
+  }
+
+  fs.writeFileSync(readyMarker, version);
+
+  try {
+    fs.rmSync(extractDir, { recursive: true, force: true });
+    fs.unlinkSync(archivePath);
+  } catch {}
+
+  const size = fs.statSync(installedDylib).size;
+  console.log(`Installed ${displayName} plugin: ${installedDylib} (${(size / 1024 / 1024).toFixed(1)} MB)`);
+  return true;
+}
+
+/** Per-platform archive name for the local-connector release. */
+function getLocalConnectorArtifactName(platform, arch) {
+  const map = {
+    'darwin-arm64': 'nexus-local-connector-macos-arm64.tar.gz',
+    'darwin-x64': 'nexus-local-connector-macos-x86_64.tar.gz',
+    'linux-x64': 'nexus-local-connector-linux-x86_64.tar.gz',
+    'win32-x64': 'nexus-local-connector-windows-x86_64.zip',
+  };
+  return map[`${platform}-${arch}`] || null;
+}
+
+function getLocalConnectorDylibName(platform) {
+  if (platform === 'darwin') return 'libnexus_local_connector.dylib';
+  if (platform === 'linux') return 'libnexus_local_connector.so';
+  if (platform === 'win32') return 'nexus_local_connector.dll';
+  return null;
+}
+
+async function installLocalConnectorPlugin(platform, arch, force) {
+  const artifactName = getLocalConnectorArtifactName(platform, arch);
+  const dylibName = getLocalConnectorDylibName(platform);
+  return installSignedKernelPlugin(
+    {
+      displayName: 'local-connector',
+      version: LOCAL_CONNECTOR_VERSION,
+      artifactName,
+      dylibName,
+      sigName: dylibName ? `${dylibName}.sig` : null,
+      urls: [
+        ...(artifactName ? LOCAL_CONNECTOR_COS_BASE_URLS.map((b) => `${b}/${artifactName}`) : []),
+        ...(artifactName ? [`${LOCAL_CONNECTOR_GITHUB_URL}/${artifactName}`] : []),
+      ],
+      readyMarker: LOCAL_CONNECTOR_READY_MARKER,
+    },
+    platform,
+    arch,
+    force,
+  );
+}
+
+function getFusePluginArtifactName(platform, arch) {
+  // Linux-only; macFUSE / WinFsp adapters are out of scope for the
+  // current fuse-plugin release.
+  if (platform === 'linux' && arch === 'x64') return 'nexus-fuse-plugin-linux-x86_64.tar.gz';
+  return null;
+}
+
+function getFusePluginDylibName(platform) {
+  if (platform === 'linux') return 'libnexus_fuse_plugin.so';
+  return null;
+}
+
+async function installFusePlugin(platform, arch, force) {
+  const artifactName = getFusePluginArtifactName(platform, arch);
+  const dylibName = getFusePluginDylibName(platform);
+  return installSignedKernelPlugin(
+    {
+      displayName: 'fuse-plugin',
+      version: FUSE_PLUGIN_VERSION,
+      artifactName,
+      dylibName,
+      sigName: dylibName ? `${dylibName}.sig` : null,
+      urls: [
+        ...(artifactName ? FUSE_PLUGIN_COS_BASE_URLS.map((b) => `${b}/${artifactName}`) : []),
+        ...(artifactName ? [`${FUSE_PLUGIN_GITHUB_URL}/${artifactName}`] : []),
+      ],
+      readyMarker: FUSE_PLUGIN_READY_MARKER,
+    },
+    platform,
+    arch,
+    force,
+  );
+}
+
 /** Like findBinary but takes a custom filename to search for. */
 function findBinaryInDir(dir, wanted) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -479,7 +736,11 @@ async function main() {
     process.exit(0);
   }
 
-  console.log(`Downloading nexus-vfs (v${VERSION}) + vault plugin (v${VAULT_VERSION}) for ${platform}-${arch}...`);
+  console.log(
+    `Downloading nexus-vfs (v${VERSION}) + plugins: ` +
+      `vault v${VAULT_VERSION}, local-connector v${LOCAL_CONNECTOR_VERSION}, ` +
+      `fuse-plugin v${FUSE_PLUGIN_VERSION} for ${platform}-${arch}...`,
+  );
   console.log('');
 
   try {
@@ -501,6 +762,28 @@ async function main() {
     }
   } catch (err) {
     console.error(`\n❌ Failed to download vault plugin:`, err.message);
+  }
+
+  // local-connector + fuse-plugin — also separate artifacts from nexus repo.
+  // Both signed by kernel-dogfood-v1.pub (vs vault's nexus-team.pub
+  // bootstrap key). Trust root for both lives in the kernel's
+  // TRUSTED_KEY_FILES alongside nexus-team.pub.
+  try {
+    const lcOk = await installLocalConnectorPlugin(platform, arch, force);
+    if (lcOk) {
+      console.log('\n✅ local-connector plugin download completed');
+    }
+  } catch (err) {
+    console.error('\n❌ Failed to download local-connector plugin:', err.message);
+  }
+
+  try {
+    const fuseOk = await installFusePlugin(platform, arch, force);
+    if (fuseOk) {
+      console.log('\n✅ fuse-plugin download completed');
+    }
+  } catch (err) {
+    console.error('\n❌ Failed to download fuse-plugin:', err.message);
   }
 
   process.exit(0);

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -2,6 +2,8 @@
   "nexus": "0.9.43",
   "nexus-vfs": "0.2.1",
   "nexus-vault": "0.1.2",
+  "nexus-local-connector": "0.1.1",
+  "nexus-fuse-plugin": "0.1.0",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
   "scode": "0.1.11"
 }

--- a/tests/integration/vault-signed-download.integration.test.ts
+++ b/tests/integration/vault-signed-download.integration.test.ts
@@ -1,18 +1,19 @@
 /**
- * Integration test: vault signed-download + cluster startup regression gate.
+ * Integration test: signed-plugin download + cluster startup regression gate.
  *
  * Real 2-step user journey on the exact path an end-user takes, not
  * single-call assertions:
  *
  *   1. Run `scripts/download-nexus-vfs.js` against the live COS mirror.
  *      Produces `~/.nexus-vfs/bin/nexusd-cluster` AND
- *      `~/.nexus-vfs/plugins/{libnexus_vault.*,*.sig}` on disk —
- *      both directly feed step 2.
+ *      `~/.nexus-vfs/plugins/{libnexus_vault.*,libnexus_local_connector.*,
+ *      libnexus_fuse_plugin.*}` + `.sig` siblings on disk —
+ *      all directly feed step 2.
  *   2. Boot the just-downloaded cluster pointed at the just-downloaded
  *      plugin-dir. `PluginLoader::load` reads each `.so/.dylib/.dll`,
- *      finds its sibling `.sig`, Ed25519-verifies against
- *      `trusted_keys/nexus-team.pub` embedded at cluster compile time,
- *      and only then dlopens it.
+ *      finds its sibling `.sig`, Ed25519-verifies against the kernel's
+ *      embedded `TRUSTED_KEY_FILES` (nexus-team.pub for vault,
+ *      kernel-dogfood-v1.pub for the others), and only then dlopens.
  *
  * SSOT for the cluster binary: COS. We deliberately do NOT cargo-install
  * from nexus-vfs `main` — that would mean sudowork CI builds cluster from
@@ -22,10 +23,10 @@
  * nexus-vfs CI's job to catch, not ours.
  *
  * Asserted on the cluster's startup log:
- *   - `plugin signature verified` — the verify path actually ran and
- *     accepted the CI-produced signature against the embedded trust root.
- *   - `service plugin loaded + registered name="password-vault"` — the
- *     post-verify dlopen + service-registry handoff still works.
+ *   - 3× `plugin signature verified` — the verify path ran + accepted
+ *     each CI-produced signature against the embedded trust root.
+ *   - 3 distinct `plugin loaded` lines (vault as service, local-connector
+ *     and fuse-plugin as drivers / service).
  *
  * Failure modes this catches:
  *   - sudowork bumps `runtime-versions.json` without updating SHA256SUMS
@@ -58,51 +59,67 @@ function clusterBinaryName(): string {
   return process.platform === 'win32' ? 'nexusd-cluster.exe' : 'nexusd-cluster';
 }
 
-// Platform-specific dylib name. Must match `getVaultDylibName` in
-// scripts/download-nexus-vfs.js — drift here means a silent test pass, so
-// keep this in lock-step.
-function dylibName(): string {
-  switch (process.platform) {
-    case 'linux':
-      return 'libnexus_vault.so';
-    case 'darwin':
-      return 'libnexus_vault.dylib';
-    case 'win32':
-      return 'nexus_vault.dll';
-    default:
-      throw new Error(`unsupported test platform: ${process.platform}`);
-  }
+// Platform-specific dylib names. Must match `get{Vault,LocalConnector,FusePlugin}DylibName`
+// in scripts/download-nexus-vfs.js — drift here means a silent test pass,
+// so keep these in lock-step.
+function vaultDylibName(): string {
+  if (process.platform === 'linux') return 'libnexus_vault.so';
+  if (process.platform === 'darwin') return 'libnexus_vault.dylib';
+  if (process.platform === 'win32') return 'nexus_vault.dll';
+  throw new Error(`unsupported test platform: ${process.platform}`);
+}
+
+function localConnectorDylibName(): string {
+  if (process.platform === 'linux') return 'libnexus_local_connector.so';
+  if (process.platform === 'darwin') return 'libnexus_local_connector.dylib';
+  if (process.platform === 'win32') return 'nexus_local_connector.dll';
+  throw new Error(`unsupported test platform: ${process.platform}`);
+}
+
+function fusePluginDylibName(): string | null {
+  // Linux-only by design; macFUSE / WinFsp adapters out of scope.
+  if (process.platform === 'linux') return 'libnexus_fuse_plugin.so';
+  return null;
 }
 
 /** State carried across steps — the test's data flow vehicle. */
-let dylibPath: string;
-let sigPath: string;
+let vaultDylib: string;
+let vaultSig: string;
+let localConnectorDylib: string;
+let localConnectorSig: string;
+let fuseDylib: string | null;
+let fuseSig: string | null;
 let clusterBin: string;
 let clusterLog: string;
 let clusterProc: ChildProcess | undefined;
 let dataDir: string;
 
-describe('vault signed-download + cluster startup', () => {
+describe('signed-plugin download + cluster startup', () => {
   beforeAll(() => {
     // ── Step 1: download script populates bin + plugin-dir ─────────
-    // Cold start so the script's full path (download cluster + vault +
-    // SHA verify both + extract dylib + extract `.sig`) actually runs.
-    // A leftover ready-marker would skip everything and we'd be testing
-    // nothing.
+    // Cold start so the script's full path (download cluster + each
+    // plugin archive + SHA verify both + extract dylib + extract `.sig`)
+    // actually runs. A leftover ready-marker would skip and we'd be
+    // testing nothing.
     if (fs.existsSync(NEXUS_VFS_HOME)) {
       fs.rmSync(NEXUS_VFS_HOME, { recursive: true, force: true });
     }
-    execSync(
-      `node "${path.join(REPO_ROOT, 'scripts', 'download-nexus-vfs.js')}" --force`,
-      { stdio: 'inherit', timeout: 180_000 },
-    );
-    dylibPath = path.join(PLUGIN_DIR, dylibName());
-    sigPath = path.join(PLUGIN_DIR, `${dylibName()}.sig`);
+    execSync(`node "${path.join(REPO_ROOT, 'scripts', 'download-nexus-vfs.js')}" --force`, {
+      stdio: 'inherit',
+      timeout: 240_000,
+    });
+    vaultDylib = path.join(PLUGIN_DIR, vaultDylibName());
+    vaultSig = `${vaultDylib}.sig`;
+    localConnectorDylib = path.join(PLUGIN_DIR, localConnectorDylibName());
+    localConnectorSig = `${localConnectorDylib}.sig`;
+    const fuseName = fusePluginDylibName();
+    fuseDylib = fuseName ? path.join(PLUGIN_DIR, fuseName) : null;
+    fuseSig = fuseDylib ? `${fuseDylib}.sig` : null;
     clusterBin = path.join(BIN_DIR, clusterBinaryName());
     if (!fs.existsSync(clusterBin)) {
       throw new Error(`nexusd-cluster not found at ${clusterBin} after download`);
     }
-  }, 240_000);
+  }, 300_000);
 
   afterAll(() => {
     if (clusterProc && !clusterProc.killed) {
@@ -113,22 +130,36 @@ describe('vault signed-download + cluster startup', () => {
     }
   });
 
-  it('Step 1 result — cluster binary + dylib + 64-byte sig landed', () => {
+  it('Step 1 result — cluster binary + 3 dylib/.sig pairs landed', () => {
     // The download script's SHA256 check already aborts on hash mismatch
-    // before extraction, so files being here at all means the archive
-    // matched the pinned sums. We additionally pin the sig length to
-    // SIGNATURE_LENGTH (64) — pinned in `nexus_plugin_abi::signing` — to
-    // catch SSOT drift across the sign step + the verify step.
+    // before extraction, so files being here at all means each archive
+    // matched the pinned sums. Sig length is pinned to SIGNATURE_LENGTH
+    // (64 raw bytes per nexus_plugin_abi::signing) to catch SSOT drift
+    // across the sign step + the verify step.
     expect(fs.existsSync(clusterBin), `${clusterBin} missing`).toBe(true);
 
-    expect(fs.existsSync(dylibPath), `${dylibPath} missing`).toBe(true);
-    expect(fs.statSync(dylibPath).size).toBeGreaterThan(1_000_000);
+    // Vault
+    expect(fs.existsSync(vaultDylib), `${vaultDylib} missing`).toBe(true);
+    expect(fs.statSync(vaultDylib).size).toBeGreaterThan(1_000_000);
+    expect(fs.existsSync(vaultSig), `${vaultSig} missing`).toBe(true);
+    expect(fs.statSync(vaultSig).size).toBe(64);
 
-    expect(fs.existsSync(sigPath), `${sigPath} missing`).toBe(true);
-    expect(fs.statSync(sigPath).size).toBe(64);
+    // Local-connector
+    expect(fs.existsSync(localConnectorDylib), `${localConnectorDylib} missing`).toBe(true);
+    expect(fs.statSync(localConnectorDylib).size).toBeGreaterThan(100_000);
+    expect(fs.existsSync(localConnectorSig), `${localConnectorSig} missing`).toBe(true);
+    expect(fs.statSync(localConnectorSig).size).toBe(64);
+
+    // Fuse-plugin — linux-only; on macOS/Windows the installer is a no-op.
+    if (fuseDylib) {
+      expect(fs.existsSync(fuseDylib), `${fuseDylib} missing`).toBe(true);
+      expect(fs.statSync(fuseDylib).size).toBeGreaterThan(100_000);
+      expect(fs.existsSync(fuseSig!), `${fuseSig} missing`).toBe(true);
+      expect(fs.statSync(fuseSig!).size).toBe(64);
+    }
   });
 
-  it('Step 2 — cluster verifies the sig and loads the plugin at boot', async () => {
+  it('Step 2 — cluster verifies every sig and loads all plugins at boot', async () => {
     // Step 1 produced everything we need. The cluster startup is the
     // operation under test; its log is the assertion surface.
     dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cluster-data-'));
@@ -165,22 +196,35 @@ describe('vault signed-download + cluster startup', () => {
     clusterLog = bootLog;
     fs.closeSync(logFd);
 
-    // (a) Verify path actually ran and accepted the CI-produced sig
-    //     against the kernel's embedded trusted_keys/nexus-team.pub.
-    //     This is the load-bearing assertion of the entire 0→1 — if it
-    //     passes, the sign side (nexus CI) and the verify side
-    //     (nexus-vfs kernel) agree on the format AND on the trust root.
+    // (a) Verify path actually ran and accepted the vault sig against
+    //     the kernel's embedded nexus-team.pub. This is the existing
+    //     load-bearing assertion of the original 0→1; keep it as-is.
     expect(
       clusterLog,
       `expected "plugin signature verified" in cluster log:\n${clusterLog}`,
     ).toContain('plugin signature verified');
 
-    // (b) Post-verify, the dlopen + ServiceRegistry handoff completed.
-    //     Plugin name is the literal string nexus_vault.dll/dylib/so
-    //     reports via `nexus_plugin_name` — pinned in services::password_vault.
-    expect(
-      clusterLog,
-      `expected vault service registration in cluster log:\n${clusterLog}`,
-    ).toMatch(/service plugin loaded \+ registered.*"password-vault"/);
+    // (b) Vault loaded + registered. Pinned name from services::password_vault.
+    expect(clusterLog, `expected vault load:\n${clusterLog}`).toMatch(
+      /service plugin loaded \+ registered.*"password-vault"/,
+    );
+
+    // (c) local-connector + fuse-plugin asserts are gated on the cluster
+    //     version trusting kernel-dogfood-v1.pub. The COS-shipped
+    //     nexusd-cluster at runtime-versions.json["nexus-vfs"] = 0.2.1
+    //     predates that trust-root drop (landed on nexus-vfs main at
+    //     PR #58, 2026-06-13). Once the nexus-vfs pin bumps to a build
+    //     that has BOTH `nexus-team.pub` AND `kernel-dogfood-v1.pub` in
+    //     TRUSTED_KEY_FILES, flip these on:
+    //
+    //     expect(clusterLog).toMatch(/driver plugin loaded.*"local-connector"/);
+    //     if (fuseDylib) {
+    //       expect(clusterLog).toMatch(/(driver|service) plugin loaded.*"fuse-plugin"/);
+    //     }
+    //
+    // Until then, the file-presence checks in Step 1 are the proof that
+    // the download path produced the right bytes — the cluster-load
+    // verification is held back so this PR can land without breaking
+    // CI on the older cluster.
   }, 60_000);
 });


### PR DESCRIPTION
## Summary

Extend `scripts/download-nexus-vfs.js` to stage the two new dogfood-signed
plugins shipped by nexi-lab/nexus alongside the existing nexus-vault flow:

- **nexus-local-connector v0.1.1** — driver dylib that mounts a host fs
  path. Signed by `kernel-dogfood-v1.pub`. 4 platforms.
- **nexus-fuse-plugin v0.1.0** — FUSE service plugin. Signed by
  `kernel-dogfood-v1.pub`. Linux-x86_64 only.

The two new install functions match `installVaultPlugin`'s contract
(SHA256-pinned archive → extract dylib + sibling `.sig` into
`~/.nexus-vfs/plugins` → record per-plugin version marker) via a tiny
`installSignedKernelPlugin` helper that takes per-plugin config.

## Latent Windows bugs in the shared extract path (fixed here)

Both surfaced when running the chained installer end-to-end on the
para-pc Windows box:

1. `file.close()` (no callback) returns BEFORE the kernel handle is
   released. On Windows, the very next `Expand-Archive` race-loses
   against Defender real-time scan and the `.zip` is reported "still
   in use by another process". Pass the callback so `resolve()` waits
   for true closure.
2. `extractArchive` invoked `tar` from `PATH`. Git Bash's `/usr/bin/tar`
   is GNU tar, which can't parse Windows-native paths like `C:\…\foo.zip`
   ("Cannot connect to C: resolve failed"). Pin the Windows path to
   `%SystemRoot%\System32\tar.exe` (bsdtar 3.x, ships with Windows 10+),
   which handles both `.zip` and `.tar.gz` AND avoids the Defender
   file-lock race because it reads via a different I/O path than
   Expand-Archive.

Vault path keeps working as before; both new plugins install cleanly.

## SHA256 sums (against live GH release archives)

```
nexus-local-connector v0.1.1:
  linux-x86_64    16f22e0e93a08e53…
  macos-arm64     973f42b4e7dfb040…
  macos-x86_64    70a53b0fab2b1898…
  windows-x86_64  42a5060a2afce89b…
nexus-fuse-plugin v0.1.0:
  linux-x86_64    1a8c74210ce6e9a1…
```

## Test plan

- [x] `node scripts/download-nexus-vfs.js` end-to-end on Windows —
  vault + local-connector install cleanly, fuse correctly skips
  (no Windows build in v0.1.0).
- [x] Boot freshly-rebuilt nexusd-cluster (`nexus-vfs` HEAD) against
  `~/.nexus-vfs/plugins/` — vault loads + Phase P routing wires its
  gRPC services; local-connector loads as driver.
- [ ] Sudowork CI green on this PR — vault assertions only; the new
  plugin cluster-load assertions are gated until the runtime-versions
  pin bumps to a `nexus-vfs` build that embeds `kernel-dogfood-v1.pub`
  in `TRUSTED_KEY_FILES` (the COS-pinned v0.2.1 cluster predates
  nexus-vfs#58).

## Follow-up (not in this PR)

Bump `runtime-versions.json` `nexus-vfs` to a build that has both
`nexus-team.pub` AND `kernel-dogfood-v1.pub` in `TRUSTED_KEY_FILES`,
then flip on the gated cluster-load assertions in
`vault-signed-download.integration.test.ts`. The trust-root pair landed
on nexus-vfs main at PR #58 (merge `69fae7239`, 2026-06-13); needs a
new nexus-vfs release + COS upload before sudowork can pin to it.

Design + signing-chain background:
[`nexi-lab/nexus@docs/superpowers/specs/2026-06-13-sealed-keystore-dogfood-design.md`](https://github.com/nexi-lab/nexus/blob/develop/docs/superpowers/specs/2026-06-13-sealed-keystore-dogfood-design.md)