### PR TITLE
ci(pr-integration-smoke): add secrets-grpc-e2e job + Docker reproducer

### DIFF
--- a/.github/workflows/pr-integration-smoke.yml
+++ b/.github/workflows/pr-integration-smoke.yml
@@ -68,3 +68,110 @@ jobs:
         # notes (incl. why we deliberately do NOT cargo-install from
         # nexus-vfs main) in tests/integration/vault-signed-download.integration.test.ts.
         run: bunx vitest run tests/integration/vault-signed-download.integration.test.ts
+
+  secrets-grpc-e2e:
+    # Full CRUD round-trip through the napi → gRPC (HTTP/2) → vault
+    # plugin dispatch → AES-256-GCM → kernel syscalls chain on Linux.
+    # Complements vault-signed-download above (which only verifies the
+    # cluster loads the signed plugins) by asserting the actual gRPC
+    # data path works end-to-end. The test is gated behind NEXUS_E2E=1
+    # so it stays opt-in for local devs; this job is the canonical
+    # place it always runs on PR.
+    #
+    # Catches regressions in: napi binding shape, gRPC routing,
+    # download-nexus-vfs.js SHA256 manifest drift,
+    # runtime-versions.json ↔ kernel ABI ↔ plugin ABI pin alignment.
+    #
+    # Local reproducer (Docker, same shape): scripts/dev/linux-e2e.sh.
+    name: Vault Secrets gRPC E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler pkg-config libssl-dev
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            native/nexus-napi/target
+          key: ${{ runner.os }}-cargo-napi-${{ hashFiles('native/nexus-napi/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-napi-
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Download nexus-vfs cluster + plugins from COS
+        # Honors src/shared/runtime-versions.json — bumping any pin in
+        # that file should re-resolve here. SHA256 mismatches caused by
+        # forgetting to update scripts/download-nexus-vfs.js fail fast.
+        run: bun run nexus-vfs:download
+
+      - name: Build nexus-napi native binding
+        run: bun run build:native
+
+      - name: Start nexusd-cluster on :2028
+        # nexusd-cluster speaks HTTP/2 gRPC. Background it, wait for the
+        # TCP listener, then fall through to the test (which does its own
+        # liveness check via a TCP probe).
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/cluster-data
+          RUST_LOG=info,kernel::kernel::plugins=info \
+            nohup "$HOME/.nexus-vfs/bin/nexusd-cluster" \
+              --bind-addr 0.0.0.0:2028 \
+              --data-dir /tmp/cluster-data \
+              --no-tls \
+              --bootstrap-mode static \
+              --plugin-dir "$HOME/.nexus-vfs/plugins" \
+              > /tmp/cluster.log 2>&1 &
+          echo "CLUSTER_PID=$!" >> "$GITHUB_ENV"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if (echo > /dev/tcp/127.0.0.1/2028) >/dev/null 2>&1; then
+              echo "cluster listening on :2028 (after ${i}s)"
+              break
+            fi
+            sleep 1
+          done
+          head -30 /tmp/cluster.log
+          grep -E "plugins loaded|plugin loaded|skip plugin|signature verified" /tmp/cluster.log || true
+
+      - name: Run secrets-grpc integration test
+        env:
+          NEXUS_E2E: '1'
+        run: bunx vitest run tests/integration/secrets-grpc.integration.test.ts
+
+      - name: Cluster log on failure
+        if: failure()
+        run: |
+          echo "=== full cluster log ==="
+          cat /tmp/cluster.log || true
+
+      - name: Stop nexusd-cluster
+        if: always()
+        run: |
+          if [ -n "${CLUSTER_PID:-}" ]; then
+            kill "$CLUSTER_PID" 2>/dev/null || true
+          fi

--- a/scripts/dev/linux-e2e.sh
+++ b/scripts/dev/linux-e2e.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# Local-reproducer for the Linux secrets-grpc end-to-end test.
+#
+# What it exercises:
+#   1. `bun run nexus-vfs:download` — fetches nexusd-cluster + vault dylib +
+#      local-connector + fuse-plugin from COS into ~/.nexus-vfs/. Catches
+#      SHA256 manifest drift in scripts/download-nexus-vfs.js the moment
+#      the pinned `runtime-versions.json` falls out of sync with the
+#      published artifacts.
+#   2. `bun run build:native` — builds the nexus-napi binding for the
+#      host platform.
+#   3. Starts nexusd-cluster on 0.0.0.0:2028 with --plugin-dir, asserting
+#      the plugin set loads with the trust root + ABI it was built
+#      against.
+#   4. Runs `tests/integration/secrets-grpc.integration.test.ts` against
+#      that live cluster — full CRUD round-trip through napi → gRPC
+#      (HTTP/2) → vault plugin → kernel syscalls.
+#
+# Run locally inside a Docker container that has Rust + Node toolchains.
+# Example invocation from a host with Docker Desktop:
+#
+#   docker run --rm \
+#     -v "$PWD:/work/sudowork:ro" \
+#     -v sudowork-cargo-registry:/usr/local/cargo/registry \
+#     -v sudowork-cargo-git:/usr/local/cargo/git \
+#     rust:1-bookworm \
+#     bash /work/sudowork/scripts/dev/linux-e2e.sh
+#
+# The script copies the repo into a writable workspace inside the
+# container so `bun install` + native build don't bleed back to the
+# host worktree.
+#
+# CI runs the same flow inline in .github/workflows/pr-integration-smoke.yml
+# (no docker indirection — the runner is already ubuntu-latest), so this
+# script stays in sync with what production CI verifies.
+
+set -uo pipefail
+
+WORK=${WORK_DIR:-/root/work}
+SOURCE_MOUNT=${SOURCE_MOUNT:-/work/sudowork}
+mkdir -p "$WORK"
+export HOME=${HOME:-/root}
+
+echo "=== ENV ==="
+uname -a
+rustc --version
+cargo --version
+echo ""
+
+echo "=== STEP 1: apt deps + bun ==="
+apt-get update -qq
+apt-get install -y -qq curl unzip ca-certificates protobuf-compiler pkg-config libssl-dev build-essential 2>&1 | tail -3
+curl -fsSL https://bun.sh/install | bash 2>&1 | tail -3
+export PATH="$HOME/.bun/bin:$PATH"
+bun --version
+echo ""
+
+echo "=== STEP 2: stage sudowork into a writable copy ==="
+cp -r "$SOURCE_MOUNT" "$WORK/sudowork"
+cd "$WORK/sudowork"
+echo ""
+
+echo "=== STEP 3: bun install ==="
+date -u
+bun install 2>&1 | tail -8
+date -u
+echo ""
+
+echo "=== STEP 4: nexus-vfs:download (cluster + plugins from COS) ==="
+date -u
+bun run nexus-vfs:download 2>&1 | tail -25
+RC4=$?
+date -u
+echo "[download rc=$RC4]"
+ls -la "$HOME/.nexus-vfs/bin/" "$HOME/.nexus-vfs/plugins/" 2>&1 | head -15
+echo ""
+
+echo "=== STEP 5: build:native (napi for the host platform) ==="
+date -u
+bun run build:native 2>&1 | tail -10
+RC5=$?
+date -u
+echo "[build:native rc=$RC5]"
+ls -la native/nexus-napi/*.node native/nexus-napi/index.* 2>&1 | head -5
+echo ""
+
+echo "=== STEP 6: launch nexusd-cluster on :2028 ==="
+mkdir -p "$WORK/cluster-data"
+RUST_LOG=info,kernel::kernel::plugins=info nohup "$HOME/.nexus-vfs/bin/nexusd-cluster" \
+  --bind-addr 0.0.0.0:2028 \
+  --data-dir "$WORK/cluster-data" \
+  --no-tls \
+  --bootstrap-mode static \
+  --plugin-dir "$HOME/.nexus-vfs/plugins" \
+  > "$WORK/cluster.log" 2>&1 &
+CLUSTER_PID=$!
+echo "cluster pid=$CLUSTER_PID"
+sleep 6
+echo "--- cluster log head ---"
+head -25 "$WORK/cluster.log"
+echo "--- plugin load events ---"
+grep -E "plugins loaded|plugin loaded|skip plugin|signature verified" "$WORK/cluster.log" | head -15
+echo ""
+
+echo "=== STEP 7: NEXUS_E2E=1 vitest run secrets-grpc ==="
+date -u
+NEXUS_E2E=1 bunx vitest run tests/integration/secrets-grpc.integration.test.ts 2>&1 | tail -30
+RC7=$?
+date -u
+echo "[vitest rc=$RC7]"
+echo ""
+
+echo "=== STEP 8: stop cluster ==="
+kill "$CLUSTER_PID" 2>/dev/null || true
+sleep 2
+echo ""
+
+echo "=== summary ==="
+echo "download:$RC4  build:native:$RC5  vitest:$RC7"
+[ "$RC4" -eq 0 ] && [ "$RC5" -eq 0 ] && [ "$RC7" -eq 0 ] && echo "ALL GREEN" || echo "FAILURES PRESENT"
+exit $RC7

--- a/tests/integration/secrets-grpc.integration.test.ts
+++ b/tests/integration/secrets-grpc.integration.test.ts
@@ -13,7 +13,6 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import * as fs from 'fs';
 import * as path from 'path';
 
 // ── Module loading ───────────────────────────────────────────────────
@@ -21,17 +20,17 @@ import * as path from 'path';
 type NapiModule = typeof import('../../native/nexus-napi');
 
 function loadNapiModule(): NapiModule | null {
-  const candidates = [
-    path.join(__dirname, '..', '..', 'native', 'nexus-napi', 'nexus-napi.darwin-arm64.node'),
-    path.join(__dirname, '..', '..', 'native', 'nexus-napi', 'nexus-napi.darwin-x64.node'),
-    path.join(__dirname, '..', '..', 'native', 'nexus-napi', 'index.node'),
-  ];
-  for (const candidate of candidates) {
-    try {
-      if (fs.existsSync(candidate)) return require(candidate);
-    } catch { /* try next */ }
+  // Defer to the package's own `index.js`, which picks the right
+  // platform-specific `.node` artifact (it tries
+  // `nexus-napi.<platform>-<arch>.node` first, then the un-suffixed
+  // `nexus-napi.node` that `napi build --release` emits). Going through
+  // index.js means this test works on Linux / macOS / Windows without
+  // hardcoding the artifact name table here.
+  try {
+    return require(path.join(__dirname, '..', '..', 'native', 'nexus-napi'));
+  } catch {
+    return null;
   }
-  return null;
 }
 
 async function isNexusAvailable(): Promise<boolean> {


### PR DESCRIPTION
## Summary

\`tests/integration/secrets-grpc.integration.test.ts\` is gated behind \`NEXUS_E2E=1\` and **nothing in CI runs it today**. Regressions in the napi → gRPC → vault chain sit dormant until someone manually invokes — running this end-to-end on Linux Docker just now caught 3 dormant bugs that had been merged blind (TCP-vs-fetch liveness probe, raw NexusGrpcClient missing authToken, Nexus wrapper requiring \`electron.app\` at vitest time — all already fixed in #865), plus unblocked the v0.2.2 + v0.1.3 ABI pairing in #866.

This PR closes the gap.

## What it adds

1. **\`secrets-grpc-e2e\` job in \`pr-integration-smoke.yml\`** — stands up a real \`nexusd-cluster\` on :2028 with the COS-downloaded plugin set, runs the gated vitest. Covers the **full CRUD round-trip** through napi → gRPC (HTTP/2) → vault plugin → AES-256-GCM → kernel syscalls — coverage no other CI job has. Catches:
   - \`download-nexus-vfs.js\` SHA256 manifest drift (bit us twice while landing #866)
   - \`runtime-versions.json\` ↔ kernel ABI ↔ plugin ABI pin alignment (the v3-kernel-rejects-v2-plugin scenario)
   - napi binding shape changes
   - vault plugin name / load semantics

   Runs after the matching \`Vault Signed Download\` smoke (which verifies plugins load) so the two jobs are complementary — load assertion vs runtime CRUD assertion. ~5-10 min/PR on warm cache.

2. **\`scripts/dev/linux-e2e.sh\`** — local Docker reproducer mirroring the CI flow. Packaged so a contributor on macOS or Windows can spin up a \`rust:1-bookworm\` container and reproduce without an Ubuntu host. Useful when debugging a CI failure or bumping any pinned version locally.

3. **Simplify \`loadNapiModule\` in the test.** The old candidate list hardcoded darwin-{arm64,x64} + index.node, which silently fell through to the index.js fallback on Linux/Windows and forced an \`cp nexus-napi.node index.node\` workaround. Use \`require(packageDir)\` instead — the package's own \`index.js\` already resolves the platform-specific .node artifact uniformly, so the test works on every platform napi-rs targets without per-OS plumbing.

## What's already covered elsewhere (so no duplication)

| Layer | Existing CI |
|---|---|
| vault plugin dlopen + symbols | \`vault-plugin-build.yml\` (nexi-lab/nexus#4356) |
| plugin signature chain + load assertion | \`vault-signed-download.integration.test.ts\` (#866) |
| vault unit logic | services unit tests |
| Full CRUD through real gRPC | **this PR** |

## Verification

Ran \`scripts/dev/linux-e2e.sh\` in \`rust:1-bookworm\` against this branch:

\`\`\`
download:0  build:native:0  vitest:0
ALL GREEN
\`\`\`

Four scenarios pass:
- complete full CRUD lifecycle (607ms)
- restore a deleted secret with data intact (614ms)
- track version history through key rotation (666ms)
- batch-migrate and verify all secrets (1142ms)

## Test plan

- [ ] CI \`Vault Secrets gRPC E2E\` job passes on this PR
- [ ] Existing \`Vault Signed Download\` job still passes (no regression in adjacent smoke job)
- [ ] Existing \`Browser Port Isolation\` job still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)