### PR TITLE
Keep SCode visible replies in user language

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -44,7 +44,7 @@ import { injectSkillsDirectoryHint, prepareFirstMessageWithSkillsIndex } from '.
 import { AcpSkillManager } from './AcpSkillManager';
 import { archiveTurnFiles, cleanupIntermediateFiles, cleanupTrackedDraftsOnCancel, type TrackedTurnFile } from './draftsCleanup';
 import { detectBashDraftRestoreCommand, FileIntentClassifier, type BashDraftRestoreDetection, type FileIntentSource, type FileOperationIntent } from './FileIntentClassifier';
-import { SCODE_COMPLETION_REMINDER, shouldRunCurrentTurnPostCleanup, shouldSkipAcpWorkspaceTrackingPath } from './acpWorkspaceTracking';
+import { buildAcpModelIdentityReminder, SCODE_COMPLETION_REMINDER, shouldRunCurrentTurnPostCleanup, shouldSkipAcpWorkspaceTrackingPath } from './acpWorkspaceTracking';
 import { mergeScodeProxyModelInfo, isModelVisionCapable, getScodeProxyModelInfoSync } from '@process/services/scode/scodeProxyModels';
 import { installWorkspaceSkillsFromTrackedFiles } from './workspaceSkillInstaller';
 import { appendGeneratedFilesMarker, extractExtension, mimeForExtension, type GeneratedFileEntry } from '@/common/generatedFiles';
@@ -1183,8 +1183,7 @@ This identity statement takes priority over the default identity in USER.md.
 
       // Inject model identity reminder for backends whose upstream identity text can be stale.
       if (activeModelNoticeId && (this.extra.backend === 'claude' || this.extra.backend === 'scode')) {
-        const staleIdentityHint = this.extra.backend === 'claude' ? 'The ANTHROPIC_MODEL environment variable and the earlier "You are powered by" text in the system prompt are stale (cached from session start) and no longer reflect the actual model.' : 'Your built-in assistant identity or branding text may still mention Claude or Anthropic even when the actual active model is different.';
-        const modelNotice = `<system-reminder>\n` + `Active model: ${activeModelNoticeId}. ` + `You are currently running as ${activeModelNoticeId}. ` + `${staleIdentityHint} ` + `When asked which model you are, answer ${activeModelNoticeId}.\n` + `</system-reminder>\n\n`;
+        const modelNotice = buildAcpModelIdentityReminder(this.extra.backend, activeModelNoticeId);
         processedContent = modelNotice + processedContent;
         this.pendingModelSwitchNotice = null;
       }

--- a/src/process/task/acpWorkspaceTracking.ts
+++ b/src/process/task/acpWorkspaceTracking.ts
@@ -5,10 +5,38 @@ export const ACP_WORKSPACE_TRACKING_SKIP_DIRS = new Set(['.codex', '.drafts', '.
 export const ACP_WORKSPACE_TRACKING_SKIP_FILES = new Set(['.gitignore', '.env', '.env.local', '.DS_Store', 'Thumbs.db']);
 
 export const SCODE_COMPLETION_REMINDER = `<system-reminder>
-任务完成时，请始终使用用户提问的语言发送一条普通助手消息，总结执行结果并列出生成或更新的文件。不要只以工具调用结束。
+语言约定：所有面向用户的自然语言回复（包括工具调用前后状态说明、阶段解释、中间总结、最终总结）必须使用用户最后一条消息的主要语言。
+
+中文用户时：除代码、命令、路径、专有名词、引用原文外，不得输出完整英文句子。工具调用状态、文件操作说明、任务进度等均须用中文表达。
+
+任务完成时：请用用户语言发送一条普通助手消息，总结执行结果并列出生成或更新的文件，不要只以工具调用结束。
 </system-reminder>
 
 `;
+
+export function buildAcpModelIdentityReminder(backend: string, activeModelNoticeId: string): string {
+  if (backend === 'scode') {
+    return (
+      `<system-reminder>\n` +
+      `当前活动模型：${activeModelNoticeId}。` +
+      `你当前正在以 ${activeModelNoticeId} 运行。` +
+      `你的内置助手身份或品牌文本可能仍会提到 Claude 或 Anthropic，即使实际活动模型不同。` +
+      `当用户询问你使用哪个模型时，请回答 ${activeModelNoticeId}。\n` +
+      `</system-reminder>\n\n`
+    );
+  }
+
+  const staleIdentityHint =
+    'The ANTHROPIC_MODEL environment variable and the earlier "You are powered by" text in the system prompt are stale (cached from session start) and no longer reflect the actual model.';
+  return (
+    `<system-reminder>\n` +
+    `Active model: ${activeModelNoticeId}. ` +
+    `You are currently running as ${activeModelNoticeId}. ` +
+    `${staleIdentityHint} ` +
+    `When asked which model you are, answer ${activeModelNoticeId}.\n` +
+    `</system-reminder>\n\n`
+  );
+}
 
 export function shouldRunCurrentTurnPostCleanup(pendingCurrentTurnPostCleanup: boolean): boolean {
   return pendingCurrentTurnPostCleanup;

--- a/tests/unit/acpWorkspaceTracking.test.ts
+++ b/tests/unit/acpWorkspaceTracking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { SCODE_COMPLETION_REMINDER, shouldRunCurrentTurnPostCleanup, shouldSkipAcpWorkspaceTrackingPath } from '@/process/task/acpWorkspaceTracking';
+import { buildAcpModelIdentityReminder, SCODE_COMPLETION_REMINDER, shouldRunCurrentTurnPostCleanup, shouldSkipAcpWorkspaceTrackingPath } from '@/process/task/acpWorkspaceTracking';
 
 describe('acpWorkspaceTracking', () => {
   test('skips sandbox runtime side effects', () => {
@@ -13,12 +13,57 @@ describe('acpWorkspaceTracking', () => {
   });
 
   test('scode completion reminder asks for the user language', () => {
-    expect(SCODE_COMPLETION_REMINDER).toContain('用户提问的语言');
+    expect(SCODE_COMPLETION_REMINDER).toContain('用户最后一条消息的主要语言');
     expect(SCODE_COMPLETION_REMINDER).toContain('不要只以工具调用结束');
+  });
+
+  test('scode completion reminder requires Chinese for tool call status', () => {
+    expect(SCODE_COMPLETION_REMINDER).toContain('工具调用前后状态说明');
+    expect(SCODE_COMPLETION_REMINDER).toContain('中文用户时');
+    expect(SCODE_COMPLETION_REMINDER).toContain('不得输出完整英文句子');
+  });
+
+  test('scode completion reminder allows exceptions for technical content', () => {
+    expect(SCODE_COMPLETION_REMINDER).toContain('代码');
+    expect(SCODE_COMPLETION_REMINDER).toContain('命令');
+    expect(SCODE_COMPLETION_REMINDER).toContain('路径');
+    expect(SCODE_COMPLETION_REMINDER).toContain('专有名词');
   });
 
   test('runs post-cleanup only when the current turn produced tracked files', () => {
     expect(shouldRunCurrentTurnPostCleanup(true)).toBe(true);
     expect(shouldRunCurrentTurnPostCleanup(false)).toBe(false);
+  });
+
+  describe('buildAcpModelIdentityReminder', () => {
+    test('scode backend uses Chinese text', () => {
+      const notice = buildAcpModelIdentityReminder('scode', 'gpt-4o');
+      expect(notice).toContain('当前活动模型');
+      expect(notice).toContain('gpt-4o');
+      expect(notice).toContain('当用户询问你使用哪个模型时');
+      expect(notice).toContain('请回答');
+      expect(notice).not.toContain('Active model:');
+      expect(notice).not.toContain('You are currently running as');
+      expect(notice).not.toContain('When asked which model you are');
+    });
+
+    test('claude backend uses English text', () => {
+      const notice = buildAcpModelIdentityReminder('claude', 'claude-opus-4-7');
+      expect(notice).toContain('Active model');
+      expect(notice).toContain('claude-opus-4-7');
+      expect(notice).toContain('When asked which model you are');
+    });
+
+    test('scode reminder includes model answer instruction in Chinese', () => {
+      const notice = buildAcpModelIdentityReminder('scode', 'deepseek-v3');
+      expect(notice).toContain('当用户询问');
+      expect(notice).toContain('请回答 deepseek-v3');
+    });
+
+    test('claude reminder includes stale identity hint', () => {
+      const notice = buildAcpModelIdentityReminder('claude', 'claude-sonnet-4-6');
+      expect(notice).toContain('ANTHROPIC_MODEL');
+      expect(notice).toContain('stale');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- strengthen the SCode completion reminder so all user-visible natural-language status text follows the user's last-message language
- use a Chinese SCode model-identity reminder to avoid English prompt priming while preserving the model-answer instruction
- add unit coverage for the language reminder and SCode/Claude model reminder behavior

## Test plan
- NODE_PATH=/Users/yobach/Downloads/sudowork/node_modules /Users/yobach/Downloads/sudowork/node_modules/.bin/vitest run tests/unit/acpWorkspaceTracking.test.ts