### PR TITLE
fix(setup): start core services on appMode transition from null

### DIFF
--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -195,13 +195,36 @@ export function initEeclawBridge(): void {
   // Set app mode and update main process cache
   // 设置应用模式并更新主进程缓存
   ipcBridge.eeclaw.setAppMode.provider(async ({ mode }) => {
+    // 读"之前的 mode"用于判定是否需要补救式启动核心服务。
+    // 直接走 ProcessConfig.getSync 拿落盘值，避免新增 getter。
+    const previousMode = ProcessConfig.getSync('system.appMode') ?? null;
+
     await ProcessConfig.set('system.appMode', mode);
     setCachedAppMode(mode);
-    mainLog('eeclawBridge', `App mode set to: ${mode}`);
+    mainLog('eeclawBridge', `App mode set to: ${mode} (previous: ${previousMode ?? 'null'})`);
 
-    // For enterprise mode, initialize ChannelManager if not already done
-    // This handles hot-start from ModeSetup when user selects Enterprise mode
-    if (mode === 'e') {
+    // 补救启动：mode 从 null 转为 c/e，说明 initializeProcess 启动时 appMode 缺失，
+    // 走的是不启动核心服务的分支；通过 setAppMode 收敛触发 startup。
+    // ModeSetup 路径（handleConsumerNext: setAppMode → startConsumerServices）下
+    // 第二次 startup() 调用因 startupInProgress=true 直接 return，无重入风险
+    // （事实见 ServiceManager.startup() 入口守卫；两次调用间隔几十毫秒，远小于
+    // runtimeInstaller.ensureAll 启动耗时）。
+    if (previousMode === null) {
+      try {
+        const { serviceManager } = await import('@process/services/serviceManager');
+        void serviceManager.startup();
+        mainLog('eeclawBridge', 'Triggered serviceManager.startup() after appMode transition from null');
+      } catch (error) {
+        mainError('eeclawBridge', 'Failed to trigger startup after appMode transition:', error);
+      }
+    }
+
+    // mode 设定后启动 ChannelManager（消费者/企业模式都需要 —— 事实见
+    // process/index.ts 的注释 "Both Enterprise and Consumer modes: start local
+    // services + ChannelManager"）。ChannelManager.initialize() 自身有
+    // this.initialized 守卫，二次调用直接 return，与 startConsumerServices /
+    // initializeProcess 触发的调用安全共存。
+    if (mode === 'c' || mode === 'e') {
       try {
         const { getChannelManager } = await import('@/channels');
         getChannelManager()

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -18,7 +18,6 @@ import './i18n'; // Initialize i18n for main process
 import { syncElectronPath } from './services/claudeCli/CliInstallService';
 import { getChannelManager } from '@/channels';
 import { ExtensionRegistry } from '@/extensions';
-import { initStatusManager } from './services/initStatus';
 import { mainLog, mainError, perfLog } from './utils/mainLogger';
 import { initializeSudoworkLogUploader } from './utils/sudoworkLogUploader';
 import { refreshEnterpriseCache } from '@/common/enterpriseDebugConfig';
@@ -96,11 +95,16 @@ export const initializeProcess = async () => {
       mainError('Process', 'Failed to initialize ChannelManager', error);
     }
     perfLog('ChannelManager', Date.now() - channelStart);
-  } else {
-    // New user (no appMode set): skip services, show ModeSetup
-    // User selects C → startConsumerServices IPC + renderer reload (no app restart needed)
-    initStatusManager.setStatus('ready', '初始化完成', 100);
   }
+  // appMode=null（真新用户 / 老用户升级）：保持 initStatus 默认 phase='pending'，
+  // 不在此处声称 'ready'。让 InitLoading 真实反映"核心服务尚未启动"，
+  // 避免 main.tsx 在服务未就绪时进入主界面。
+  // 后续收敛路径：
+  //   - 真新用户：main.tsx 用 needsSetup 优先级显示 ModeSetup；用户选模式后
+  //     handleConsumerNext → setAppMode → eeclawBridge.setAppMode.provider 触发 startup。
+  //   - 老用户升级（sudowork_auth_v2 存在）：main.tsx 显示 InitLoading；
+  //     useAppMode fire-and-forget setAppMode('c') → 同上触发 startup。
+  //   - 两条路径都在 setAppMode.provider 收敛，确保核心服务一定被启动。
 
   perfLog('total_startup', Date.now() - totalStart);
   mainLog('Process', `Initialization complete in ${Date.now() - totalStart}ms`);

--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -49,15 +49,15 @@ const OS_NAME_MAP: Record<string, string> = { darwin: 'macos', win32: 'windows',
 /** Node.js process.arch → artifact arch token (note: arm64 → aarch64). */
 const ARCH_NAME_MAP: Record<string, string> = { arm64: 'aarch64', x64: 'x86_64' };
 
-/** Known-good SHA256 sums for v0.2.1 (mirrors SHA256SUMS.txt in the bucket;
+/** Known-good SHA256 sums for v0.2.2 (mirrors SHA256SUMS.txt in the bucket;
  *  keep in sync with scripts/download-nexus-vfs.js). */
 const NEXUS_VFS_SHA256SUMS: Record<string, string> = {
-  'nexusd-cluster-linux-aarch64.tar.gz': '83336737e360541796ce04fda243b1de0072afb54743dcf39c0ec7b7aec09e03',
-  'nexusd-cluster-linux-x86_64.tar.gz': '55f35a600d5c2ce3858ba66053ed6e2b8bfdb3ba4977e73639be927ccbd33174',
-  'nexusd-cluster-macos-aarch64.tar.gz': 'e7c1ab832445b23434e557cd10532f8da5de29028c9e3ee7508029165c35dfd1',
-  'nexusd-cluster-macos-x86_64.tar.gz': 'cca3f5df353e1bb7eee4b2d07e81932477edb86f91b77e83c50cfbef5be59d9c',
-  'nexusd-cluster-windows-aarch64.zip': 'cbc289132b781f2a52231cc223bb07fa1f575dad3b04a03646135c18a1e93b44',
-  'nexusd-cluster-windows-x86_64.zip': 'bfb785aa0b24f8966a631281454464dc1bb01c4956e002807c21553399e2e5e0',
+  'nexusd-cluster-linux-aarch64.tar.gz': 'fadc8c54c8cca44dc58dbd6194c203354ee282afe2ce9daec8a6056e4683e8c3',
+  'nexusd-cluster-linux-x86_64.tar.gz': 'b5a7730dadd2cbbf47727a3bb6e7989d8facf178fec75076061845867493b0d9',
+  'nexusd-cluster-macos-aarch64.tar.gz': '93eda20acfc5b64135781cc41aff2e4265b1046800967ed4ca85e2321c53175c',
+  'nexusd-cluster-macos-x86_64.tar.gz': 'd6464618413853320ac33103239880a36e564e36f41ff9456e1fa76db89269ec',
+  'nexusd-cluster-windows-aarch64.zip': 'be530516894f4115ad1971f5a6c6a0d4191ba8141f6b213da128381bb552e056',
+  'nexusd-cluster-windows-x86_64.zip': '03e589f7a288a62e0399d4c9dececbb16be342f258842dfb6c6b37b6c3919901',
 };
 
 export type NexusVfsStage = 'idle' | 'checking' | 'downloading' | 'installing' | 'starting' | 'ready' | 'error';


### PR DESCRIPTION
The previous else branch in initializeProcess called setStatus('ready') without
starting any core service, leaving the renderer free to enter the main view
while Nexus / secrets / auth-proxy / ChannelManager were never launched. This
broke the legacy-user upgrade path (appMode=null + sudowork_auth_v2 present),
where useAppMode auto-set appMode='c' but the main process never reacted.

- process/index.ts: drop the dishonest setStatus('ready'); keep phase='pending'
  so InitLoading honestly reflects "core services not yet started".
- bridge/eeclawBridge.ts: setAppMode.provider now triggers serviceManager.startup()
  when previousMode was null, and starts ChannelManager for both 'c' and 'e'
  (was 'e' only). Re-entry from startConsumerServices is safely blocked by
  startupInProgress and ChannelManager.initialized guards.

Also bumps nexus-vfs SHA256SUMS to v0.2.2 to match the upstream binary refresh.
