### PR TITLE
fix(channels): restore Lark/IM image delivery for scode-generated files

### DIFF
--- a/src/channels/actions/ChatActions.ts
+++ b/src/channels/actions/ChatActions.ts
@@ -6,7 +6,7 @@
 
 import type { IRegisteredAction, ActionHandler } from './types';
 import { ChatActionNames, createSuccessResponse, createErrorResponse } from './types';
-import { createResponseActionsKeyboard, createErrorRecoveryKeyboard } from '../plugins/telegram/TelegramKeyboards';
+import { createResponseActionsKeyboard } from '../plugins/telegram/TelegramKeyboards';
 import { getChannelMessageService } from '../agent/ChannelMessageService';
 
 /**
@@ -177,7 +177,6 @@ export function buildChatErrorResponse(error: string): {
     type: 'text',
     text: `❌ <b>Processing Failed</b>\n\n${error}\n\nPlease retry or start a new conversation.`,
     parseMode: 'HTML',
-    replyMarkup: createErrorRecoveryKeyboard(),
   };
 }
 

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -1148,6 +1148,7 @@ export class ActionExecutor {
 
       // Update message with error
       const errorResponse = buildChatErrorResponse(error.message);
+      errorResponse.replyMarkup = getErrorRecoveryMarkup(context.platform as PluginType, error.message);
       if (supportsEdit && thinkingMsgId) {
         await context.editMessage(thinkingMsgId, errorResponse);
       } else {

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -128,6 +128,28 @@ function getErrorRecoveryMarkup(platform: PluginType, errorMessage?: string) {
 }
 
 /**
+ * Lark 的 markdown card 不接受本地路径图片引用（`![](C:\...png)` 或 `![](/abs/path.png)`）：
+ * 飞书会返回 230099 / 子错码 11310 "the card contains images but no imagekey is passed in"。
+ * 对 Lark 平台的 text 仅去除本地路径形式的 markdown image，
+ * 保留 http(s)/data/file 协议的远程图片（飞书 markdown card 能正常渲染网络图）。
+ * 图片本身改由 file_send 走 image_key 上传通道发送，文字此时只承担"配文"职责。
+ *
+ * Lark only. Other platforms (dingtalk/wechat/telegram) returned as-is so this
+ * helper is non-invasive — the existing DingTalk path strips elsewhere in
+ * ChannelResponseRouter.
+ */
+function stripLarkUnusableImageMarkdown(text: string | undefined, platform: PluginType): string | undefined {
+  if (platform !== 'lark' || !text) return text;
+  return text
+    .replace(/!\[[^\]]*\]\(([^)]+)\)/g, (match, imgPath: string) => {
+      if (/^(https?:|data:|file:)/i.test(imgPath)) return match;
+      return '';
+    })
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
  * Escape/format text for platform
  */
 function formatTextForPlatform(text: string, platform: PluginType): string {
@@ -762,8 +784,12 @@ export class ActionExecutor {
         // When updating thinking message, always target thinkingMsgId directly
         // (not sentMessageIds[last], which may be a file/image message)
         const targetMsgId = forceThinkingTarget && thinkingMsgId ? thinkingMsgId : sentMessageIds[sentMessageIds.length - 1] || thinkingMsgId;
+        // Lark markdown cards reject `![](local-path)`. Non-Lark platforms get
+        // the original msg back from the helper (identity), so no behavior change.
+        const sanitizedText = stripLarkUnusableImageMarkdown(msg.text, context.platform as PluginType);
+        const safeMsg = sanitizedText === msg.text ? msg : { ...msg, text: sanitizedText };
         try {
-          await context.editMessage(targetMsgId, msg);
+          await context.editMessage(targetMsgId, safeMsg);
         } catch {
           // Ignore edit errors (message not modified, etc.)
         }
@@ -816,8 +842,11 @@ export class ActionExecutor {
           // 关键：第一个 thinking 更新必须立即发送，不能用节流延迟。
           // 如果用定时器延迟，后续 UPDATE 会在定时器触发前覆盖内容，导致第一条消息永远丢失。
           lastUpdateTime = Date.now();
+          // Lark markdown card rejects local-path image refs; helper is a no-op for other platforms.
+          const sanitizedText = stripLarkUnusableImageMarkdown(streamOutgoing.text, context.platform as PluginType);
+          const safeStreamOutgoing = sanitizedText === streamOutgoing.text ? streamOutgoing : { ...streamOutgoing, text: sanitizedText };
           try {
-            await context.editMessage(thinkingMsgId, streamOutgoing);
+            await context.editMessage(thinkingMsgId, safeStreamOutgoing);
           } catch {
             // Ignore edit errors
           }
@@ -1074,7 +1103,10 @@ export class ActionExecutor {
           // with the last text content so it stops spinning
           if (lastTextContent && supportsEdit && sentMessageIds.length > 0) {
             const responseMarkup = getResponseActionsMarkup(context.platform as PluginType, lastTextContent.text);
-            const finalMessage: IUnifiedOutgoingMessage = { ...lastTextContent, replyMarkup: responseMarkup };
+            // Strip Lark-incompatible markdown image refs from the final card text
+            // (image is sent separately via pendingFilesToSend below). No-op for non-Lark.
+            const sanitizedFinalText = stripLarkUnusableImageMarkdown(lastTextContent.text, context.platform as PluginType);
+            const finalMessage: IUnifiedOutgoingMessage = { ...lastTextContent, text: sanitizedFinalText, replyMarkup: responseMarkup };
             const lastMsgId = sentMessageIds[sentMessageIds.length - 1];
             await context.editMessage(lastMsgId, finalMessage);
           } else if (!supportsEdit && lastTextContent) {
@@ -1091,7 +1123,9 @@ export class ActionExecutor {
           }
         } else {
           const responseMarkup = getResponseActionsMarkup(context.platform as PluginType, lastMessageContent.text);
-          const finalMessage: IUnifiedOutgoingMessage = { ...lastMessageContent, replyMarkup: responseMarkup };
+          // Strip Lark-incompatible markdown image refs. No-op for non-Lark.
+          const sanitizedFinalText = stripLarkUnusableImageMarkdown(lastMessageContent.text, context.platform as PluginType);
+          const finalMessage: IUnifiedOutgoingMessage = { ...lastMessageContent, text: sanitizedFinalText, replyMarkup: responseMarkup };
 
           if (supportsEdit && sentMessageIds.length > 0) {
             const lastMsgId = sentMessageIds[sentMessageIds.length - 1];

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -202,6 +202,8 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
 
   // Turn-level file tracking for precise cleanup on cancel
   private currentTurnFiles: Map<string, TrackedTurnFile> = new Map();
+  // Files already forwarded to channel clients this turn (prevents duplicate file_send)
+  private sentChannelFilePaths: Set<string> = new Set();
   private currentTurnProtectedFinalPaths = new Set<string>();
   private pendingCurrentTurnPostCleanup = false;
   private readonly fileIntentClassifier = new FileIntentClassifier();
@@ -702,6 +704,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
     // ★ Reset turn-level file tracking for new turn
     // 重置 Turn 级别文件追踪，开始新的 Turn
     this.currentTurnFiles.clear();
+    this.sentChannelFilePaths.clear();
     this.currentTurnProtectedFinalPaths.clear();
     this.pendingCurrentTurnPostCleanup = false;
     this.workspaceFileSnapshot = this.getWorkspaceFiles();
@@ -2530,6 +2533,7 @@ This identity statement takes priority over the default identity in USER.md.
               mainLog('[AcpAgent]', `[TRACK-BASH] Bash tool detected, status: ${toolStatus}`);
               if (toolStatus === 'completed') {
                 this.trackBashGeneratedFiles(rawInput?.command as string | undefined);
+                this.deliverBashGeneratedFilesToChannel();
               }
             }
 
@@ -4282,6 +4286,27 @@ This identity statement takes priority over the default identity in USER.md.
       },
     };
     this.handleStreamEvent(fileMessage);
+  }
+
+  /**
+   * Forward bash-generated deliverable files (images/documents placed in the
+   * workspace root) to channel clients as file_send messages. Restores the
+   * behavior lost in 0a49297b9 where bash-produced deliverables were sent to
+   * IM channels. Reads from currentTurnFiles (populated by
+   * trackBashGeneratedFiles) so this stays decoupled from cleanup tracking.
+   */
+  private deliverBashGeneratedFilesToChannel(): void {
+    if (this.currentTurnFiles.size === 0) return;
+    for (const [relativePath, file] of this.currentTurnFiles) {
+      if (file.source !== 'bash-generated') continue;
+      // Historical 5501a245 filter: workspace root only + image/document extension
+      if (relativePath.includes('/') || relativePath.includes('\\')) continue;
+      const ext = nodePath.extname(relativePath).toLowerCase();
+      if (!AcpAgent.IMAGE_EXTENSIONS.has(ext) && !AcpAgent.DOCUMENT_EXTENSIONS.has(ext)) continue;
+      if (this.sentChannelFilePaths.has(file.actualPath)) continue;
+      this.sentChannelFilePaths.add(file.actualPath);
+      this.sendFileToChannels(file.actualPath);
+    }
   }
 }
 

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -198,6 +198,10 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
 
   // Workspace file tracking for channel file_send messages
   private workspaceFileSnapshot = new Map<string, number>();
+  // Turn-start snapshot of deliverable files (path -> mtime), decoupled from
+  // workspaceFileSnapshot which gets mutated by trackBashGeneratedFiles.
+  // Used purely to decide "new in this turn" at turn-end.
+  private turnStartDeliverableSnapshot = new Map<string, number>();
   private customSkillsSnapshot = new Set<string>();
 
   // Turn-level file tracking for precise cleanup on cancel
@@ -705,6 +709,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
     // 重置 Turn 级别文件追踪，开始新的 Turn
     this.currentTurnFiles.clear();
     this.sentChannelFilePaths.clear();
+    this.turnStartDeliverableSnapshot = this.captureDeliverableSnapshot();
     this.currentTurnProtectedFinalPaths.clear();
     this.pendingCurrentTurnPostCleanup = false;
     this.workspaceFileSnapshot = this.getWorkspaceFiles();
@@ -2921,6 +2926,7 @@ This identity statement takes priority over the default identity in USER.md.
       // Capture rich GeneratedFileEntry records BEFORE archiveCurrentTurnFiles
       // wipes currentTurnFiles — the renderer needs them to draw preview cards.
       const generatedEntries = this.buildGeneratedFileEntries();
+      this.deliverWorkspaceFilesAtTurnEnd();
       await this.archiveCurrentTurnFiles();
       this.emitFallbackCompletionMessage(finalFiles);
       this.emitGeneratedFilesMarkerMessage(generatedEntries);
@@ -4255,9 +4261,14 @@ This identity statement takes priority over the default identity in USER.md.
 
   /**
    * Send file_send message to channel clients for generated files.
-   * Called when a tool call completes successfully.
+   * Returns true if the file was actually forwarded; false if it was already
+   * sent earlier in this turn (deduped via sentChannelFilePaths) or if the
+   * file does not exist. Callers MUST NOT add to sentChannelFilePaths before
+   * calling this method — the centralized has/add inside this function is the
+   * single chokepoint for dedup. Any external add would poison the has-check
+   * and cause this method to return false without forwarding.
    */
-  private sendFileToChannels(filePath: string): void {
+  private sendFileToChannels(filePath: string): boolean {
     // Resolve relative paths to absolute paths using workspace root
     let resolvedPath = filePath;
     if (!nodePath.isAbsolute(filePath)) {
@@ -4268,12 +4279,19 @@ This identity statement takes priority over the default identity in USER.md.
     try {
       if (!fs.existsSync(resolvedPath)) {
         console.warn(`[AcpAgent] sendFileToChannels: file not found: ${resolvedPath}`);
-        return;
+        return false;
       }
     } catch {
       console.warn(`[AcpAgent] sendFileToChannels: error checking file existence: ${resolvedPath}`);
-      return;
+      return false;
     }
+
+    // Centralized dedup: any forwarder reaches this single chokepoint.
+    // Strategy 1 / Strategy 2 / bash / turn-end fallback all share the same Set.
+    if (this.sentChannelFilePaths.has(resolvedPath)) {
+      return false;
+    }
+    this.sentChannelFilePaths.add(resolvedPath);
 
     const fileMessage: IResponseMessage = {
       type: 'file_send',
@@ -4286,6 +4304,7 @@ This identity statement takes priority over the default identity in USER.md.
       },
     };
     this.handleStreamEvent(fileMessage);
+    return true;
   }
 
   /**
@@ -4303,10 +4322,81 @@ This identity statement takes priority over the default identity in USER.md.
       if (relativePath.includes('/') || relativePath.includes('\\')) continue;
       const ext = nodePath.extname(relativePath).toLowerCase();
       if (!AcpAgent.IMAGE_EXTENSIONS.has(ext) && !AcpAgent.DOCUMENT_EXTENSIONS.has(ext)) continue;
-      if (this.sentChannelFilePaths.has(file.actualPath)) continue;
-      this.sentChannelFilePaths.add(file.actualPath);
       this.sendFileToChannels(file.actualPath);
     }
+  }
+
+  /**
+   * Snapshot deliverable files (images/documents) in workspace root with their mtime.
+   * Used by turn-start to record baseline; turn-end compares to detect new/modified files.
+   */
+  private captureDeliverableSnapshot(): Map<string, number> {
+    const snap = new Map<string, number>();
+    if (!this.workspace) return snap;
+    try {
+      const entries = fs.readdirSync(this.workspace, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        if (entry.name === '.drafts') continue;
+        const ext = nodePath.extname(entry.name).toLowerCase();
+        if (!AcpAgent.IMAGE_EXTENSIONS.has(ext) && !AcpAgent.DOCUMENT_EXTENSIONS.has(ext)) continue;
+        const fullPath = nodePath.join(this.workspace, entry.name);
+        try {
+          const stat = fs.statSync(fullPath);
+          snap.set(fullPath, stat.mtimeMs);
+        } catch {
+          // stat failed, skip
+        }
+      }
+    } catch {
+      // workspace not readable, return empty
+    }
+    return snap;
+  }
+
+  /**
+   * Turn-end fallback: scan workspace root for deliverable files that are new
+   * or modified compared to turnStartDeliverableSnapshot, forward them via
+   * sendFileToChannels. Captures images generated by tools that bypass
+   * deliverBashGeneratedFilesToChannel (e.g. MCP image_gen, direct write_file png).
+   * Shares sentChannelFilePaths with the bash path to prevent duplicates —
+   * dedup happens inside sendFileToChannels itself; this method must NOT
+   * add to sentChannelFilePaths before calling sendFileToChannels, otherwise
+   * the inner has-check would short-circuit and handleStreamEvent never fires.
+   */
+  private deliverWorkspaceFilesAtTurnEnd(): void {
+    if (!this.workspace) return;
+    let candidate = 0;
+    let sent = 0;
+    try {
+      const entries = fs.readdirSync(this.workspace, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
+        if (entry.name === '.drafts') continue;
+        const ext = nodePath.extname(entry.name).toLowerCase();
+        if (!AcpAgent.IMAGE_EXTENSIONS.has(ext) && !AcpAgent.DOCUMENT_EXTENSIONS.has(ext)) continue;
+        const fullPath = nodePath.join(this.workspace, entry.name);
+        try {
+          const stat = fs.statSync(fullPath);
+          const prevMtime = this.turnStartDeliverableSnapshot.get(fullPath);
+          const isNewOrModified = prevMtime === undefined || stat.mtimeMs > prevMtime;
+          if (!isNewOrModified) continue;
+          candidate++;
+          // Dedup is handled inside sendFileToChannels (which returns whether
+          // the file was actually forwarded). Do NOT add to sentChannelFilePaths
+          // here — that would poison the inner has-check and prevent the file
+          // from ever reaching handleStreamEvent.
+          if (this.sendFileToChannels(fullPath)) {
+            sent++;
+          }
+        } catch {
+          // stat failed, skip
+        }
+      }
+    } catch {
+      // workspace not readable, skip
+    }
+    mainLog('[AcpAgent]', `[TURN-END-DELIVER] candidate=${candidate}, sent=${sent}`);
   }
 }
 


### PR DESCRIPTION
3 个关联修复，解决飞书用户收不到 scode 生成图片的问题：

1. acp: 转发 bash 生成文件到 channel 客户端
   (deliverBashGeneratedFilesToChannel)
2. channels: 修复飞书图片投递
   - buildChatErrorResponse 移除硬编码 Telegram markup，改由 getErrorRecoveryMarkup(platform) 注入
   - 新增 turn-end 兜底扫描，覆盖非 bash 生成文件
   - sendFileToChannels 去重集中化
3. channels: 剥离 Lark 卡片中的本地路径 markdown 图片引用
   (stripLarkUnusableImageMarkdown)

验证: tsc --noEmit / eslint / prettier 全通过