### PR TITLE
fix: default SCode chat model to auto

### DIFF
--- a/src/common/acp/defaultModels.ts
+++ b/src/common/acp/defaultModels.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const DEFAULT_SCODE_MODEL_ID = 'gemini-3.5-flash';
+export const DEFAULT_SCODE_MODEL_ID = 'auto';
 
 export function getDefaultAcpModelId(backend: string | null | undefined): string | null {
   switch (backend) {

--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -220,7 +220,7 @@ export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | un
     nextModels[normalizeModelAlias(modelId)] = buildSudorouterModelEntry(modelId);
   }
 
-  const defaultModel = resolveDefaultModelAlias(existing?.default_model, nextModels) || modelIds[0];
+  const defaultModel = SCODE_AUTO_MODEL_ALIAS;
   const nextConfig: ScodeConfig = {
     ...existing,
     auth_modes: {

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -1,11 +1,12 @@
 import { ipcBridge } from '@/common';
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
-import { ConfigStorage, DEFAULT_IMAGE_GENERATION_MODEL } from '@/common/storage';
+import { ConfigStorage, DEFAULT_IMAGE_GENERATION_MODEL, type IConfigStorageRefer } from '@/common/storage';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { withCsrfToken } from '@/webserver/middleware/csrfClient';
 import { getSudorouterPrimaryModelPath, mergeSudorouterProvidersIntoConfig } from '@/common/sudoclawModelConfig';
-import { buildScodeConfigFromLoginPayload } from '@/common/scodeConfig';
+import { buildScodeConfigFromLoginPayload, SCODE_AUTO_MODEL_ALIAS } from '@/common/scodeConfig';
 import { extractLoginSudoclawPayload, mergeLoginUserData } from '@/common/sudoworkAuthLogin';
+import type { AcpModelInfo } from '@/types/acpTypes';
 
 type AuthStatus = 'checking' | 'syncing' | 'authenticated' | 'unauthenticated';
 
@@ -80,6 +81,39 @@ interface RegisterResult {
   success: boolean;
   message?: string;
   code?: LoginErrorCode;
+}
+
+async function syncScodeGuidModelPreference(modelId: string): Promise<void> {
+  try {
+    const config = ((await ConfigStorage.get('acp.config').catch((): undefined => undefined)) || {}) as IConfigStorageRefer['acp.config'];
+    const backendConfig = config.scode || {};
+    await ConfigStorage.set('acp.config', {
+      ...config,
+      scode: {
+        ...backendConfig,
+        preferredModelId: modelId,
+      },
+    });
+  } catch {
+    /* best-effort */
+  }
+
+  try {
+    const cached = ((await ConfigStorage.get('acp.cachedModels').catch((): undefined => undefined)) || {}) as Record<string, AcpModelInfo>;
+    const scodeCached = cached.scode as AcpModelInfo | undefined;
+    if (!scodeCached?.availableModels?.length) return;
+    const match = scodeCached.availableModels.find((model) => model.id === modelId);
+    await ConfigStorage.set('acp.cachedModels', {
+      ...cached,
+      scode: {
+        ...scodeCached,
+        currentModelId: modelId,
+        currentModelLabel: match?.label || modelId,
+      },
+    });
+  } catch {
+    /* best-effort */
+  }
 }
 
 type LoginSuccessResponse = {
@@ -362,6 +396,7 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
       if (defaultModel) {
         await ipcBridge.scode.setDefaultModel.invoke({ modelId: defaultModel }).catch(() => {});
       }
+      await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
 
       // Sync sudoclaw.json only for legacy gateway compatibility. Failure must not block Sudocode.
       try {
@@ -652,6 +687,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           setUser(authStorage.user);
           setStatus('authenticated');
           setReady(true);
+          await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
 
           // Sync token to ConfigStorage for eeclawBridge
           // Prefer ProcessConfig's refresh_token if it's newer (main process may have rotated it)
@@ -714,6 +750,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         setUser({ ...authStorage.user, token: authStorage.access_token });
         setStatus('authenticated');
         setReady(true);
+        await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
 
         const restoredUserId = resolveConsumerUserId(authStorage.user);
         // 从 localStorage 恢复登录状态时，也保存手机号到文件
@@ -776,6 +813,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         setUser(parsed);
         setStatus('authenticated');
         setReady(true);
+        await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
 
         const restoredUserId = resolveConsumerUserId(parsed as Partial<AuthUser>);
         if (isDesktopRuntime && parsed.phone) {
@@ -1026,6 +1064,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           if (defaultModel) {
             await ipcBridge.scode.setDefaultModel.invoke({ modelId: defaultModel }).catch(() => {});
           }
+          await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
         }
       } else {
         await ipcBridge.scode.saveConfig.invoke({ config: {} }).catch(() => {});

--- a/tests/unit/scodeConfig.test.ts
+++ b/tests/unit/scodeConfig.test.ts
@@ -66,7 +66,7 @@ describe('scodeConfig', () => {
     expect(next.models?.['custom-openai/gpt-4o']?.supports_tools).toBe(true);
     expect(next.models?.['custom-openai/gpt-4o']?.supports_reasoning).toBe(true);
     expect(next.models?.['custom-openai/gpt-4o']?.context).toEqual({ input: 128, output: 32 });
-    expect(next.default_model).toBe('custom-openai/gpt-4o');
+    expect(next.default_model).toBe(SCODE_AUTO_MODEL_ALIAS);
   });
 
   it('adds and replaces a custom OpenAI-compatible provider', () => {
@@ -112,7 +112,34 @@ describe('scodeConfig', () => {
     expect(next.auth_modes?.['api-key']).toBeUndefined();
     expect(next.models?.['gemini-3-flash-preview']).toBeTruthy();
     expect(next.models?.['custom-openai/gpt-4o']).toBeUndefined();
-    expect(next.default_model).toBe('gemini-3-flash-preview');
+    expect(next.default_model).toBe(SCODE_AUTO_MODEL_ALIAS);
+  });
+
+  it('defaults new login configs to the auto sudorouter model alias', () => {
+    const next = buildScodeConfigFromLoginPayload({
+      sudorouterKey: 'router-key',
+      modelServiceUrl: 'https://hk.sudorouter.ai/v1',
+      models: ['gemini-3-flash-preview'],
+    });
+
+    expect(next.default_model).toBe(SCODE_AUTO_MODEL_ALIAS);
+    expect(next.models?.[SCODE_AUTO_MODEL_ALIAS]?.providers?.proxy?.model).toBe(SCODE_AUTO_ROUTER_MODEL_ID);
+  });
+
+  it('resets existing user-selected sudorouter model to auto on login refresh', () => {
+    const next = buildScodeConfigFromLoginPayload(
+      {
+        sudorouterKey: 'router-key',
+        modelServiceUrl: 'https://hk.sudorouter.ai/v1',
+        models: ['gemini-3-flash-preview', 'gpt-4o'],
+      },
+      {
+        default_model: 'gpt-4o',
+        models: {},
+      }
+    );
+
+    expect(next.default_model).toBe(SCODE_AUTO_MODEL_ALIAS);
   });
 
   it('extracts and reapplies custom providers for database-backed scode settings', () => {


### PR DESCRIPTION
## Summary
- default SCode chat configs to the `auto` model alias on login/config refresh
- sync persisted SCode UI model preference/cache to `auto` after auth restore or login
- keep image generation model unchanged

## Test
- bun run test tests/unit/scodeConfig.test.ts tests/unit/scodeProxyModels.test.ts
- manually verified app startup and login default model behavior in dev mode