### PR TITLE
Fix SCode usage display after prompt timeout

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -75,6 +75,7 @@ import { extractTextFromMessage, processCronInMessage } from './MessageMiddlewar
 import { processAtFileReferences } from './acp/AcpAtFileProcessor';
 import { StreamTextBuffer, CronTextAccumulator, filterThinkTagsFromMessage, preprocessContentMessage } from './acp/AcpMessagePipeline';
 import { clearAcpSessionId, saveAcpSessionId, saveSessionMode, saveModelId, saveContextUsage } from './acp/AcpPersistence';
+import { extractLatestScodeAssistantUsageFromJsonl, findScodeSessionFile, normalizePromptUsageForMessage, SCODE_LATE_RECONCILIATION_DEFAULTS } from './acpUsageReconciliation';
 import { resolveImageConfig, callImagesGenerations, callImagesEdits, saveImageResult, resolveChatModel, callChatCompletionsWithImage, readSudorouterCredentials } from '../bridge/imageGenerationBridge';
 import { resolveWorkspaceSkillsDir } from '../utils/workspaceSkillsDir';
 import { readAssistantResource, ruleFilePattern } from '@process/utils/assistantResources';
@@ -124,22 +125,6 @@ interface InitializeResult {
 function normalizeToolCallStatus(status: string | undefined): 'pending' | 'in_progress' | 'completed' | 'failed' {
   if (!status) return 'pending';
   return status as 'pending' | 'in_progress' | 'completed' | 'failed';
-}
-
-function normalizePromptUsageForMessage(usage: AcpPromptResponseUsage): TurnTokenUsage | null {
-  if (typeof usage.totalTokens !== 'number') return null;
-  return {
-    totalTokens: usage.totalTokens,
-    ...(typeof usage.inputTokens === 'number' && { inputTokens: usage.inputTokens }),
-    ...(typeof usage.outputTokens === 'number' && { outputTokens: usage.outputTokens }),
-    ...(usage.cachedReadTokens !== undefined && { cachedReadTokens: usage.cachedReadTokens }),
-    ...(usage.cachedWriteTokens !== undefined && { cachedWriteTokens: usage.cachedWriteTokens }),
-    ...(usage.thoughtTokens !== undefined && { thoughtTokens: usage.thoughtTokens }),
-    ...(usage.contextWindowTokens !== undefined && { contextWindowTokens: usage.contextWindowTokens }),
-    ...(usage.estimatedSessionTokens !== undefined && { estimatedSessionTokens: usage.estimatedSessionTokens }),
-    ...(usage.costUnits !== undefined && { costUnits: usage.costUnits }),
-    ...(usage.costCurrency !== undefined && { costCurrency: usage.costCurrency }),
-  };
 }
 
 export interface AcpAgentData {
@@ -192,6 +177,8 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
   private pendingModelSwitchNotice: string | null = null;
   private hasReceivedUsageUpdate = false;
   private lastAssistantTextMsgId: string | null = null;
+  /** Pending token usage to apply when assistant text message arrives */
+  private pendingTokenUsage: TurnTokenUsage | null = null;
   private turnHadVisibleAssistantContent = false;
   private turnEventSequence = 0;
   private lastVisibleAssistantContentSequence = 0;
@@ -706,6 +693,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
     this.stopPromise = null;
     this.hasReceivedUsageUpdate = false;
     this.lastAssistantTextMsgId = null;
+    this.pendingTokenUsage = null;
     this.turnHadVisibleAssistantContent = false;
     this.turnEventSequence = 0;
     this.lastVisibleAssistantContentSequence = 0;
@@ -1016,8 +1004,11 @@ This identity statement takes priority over the default identity in USER.md.
         // Handle sendToConnection error result (not thrown)
         if (!result.success) {
           const acpError = (result as { success: false; error: AcpError }).error;
+          // Telemetry: end turn tracking (error)
+          endTurnError(this.conversation_id, acpError.type?.toString() || 'UNKNOWN');
+          // Telemetry: end conversation tracking (error)
           endConversationError(this.conversation_id);
-          conversationBreadcrumbs.error(this.conversation_id, acpError.type.toString() || 'unknown', acpError.message);
+          conversationBreadcrumbs.error(this.conversation_id, acpError.type?.toString() || 'unknown', acpError.message);
         }
         return result;
       }
@@ -1027,8 +1018,11 @@ This identity statement takes priority over the default identity in USER.md.
       // Handle sendToConnection error result (not thrown)
       if (!result.success) {
         const acpError = (result as { success: false; error: AcpError }).error;
+        // Telemetry: end turn tracking (error)
+        endTurnError(this.conversation_id, acpError.type?.toString() || 'UNKNOWN');
+        // Telemetry: end conversation tracking (error)
         endConversationError(this.conversation_id);
-        conversationBreadcrumbs.error(this.conversation_id, acpError.type.toString() || 'unknown', acpError.message);
+        conversationBreadcrumbs.error(this.conversation_id, acpError.type?.toString() || 'unknown', acpError.message);
       }
       return result;
     } catch (e) {
@@ -1046,21 +1040,33 @@ This identity statement takes priority over the default identity in USER.md.
       let errorCode: string | undefined;
       if (errorMsg.includes('timeout') || errorMsg.includes('Timeout') || errorMsg.includes('timed out')) {
         errorCode = 'E002';
+        // Telemetry: end turn tracking (error)
+        endTurnError(this.conversation_id, 'E002');
         endConversationError(this.conversation_id, 'E002');
       } else if (errorMsg.includes('authentication') || errorMsg.includes('认证失败')) {
         errorCode = 'E006';
+        // Telemetry: end turn tracking (error)
+        endTurnError(this.conversation_id, 'E006');
         endConversationError(this.conversation_id, 'E006');
       } else if (errorMsg.includes('interrupted') || errorMsg.includes('SSE') || errorMsg.includes('stream')) {
         errorCode = 'E003';
+        // Telemetry: end turn tracking (error)
+        endTurnError(this.conversation_id, 'E003');
         endConversationError(this.conversation_id, 'E003');
       } else if (errorMsg.includes('parse') || errorMsg.includes('JSON') || errorMsg.includes('invalid response')) {
         errorCode = 'E005';
+        // Telemetry: end turn tracking (error)
+        endTurnError(this.conversation_id, 'E005');
         endConversationError(this.conversation_id, 'E005');
       } else if (errorMsg.includes('connection') || errorMsg.includes('Connection')) {
         errorCode = 'E001';
+        // Telemetry: end turn tracking (error)
+        endTurnError(this.conversation_id, 'E001');
         endConversationError(this.conversation_id, 'E001');
       } else {
         errorCode = 'E009';
+        // Telemetry: end turn tracking (error)
+        endTurnError(this.conversation_id, 'E009');
         endConversationError(this.conversation_id, 'E009');
       }
 
@@ -1241,6 +1247,10 @@ This identity statement takes priority over the default identity in USER.md.
       } else if (errorMsg.includes('timeout') || errorMsg.includes('Timeout') || errorMsg.includes('timed out')) {
         errorType = AcpErrorType.TIMEOUT;
         retryable = true;
+        // For scode backend, attempt late reconciliation after timeout
+        if (this.options.backend === 'scode') {
+          void this.attemptScodeLateReconciliation();
+        }
       } else if (errorMsg.includes('permission') || errorMsg.includes('Permission')) {
         errorType = AcpErrorType.PERMISSION_DENIED;
       } else if (errorMsg.includes('connection') || errorMsg.includes('Connection')) {
@@ -1359,6 +1369,106 @@ This identity statement takes priority over the default identity in USER.md.
     } catch (err) {
       mainWarn('[AcpAgent]', `Failed to clear context overflow recovery state: ${err instanceof Error ? err.message : String(err)}`);
     }
+  }
+
+  private async sleepForLateReconciliation(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private getLatestAssistantTextMsgIdFromDb(): string | null {
+    try {
+      const db = getDatabase();
+      const result = db.getConversationMessages(this.conversation_id, 0, 100, 'DESC');
+      for (const msg of result.data) {
+        if (msg.type === 'text' && msg.position === 'left') {
+          return msg.msg_id || msg.id;
+        }
+      }
+    } catch (err) {
+      mainWarn('[AcpAgent]', `[LATE-RECONCILE] Failed to read latest assistant message: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return null;
+  }
+
+  private patchAssistantTokenUsage(msgId: string, tokenUsage: TurnTokenUsage, options: { flush?: boolean } = {}): void {
+    if (options.flush) {
+      this.streamTextBuffer.flushAll();
+    }
+
+    const usagePatch: IResponseMessage = {
+      type: 'content',
+      conversation_id: this.conversation_id,
+      msg_id: msgId,
+      data: {
+        content: '',
+        tokenUsage,
+      },
+    };
+    const tMessage = transformMessage(usagePatch);
+    if (tMessage) {
+      addOrUpdateMessage(this.conversation_id, tMessage, this.options.backend);
+    }
+    ipcBridge.acpConversation.responseStream.emit(usagePatch);
+  }
+
+  /**
+   * SCode can continue running after Sudowork's prompt call times out. In that
+   * case the final usage lands in the SCode session JSONL later, so poll for a
+   * bounded window and patch only tokenUsage onto the latest assistant message.
+   */
+  private async attemptScodeLateReconciliation(): Promise<void> {
+    if (this.options.backend !== 'scode' || !this.workspace || !this.extra.acpSessionId) {
+      return;
+    }
+
+    const sessionId = this.extra.acpSessionId;
+    const { attempts, intervalMs } = SCODE_LATE_RECONCILIATION_DEFAULTS;
+    let sessionFile: string | null = null;
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        sessionFile = sessionFile ?? (await findScodeSessionFile(this.workspace, sessionId));
+        if (!sessionFile) {
+          mainLog('[AcpAgent]', `[LATE-RECONCILE] SCode session file not found for ${sessionId}, attempt ${attempt}/${attempts}`);
+        } else {
+          const content = await fs.promises.readFile(sessionFile, 'utf-8');
+          const usageEntry = extractLatestScodeAssistantUsageFromJsonl(content);
+          if (usageEntry) {
+            const patchMsgId = this.lastAssistantTextMsgId || this.getLatestAssistantTextMsgIdFromDb();
+            if (!patchMsgId) {
+              mainLog('[AcpAgent]', `[LATE-RECONCILE] Usage found for ${sessionId}, but no assistant message is available to patch`);
+              return;
+            }
+
+            mainLog('[AcpAgent]', `[LATE-RECONCILE] Applying SCode usage from ${sessionFile} to msg_id=${patchMsgId}`);
+            this.patchAssistantTokenUsage(patchMsgId, usageEntry.usage);
+            updateTurnTokens(this.conversation_id, {
+              totalTokens: usageEntry.usage.totalTokens,
+              inputTokens: usageEntry.usage.inputTokens ?? 0,
+              outputTokens: usageEntry.usage.outputTokens ?? 0,
+              cachedReadTokens: usageEntry.usage.cachedReadTokens,
+              cachedWriteTokens: usageEntry.usage.cachedWriteTokens,
+              thoughtTokens: usageEntry.usage.thoughtTokens,
+              contextWindowTokens: usageEntry.usage.contextWindowTokens,
+              estimatedSessionTokens: usageEntry.usage.estimatedSessionTokens,
+              costUnits: usageEntry.usage.costUnits,
+              costCurrency: usageEntry.usage.costCurrency,
+            });
+            return;
+          }
+
+          mainLog('[AcpAgent]', `[LATE-RECONCILE] No assistant usage yet in ${sessionFile}, attempt ${attempt}/${attempts}`);
+        }
+      } catch (err) {
+        mainWarn('[AcpAgent]', `[LATE-RECONCILE] Attempt ${attempt}/${attempts} failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      if (attempt < attempts) {
+        await this.sleepForLateReconciliation(intervalMs);
+      }
+    }
+
+    mainLog('[AcpAgent]', `[LATE-RECONCILE] No SCode usage reconciled for ${sessionId} after ${attempts} attempts`);
   }
 
   async confirm(id: string, callId: string, data: AcpPermissionOption) {
@@ -2899,22 +3009,15 @@ This identity statement takes priority over the default identity in USER.md.
     updateTurnTokens(this.conversation_id, usage);
 
     const tokenUsage = normalizePromptUsageForMessage(usage);
-    if (tokenUsage && this.lastAssistantTextMsgId) {
-      this.streamTextBuffer.flushAll();
-      const usagePatch: IResponseMessage = {
-        type: 'content',
-        conversation_id: this.conversation_id,
-        msg_id: this.lastAssistantTextMsgId,
-        data: {
-          content: '',
-          tokenUsage,
-        },
-      };
-      const tMessage = transformMessage(usagePatch);
-      if (tMessage) {
-        addOrUpdateMessage(this.conversation_id, tMessage, this.options.backend);
+    if (tokenUsage) {
+      if (this.lastAssistantTextMsgId) {
+        // Assistant text already arrived - patch usage directly
+        this.patchAssistantTokenUsage(this.lastAssistantTextMsgId, tokenUsage, { flush: true });
+      } else {
+        // Usage arrived before assistant text - store as pending
+        this.pendingTokenUsage = tokenUsage;
+        mainLog('[AcpAgent]', `[PENDING-USAGE] Stored pending usage: total=${tokenUsage.totalTokens}`);
       }
-      ipcBridge.acpConversation.responseStream.emit(usagePatch);
     }
 
     if (this.hasReceivedUsageUpdate) return;
@@ -3407,6 +3510,13 @@ This identity statement takes priority over the default identity in USER.md.
       case 'text':
         if (message.position === 'left') {
           this.lastAssistantTextMsgId = message.msg_id || message.id;
+          // Apply pending token usage if it arrived before the assistant text
+          if (this.pendingTokenUsage) {
+            const pendingUsage = this.pendingTokenUsage;
+            this.pendingTokenUsage = null;
+            mainLog('[AcpAgent]', `[PENDING-USAGE] Applying pending usage to msg_id=${this.lastAssistantTextMsgId}: total=${pendingUsage.totalTokens}`);
+            this.patchAssistantTokenUsage(this.lastAssistantTextMsgId, pendingUsage);
+          }
         }
         responseMessage.type = 'content';
         responseMessage.data = message.content.content;

--- a/src/process/task/acpUsageReconciliation.ts
+++ b/src/process/task/acpUsageReconciliation.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TurnTokenUsage } from '@/common/chatLib';
+import type { AcpPromptResponseUsage } from '@/types/acpTypes';
+import type { Dirent } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as nodePath from 'node:path';
+
+type JsonRecord = Record<string, unknown>;
+
+const SCODE_SESSION_POLL_ATTEMPTS = 24;
+const SCODE_SESSION_POLL_INTERVAL_MS = 15_000;
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readRecord(value: unknown): JsonRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as JsonRecord) : undefined;
+}
+
+function readNestedRecord(value: unknown, key: string): JsonRecord | undefined {
+  return readRecord(readRecord(value)?.[key]);
+}
+
+function pickNumber(record: JsonRecord | undefined, ...keys: string[]): number | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = numberOrUndefined(record[key]);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function pickString(record: JsonRecord | undefined, ...keys: string[]): string | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = stringOrUndefined(record[key]);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+export function normalizePromptUsageForMessage(usage: Partial<AcpPromptResponseUsage>): TurnTokenUsage | null {
+  if (typeof usage.totalTokens !== 'number') return null;
+  return {
+    totalTokens: usage.totalTokens,
+    ...(typeof usage.inputTokens === 'number' && { inputTokens: usage.inputTokens }),
+    ...(typeof usage.outputTokens === 'number' && { outputTokens: usage.outputTokens }),
+    ...(usage.cachedReadTokens !== undefined && { cachedReadTokens: usage.cachedReadTokens }),
+    ...(usage.cachedWriteTokens !== undefined && { cachedWriteTokens: usage.cachedWriteTokens }),
+    ...(usage.thoughtTokens !== undefined && { thoughtTokens: usage.thoughtTokens }),
+    ...(usage.contextWindowTokens !== undefined && { contextWindowTokens: usage.contextWindowTokens }),
+    ...(usage.estimatedSessionTokens !== undefined && { estimatedSessionTokens: usage.estimatedSessionTokens }),
+    ...(usage.costUnits !== undefined && { costUnits: usage.costUnits }),
+    ...(usage.costCurrency !== undefined && { costCurrency: usage.costCurrency }),
+  };
+}
+
+export function normalizeScodeUsageForMessage(rawUsage: unknown, rawMeta?: unknown): TurnTokenUsage | null {
+  const usage = readRecord(rawUsage);
+  if (!usage) return null;
+
+  const meta = readRecord(rawMeta);
+  const sudocodeMeta = readNestedRecord(meta, 'sudocode');
+  const inputTokens = pickNumber(usage, 'inputTokens', 'input_tokens');
+  const outputTokens = pickNumber(usage, 'outputTokens', 'output_tokens');
+  let totalTokens = pickNumber(usage, 'totalTokens', 'total_tokens');
+  if (totalTokens === undefined && inputTokens !== undefined && outputTokens !== undefined) {
+    totalTokens = inputTokens + outputTokens;
+  }
+  if (totalTokens === undefined) return null;
+
+  const cachedReadTokens = pickNumber(usage, 'cachedReadTokens', 'cache_read_input_tokens', 'cached_read_tokens');
+  const cachedWriteTokens = pickNumber(usage, 'cachedWriteTokens', 'cache_creation_input_tokens', 'cached_write_tokens');
+  const thoughtTokens = pickNumber(usage, 'thoughtTokens', 'thought_tokens');
+  const contextWindowTokens = pickNumber(sudocodeMeta, 'contextWindowTokens') ?? pickNumber(usage, 'contextWindowTokens', 'context_window_tokens');
+  const estimatedSessionTokens = pickNumber(sudocodeMeta, 'estimatedSessionTokens') ?? pickNumber(usage, 'estimatedSessionTokens', 'estimated_session_tokens');
+  const costUnits = pickNumber(sudocodeMeta, 'costUnits') ?? pickNumber(usage, 'costUnits', 'cost_units');
+  const costCurrency = pickString(sudocodeMeta, 'costCurrency') ?? pickString(usage, 'costCurrency', 'cost_currency');
+
+  return {
+    totalTokens,
+    ...(inputTokens !== undefined && { inputTokens }),
+    ...(outputTokens !== undefined && { outputTokens }),
+    ...(cachedReadTokens !== undefined && { cachedReadTokens }),
+    ...(cachedWriteTokens !== undefined && { cachedWriteTokens }),
+    ...(thoughtTokens !== undefined && { thoughtTokens }),
+    ...(contextWindowTokens !== undefined && { contextWindowTokens }),
+    ...(estimatedSessionTokens !== undefined && { estimatedSessionTokens }),
+    ...(costUnits !== undefined && { costUnits }),
+    ...(costCurrency !== undefined && { costCurrency }),
+  };
+}
+
+export interface ScodeUsageEntry {
+  messageId: string | null;
+  usage: TurnTokenUsage;
+}
+
+export function extractLatestScodeAssistantUsageFromJsonl(content: string): ScodeUsageEntry | null {
+  const lines = content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const entry = JSON.parse(lines[i]) as JsonRecord;
+      const message = readRecord(entry.message) ?? entry;
+      if (message.role !== 'assistant') continue;
+
+      const usage = normalizeScodeUsageForMessage(message.usage, message._meta ?? entry._meta);
+      if (!usage) continue;
+
+      const messageId = stringOrUndefined(message.id) ?? stringOrUndefined(message.msg_id) ?? stringOrUndefined(entry.id) ?? stringOrUndefined(entry.msg_id) ?? null;
+      return { messageId, usage };
+    } catch {
+      // Ignore malformed or partially written JSONL lines.
+    }
+  }
+
+  return null;
+}
+
+export async function findScodeSessionFile(workspace: string, sessionId: string): Promise<string | null> {
+  const sessionsRoot = nodePath.join(workspace, '.scode', 'sessions');
+  const directCandidates = [nodePath.join(sessionsRoot, sessionId, 'session.jsonl'), nodePath.join(sessionsRoot, `${sessionId}.jsonl`)];
+
+  for (const candidate of directCandidates) {
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  let entries;
+  try {
+    entries = await fs.readdir(sessionsRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const stack = entries.map((entry) => nodePath.join(sessionsRoot, entry.name));
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let stat;
+    try {
+      stat = await fs.stat(current);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      const children = await fs.readdir(current, { withFileTypes: true }).catch((): Dirent[] => []);
+      for (const child of children) stack.push(nodePath.join(current, child.name));
+      continue;
+    }
+
+    if (stat.isFile() && nodePath.basename(current) === `${sessionId}.jsonl`) {
+      return current;
+    }
+  }
+
+  return null;
+}
+
+export const SCODE_LATE_RECONCILIATION_DEFAULTS = {
+  attempts: SCODE_SESSION_POLL_ATTEMPTS,
+  intervalMs: SCODE_SESSION_POLL_INTERVAL_MS,
+};

--- a/tests/unit/acpUsageHandling.test.ts
+++ b/tests/unit/acpUsageHandling.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { extractLatestScodeAssistantUsageFromJsonl, findScodeSessionFile, normalizePromptUsageForMessage, normalizeScodeUsageForMessage } from '@/process/task/acpUsageReconciliation';
+
+describe('normalizePromptUsageForMessage', () => {
+  it('keeps PromptResponse usage fields for message token usage', () => {
+    expect(
+      normalizePromptUsageForMessage({
+        totalTokens: 200,
+        inputTokens: 150,
+        outputTokens: 50,
+        cachedReadTokens: 30,
+        cachedWriteTokens: 10,
+        thoughtTokens: 20,
+        contextWindowTokens: 100000,
+        estimatedSessionTokens: 5000,
+        costUnits: 43700,
+        costCurrency: 'sudo_point',
+      })
+    ).toEqual({
+      totalTokens: 200,
+      inputTokens: 150,
+      outputTokens: 50,
+      cachedReadTokens: 30,
+      cachedWriteTokens: 10,
+      thoughtTokens: 20,
+      contextWindowTokens: 100000,
+      estimatedSessionTokens: 5000,
+      costUnits: 43700,
+      costCurrency: 'sudo_point',
+    });
+  });
+
+  it('rejects PromptResponse usage without totalTokens', () => {
+    expect(normalizePromptUsageForMessage({ inputTokens: 100, outputTokens: 50 })).toBeNull();
+  });
+});
+
+describe('normalizeScodeUsageForMessage', () => {
+  it('derives total tokens from SCode snake_case input and output fields', () => {
+    expect(
+      normalizeScodeUsageForMessage({
+        input_tokens: 1370,
+        output_tokens: 697,
+        cache_read_input_tokens: 39885,
+        cache_creation_input_tokens: 12,
+        cost_units: 158609,
+        cost_currency: 'sudo_point',
+      })
+    ).toEqual({
+      totalTokens: 2067,
+      inputTokens: 1370,
+      outputTokens: 697,
+      cachedReadTokens: 39885,
+      cachedWriteTokens: 12,
+      costUnits: 158609,
+      costCurrency: 'sudo_point',
+    });
+  });
+
+  it('prefers Sudocode meta cost fields over usage cost fields', () => {
+    expect(
+      normalizeScodeUsageForMessage(
+        {
+          total_tokens: 100,
+          cost_units: 1,
+          cost_currency: 'usd',
+        },
+        {
+          sudocode: {
+            costUnits: 43700,
+            costCurrency: 'sudo_point',
+            contextWindowTokens: 200000,
+            estimatedSessionTokens: 3210,
+          },
+        }
+      )
+    ).toEqual({
+      totalTokens: 100,
+      contextWindowTokens: 200000,
+      estimatedSessionTokens: 3210,
+      costUnits: 43700,
+      costCurrency: 'sudo_point',
+    });
+  });
+
+  it('returns null when no total can be derived', () => {
+    expect(normalizeScodeUsageForMessage({ input_tokens: 10 })).toBeNull();
+  });
+});
+
+describe('extractLatestScodeAssistantUsageFromJsonl', () => {
+  it('extracts usage from the latest real SCode message-shaped assistant entry', () => {
+    const jsonl = [
+      JSON.stringify({
+        message: {
+          role: 'assistant',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cost_units: 100,
+            cost_currency: 'sudo_point',
+          },
+        },
+        type: 'message',
+      }),
+      'not json',
+      JSON.stringify({
+        message: {
+          blocks: [{ text: 'done', type: 'text' }],
+          role: 'assistant',
+          usage: {
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 39885,
+            cost_currency: 'sudo_point',
+            cost_units: 158609,
+            input_tokens: 1370,
+            output_tokens: 697,
+          },
+        },
+        type: 'message',
+      }),
+    ].join('\n');
+
+    expect(extractLatestScodeAssistantUsageFromJsonl(jsonl)).toEqual({
+      messageId: null,
+      usage: {
+        totalTokens: 2067,
+        inputTokens: 1370,
+        outputTokens: 697,
+        cachedReadTokens: 39885,
+        cachedWriteTokens: 0,
+        costUnits: 158609,
+        costCurrency: 'sudo_point',
+      },
+    });
+  });
+
+  it('ignores compaction and tool entries without assistant message usage', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'compaction', usage: { input_tokens: 1, output_tokens: 1 } }),
+      JSON.stringify({ message: { role: 'tool' }, type: 'message' }),
+    ].join('\n');
+
+    expect(extractLatestScodeAssistantUsageFromJsonl(jsonl)).toBeNull();
+  });
+});
+
+describe('findScodeSessionFile', () => {
+  it('finds nested SCode session files named after the ACP session id', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'scode-session-'));
+    const sessionId = 'session-1781507199209-0';
+    const sessionDir = path.join(root, '.scode', 'sessions', 'f4975f5977d43141');
+    await mkdir(sessionDir, { recursive: true });
+    const sessionFile = path.join(sessionDir, `${sessionId}.jsonl`);
+    await writeFile(sessionFile, '{}\n');
+
+    await expect(findScodeSessionFile(root, sessionId)).resolves.toBe(sessionFile);
+  });
+});


### PR DESCRIPTION
## Summary
- close telemetry turns on ACP send errors so timeout/error turns do not leak
- keep prompt usage pending until an assistant text message is available, then patch `content.tokenUsage` onto that message
- add bounded SCode late reconciliation for timeout cases, reading the real `.scode/sessions/**/<sessionId>.jsonl` layout and `message.usage` JSONL shape
- normalize SCode snake_case usage fields including `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cost_units`, and `cost_currency`

## Tests
- `NODE_PATH=/Users/yobach/Downloads/sudowork/node_modules /Users/yobach/Downloads/sudowork/node_modules/.bin/vitest run tests/unit/acpUsageHandling.test.ts tests/unit/acpWorkspaceTracking.test.ts`
- `NODE_PATH=/Users/yobach/Downloads/sudowork/node_modules /Users/yobach/Downloads/sudowork/node_modules/.bin/vitest run tests/unit/acp*.test.ts`
- `NODE_PATH=/Users/yobach/Downloads/sudowork/node_modules /Users/yobach/Downloads/sudowork/node_modules/.bin/tsc --noEmit --pretty false`