### PR TITLE
fix(chat): preserve tool call and strip injected prompts

### DIFF
--- a/src/common/chatLib.ts
+++ b/src/common/chatLib.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { IResponseMessage } from './ipcBridge';
+import { uuid } from './utils';
 import type { CodexPermissionRequest } from '@/common/codex/types';
 import type { ExecCommandBeginData, ExecCommandEndData, ExecCommandOutputDeltaData, McpToolCallBeginData, McpToolCallEndData, PatchApplyBeginData, PatchApplyEndData, TurnDiffData, WebSearchBeginData, WebSearchEndData } from '@/common/codex/types/eventData';
 import type { AcpBackend, AcpPermissionRequest, PlanUpdate, ToolCallUpdate } from '@/types/acpTypes';
-import type { IResponseMessage } from './ipcBridge';
-import { uuid } from './utils';
 
 /**
  * 安全的路径拼接函数，兼容Windows和Mac
@@ -695,8 +695,18 @@ export const composeMessage = (message: TMessage | undefined, list: TMessage[] |
     for (let i = 0, len = list.length; i < len; i++) {
       const msg = list[i];
       if (msg.type === 'acp_tool_call' && msg.content.update?.toolCallId === message.content.update?.toolCallId) {
-        // Create new object instead of mutating original
-        const merged = { ...msg.content, ...message.content };
+        // Preserve previously streamed fields inside `update` so a completion
+        // packet that only contains status/content does not wipe rawInput/title.
+        const merged = {
+          ...msg.content,
+          ...message.content,
+          update: {
+            ...msg.content.update,
+            ...message.content.update,
+            rawInput: message.content.update?.rawInput ?? msg.content.update?.rawInput,
+            content: message.content.update?.content ?? msg.content.update?.content,
+          },
+        };
         return updateMessage(i, { ...msg, content: merged });
       }
     }

--- a/src/process/providers/RemoteConversationProvider.ts
+++ b/src/process/providers/RemoteConversationProvider.ts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getDatabase } from '@process/database';
+import WorkerManage from '@process/WorkerManage';
+import { initMossApi, type MossSessionApi } from '@process/remote/MossSessionApi';
+import { mainLog, mainError } from '@process/utils/mainLogger';
+import { ProcessConfig } from '@process/initStorage';
 import type { IConversationProvider, IProviderConfig } from './types';
 import type { TChatConversation } from '@/common/storage';
 import type { TMessage } from '@/common/chatLib';
 import type { ICreateConversationParams, IBridgeResponse, ISendMessageParams } from '@/common/ipcBridge';
 import type { AcpModelInfo } from '@/types/acpTypes';
-import { getDatabase } from '@process/database';
-import WorkerManage from '@process/WorkerManage';
-import { initMossApi, type MossSessionApi } from '@process/remote/MossSessionApi';
-import { mainLog, mainError } from '@process/utils/mainLogger';
 import { uuid } from '@/common/utils';
-import { ProcessConfig } from '@process/initStorage';
 import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
 
 const HIDDEN_CRON_SESSIONS_KEY = 'remote.hiddenCronSessionIds';
@@ -560,7 +560,7 @@ export class RemoteConversationProvider implements IConversationProvider {
       if (msgRole === 'user' && Array.isArray(contentArray)) {
         for (const block of contentArray) {
           if (block?.type === 'text') {
-            const textContent = block.text || '';
+            const textContent = this.extractDisplayUserContent(block.text || '');
             if (textContent && textContent.trim()) {
               messages.push({
                 id: `${conversationId}-${messageIndex++}`,
@@ -623,14 +623,15 @@ export class RemoteConversationProvider implements IConversationProvider {
           : typeof contentArray === 'string'
             ? contentArray
             : '';
-        if (textContent && textContent.trim()) {
+        const displayText = this.extractDisplayUserContent(textContent);
+        if (displayText && displayText.trim()) {
           messages.push({
             id: `${conversationId}-${messageIndex++}`,
             conversation_id: conversationId,
             type: 'text',
             role: 'user',
             position: 'right',
-            content: { content: textContent },
+            content: { content: displayText },
             create_time: timestamp,
             status: finishedMessageStatus,
           } as unknown as TMessage);
@@ -738,6 +739,15 @@ export class RemoteConversationProvider implements IConversationProvider {
       }
     }
     return typeof input === 'object' ? (input as Record<string, unknown>) : { input };
+  }
+
+  private extractDisplayUserContent(content: string): string {
+    let userContent = content;
+    if (userContent.includes('[User Request]')) {
+      const parts = userContent.split('[User Request]');
+      userContent = parts[parts.length - 1]?.trim() || userContent;
+    }
+    return userContent;
   }
 
   private getMossToolKind(toolName: string): 'read' | 'edit' | 'execute' {

--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -4,19 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IMessageText } from '@/common/chatLib';
-import { NEXUS_FILES_MARKER } from '@/common/constants';
-import { parseGeneratedFilesMarker } from '@/common/generatedFiles';
 import { Alert, Message, Tag, Tooltip } from '@arco-design/web-react';
 import { Copy, Lightning } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { copyText } from '@/renderer/utils/clipboard';
-import { filterUserVisibleFiles } from '@/renderer/utils/messageFiles';
-import { getInstalledSkillDisplay } from '@/renderer/utils/skillDisplay';
-import { skillHub } from '@/common/ipcBridge';
-import { isElectronDesktop } from '@/renderer/utils/platform';
 import CollapsibleContent from '../components/CollapsibleContent';
 import FilePreview from '../components/FilePreview';
 import HorizontalFileList from '../components/HorizontalFileList';
@@ -24,6 +16,14 @@ import MarkdownView from '../components/Markdown';
 import { stripThinkTags, hasThinkTags } from '../utils/thinkTagFilter';
 import GeneratedFileCards from './GeneratedFileCard';
 import MessageCronBadge from './MessageCronBadge';
+import { isElectronDesktop } from '@/renderer/utils/platform';
+import { skillHub } from '@/common/ipcBridge';
+import { getInstalledSkillDisplay } from '@/renderer/utils/skillDisplay';
+import { filterUserVisibleFiles } from '@/renderer/utils/messageFiles';
+import { copyText } from '@/renderer/utils/clipboard';
+import { parseGeneratedFilesMarker } from '@/common/generatedFiles';
+import { NEXUS_FILES_MARKER } from '@/common/constants';
+import type { IMessageText } from '@/common/chatLib';
 
 const parseFileMarker = (content: string) => {
   const markerIndex = content.indexOf(NEXUS_FILES_MARKER);
@@ -39,6 +39,12 @@ const parseFileMarker = (content: string) => {
         .filter(Boolean)
     : [];
   return { text, files };
+};
+
+export const stripInjectedUserPrompt = (content: string): string => {
+  if (!content.includes('[User Request]')) return content;
+  const parts = content.split('[User Request]');
+  return parts[parts.length - 1]?.trim() || content;
 };
 
 const useFormatContent = (content: string) => {
@@ -67,10 +73,19 @@ const MessageText: React.FC<{ message: IMessageText; isStreaming?: boolean; foot
     return rawContent;
   }, [message.content.content]);
 
+  const isUserMessage = message.position === 'right';
+
+  const displayContent = useMemo(() => {
+    if (!isUserMessage || typeof contentToRender !== 'string') {
+      return contentToRender;
+    }
+    return stripInjectedUserPrompt(contentToRender);
+  }, [contentToRender, isUserMessage]);
+
   // Pull out AI-generated-file preview cards (NEXUS_GENERATED_FILES marker).
   // Done before parseFileMarker so the user-side NEXUS_FILES path can keep
   // assuming its content is unprefixed.
-  const generated = useMemo(() => (typeof contentToRender === 'string' ? parseGeneratedFilesMarker(contentToRender) : { textBefore: contentToRender as string, files: [], ok: false }), [contentToRender]);
+  const generated = useMemo(() => (typeof displayContent === 'string' ? parseGeneratedFilesMarker(displayContent) : { textBefore: displayContent as string, files: [], ok: false }), [displayContent]);
 
   const { text: rawText, files } = parseFileMarker(generated.textBefore);
   const text = rawText.trimEnd();
@@ -78,8 +93,7 @@ const MessageText: React.FC<{ message: IMessageText; isStreaming?: boolean; foot
   const { data, json } = useFormatContent(text);
   const { t } = useTranslation();
   const [showCopyAlert, setShowCopyAlert] = useState(false);
-  const isUserMessage = message.position === 'right';
-  const hasCodeFence = typeof contentToRender === 'string' ? /```/.test(contentToRender) : false;
+  const hasCodeFence = typeof displayContent === 'string' ? /```/.test(displayContent) : false;
   const hasCodeLikeContent = json || hasCodeFence;
   const skills = message.content.skills || [];
 

--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useCallback, useEffect, useRef } from 'react';
+import { createContext } from '../utils/createContext';
 import { ipcBridge } from '@/common';
 import type { TMessage } from '@/common/chatLib';
 import { composeMessage } from '@/common/chatLib';
-import { useCallback, useEffect, useRef } from 'react';
-import { createContext } from '../utils/createContext';
 
 const [useMessageList, MessageListProvider, useUpdateMessageList] = createContext([] as TMessage[]);
 
@@ -139,7 +139,16 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
       const existingMsg = list[existingIdx];
       if (existingMsg.type === 'acp_tool_call') {
         const newList = list.slice();
-        const merged = { ...existingMsg.content, ...message.content };
+        const merged = {
+          ...existingMsg.content,
+          ...message.content,
+          update: {
+            ...existingMsg.content.update,
+            ...message.content.update,
+            rawInput: message.content.update?.rawInput ?? existingMsg.content.update?.rawInput,
+            content: message.content.update?.content ?? existingMsg.content.update?.content,
+          },
+        };
         newList[existingIdx] = { ...existingMsg, content: merged };
         return newList;
       }

--- a/tests/unit/acpAdapter.test.ts
+++ b/tests/unit/acpAdapter.test.ts
@@ -115,6 +115,51 @@ describe('AcpAdapter - rawInput merging (#1113)', () => {
     expect((messages[0] as any).content.update.rawInput).toEqual({ path: '/some/file.txt' });
   });
 
+  it('should preserve previous rawInput when tool_call_update only changes status/content', () => {
+    const initialToolCall: ToolCallUpdate = {
+      sessionId: 'test-session',
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'tool-999',
+        status: 'pending',
+        title: 'Bash',
+        kind: 'execute',
+        rawInput: {
+          command: 'bash write_file --path /tmp/demo.txt',
+          description: 'write file',
+        },
+      },
+    };
+
+    adapter.convertSessionUpdate(initialToolCall);
+
+    const toolCallUpdateStatus: ToolCallUpdateStatus = {
+      sessionId: 'test-session',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'tool-999',
+        status: 'completed',
+        content: [
+          {
+            type: 'content',
+            content: {
+              type: 'text',
+              text: 'done',
+            },
+          },
+        ],
+      },
+    };
+
+    const messages = adapter.convertSessionUpdate(toolCallUpdateStatus);
+
+    expect(messages).toHaveLength(1);
+    expect((messages[0] as any).content.update.rawInput).toEqual({
+      command: 'bash write_file --path /tmp/demo.txt',
+      description: 'write file',
+    });
+  });
+
   it('should return null for tool_call_update without existing tool call', () => {
     const toolCallUpdateStatus: ToolCallUpdateStatus = {
       sessionId: 'test-session',
@@ -208,18 +253,12 @@ describe('AcpAdapter - AskUserQuestion v2', () => {
       expect.objectContaining({
         id: 'save_scope',
         prompt: '保存到哪里？',
-        options: [
-          expect.objectContaining({ label: 'Project', value: 'project' }),
-          expect.objectContaining({ label: 'User', value: 'user' }),
-        ],
+        options: [expect.objectContaining({ label: 'Project', value: 'project' }), expect.objectContaining({ label: 'User', value: 'user' })],
       }),
       expect.objectContaining({
         id: 'default_language',
         prompt: '默认语言？',
-        options: [
-          expect.objectContaining({ label: 'zh-CN', value: 'zh-CN' }),
-          expect.objectContaining({ label: 'en-US', value: 'en-US' }),
-        ],
+        options: [expect.objectContaining({ label: 'zh-CN', value: 'zh-CN' }), expect.objectContaining({ label: 'en-US', value: 'en-US' })],
       }),
     ]);
   });
@@ -274,9 +313,7 @@ describe('AcpAdapter - AskUserQuestion v2', () => {
                     ],
                   },
                 ],
-                answers: [
-                  { id: 'save_scope', value: 'project', label: 'Project' },
-                ],
+                answers: [{ id: 'save_scope', value: 'project', label: 'Project' }],
               }),
             },
           },

--- a/tests/unit/messageTextPromptStrip.test.ts
+++ b/tests/unit/messageTextPromptStrip.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { stripInjectedUserPrompt } from '@/renderer/messages/MessagetText';
+
+describe('stripInjectedUserPrompt', () => {
+  it('removes injected assistant rules and cron skill blocks from user prompts', () => {
+    const input = `[Scheduled Task Skill — you MUST follow this to manage scheduled tasks; output the [CRON_*] commands directly in your reply]
+
+[Assistant Rules - You MUST follow these instructions]
+
+[User Request]
+生成一个 go 语言的 knn 算法`;
+
+    expect(stripInjectedUserPrompt(input)).toBe('生成一个 go 语言的 knn 算法');
+  });
+
+  it('returns the original content when no user request marker is present', () => {
+    expect(stripInjectedUserPrompt('hello world')).toBe('hello world');
+  });
+});

--- a/tests/unit/remoteConversationProviderSync.test.ts
+++ b/tests/unit/remoteConversationProviderSync.test.ts
@@ -34,25 +34,56 @@ describe('RemoteConversationProvider Moss sync conversion', () => {
     const { default: RemoteConversationProvider } = await import('../../src/process/providers/RemoteConversationProvider');
     const provider = new RemoteConversationProvider({} as any);
 
-    const { messages, foundModel } = (provider as any).convertMossMessagesToTMessages([
-      {
-        type: 'user',
-        timestamp: '2026-06-10T00:00:00.000Z',
-        message: { content: [{ type: 'text', text: '记住我是 ybc' }] },
-      },
-      {
-        type: 'assistant',
-        timestamp: '2026-06-10T00:00:01.000Z',
-        message: {
-          model: 'gemini-3.5-flash',
-          content: [{ type: 'text', text: '已记住' }],
+    const { messages, foundModel } = (provider as any).convertMossMessagesToTMessages(
+      [
+        {
+          type: 'user',
+          timestamp: '2026-06-10T00:00:00.000Z',
+          message: { content: [{ type: 'text', text: '记住我是 ybc' }] },
         },
-      },
-    ], 'conv-1', 'moss-session-1');
+        {
+          type: 'assistant',
+          timestamp: '2026-06-10T00:00:01.000Z',
+          message: {
+            model: 'gemini-3.5-flash',
+            content: [{ type: 'text', text: '已记住' }],
+          },
+        },
+      ],
+      'conv-1',
+      'moss-session-1'
+    );
 
     expect(foundModel).toBe('gemini-3.5-flash');
     expect(messages).toHaveLength(2);
     expect(messages.map((message: any) => message.status)).toEqual(['finish', 'finish']);
     expect(messages.map((message: any) => message.position)).toEqual(['right', 'left']);
+  });
+
+  it('strips injected cron prompt blocks from remote user messages', async () => {
+    const { default: RemoteConversationProvider } = await import('../../src/process/providers/RemoteConversationProvider');
+    const provider = new RemoteConversationProvider({} as any);
+
+    const { messages } = (provider as any).convertMossMessagesToTMessages(
+      [
+        {
+          type: 'user',
+          timestamp: '2026-06-10T00:00:00.000Z',
+          message: {
+            content: [
+              {
+                type: 'text',
+                text: '[Scheduled Task Skill — you MUST follow this to manage scheduled tasks; output the [CRON_*] commands directly in your reply]\n\n[Assistant Rules - You MUST follow these instructions]\n\n[User Request]\n生成一个 go 语言的 knn 算法',
+              },
+            ],
+          },
+        },
+      ],
+      'conv-1',
+      'moss-session-1'
+    );
+
+    expect(messages).toHaveLength(1);
+    expect((messages[0] as any).content.content).toBe('生成一个 go 语言的 knn 算法');
   });
 });


### PR DESCRIPTION
Fixes two regressions:\n- preserve acp_tool_call rawInput/content during completion merge\n- strip injected Scheduled Task / User Request prompt blocks in remote conversation replay and renderer fallback\n\nIncludes regression tests.