### PR TITLE
fix(cron): enforce client_cron_enabled consistently across UI, skill, and execution

### DIFF
--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -504,6 +504,17 @@ const resolveBuiltinResourceDir = (dirPath: string): string => {
 };
 
 /**
+ * Absolute path of a bundled builtin skill's directory in the app resources
+ * (e.g. `skills/_builtin/cron`). This is the install SOURCE — stable across
+ * personal/enterprise mode, unlike getBuiltinSkillsDir() which points at the
+ * user's synced `_system`/`system` dir and differs by mode. Use this when code
+ * must read a builtin skill file directly (not just point an agent at a path).
+ */
+export const getBundledBuiltinSkillDir = (skillName: string): string => {
+  return path.join(resolveBuiltinResourceDir('skills'), SKILL_SUBDIRS.legacyBuiltin, skillName);
+};
+
+/**
  * 将内置 skills 从 bundle 同步到用户目录的 `_system/`（每次启动都强制 overwrite）。
  * Sync bundled builtin skills into the user's `_system/` directory on every startup.
  *
@@ -533,12 +544,7 @@ const resolveBuiltinResourceDir = (dirPath: string): string => {
  * ignore the sibling path entirely.
  */
 const resolveAiDevBrowserPackageDir = (): string | null => {
-  const candidates = app.isPackaged
-    ? [path.join(app.getAppPath().replace('app.asar', 'app.asar.unpacked'), 'vendor/ai-dev-browser/ai_dev_browser'), path.join(process.resourcesPath, 'ai-dev-browser/ai_dev_browser')]
-    : [
-        path.join(app.getAppPath(), 'vendor/ai-dev-browser/ai_dev_browser'),
-        path.join(app.getAppPath(), '..', 'ai-dev-browser', 'ai_dev_browser'),
-      ];
+  const candidates = app.isPackaged ? [path.join(app.getAppPath().replace('app.asar', 'app.asar.unpacked'), 'vendor/ai-dev-browser/ai_dev_browser'), path.join(process.resourcesPath, 'ai-dev-browser/ai_dev_browser')] : [path.join(app.getAppPath(), 'vendor/ai-dev-browser/ai_dev_browser'), path.join(app.getAppPath(), '..', 'ai-dev-browser', 'ai_dev_browser')];
   return candidates.find((p) => existsSync(p)) ?? null;
 };
 
@@ -1030,7 +1036,7 @@ const initStorage = async () => {
 
       // 首先清理不再存在于内置列表中的旧内置助手
       // First, clean up old built-in assistants that are no longer in the built-in list
-      const builtinIds = new Set(builtinAssistants.map(a => a.id));
+      const builtinIds = new Set(builtinAssistants.map((a) => a.id));
       for (let i = updatedAgents.length - 1; i >= 0; i--) {
         const agent = updatedAgents[i];
         // 如果是以 builtin- 开头，但在当前内置列表中找不到，则删除

--- a/src/process/services/cron/cronPolicy.ts
+++ b/src/process/services/cron/cronPolicy.ts
@@ -37,13 +37,20 @@ export function resetCronPolicyCache(): void {
   cache = null;
 }
 
-export async function getClientCronEnabled(): Promise<boolean> {
+/**
+ * @param forceFresh skip the in-memory TTL cache and re-fetch. Used at skill
+ *   injection time so a mid-session admin flag flip takes effect without an app
+ *   restart (the cache would otherwise hold the launch-time value for 60s).
+ */
+export async function getClientCronEnabled(forceFresh = false): Promise<boolean> {
   if (!isEnterpriseMode()) {
+    mainLog('CronPolicy', 'resolved enabled=true (personal mode)');
     return true;
   }
 
   const now = Date.now();
-  if (cache && now - cache.fetchedAt < TENANT_CONFIG_TTL_MS) {
+  if (!forceFresh && cache && now - cache.fetchedAt < TENANT_CONFIG_TTL_MS) {
+    mainLog('CronPolicy', `resolved enabled=${cache.enabled} (cache, age=${Math.round((now - cache.fetchedAt) / 1000)}s)`);
     return cache.enabled;
   }
 
@@ -54,10 +61,15 @@ export async function getClientCronEnabled(): Promise<boolean> {
       if (response.ok) {
         const json = (await response.json()) as { success?: boolean; data?: Record<string, unknown> };
         const resolved = resolveTenantConfig(json?.data ?? null);
-        cache = { enabled: resolved.client_cron_enabled !== false, fetchedAt: now };
-        // Persist for offline fallback; failure to persist must not block policy resolution.
-        ProcessConfig.set('eeclaw.tenantConfig', resolved).catch(() => {});
-        return cache.enabled;
+        const enabled = resolved.client_cron_enabled !== false;
+        cache = { enabled, fetchedAt: now };
+        // Persist the confirmed flag for the offline fallback. The marker lets a
+        // later offline read distinguish "confirmed enabled" from "never
+        // confirmed" so the fallback can fail closed. Persist failures must not
+        // block policy resolution.
+        ProcessConfig.set('eeclaw.tenantConfig', { ...resolved, client_cron_enabled: enabled, cron_confirmed: true }).catch(() => {});
+        mainLog('CronPolicy', `resolved enabled=${enabled} (fetched from server${forceFresh ? ', forced fresh' : ''})`);
+        return enabled;
       }
       mainWarn('CronPolicy', `tenant config fetch returned ${response.status}, using fallback`);
     } catch (error) {
@@ -65,17 +77,32 @@ export async function getClientCronEnabled(): Promise<boolean> {
     }
   }
 
-  // Offline fallback: last persisted resolved config; default enabled to match
-  // resolveTenantConfig semantics (only an explicit false disables).
-  let enabled = true;
+  // Strict fail-closed offline fallback (enterprise): cron is allowed only if a
+  // previous successful fetch affirmatively confirmed it enabled. An unreachable
+  // server with nothing confirmed → disabled, so an admin's disable is honored
+  // even offline and a fresh install never silently enables cron.
+  let enabled = false;
   try {
     const persisted = ProcessConfig.getSync('eeclaw.tenantConfig');
-    enabled = persisted?.client_cron_enabled !== false;
+    enabled = persisted?.cron_confirmed === true && persisted?.client_cron_enabled !== false;
   } catch {
     /* ignore */
   }
+  mainWarn('CronPolicy', `resolved enabled=${enabled} (offline fail-closed fallback)`);
   cache = { enabled, fetchedAt: now };
   return enabled;
+}
+
+/**
+ * Whether the cron skill may be advertised to an agent. Same decision as the
+ * execution gate, used at skill-injection time so the skill is never offered
+ * when the org has cron disabled (the agent then never attempts it).
+ */
+export async function isCronSkillAllowed(): Promise<boolean> {
+  // Force-fresh: skill injection happens at the start of a session, and an admin
+  // may have flipped the flag since app launch. Read the current value so the
+  // agent's cron capability matches policy without an app restart.
+  return getClientCronEnabled(true);
 }
 
 /**

--- a/src/process/task/MessageMiddleware.ts
+++ b/src/process/task/MessageMiddleware.ts
@@ -7,7 +7,7 @@
 import type { TMessage } from '@/common/chatLib';
 import { ipcBridge } from '@/common';
 import type { AcpBackendAll } from '@/types/acpTypes';
-import { cronService } from '@process/services/cron/CronService';
+import { getCronProvider } from '@process/providers/cron';
 import { getClientCronEnabled } from '@process/services/cron/cronPolicy';
 import { detectCronCommands, stripCronCommands, type CronCommand } from './CronCommandDetector';
 import { hasThinkTags, stripThinkTags } from './ThinkTagDetector';
@@ -191,11 +191,17 @@ async function handleCronCommands(conversationId: string, agentType: AcpBackendA
 
   const responses: string[] = [];
 
+  // Route through the active provider, not the local cronService singleton, so
+  // a remote-mode agent's jobs land on moss (RemoteCronProvider → gated moss
+  // API) — the same backend the cron UI reads/writes. Local mode's provider
+  // delegates to cronService, so that path is unchanged. (#854/#835)
+  const provider = getCronProvider();
+
   for (const cmd of commands) {
     try {
       switch (cmd.kind) {
         case 'create': {
-          const job = await cronService.addJob({
+          const job = await provider.addJob({
             name: cmd.name,
             schedule: { kind: 'cron', expr: cmd.schedule, description: cmd.scheduleDescription },
             message: cmd.message,
@@ -214,7 +220,7 @@ async function handleCronCommands(conversationId: string, agentType: AcpBackendA
           // created by this conversation. A per-conversation list made every
           // new chat report "no tasks" while the cron UI showed them, and
           // defeated the skill's query-before-create duplicate check (#835).
-          const jobs = await cronService.listJobs();
+          const jobs = await provider.listJobs();
           if (jobs.length === 0) {
             responses.push('📋 No scheduled tasks.');
           } else {
@@ -232,7 +238,7 @@ async function handleCronCommands(conversationId: string, agentType: AcpBackendA
         }
 
         case 'delete': {
-          await cronService.removeJob(cmd.jobId);
+          await provider.removeJob(cmd.jobId);
           // Emit event to renderer process for real-time UI update
           ipcBridge.cron.onJobRemoved.emit({ jobId: cmd.jobId });
           responses.push(`🗑️ Task deleted: ${cmd.jobId}`);

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -21,7 +21,40 @@ import * as fs from 'node:fs';
 import { initMossApi } from '../remote/MossSessionApi';
 import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
 import { filterEnabledSkillNames } from '../utils/enabledSkillFilter';
-import { ProcessConfig } from '../initStorage';
+import { ProcessConfig, getBundledBuiltinSkillDir } from '../initStorage';
+import { hasCronCommands } from './CronCommandDetector';
+import { isCronSkillAllowed } from '../services/cron/cronPolicy';
+
+/**
+ * Cron instruction inlined into a remote session's first message. The moss
+ * container can't read sudowork's local cron SKILL.md, so we inline it here.
+ * - When cron is ALLOWED: the full skill (single source of truth for the
+ *   [CRON_CREATE]/[CRON_LIST]/[CRON_DELETE] contract the local AcpAgent points
+ *   at by path).
+ * - When cron is DISABLED: an explicit ban, so the agent does NOT silently
+ *   hallucinate "task created". Banning must be active, not just omission.
+ */
+async function buildRemoteCronInstruction(): Promise<string> {
+  if (!(await isCronSkillAllowed())) {
+    mainLog('RemoteAgent', 'cron disabled by org — injecting explicit ban instruction');
+    return CRON_DISABLED_INSTRUCTION;
+  }
+  try {
+    // Read from the bundled SOURCE, not getBuiltinSkillsDir() — the latter
+    // resolves to the user's _system/system dir which differs by mode and was
+    // ENOENT in enterprise mode (the file lives at _system but the enterprise
+    // path computes `system`). The bundled path is stable across modes.
+    const skillPath = nodePath.join(getBundledBuiltinSkillDir('cron'), 'SKILL.md');
+    const skillContent = await fs.promises.readFile(skillPath, 'utf-8');
+    mainLog('RemoteAgent', `cron enabled — injecting cron skill instruction from ${skillPath}`);
+    return `[Scheduled Task Skill — you MUST follow this to manage scheduled tasks; output the [CRON_*] commands directly in your reply]\n${skillContent}`;
+  } catch (err) {
+    mainError('RemoteAgent', `Failed to read cron SKILL.md: ${err}`);
+    return CRON_DISABLED_INSTRUCTION;
+  }
+}
+
+const CRON_DISABLED_INSTRUCTION = '[Scheduled Tasks — DISABLED]\n' + 'Scheduled task / cron functionality is disabled by your organization. ' + 'You CANNOT create, list, modify, or delete scheduled tasks. ' + 'If the user asks you to schedule, create, or manage a recurring/timed task, you MUST tell them that scheduled tasks are disabled by their organization and that an administrator must enable the feature. ' + 'NEVER claim that a scheduled task was created, and NEVER invent a task ID.';
 
 /**
  * Default idle detach timeout for finished remote sessions.
@@ -96,6 +129,25 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
 
   /** Turn-level file tracking for precise cleanup on cancel */
   private currentTurnFiles: Map<string, { path: string; intent: 'draft' | 'final'; kind: 'create' | 'edit' }> = new Map();
+
+  /**
+   * Accumulated assistant text for the current turn. Remote agents read the
+   * sudowork cron skill and emit [CRON_CREATE]/[CRON_LIST]/[CRON_DELETE] text
+   * commands in their reply; unlike AcpAgent we must detect and process those
+   * on the client (moss does not handle these text commands), otherwise the
+   * agent's "created" narration is shown while nothing is created and the
+   * client_cron_enabled gate never runs. See processFinishedCronCommands.
+   */
+  private currentTurnText = '';
+  private currentTurnMsgId: string | null = null;
+
+  /**
+   * Whether the inlined cron skill instruction has been sent to the moss session.
+   * The moss container can't read sudowork's local cron SKILL.md, so we inline
+   * the cron command contract into the first message of a session (when org
+   * policy allows). Reset when a new session is created.
+   */
+  private cronSkillInjected = false;
 
   constructor(data: RemoteAgentData) {
     super('remote-agent', data);
@@ -453,6 +505,8 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
     this.processingStartTime = Date.now();
     this.turnActive = true;
     this.userCancelled = false;
+    this.currentTurnText = '';
+    this.currentTurnMsgId = null;
     this.stopPromise = null;
 
     // ★ Reset turn-level file tracking for new turn
@@ -505,6 +559,22 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
         contentToSend = `${fileRefs} ${contentToSend}`;
       }
 
+      // Tell the remote (moss) agent about scheduled tasks, once per session.
+      // The moss container can't read the local cron SKILL.md, so the
+      // instruction is inlined: the full skill when cron is allowed, or an
+      // explicit ban when disabled (so the agent never hallucinates a created
+      // task). Always inject one or the other.
+      if (!this.cronSkillInjected) {
+        this.cronSkillInjected = true;
+        try {
+          const cronInstruction = await buildRemoteCronInstruction();
+          contentToSend = `${cronInstruction}\n\n[User Request]\n${contentToSend}`;
+          mainLog('RemoteAgent', 'Injected cron instruction into first message');
+        } catch (err) {
+          mainError('RemoteAgent', `Failed to build cron instruction: ${err}`);
+        }
+      }
+
       // Send to Moss Server
       const result = this.connection.sendMessage({
         content: contentToSend,
@@ -538,6 +608,8 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
     this.processingStartTime = options?.startedAt ?? Date.now();
     this.turnActive = true;
     this.userCancelled = false;
+    this.currentTurnText = '';
+    this.currentTurnMsgId = null;
     this.stopPromise = null;
     this.currentTurnFiles.clear();
     this.workspaceFileSnapshot = this.getWorkspaceFiles();
@@ -841,6 +913,13 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
     const enrichedMsg = { ...msg, conversation_id: this.conversation_id };
     ipcBridge.conversation.responseStream.emit(enrichedMsg);
 
+    // Accumulate assistant text so cron commands emitted in the reply can be
+    // detected and processed on finish (see processFinishedCronCommands).
+    if (msg.type === 'content' && typeof msg.data === 'string') {
+      this.currentTurnText += msg.data;
+      this.currentTurnMsgId = msg.msg_id || this.currentTurnMsgId;
+    }
+
     // Persist messages to local DB for enterprise mode local-first reads
     // 将消息持久化到本地数据库，支持企业模式本地优先读取
     if (msg.type === 'content' || msg.type === 'user_content' || msg.type === 'acp_tool_call' || msg.type === 'error') {
@@ -887,12 +966,71 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
       this.status = 'finished';
       this.turnActive = false;
       this.processingStartTime = undefined;
+
+      // Process any cron commands the agent emitted this turn before resetting
+      // turn state. Fire-and-forget — feedback is sent back into the session.
+      const finishedText = this.currentTurnText;
+      const finishedMsgId = this.currentTurnMsgId;
+      this.currentTurnText = '';
+      this.currentTurnMsgId = null;
+      if (hasCronCommands(finishedText)) {
+        void this.processFinishedCronCommands(finishedText, finishedMsgId);
+      }
+
       // Clear turn-level file tracking for next turn
       // 清空 Turn 级别文件追踪，为下一个 Turn 做准备
       this.currentTurnFiles.clear();
       mainLog('RemoteAgent', '[FINISH] Cleared currentTurnFiles for next turn');
       // Session is quiescent — start (or restart) idle detach countdown.
       this.scheduleIdleDetachTimer();
+    }
+  }
+
+  /**
+   * Detect and execute cron commands the remote agent emitted in its reply.
+   * Routes through MessageMiddleware.processCronInMessage, which applies the
+   * client_cron_enabled gate and (via getCronProvider) creates jobs on the
+   * active backend — moss in remote mode. Any system response (the
+   * disabled-by-org refusal, or the created/listed/deleted result) is emitted
+   * to the UI and fed back into the moss session so the agent relays an honest
+   * answer instead of falsely claiming success.
+   */
+  private async processFinishedCronCommands(text: string, msgId: string | null): Promise<void> {
+    try {
+      // Lazy import: MessageMiddleware pulls in the cron provider/database graph;
+      // importing it at module top-level would bloat RemoteAgent's load and its
+      // test harness. Cron commands are rare, so a per-occurrence import is fine.
+      const { processCronInMessage } = await import('./MessageMiddleware');
+      const message: TMessage = {
+        id: msgId || uuid(),
+        msg_id: msgId || uuid(),
+        type: 'text',
+        position: 'left',
+        conversation_id: this.conversation_id,
+        content: { content: text },
+        status: 'finish',
+        createdAt: Date.now(),
+      } as TMessage;
+
+      const collectedResponses: string[] = [];
+      // Remote sessions run the moss default backend; 'scode' is the label used
+      // for the cron job's agentType metadata.
+      await processCronInMessage(this.conversation_id, 'scode', message, (sysMsg) => {
+        collectedResponses.push(sysMsg);
+        ipcBridge.conversation.responseStream.emit({
+          type: 'system',
+          conversation_id: this.conversation_id,
+          msg_id: uuid(),
+          data: sysMsg,
+        });
+      });
+
+      if (collectedResponses.length > 0 && this.connection) {
+        const feedbackMessage = `[System Response]\n${collectedResponses.join('\n')}`;
+        this.connection.sendMessage({ content: feedbackMessage, msg_id: uuid() });
+      }
+    } catch (err) {
+      mainError('RemoteAgent', `Failed to process cron commands: ${err}`);
     }
   }
 

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -6,6 +6,7 @@
 
 import { DRAFTS_DIR_NAME } from '@/common/constants';
 import { getBuiltinSkillsDir, loadSkillsContent } from '@process/initStorage';
+import { isCronSkillAllowed } from '@process/services/cron/cronPolicy';
 import { AcpSkillManager, buildSkillsIndexText, type SkillIndex } from './AcpSkillManager';
 import type { PresetAgentType } from '@/types/acpTypes';
 import { getNodeBinaryPath, isNodeInstalled } from '@process/services/claudeCli/NodeRuntimeService';
@@ -380,10 +381,14 @@ export async function prepareFirstMessageWithSkillsIndex(content: string, config
   const skillManager = AcpSkillManager.getInstance();
   await skillManager.discoverBuiltinSkills();
 
-  const builtinSkillsIndex = skillManager.getBuiltinSkillsIndex();
+  // Org policy: when client cron is disabled (enterprise client_cron_enabled=false),
+  // the cron skill must NOT be advertised — so the agent never attempts it.
+  const cronAllowed = await isCronSkillAllowed();
+  const builtinSkillsIndex = skillManager.getBuiltinSkillsIndex().filter((s) => cronAllowed || s.name !== 'cron');
   if (builtinSkillsIndex.length > 0) {
     const systemSkillsDir = getBuiltinSkillsDir();
     const indexText = buildSkillsIndexText(builtinSkillsIndex);
+    const cronExampleLine = cronAllowed ? `\n- Builtin "cron" skill: ${systemSkillsDir}/cron/SKILL.md` : '';
 
     // 告诉 Agent 只从 builtin skills 目录按需读取
     // Tell Agent to read only from the builtin skills directory on demand
@@ -397,12 +402,19 @@ Each skill has a SKILL.md file containing detailed instructions.
 When a user request matches a skill's description, you MUST read that skill's SKILL.md and follow its instructions INSTEAD OF using any native tool for that capability. For example, use the "browser" skill for web browsing instead of any built-in WebFetch or WebSearch tool.
 
 For example:
-- Builtin "browser" skill: ${systemSkillsDir}/browser/SKILL.md
-- Builtin "cron" skill: ${systemSkillsDir}/cron/SKILL.md
+- Builtin "browser" skill: ${systemSkillsDir}/browser/SKILL.md${cronExampleLine}
 
 Skill capabilities are subject to organization policy: if the system refuses a skill command as disabled by the organization, relay the refusal to the user and do not retry.`;
 
     instructions.push(skillsInstruction);
+  }
+
+  // Explicit ban: when cron is disabled, omitting the skill is not enough — the
+  // agent may still hallucinate a created task from prior knowledge. Tell it
+  // directly that scheduled tasks are unavailable. (Omitted in personal mode and
+  // when cron is enabled.)
+  if (!cronAllowed) {
+    instructions.push('[Scheduled Tasks — DISABLED]\n' + 'Scheduled task / cron functionality is disabled by your organization. You CANNOT create, list, modify, or delete scheduled tasks. ' + 'If asked to schedule or manage a recurring/timed task, tell the user it is disabled by their organization and an administrator must enable it. ' + 'NEVER claim a scheduled task was created, and NEVER invent a task ID.');
   }
 
   if (instructions.length === 0) {

--- a/src/renderer/context/TenantConfigContext.tsx
+++ b/src/renderer/context/TenantConfigContext.tsx
@@ -20,6 +20,14 @@ interface TenantConfigContextValue {
   config: Required<TenantConfig>;
   /** 加载状态 */
   loading: boolean;
+  /**
+   * Whether the enterprise tenant config was confirmed from the server this
+   * session. Policy-bearing flags (e.g. client_cron_enabled) must fail closed
+   * when this is false — the cached config may be stale and an admin may have
+   * disabled the feature while the client was offline. Always true in personal
+   * mode (no enterprise policy to confirm).
+   */
+  confirmed: boolean;
   /** 手动刷新配置 */
   refresh: () => Promise<void>;
 }
@@ -53,6 +61,9 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
   });
 
   const [loading, setLoading] = useState(false);
+  // Confirmed only after a successful enterprise server fetch this session.
+  // Personal mode has no enterprise policy, so it is always considered confirmed.
+  const [confirmed, setConfirmed] = useState(false);
   const isRefreshing = useRef(false);
   const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -89,6 +100,7 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
         if (data.success && data.data) {
           const mergedConfig = resolveTenantConfig(data.data);
           setConfig(mergedConfig);
+          setConfirmed(true);
           localStorage.setItem(TENANT_CONFIG_STORAGE_KEY, JSON.stringify(mergedConfig));
           await ConfigStorage.set('eeclaw.tenantName', mergedConfig.app_company_name);
           console.log('[TenantConfig] Enterprise config updated:', mergedConfig);
@@ -176,6 +188,7 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
       // 登出 → 重置 config 为默认值，停止轮询
       // 注意：不清除 localStorage，保留缓存供下次启动登录页使用
       setConfig(DEFAULT_TENANT_CONFIG);
+      setConfirmed(false);
       stopPolling();
     }
   }, [status, isEnterprise, user?.enterprise_code, fetchConfig, startPolling, stopPolling]);
@@ -191,9 +204,12 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
     () => ({
       config,
       loading,
+      // Personal mode has no enterprise policy to confirm; enterprise requires a
+      // successful server fetch this session before policy flags are trusted.
+      confirmed: !isEnterprise || confirmed,
       refresh: fetchConfig,
     }),
-    [config, loading, fetchConfig]
+    [config, loading, confirmed, isEnterprise, fetchConfig]
   );
 
   return <TenantConfigContext.Provider value={value}>{children}</TenantConfigContext.Provider>;

--- a/src/renderer/hooks/useCronEnabled.ts
+++ b/src/renderer/hooks/useCronEnabled.ts
@@ -17,11 +17,15 @@ import { useTenantConfig } from '@/renderer/context/TenantConfigContext';
  */
 export function useCronEnabled(): boolean {
   const { isEnterprise } = useAppMode();
-  const { config } = useTenantConfig();
+  const { config, confirmed } = useTenantConfig();
 
   if (!isEnterprise) {
     return true;
   }
-  // resolveTenantConfig normalizes this to a boolean (default true).
-  return config.client_cron_enabled !== false;
+  // Fail closed: in enterprise mode, show cron only when the tenant config was
+  // confirmed from the server this session AND the flag is not disabled. A stale
+  // cache (e.g. a failed startup refresh after an admin disabled cron) must not
+  // keep the UI visible. resolveTenantConfig normalizes the flag to a boolean
+  // (default true), so `confirmed` is what guards staleness.
+  return confirmed && config.client_cron_enabled !== false;
 }

--- a/tests/unit/agentUtils.test.ts
+++ b/tests/unit/agentUtils.test.ts
@@ -21,10 +21,22 @@ vi.mock('../../src/process/initStorage', () => ({
   loadSkillsContent: vi.fn(async () => ''),
 }));
 
+vi.mock('electron', () => ({
+  app: { getPath: (_key: string) => '/tmp/.nexus-test' },
+}));
+
+const isCronSkillAllowed = vi.fn(async () => true);
+vi.mock('@process/services/cron/cronPolicy', () => ({
+  isCronSkillAllowed: () => isCronSkillAllowed(),
+}));
+
 describe('prepareFirstMessageWithSkillsIndex', () => {
   beforeEach(() => {
     discoverBuiltinSkills.mockClear();
     getBuiltinSkillsIndex.mockClear();
+    getBuiltinSkillsIndex.mockReturnValue([{ name: 'cron', description: 'Builtin cron skill' }]);
+    isCronSkillAllowed.mockReset();
+    isCronSkillAllowed.mockResolvedValue(true);
   });
 
   it('injects only builtin skill paths for ACP/OpenClaw agents', async () => {
@@ -57,6 +69,48 @@ describe('prepareFirstMessageWithSkillsIndex', () => {
     expect(discoverBuiltinSkills).toHaveBeenCalledOnce();
     expect(result).toContain('/tmp/.nexus/skills/_system/_builtin/{skill-name}/SKILL.md');
     expect(result).toContain('cron');
+  });
+
+  it('omits the cron skill when org policy disallows it (#854)', async () => {
+    isCronSkillAllowed.mockResolvedValue(false);
+    getBuiltinSkillsIndex.mockReturnValue([
+      { name: 'cron', description: 'Builtin cron skill' },
+      { name: 'browser', description: 'Builtin browser skill' },
+    ]);
+
+    const { prepareFirstMessageWithSkillsIndex } = await import('../../src/process/task/agentUtils');
+    const result = await prepareFirstMessageWithSkillsIndex('do something', {
+      presetContext: 'rules',
+      workspace: '/tmp/workspace',
+      presetAgentType: 'claude',
+    });
+
+    // The cron skill index entry / file path is omitted...
+    expect(result).not.toContain('cron/SKILL.md');
+    expect(result).not.toContain('- cron:');
+    // ...but an explicit ban is injected so the agent can't hallucinate success.
+    expect(result).toContain('[Scheduled Tasks — DISABLED]');
+    expect(result).toContain('NEVER claim a scheduled task was created');
+    expect(result).toContain('browser');
+  });
+
+  it('includes the cron skill when org policy allows it', async () => {
+    isCronSkillAllowed.mockResolvedValue(true);
+    getBuiltinSkillsIndex.mockReturnValue([
+      { name: 'cron', description: 'Builtin cron skill' },
+      { name: 'browser', description: 'Builtin browser skill' },
+    ]);
+
+    const { prepareFirstMessageWithSkillsIndex } = await import('../../src/process/task/agentUtils');
+    const result = await prepareFirstMessageWithSkillsIndex('do something', {
+      presetContext: 'rules',
+      workspace: '/tmp/workspace',
+      presetAgentType: 'claude',
+    });
+
+    expect(result).toContain('cron/SKILL.md');
+    expect(result).toContain('browser');
+    expect(result).not.toContain('[Scheduled Tasks — DISABLED]');
   });
 
   it('injects workspace skills directory hint before user request', async () => {

--- a/tests/unit/cronCommandListScope.test.ts
+++ b/tests/unit/cronCommandListScope.test.ts
@@ -8,15 +8,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const listJobsMock = vi.fn(async () => [] as unknown[]);
-const listJobsByConversationMock = vi.fn(async () => [] as unknown[]);
 
-vi.mock('@process/services/cron/CronService', () => ({
-  cronService: {
+// handleCronCommands routes through getCronProvider() (#854); the local provider
+// delegates to cronService, but tests mock the provider directly.
+vi.mock('@process/providers/cron', () => ({
+  getCronProvider: () => ({
     listJobs: () => listJobsMock(),
-    listJobsByConversation: (conversationId: string) => listJobsByConversationMock(conversationId),
     addJob: vi.fn(),
     removeJob: vi.fn(),
-  },
+  }),
 }));
 
 vi.mock('@/common', () => ({
@@ -64,7 +64,6 @@ describe('[CRON_LIST] scope (issue #835)', () => {
   beforeEach(() => {
     listJobsMock.mockReset();
     listJobsMock.mockResolvedValue([]);
-    listJobsByConversationMock.mockReset();
   });
 
   it('lists jobs created by other conversations', async () => {
@@ -74,7 +73,6 @@ describe('[CRON_LIST] scope (issue #835)', () => {
     const result = await processAgentResponse('conv-b', 'scode', finishedMessage('[CRON_LIST]'));
 
     expect(listJobsMock).toHaveBeenCalled();
-    expect(listJobsByConversationMock).not.toHaveBeenCalled();
     expect(result.systemResponses.join('\n')).toContain('Weather reminder');
     expect(result.systemResponses.join('\n')).toContain('cron_1');
   });

--- a/tests/unit/cronPolicyGate.test.ts
+++ b/tests/unit/cronPolicyGate.test.ts
@@ -79,7 +79,7 @@ describe('cronPolicy.getClientCronEnabled (issue #854)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to the last persisted value when the server is unreachable', async () => {
+  it('offline + persisted confirmed-true → enabled', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => {
@@ -88,7 +88,24 @@ describe('cronPolicy.getClientCronEnabled (issue #854)', () => {
     );
     getSyncMock.mockImplementation((key: string) => {
       if (key === 'eeclaw.serverUrl') return 'http://moss.example';
-      if (key === 'eeclaw.tenantConfig') return { client_cron_enabled: false };
+      if (key === 'eeclaw.tenantConfig') return { client_cron_enabled: true, cron_confirmed: true };
+      return undefined;
+    });
+
+    const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
+    expect(await getClientCronEnabled()).toBe(true);
+  });
+
+  it('offline + persisted confirmed-false → disabled (honors prior disable)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      })
+    );
+    getSyncMock.mockImplementation((key: string) => {
+      if (key === 'eeclaw.serverUrl') return 'http://moss.example';
+      if (key === 'eeclaw.tenantConfig') return { client_cron_enabled: false, cron_confirmed: true };
       return undefined;
     });
 
@@ -96,7 +113,7 @@ describe('cronPolicy.getClientCronEnabled (issue #854)', () => {
     expect(await getClientCronEnabled()).toBe(false);
   });
 
-  it('defaults to enabled when unreachable with nothing persisted', async () => {
+  it('FAIL-CLOSED: offline with nothing persisted → disabled', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => {
@@ -105,36 +122,99 @@ describe('cronPolicy.getClientCronEnabled (issue #854)', () => {
     );
 
     const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
-    expect(await getClientCronEnabled()).toBe(true);
+    expect(await getClientCronEnabled()).toBe(false);
+  });
+
+  it('FAIL-CLOSED: offline with a stale config lacking the confirmed marker → disabled', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      })
+    );
+    getSyncMock.mockImplementation((key: string) => {
+      if (key === 'eeclaw.serverUrl') return 'http://moss.example';
+      // legacy/stale record with no cron_confirmed marker, flag defaulted true
+      if (key === 'eeclaw.tenantConfig') return { client_cron_enabled: true };
+      return undefined;
+    });
+
+    const { getClientCronEnabled } = await import('@/process/services/cron/cronPolicy');
+    expect(await getClientCronEnabled()).toBe(false);
   });
 });
 
-describe('handleCronCommands org-policy refusal (issue #854)', () => {
-  it('refuses all cron commands with an explicit message when disabled', async () => {
-    vi.resetModules();
-    const addJobMock = vi.fn();
-    vi.doMock('@process/services/cron/CronService', () => ({
-      cronService: { addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() },
-    }));
-    vi.doMock('@process/services/cron/cronPolicy', () => ({
-      getClientCronEnabled: vi.fn(async () => false),
-    }));
-    vi.doMock('@/common', () => ({
-      ipcBridge: { cron: { onJobCreated: { emit: vi.fn() }, onJobRemoved: { emit: vi.fn() } } },
-    }));
-
-    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
-    const message = {
+describe('handleCronCommands org-policy refusal + provider routing (issues #854/#835)', () => {
+  const createMessage = () =>
+    ({
       id: 'msg-1',
       conversation_id: 'conv-1',
       type: 'content',
       status: 'finish',
       content: { content: '[CRON_CREATE]\nname: T\nschedule: 0 9 * * *\nschedule_description: daily\nmessage: hi\n[/CRON_CREATE]' },
-    } as never;
+    }) as never;
 
-    const result = await processAgentResponse('conv-1', 'scode', message);
+  function mockCommon() {
+    vi.doMock('@/common', () => ({
+      ipcBridge: { cron: { onJobCreated: { emit: vi.fn() }, onJobRemoved: { emit: vi.fn() } } },
+    }));
+  }
+
+  it('refuses all cron commands with an explicit message when disabled, without touching the provider', async () => {
+    vi.resetModules();
+    const addJobMock = vi.fn();
+    vi.doMock('@process/providers/cron', () => ({
+      getCronProvider: () => ({ addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
+    }));
+    vi.doMock('@process/services/cron/cronPolicy', () => ({
+      getClientCronEnabled: vi.fn(async () => false),
+    }));
+    mockCommon();
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-1', 'scode', createMessage());
 
     expect(result.systemResponses.join('\n')).toContain('disabled by your organization');
     expect(addJobMock).not.toHaveBeenCalled();
+  });
+
+  it('routes create through getCronProvider (not the local cronService) when enabled', async () => {
+    vi.resetModules();
+    const addJobMock = vi.fn(async () => ({ id: 'cron_x', name: 'T' }));
+    vi.doMock('@process/providers/cron', () => ({
+      getCronProvider: () => ({ addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
+    }));
+    vi.doMock('@process/services/cron/cronPolicy', () => ({
+      getClientCronEnabled: vi.fn(async () => true),
+    }));
+    mockCommon();
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-1', 'scode', createMessage());
+
+    expect(addJobMock).toHaveBeenCalledTimes(1);
+    expect(result.systemResponses.join('\n')).toContain('Scheduled task created');
+  });
+
+  it('surfaces a provider failure (e.g. moss 403) as an error, not a false success', async () => {
+    vi.resetModules();
+    const addJobMock = vi.fn(async () => {
+      throw new Error('Failed to create cron jobs: 403 {"error":"cron_disabled_by_org"}');
+    });
+    vi.doMock('@process/providers/cron', () => ({
+      getCronProvider: () => ({ addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
+    }));
+    // Gate enabled (e.g. stale-true locally) so we exercise the provider path.
+    vi.doMock('@process/services/cron/cronPolicy', () => ({
+      getClientCronEnabled: vi.fn(async () => true),
+    }));
+    mockCommon();
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-1', 'scode', createMessage());
+
+    const text = result.systemResponses.join('\n');
+    expect(text).toContain('cron_disabled_by_org');
+    expect(text).not.toContain('Scheduled task created');
   });
 });


### PR DESCRIPTION
Closes #854 (client-side). Companion server-side gate: sudoprivacy/moss#86 (cronApi internal gate).

## Requirements

Cron must behave identically on every surface (UI visibility, skill advertisement, execution):
1. **Personal mode**: always show cron UI, always allow the cron skill.
2. **Enterprise + `client_cron_enabled=true`**: show UI, allow cron skill/tool, agent can create/list/delete by instruction (jobs created on moss).
3. **Enterprise + `client_cron_enabled=false`**: hide UI, **explicitly ban** the cron skill/tool — the agent must not silently hallucinate a created task.

## Changes (sudowork only; one commit)

- **`cronPolicy`**: strict **fail-closed** offline. Persist the confirmed flag with a `cron_confirmed` marker; offline, cron is allowed only if a prior fetch confirmed it enabled. Logs its decision on every path (cache / server fetch / offline fallback). `isCronSkillAllowed()` force-refreshes (bypasses the 60s cache) so a mid-session admin flag flip takes effect **without an app restart**.
- **`agentUtils.prepareFirstMessageWithSkillsIndex`** (local agent): omit the cron skill from the injected index when disabled, AND inject an explicit "scheduled tasks are disabled — never claim one was created / invent an ID" instruction. When enabled, the skill is advertised as normal.
- **`RemoteAgent`**: on the first message of a session, inline the cron instruction (the moss container can't read the local skill file). When enabled → the full cron SKILL.md (read from the **bundled** `skills/_builtin/cron` path, which is stable across personal/enterprise mode — the user-synced `getBuiltinSkillsDir()` resolves to `system` vs `_system` by mode and was ENOENT in enterprise, which previously made an enabled agent fall back to the ban). When disabled → the explicit ban. On finish, detect emitted `[CRON_*]` commands and run `processFinishedCronCommands` (gate + provider) so they execute on moss instead of being shown as hallucinated success.
- **`MessageMiddleware.handleCronCommands`**: route create/list/delete through `getCronProvider()` (remote-mode jobs land on moss) instead of the local `cronService` singleton; keep the `getClientCronEnabled()` refusal gate. A provider failure (e.g. moss 403) surfaces as an error, not a false success. Local/personal mode is behavior-identical.
- **`TenantConfigContext` + `useCronEnabled`**: track whether the enterprise tenant config was confirmed from the server this session; the cron UI shows only when confirmed AND the flag is not disabled, so a stale cache can't keep cron visible after an admin disables it. Personal mode is always confirmed.
- **`initStorage`**: add `getBundledBuiltinSkillDir(name)` — resolves a builtin skill's bundled source dir (stable across modes), used by RemoteAgent to read the cron skill reliably.

## Consistency (end state)

| State | UI | Skill | Execution |
|---|---|---|---|
| Personal | shown | injected | allowed |
| Enterprise + true (confirmed) | shown | injected (local + remote inlined) | allowed → creates on moss |
| Enterprise + false | hidden | omitted + explicit ban instruction | blocked; agent declines, no fake ID |
| Enterprise, unconfirmed/offline | hidden | omitted + ban | blocked (fail-closed) |

## Verified live (packaged app, enterprise remote)

- Flag **off**: agent explicitly says scheduled tasks are disabled by the org (no hallucinated success). ✓
- Flag **on**: logging confirmed the policy resolves `enabled=true` and force-fresh works after a mid-session flip; the enterprise skill-path ENOENT that made an enabled agent fall back to the ban is fixed (now reads the bundled path). End-to-end create-on-moss pending server reachability for a final confirmation.

## Tests

`cronPolicy` (fail-closed/confirmed-marker, force-fresh), `agentUtils` (skill omitted+ban when disabled, included when enabled), `MessageMiddleware` (provider routing, refusal, 403-surfaces-as-error), `#835` list-scope retained. tsc/eslint/prettier clean on changed files. Pre-existing `agentUtils.test.ts` electron-mock failures (present on clean dev) are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)