### PR TITLE
refactor(agents): consolidate agent visibility filtering into SSOT

### DIFF
--- a/src/renderer/hooks/useMultiAgentDetection.tsx
+++ b/src/renderer/hooks/useMultiAgentDetection.tsx
@@ -2,10 +2,11 @@
  * Hook for detecting multi-agent mode on application startup
  */
 
-import { ipcBridge } from '@/common';
 import { Message } from '@arco-design/web-react';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { filterAvailableAgentsForUi } from '@/renderer/shared/agents/availableAgents';
+import { ipcBridge } from '@/common';
 
 export const useMultiAgentDetection = () => {
   const { t } = useTranslation();
@@ -16,8 +17,7 @@ export const useMultiAgentDetection = () => {
       try {
         const response = await ipcBridge.acpConversation.getAvailableAgents.invoke();
         if (response && response.success && response.data) {
-          // 检测是否有多个ACP智能体（不包括内置的Gemini）
-          const acpAgents = response.data.filter((agent: { backend: string; name: string; cliPath?: string }) => agent.backend !== 'gemini');
+          const acpAgents = filterAvailableAgentsForUi(response.data);
           if (acpAgents.length > 1) {
             message.success(t('conversation.welcome.multiAgentModeEnabled'));
           }

--- a/src/renderer/pages/conversation/hooks/useConversationAgents.ts
+++ b/src/renderer/pages/conversation/hooks/useConversationAgents.ts
@@ -23,7 +23,7 @@ export type UseConversationAgentsResult = {
 
 /**
  * Hook to fetch available CLI agents and preset assistants for the conversation tab dropdown.
- * Filters out gemini-CLI agents (BUG-4: matches useGuidAgentSelection filter logic).
+ * Agent visibility is controlled by filterAvailableAgentsForUi (SSOT).
  */
 export const useConversationAgents = (): UseConversationAgentsResult => {
   const {

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Robot } from '@icon-park/react';
+import React from 'react';
+import type { AvailableAgent } from '../types';
+import styles from '../index.module.css';
 import { getAgentLogo } from '@/renderer/utils/agentLogo';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { useLayoutContext } from '@/renderer/context/LayoutContext';
-import type { AvailableAgent } from '../types';
 import type { AcpBackendAll } from '@/types/acpTypes';
-import { Robot } from '@icon-park/react';
-import React from 'react';
-import styles from '../index.module.css';
 
 type AgentPillBarProps = {
   availableAgents: AvailableAgent[];
@@ -159,7 +159,7 @@ const AgentPillBar: React.FC<AgentPillBarProps> = ({ availableAgents, selectedAg
           }}
         >
           {sortedAgents
-            .filter((agent) => agent.backend !== 'custom' && agent.backend !== 'gemini')
+            .filter((agent) => agent.backend !== 'custom')
             .map((agent, index) => {
               const isSelected = selectedAgentKey === getAgentKey(agent);
               const extensionAvatar = resolveExtensionAssetUrl(agent.isExtension ? agent.avatar : undefined);

--- a/src/renderer/pages/settings/CustomAcpAgent/CustomAcpAgentModal.tsx
+++ b/src/renderer/pages/settings/CustomAcpAgent/CustomAcpAgentModal.tsx
@@ -4,18 +4,18 @@
  *
  * Redesigned modal with CLI card selection, logo display, and collapsible advanced JSON config.
  */
-import type { AcpBackendConfig, AcpBackend } from '@/types/acpTypes';
-import { ACP_BACKENDS_ALL } from '@/types/acpTypes';
 import { Alert, Input, Spin, Collapse } from '@arco-design/web-react';
 import React, { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
+import { CheckSmall } from '@icon-park/react';
+import type { AcpBackendConfig, AcpBackend } from '@/types/acpTypes';
+import { ACP_BACKENDS_ALL } from '@/types/acpTypes';
 import { useThemeContext } from '@/renderer/context/ThemeContext';
 import AionModal from '@/renderer/components/base/AionModal';
 import { uuid } from '@/common/utils';
 import { acpConversation } from '@/common/ipcBridge';
-import { CheckSmall } from '@icon-park/react';
 
 // CLI Logo 导入 / CLI Logo imports
 import CodeBuddyLogo from '@/renderer/assets/logos/codebuddy.svg';
@@ -85,7 +85,7 @@ const CustomAcpAgentModal: React.FC<CustomAcpAgentModalProps> = ({ visible, agen
         // 只展示第三方独立 CLI（goose, auggie, kimi, opencode）
         // Only show third-party standalone CLIs (goose, auggie, kimi, opencode)
         const filteredAgents = response.data.filter((a) => {
-          if (['gemini', 'custom', 'codex'].includes(a.backend)) return false;
+          if (['custom', 'codex'].includes(a.backend)) return false;
           const backendConfig = ACP_BACKENDS_ALL[a.backend];
           return backendConfig && !backendConfig.authRequired;
         });

--- a/src/renderer/shared/agents/availableAgents.ts
+++ b/src/renderer/shared/agents/availableAgents.ts
@@ -8,8 +8,13 @@ import type { AvailableAgent } from './types';
 
 export const AVAILABLE_AGENTS_SWR_KEY = 'acp.agents.available';
 
+/**
+ * Single source of truth for which agents are visible in the UI.
+ * Backend `enabled` flag controls detection/MCP sync; this function
+ * controls what the user sees after detection.
+ */
 export function filterAvailableAgentsForUi(availableAgents: AvailableAgent[]): AvailableAgent[] {
-  return availableAgents;
+  return availableAgents.filter((agent) => agent.backend !== 'gemini');
 }
 
 export function splitConversationDropdownAgents(availableAgents: AvailableAgent[]): {

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -362,7 +362,7 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     name: 'Google CLI',
     cliCommand: 'gemini',
     authRequired: true,
-    enabled: true, // ✅ 内置 Gemini 后端，使用 `gemini` 命令启动（无需安装 CLI）
+    enabled: false, // Gemini is accessed via model platform (API key), not as a standalone agent backend
     supportsStreaming: true,
   },
   qwen: {

--- a/tests/unit/availableAgents.test.ts
+++ b/tests/unit/availableAgents.test.ts
@@ -22,9 +22,8 @@ describe('availableAgents helpers', () => {
     expect(AVAILABLE_AGENTS_SWR_KEY).toBe('acp.agents.available');
   });
 
-  it('filters out gemini cli entries but keeps builtin gemini', () => {
+  it('filters out gemini agents from UI', () => {
     expect(filterAvailableAgentsForUi(agents)).toEqual([
-      { backend: 'gemini', name: 'Gemini' },
       { backend: 'claude', name: 'Claude Code', cliPath: '/usr/local/bin/claude' },
       { backend: 'custom', name: 'Custom Agent', customAgentId: 'custom-1' },
       { backend: 'custom', name: 'Preset Assistant', customAgentId: 'builtin-writer', isPreset: true },
@@ -35,7 +34,6 @@ describe('availableAgents helpers', () => {
   it('splits conversation dropdown agents into cli and preset groups', () => {
     expect(splitConversationDropdownAgents(filterAvailableAgentsForUi(agents))).toEqual({
       cliAgents: [
-        { backend: 'gemini', name: 'Gemini' },
         { backend: 'claude', name: 'Claude Code', cliPath: '/usr/local/bin/claude' },
       ],
       presetAssistants: [


### PR DESCRIPTION
## Summary
- **Backend SSOT**: Set gemini `enabled: false` in `ACP_BACKENDS_ALL` — gemini is accessed via model platform (API key), not as a standalone agent backend. Stops detection (`which gemini`), MCP sync, and the "adding to 3 agents" count mismatch.
- **Frontend SSOT**: Implemented `filterAvailableAgentsForUi()` as the single place that decides agent UI visibility. Removed scattered `.filter(gemini)` from 3 components.
- **Two-layer design**: Backend `enabled` controls detection/sync. Frontend `filterAvailableAgentsForUi` controls display. Each has one job.

## Motivation
While debugging browser-panel MCP registration (#887), toggling the switch showed "adding to 3 agents" but the UI only exposed 2 (Sudo Code + Claude Code). The third was gemini — detected by backend but hidden by scattered frontend filters. Classic front-back inconsistency from tech debt.

## Changes
| File | What changed |
|------|-------------|
| `acpTypes.ts` | gemini `enabled: true` → `false` |
| `availableAgents.ts` | `filterAvailableAgentsForUi` now filters gemini (was no-op) |
| `useMultiAgentDetection.tsx` | Use `filterAvailableAgentsForUi` instead of inline filter |
| `AgentPillBar.tsx` | Remove `gemini` from inline filter (keep `custom`) |
| `CustomAcpAgentModal.tsx` | Remove `gemini` from excludes array |
| `useConversationAgents.ts` | Update comment |
| `availableAgents.test.ts` | Update expectations |

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bunx vitest run tests/unit/availableAgents.test.ts` — 3/3 pass
- [x] `bunx eslint` on changed files — no new errors
- [ ] Start Sudowork → MCP toggle shows "2 agents" (not 3)
- [ ] Agent pill bar shows Sudo Code + Claude Code (no Gemini)