### PR TITLE
fix(types): resolve 3 pre-existing tsc errors on dev (root-cause, no casts)

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -12,6 +12,7 @@ import type { AcpBackend, AcpBackendAll, AcpModelInfo, PresetAgentType } from '.
 import type { ScodeCustomModelProvider } from './scodeConfig';
 import type { SlashCommandItem } from './slash/types';
 import type { IMcpServer, IProvider, TChatConversation, TProviderWithModel, ICssTheme } from './storage';
+import type { SecretMetadata } from './nexus/nexus-secret-client';
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from './types/preview';
 import type { UpdateCheckRequest, UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult, AutoUpdateStatus } from './updateTypes';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from './utils/protocolDetector';
@@ -1764,17 +1765,12 @@ export const sudoworkAuth = {
 // ==================== Secret Management API ====================
 // Manage service secrets stored in Nexus secret store
 
-export interface ISecretMetadata {
-  id: string;
-  namespace: string;
-  key: string;
-  description?: string;
-  enabled: boolean;
-  currentVersion: number;
-  deletedAt?: number;
-  createdAt: number;
-  updatedAt: number;
-}
+/**
+ * Secret metadata as actually produced by NexusSecretClient — the single source
+ * of truth. (Previously a drifted duplicate with never-produced id/enabled/
+ * deletedAt fields, which made the secret.list provider fail to type-check.)
+ */
+export type ISecretMetadata = SecretMetadata;
 
 export const secret = {
   /** Get a secret value by namespace and key */

--- a/src/common/utils/workspaceSkillSync.ts
+++ b/src/common/utils/workspaceSkillSync.ts
@@ -46,9 +46,10 @@ export function shouldSyncWorkspaceSkills(conversation?: TChatConversation, requ
     return false;
   }
 
-  if (conversation.type === 'openclaw-gateway') {
-    return true;
-  }
+  // NOTE: legacy 'openclaw-gateway' conversations are migrated to acp + scode
+  // (see initStorage / CronService), and the type is no longer part of the
+  // TChatConversation union — so a dead `=== 'openclaw-gateway'` branch was removed
+  // here. Migrated conversations are covered by the acp + scode case below.
 
   if (conversation.type === 'acp' && conversation.extra?.backend === 'claude') {
     return true;

--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -62,7 +62,7 @@ const GeminiSubMenu: React.FC<{
   return (
     <Dropdown
       trigger='hover'
-      position='rt'
+      position='br'
       popupVisible={open}
       onVisibleChange={setOpen}
       droplist={


### PR DESCRIPTION
`bunx tsc --noEmit` is currently **red on `dev`** with 3 errors (release-build gate). Each fixed at root — no casts/suppressions.

1. **`workspaceSkillSync.ts`** — `conversation.type === 'openclaw-gateway'` could never match: `openclaw-gateway` is a deprecated type (agents migrated to `scode`), not in the `TChatConversation` union. Removed the dead branch; migrated convs are `acp`+`scode`, already handled by the next branch. (Completes the deprecation — SSOT-aligned, DRY.)
2. **`ipcBridge.ts`** — `ISecretMetadata` had drifted from `NexusSecretClient`'s `SecretMetadata` (declared never-produced `id/enabled/deletedAt`), so the `secret.list` provider didn't type-check. No consumers use those fields, so `ISecretMetadata` is now an alias to the producer type (type-only import — erased at build, no native addon pulled into the renderer). **Single source of truth.**
3. **`GuidModelSelector.tsx`** — `Dropdown position='rt'` is invalid (`rt` is a Popover position; Dropdown allows `tl/tr/bl/br/top/bottom`). Changed to `'br'`.

**Verification:** `bunx tsc --noEmit` → 0 errors; PR-gating secrets unit tests pass (nexus-secret-client 11✓, secret-cache 6✓); changed-file formatting clean.

> Heads-up (out of scope here): `dev` also has ~29 failing **`.dom`** tenant-config tests (e.g. `useTenantConfigItems.dom.test.ts`) — identical on pristine `dev`, not gated by PR CI. Flagging separately; not touched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)