### PR TITLE
test(secrets-grpc): unblock the suite on Linux/macOS-arm64/Windows

### DIFF
--- a/tests/integration/secrets-grpc.integration.test.ts
+++ b/tests/integration/secrets-grpc.integration.test.ts
@@ -35,12 +35,24 @@ function loadNapiModule(): NapiModule | null {
 }
 
 async function isNexusAvailable(): Promise<boolean> {
-  try {
-    await fetch('http://localhost:2028', { signal: AbortSignal.timeout(2000) });
-    return true;
-  } catch {
-    return false;
-  }
+  // nexusd-cluster is an HTTP/2 gRPC server. Node's built-in `fetch` (HTTP/1.1
+  // via undici) sees the HTTP/2 SETTINGS frame and errors out on the protocol
+  // mismatch even when the server is up, so a fetch-based liveness probe is a
+  // false negative against gRPC. Use a plain TCP connect — gRPC requires HTTP/2
+  // anyway, so a successful TCP handshake on the gRPC port is all we need
+  // before the napi client opens its own channel.
+  return await new Promise<boolean>((resolve) => {
+    const net = require('net') as typeof import('net');
+    const socket = net.connect({ host: '127.0.0.1', port: 2028 });
+    const done = (ok: boolean) => {
+      try { socket.destroy(); } catch { /* swallow */ }
+      resolve(ok);
+    };
+    socket.setTimeout(2000);
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+    socket.once('timeout', () => done(false));
+  });
 }
 
 // ── Test suite ─────────────────────────────────────────────────────
@@ -70,8 +82,19 @@ describe.skipIf(!process.env.NEXUS_E2E)('Vault Secrets gRPC Integration', () => 
     const mod = await import('../../src/common/nexus/nexus-secret-client');
     NexusSecretClient = mod.NexusSecretClient;
 
-    const grpcClient = new napiModule.NexusGrpcClient('http://localhost:2028');
-    client = new NexusSecretClient(grpcClient, '');
+    // We can't use the high-level `Nexus` wrapper here because its
+    // `loadNativeBinding` reaches into `require('electron').app.getAppPath()`
+    // — vitest runs under plain Node, no Electron, so that path is empty
+    // and the napi module never loads. Instead, drive the raw napi client
+    // and wrap it in a minimal `{ callBinary }` adapter that carries the
+    // empty auth token through (the napi binding requires three args).
+    const rawClient = new napiModule.NexusGrpcClient('http://localhost:2028');
+    const nexusAdapter = {
+      callBinary: (method: string, payload: Buffer): Buffer =>
+        rawClient.callBinary(method, payload, ''),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client = new NexusSecretClient(nexusAdapter as any);
   }, 30000);
 
   afterAll(() => {


### PR DESCRIPTION
## Summary

Three test plumbing fixes turned up while running \`tests/integration/secrets-grpc.integration.test.ts\` against a real \`nexusd-cluster\` on Windows (vault v0.1.2 dll, same dll the macOS x86_64 E2E used). None of these change vault or the gRPC contract — they fix test plumbing that was platform-specific or coupled to Electron.

1. \`isNexusAvailable\` used \`fetch('http://localhost:2028')\` to probe nexusd-cluster. nexusd-cluster speaks HTTP/2 (gRPC); Node's built-in \`fetch\` (undici) is HTTP/1.1, sees the HTTP/2 SETTINGS frame and throws on the protocol mismatch even when the server is healthy. Replace with a plain TCP connect — gRPC requires HTTP/2 anyway, so a successful TCP handshake on the gRPC port is all we need before the napi client opens its own channel.
2. The suite instantiated the raw \`napiModule.NexusGrpcClient\` and handed it to \`NexusSecretClient(grpcClient, '')\`. The napi binding is \`callBinary(method, payload, authToken)\` — three required strings; \`NexusSecretClient.dispatch\` only forwards two, so the raw path surfaced as \`Failed to convert JavaScript value 'Undefined' into rust type 'String'\`. Wrap the raw napi client in a minimal \`{ callBinary }\` adapter that carries the empty auth token through — same shape \`NexusSecretClient\` expects from the high-level \`Nexus\` wrapper.
3. The natural alternative — \`new Nexus({ endpoint, authToken: '' })\` — can't be used inside vitest because \`loadNativeBinding\` reaches into \`require('electron').app.getAppPath()\`, which under plain Node returns nothing and the require fails. The adapter above sidesteps that — production paths still go through \`Nexus\`, only the test runs without Electron.

## Verification (Windows)

\`\`\`
$ NEXUS_E2E=1 bunx vitest run tests/integration/secrets-grpc.integration.test.ts

✓ should complete full CRUD lifecycle (383ms)
✓ should restore a deleted secret with data intact
✓ should track version history through key rotation
✓ should batch-migrate and verify all secrets

Test Files  1 passed (1)
Tests       4 passed (4)
\`\`\`

Environment: Windows 11 / AMD64, nexusd-cluster v0.2.1 + COS-downloaded vault dll v0.1.2 + napi module built via VsDevCmd. Plugin load confirmed in cluster log: \`plugins loaded count=1 names=[\"password-vault\"]\`. Full data path TS → @bufbuild/protobuf → napi callBinary → gRPC (HTTP/2) → vault plugin dispatch → AES-256-GCM → kernel syscalls verified end-to-end. namespace \`__test__:<ts>\` (containing the NTFS-illegal \`:\`) round-trips cleanly — the v0.1.2 percent-encoding works on Windows.

## Test plan

- [x] Local: \`NEXUS_E2E=1 bunx vitest run tests/integration/secrets-grpc.integration.test.ts\` passes on Windows
- [ ] CI (default): suite still skips when \`NEXUS_E2E\` is unset (the \`describe.skipIf\` gate)
- [ ] Linux / macOS arm64 contributors can now opt in to running the suite with \`NEXUS_E2E=1\` and a running nexusd-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)