### PR TITLE
fix(nexus-vfs): pass data dir to vault plugin

### DIFF
--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -394,12 +394,28 @@ class DynamicNexusVfsService {
       }
     }
 
-    fs.mkdirSync(this.getDaemonDataDir(), { recursive: true });
+    const daemonDataDir = this.getDaemonDataDir();
+    fs.mkdirSync(daemonDataDir, { recursive: true });
+
+    // Use install root (~/.nexus-vfs) as cwd for the spawned process.
+    // This ensures the process starts in a writable directory regardless of
+    // the current working directory of the main process.
+    const spawnCwd = this.getInstallRoot();
+    if (!fs.existsSync(spawnCwd)) {
+      fs.mkdirSync(spawnCwd, { recursive: true });
+    }
 
     const spawnStart = Date.now();
     this.emit('starting', `Starting nexus-vfs on ${NEXUS_VFS_BIND_HOST}:${this._port}`);
-    mainLog('NexusVfs', `Spawning: ${launchCommand.command} ${launchCommand.args.join(' ')}`);
-    this.process = spawn(launchCommand.command, launchCommand.args, { stdio: 'pipe' });
+    mainLog('NexusVfs', `Spawning: ${launchCommand.command} ${launchCommand.args.join(' ')} cwd=${spawnCwd}`);
+    // Pass NEXUS_DATA_DIR to the vault plugin which depends on it internally.
+    // Without this, the plugin falls back to relative ./nexus-data which may fail
+    // in packaged app where cwd could be read-only.
+    this.process = spawn(launchCommand.command, launchCommand.args, {
+      stdio: 'pipe',
+      cwd: spawnCwd,
+      env: { ...process.env, NEXUS_DATA_DIR: daemonDataDir },
+    });
     processSupervisor.track(this.process);
 
     this.process.stdout?.on('data', (d: Buffer) => {

--- a/tests/unit/DynamicNexusVfsService.test.ts
+++ b/tests/unit/DynamicNexusVfsService.test.ts
@@ -1,0 +1,145 @@
+import { spawn } from 'child_process';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn((value: unknown) => String(value).includes('nexusd-cluster')),
+  mkdirSync: vi.fn(),
+}));
+
+// Mock electron app
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'home') return '/mock-home';
+      return '/mock-app';
+    },
+    isPackaged: false,
+    getAppPath: () => '/mock-app',
+  },
+}));
+
+// Mock fs binary checks and directory creation
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: fsMocks.existsSync,
+    mkdirSync: fsMocks.mkdirSync,
+  };
+});
+
+// Mock child_process spawn
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  exec: vi.fn(() => Promise.resolve({ stdout: '', stderr: '' })),
+}));
+
+// Mock processSupervisor
+vi.mock('@process/ProcessSupervisor', () => ({
+  processSupervisor: {
+    track: vi.fn(),
+  },
+}));
+
+// Mock archiveProgress
+vi.mock('@process/services/archiveProgress', () => ({
+  extractTarGzWithProgress: vi.fn(),
+  extractZipWithProgress: vi.fn(),
+}));
+
+// Mock VaultPluginInstaller
+vi.mock('@process/services/nexus-vfs/VaultPluginInstaller', () => ({
+  vaultPluginInstaller: {
+    isPlatformSupported: () => false,
+    checkInstalledSync: () => false,
+    install: vi.fn(),
+  },
+}));
+
+// Mock logger
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+
+describe('DynamicNexusVfsService', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    originalEnv = { ...process.env };
+    vi.clearAllMocks();
+
+    // Create a mock process for spawn
+    const mockProcess = {
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      pid: 12345,
+    };
+    (spawn as Mock).mockReturnValue(mockProcess);
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe('start()', () => {
+    it('passes NEXUS_DATA_DIR environment variable to spawned process', async () => {
+      const { dynamicNexusVfsService } = await import('../../src/process/services/nexus-vfs/DynamicNexusVfsService');
+
+      // Mock internal methods to avoid real port checks
+      vi.spyOn(dynamicNexusVfsService as any, 'checkInstalledSync').mockReturnValue(true);
+      vi.spyOn(dynamicNexusVfsService as any, 'isPortInUse').mockResolvedValue(false);
+      vi.spyOn(dynamicNexusVfsService as any, 'waitForPortReady').mockResolvedValue(undefined);
+
+      await dynamicNexusVfsService.start();
+
+      expect(spawn).toHaveBeenCalled();
+      const spawnCall = (spawn as Mock).mock.calls[0];
+      const spawnOptions = spawnCall[2];
+
+      expect(spawnOptions).toBeDefined();
+      expect(spawnOptions.env).toBeDefined();
+      expect(spawnOptions.env.NEXUS_DATA_DIR).toBe('/mock-home/.nexus-vfs/data');
+    });
+
+    it('sets cwd to install root (~/.nexus-vfs) for stable working directory', async () => {
+      const { dynamicNexusVfsService } = await import('../../src/process/services/nexus-vfs/DynamicNexusVfsService');
+
+      vi.spyOn(dynamicNexusVfsService as any, 'checkInstalledSync').mockReturnValue(true);
+      vi.spyOn(dynamicNexusVfsService as any, 'isPortInUse').mockResolvedValue(false);
+      vi.spyOn(dynamicNexusVfsService as any, 'waitForPortReady').mockResolvedValue(undefined);
+
+      await dynamicNexusVfsService.start();
+
+      const spawnCall = (spawn as Mock).mock.calls[0];
+      const spawnOptions = spawnCall[2];
+
+      expect(spawnOptions.cwd).toBe('/mock-home/.nexus-vfs');
+    });
+
+    it('inherits process.env in spawn options', async () => {
+      const { dynamicNexusVfsService } = await import('../../src/process/services/nexus-vfs/DynamicNexusVfsService');
+
+      vi.spyOn(dynamicNexusVfsService as any, 'checkInstalledSync').mockReturnValue(true);
+      vi.spyOn(dynamicNexusVfsService as any, 'isPortInUse').mockResolvedValue(false);
+      vi.spyOn(dynamicNexusVfsService as any, 'waitForPortReady').mockResolvedValue(undefined);
+
+      // Set a test env var
+      process.env.TEST_VAR = 'test-value';
+
+      await dynamicNexusVfsService.start();
+
+      const spawnCall = (spawn as Mock).mock.calls[0];
+      const spawnOptions = spawnCall[2];
+
+      expect(spawnOptions.env.TEST_VAR).toBe('test-value');
+    });
+  });
+});


### PR DESCRIPTION
## Root cause

Packaged app startup passes `--data-dir` to `nexusd-cluster`, but the vault plugin reads `NEXUS_DATA_DIR` internally. When that env var is missing, the plugin falls back to relative `./nexus-data`. Dev startup hides this because the project cwd is writable; packaged startup can use a read-only or unstable cwd, causing `create vault data dir: ReadOnlyFilesystem`.

## Fix

- Reuse the resolved daemon data dir for both `--data-dir` and `NEXUS_DATA_DIR`.
- Spawn `nexusd-cluster` with a stable writable cwd under `~/.nexus-vfs`.
- Add unit coverage for spawn cwd, `NEXUS_DATA_DIR`, and env inheritance.

## Verification

- `bun run test tests/unit/DynamicNexusVfsService.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint tests/unit/DynamicNexusVfsService.test.ts`

Note: full lint on `DynamicNexusVfsService.ts` still reports pre-existing empty catch blocks unrelated to this change.