### PR TITLE
fix(browser): route URL preview to right-panel BrowserPanel instead of full-screen overlay

### DIFF
--- a/src/process/utils/previewUtils.ts
+++ b/src/process/utils/previewUtils.ts
@@ -28,7 +28,19 @@ export function handlePreviewOpenEvent(message: IResponseMessage | { type: strin
     return false;
   }
 
-  ipcBridge.preview.open.emit(data);
+  // URL content → open in the right-panel BrowserPanel tab (side-by-side
+  // with the conversation). Other content types (code, file previews, etc.)
+  // continue to use the full-screen PreviewPanel overlay.
+  if (data.contentType === 'url') {
+    const conversationId = 'conversation_id' in message ? (message as IResponseMessage).conversation_id : undefined;
+    ipcBridge.rightPanelBrowser.open.emit({
+      url: data.content,
+      switchTab: true,
+      ...(conversationId ? { conversationId } : {}),
+    });
+  } else {
+    ipcBridge.preview.open.emit(data);
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary

When the agent calls `browser page_goto`, NavigationInterceptor was emitting `preview.open` which opened a full-screen PreviewPanel overlay covering the entire conversation area. Users couldn't see the chat while the browser was open.

Now URL content routes to `rightPanelBrowser.open` instead, which opens in the right-side panel's "浏览器" tab (side-by-side with conversation). Non-URL previews (code, files, etc.) still use the full-screen PreviewPanel.

## Before/After

**Before:** BrowserPanel covers entire conversation area — user can't see agent's messages
**After:** BrowserPanel opens in right-side panel tab — conversation and browser visible side-by-side

## Verified

Local e2e: agent calls `browser page_goto --url example.com` → `hasPreviewOverlay=false`, `rightPanel=true`, conversation content fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)