### PR TITLE
fix(db): never sideline the DB file on engine/environment errors (apparent data loss)

### DIFF
--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -84,18 +84,50 @@ export class AionUIDatabase {
       }
 
       // 备份损坏的数据库文件
-      // Backup corrupted database file
+      // Backup corrupted database file.
+      // WAL mode keeps recent committed transactions in the -wal sidecar until
+      // checkpoint, with -shm as its shared-memory index. These MUST be handled
+      // together with the main file: (a) moving them with the backup keeps it a
+      // complete, restorable snapshot rather than a stale one, and (b) any -wal/-shm
+      // left next to finalPath would be inherited by the fresh database created
+      // below — SQLite associates them with the new file and can itself read the
+      // mismatched WAL as corrupt. So move sidecars alongside the backup, and never
+      // leave one behind.
+      const sidecarSuffixes = ['-wal', '-shm'];
       if (fs.existsSync(finalPath)) {
         const backupPath = `${finalPath}.backup.${Date.now()}`;
         try {
           fs.renameSync(finalPath, backupPath);
           mainLog('Database', `Backed up corrupted database to: ${backupPath}`);
+          for (const suffix of sidecarSuffixes) {
+            const sidecar = `${finalPath}${suffix}`;
+            if (!fs.existsSync(sidecar)) continue;
+            try {
+              fs.renameSync(sidecar, `${backupPath}${suffix}`);
+            } catch {
+              // If it can't travel with the backup, it must at least not remain
+              // next to the fresh db — remove it.
+              try {
+                fs.unlinkSync(sidecar);
+              } catch {
+                // ignore
+              }
+            }
+          }
         } catch (e) {
           mainError('Database', 'Failed to backup corrupted database:', e);
           // 备份失败则尝试直接删除
-          // If backup fails, try to delete instead
+          // If backup fails, try to delete instead — including the WAL sidecars,
+          // so the fresh db does not inherit a stale -wal/-shm.
           try {
             fs.unlinkSync(finalPath);
+            for (const suffix of sidecarSuffixes) {
+              try {
+                fs.unlinkSync(`${finalPath}${suffix}`);
+              } catch {
+                // sidecar may not exist; ignore
+              }
+            }
             mainLog('Database', `Deleted corrupted database file`);
           } catch (e2) {
             mainError('Database', 'Failed to delete corrupted database:', e2);

--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -22,6 +22,26 @@ import { resolveSecret, cachePut } from '@common/nexus/secret-cache';
 import { SecretMigrationCoordinator } from '@common/nexus/secret-migration';
 
 /**
+ * True ONLY for errors indicating the SQLite *file* itself is corrupt/unreadable as
+ * a database — the single case where renaming it aside is safe. Engine/environment
+ * failures (missing or ABI-mismatched native binding, permission denied, locked db)
+ * must NOT sideline the user's data: doing so turns a recoverable install/runtime
+ * problem into apparent data loss. When in doubt, treat as NOT corrupt (fail loud,
+ * keep the file).
+ */
+function isCorruptDatabaseFileError(error: unknown): boolean {
+  const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  const code = String((error as { code?: unknown })?.code ?? '').toUpperCase();
+  return (
+    code === 'SQLITE_CORRUPT' ||
+    code === 'SQLITE_NOTADB' ||
+    msg.includes('malformed') || // SQLITE_CORRUPT: "database disk image is malformed"
+    msg.includes('file is not a database') || // SQLITE_NOTADB
+    msg.includes('file is encrypted or is not a database')
+  );
+}
+
+/**
  * Main database class for Sudowork
  * Uses better-sqlite3 for fast, synchronous SQLite operations
  */
@@ -41,7 +61,17 @@ export class AionUIDatabase {
       this.db = new BetterSqlite3(finalPath);
       this.initialize();
     } catch (error) {
-      mainError('Database', 'Failed to initialize, attempting recovery...', error);
+      // Only a genuinely corrupt DB *file* may be safely renamed aside and recreated.
+      // An engine/environment failure (missing or ABI-mismatched native binding,
+      // permission denied, locked db) leaves the file perfectly intact — sidelining
+      // it there would turn a recoverable install/runtime problem into apparent data
+      // loss. So fail loud and leave the user's data untouched in that case.
+      if (!isCorruptDatabaseFileError(error)) {
+        mainError('Database', 'Failed to open database — not a file-corruption error, leaving the database file untouched.', error);
+        throw error;
+      }
+
+      mainError('Database', 'Database file appears corrupted, attempting recovery...', error);
       // 尝试恢复：关闭并重新创建数据库
       // Try to recover by closing and recreating database
       try {


### PR DESCRIPTION
## What happened
A user's conversation history disappeared from the UI. Root cause: the `better-sqlite3` **native binding was missing** (an `electron-rebuild` hiccup on a box without a C++ toolchain), so `new BetterSqlite3()` threw `Could not locate the bindings file`. `AionUIDatabase`'s constructor then **misclassified that engine-load failure as file corruption**, renamed the intact `sudowork.db` aside to `sudowork.db.backup.<ts>`, and started an empty DB → history gone. The data was never lost (it was in the backup), but the app *presented* an install hiccup as data loss.

## The bug
The constructor's `catch` treated **any** open failure as "corrupt file" and rename-aside-then-recreate. But binding-missing / ABI-mismatch / `EPERM` / locked-db all leave the file perfectly intact.

## The fix
Classify at the root. Only a genuine SQLite **file-corruption signature** may trigger the rename-aside recovery:
- `SQLITE_CORRUPT` / `SQLITE_NOTADB` codes
- `"malformed"`, `"file is not a database"`, `"file is encrypted or is not a database"`

Every other error now **re-throws** — fail loud, leave the user's data untouched. The check lives in one conservative helper (`isCorruptDatabaseFileError`) that defaults to **NOT corrupt** when uncertain (safer to fail loud than to destroy data).

## Why this is the right shape
- **Simpler contract** — recovery now has a clear precondition (file-corruption only) instead of "any error → move the file".
- **SSOT / DRY** — one helper defines "is this corruption?".
- **Systematic, not a patch** — fixes the misclassification for *all* non-corruption errors, not just the binding case that surfaced it.
- **No infra/boundary changes** — pure app-level logic in sudowork's own DB wrapper.

`bunx tsc --noEmit` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)