### PR TITLE
fix(channels): DingTalk image/file delivery + AI Card streaming

### DIFF
--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -775,21 +775,53 @@ export class ActionExecutor {
       // Buffer pending files to send after stream ends (ensure text outputs first, files last)
       const pendingFilesToSend: IUnifiedOutgoingMessage[] = [];
 
+      // msg_id → cardId 精确路由表。composeMessage 对同段文本 insert/update 复用同一个 msg_id
+      // (chatLib.ts:730)，用它把流式 update 精确路由到该段的 card，而不是盲目打 sentMessageIds[last]
+      // —— 后者会与异步建卡竞态，把内容打错 card 或被 isFinished 分支吞掉。
+      // msg_id → cardId routing. composeMessage reuses one msg_id per text segment, so we can
+      // route streaming updates to the exact card instead of sentMessageIds[last], which races
+      // with async card creation and misroutes content.
+      const msgIdToCardId: Map<string, string> = new Map();
+      // 正在 await 创建 card 的 msg_id 集合。建卡 await 窗口内到达的同段 update，其 msg_id 在
+      // msgIdToCardId 里还没有（newMsgId 要等 await 后），用此集合识别并暂存，建卡完成后 flush。
+      // msg_ids whose card is still being created (await window). Updates arriving in this window
+      // can't find their card in msgIdToCardId yet, so we defer them and flush once the card lands.
+      const creatingCardForMsg: Set<string> = new Set();
+      // 按 msg_id 暂存的 deferred update（全量覆盖，依赖 streamAICard isFull=true）。
+      // Deferred updates keyed by msg_id (last-write-wins, relies on streamAICard isFull=true).
+      const deferredByMsgId: Map<string, IUnifiedOutgoingMessage> = new Map();
+
       // 执行消息编辑的函数
       // Function to perform message edit
       const doEditMessage = async (msg: IUnifiedOutgoingMessage, forceThinkingTarget = false) => {
         if (!supportsEdit) return; // WeChat doesn't support edit
 
+        // 路由决策：优先按 msg_id 精确路由；建卡窗口内的同段 update 暂存；其余 fallback 到 last。
+        // Routing: prefer exact msg_id lookup; defer if that segment's card is still being created;
+        // otherwise fall back to sentMessageIds[last] (legacy behavior).
+        let targetMsgId: string | undefined;
+        let deferred = false;
+        if (forceThinkingTarget && thinkingMsgId) {
+          targetMsgId = thinkingMsgId;
+        } else if (msg.msg_id && msgIdToCardId.has(msg.msg_id)) {
+          targetMsgId = msgIdToCardId.get(msg.msg_id);
+        } else if (msg.msg_id && creatingCardForMsg.has(msg.msg_id)) {
+          // 该段的 card 还在异步创建，暂存最新全量内容，建卡完成后 flush 到正确 card。
+          // This segment's card is still being created; stash the latest full content and flush later.
+          deferredByMsgId.set(msg.msg_id, msg);
+          deferred = true;
+        } else {
+          targetMsgId = sentMessageIds[sentMessageIds.length - 1] || thinkingMsgId;
+        }
+        if (deferred) return;
+
         lastUpdateTime = Date.now();
-        // When updating thinking message, always target thinkingMsgId directly
-        // (not sentMessageIds[last], which may be a file/image message)
-        const targetMsgId = forceThinkingTarget && thinkingMsgId ? thinkingMsgId : sentMessageIds[sentMessageIds.length - 1] || thinkingMsgId;
         // Lark markdown cards reject `![](local-path)`. Non-Lark platforms get
         // the original msg back from the helper (identity), so no behavior change.
         const sanitizedText = stripLarkUnusableImageMarkdown(msg.text, context.platform as PluginType);
         const safeMsg = sanitizedText === msg.text ? msg : { ...msg, text: sanitizedText };
         try {
-          await context.editMessage(targetMsgId, safeMsg);
+          await context.editMessage(targetMsgId!, safeMsg);
         } catch {
           // Ignore edit errors (message not modified, etc.)
         }
@@ -814,7 +846,7 @@ export class ActionExecutor {
         // Tool confirmation cards set replyMarkup (e.g., for Confirming status),
         // but DingTalk interprets replyMarkup as "stream complete" and finishes the AI Card.
         // Channel conversations use yoloMode (auto-approve), so confirmation buttons are unnecessary.
-        const streamOutgoing: IUnifiedOutgoingMessage = { ...outgoingMessage, replyMarkup: undefined };
+        const streamOutgoing: IUnifiedOutgoingMessage = { ...outgoingMessage, replyMarkup: undefined, msg_id: message.msg_id };
 
         // 保存最后一条消息内容（不含 replyMarkup，最终消息会单独添加）
         // Save last message content (without replyMarkup, final message adds it separately)
@@ -835,6 +867,9 @@ export class ActionExecutor {
           // First text streaming message: update thinking message instead of inserting
           // 第一个text流式消息：更新thinking消息而不是插入新消息
           thinkingUpdated = true;
+          // 首个 text 段复用 thinking card，建立 msg_id → thinkingMsgId 映射，后续同段 update 精确路由。
+          // First text segment reuses the thinking card; map its msg_id so later updates route here.
+          if (streamOutgoing.msg_id) msgIdToCardId.set(streamOutgoing.msg_id, thinkingMsgId);
 
           // CRITICAL: First thinking update must be sent IMMEDIATELY without throttle delay.
           // If we delay it with a timer, subsequent UPDATE messages will overwrite the content
@@ -927,13 +962,44 @@ export class ActionExecutor {
             const fileValid = streamOutgoing.fileUrl ? isValidFilePath(streamOutgoing.fileUrl) : false;
             const imageValid = streamOutgoing.imageUrl ? isValidFilePath(streamOutgoing.imageUrl) : false;
             console.log(`[ActionExecutor] 📥 NEW message: type=${streamOutgoing.type}, imageUrl=${streamOutgoing.imageUrl || 'none'}(valid=${imageValid}), fileUrl=${streamOutgoing.fileUrl || 'none'}(valid=${fileValid}), sentFiles now=${Array.from(sentFiles).join(',') || 'empty'}`);
+            const segmentMsgId = streamOutgoing.msg_id;
             try {
-              const newMsgId = await context.sendMessage(streamOutgoing);
+              // 先标记该段 card 正在创建，使后续 await 窗口内到达的同段 update 被 deferred。
+              // Mark this segment's card as creating first, so same-segment updates in the await
+              // window below are deferred instead of misrouted.
+              if (segmentMsgId) creatingCardForMsg.add(segmentMsgId);
+              // 切换到新段前，把上一段被 throttle 暂存的尾内容 flush 到它的 card。否则接下来
+              // createAndDeliverAICard 会 finalize 旧 card，而这段尾还没 stream → 旧 card 缺尾。
+              // Flush the previous segment's throttled tail to its card before the new card is created
+              // and the old one finalized, otherwise that tail never lands and the old card reads truncated.
+              if (pendingMessage) {
+                if (pendingUpdateTimer) {
+                  clearTimeout(pendingUpdateTimer);
+                  pendingUpdateTimer = null;
+                }
+                await doEditMessage(pendingMessage);
+                pendingMessage = null;
+              }
+              const createdCardId = await context.sendMessage(streamOutgoing);
               // image/file 已在上方特殊处理并 return，此处仅处理 text/buttons
               // image/file already handled above with return, here only text/buttons
-              sentMessageIds.push(newMsgId);
+              sentMessageIds.push(createdCardId);
+              // 建立 msg_id → cardId 映射，并 flush 建卡窗口内暂存的同段 update 到新 card。
+              // Register msg_id → cardId and flush any deferred updates for this segment to the new card.
+              if (segmentMsgId) {
+                msgIdToCardId.set(segmentMsgId, createdCardId);
+                const deferred = deferredByMsgId.get(segmentMsgId);
+                if (deferred) {
+                  deferredByMsgId.delete(segmentMsgId);
+                  void doEditMessage(deferred);
+                }
+              }
             } catch {
               // Ignore send errors
+            } finally {
+              // 无论成功失败都要清理 creating 标记，否则该段后续 update 会永久 deferred 而丢失。
+              // Always clear the creating flag so later updates don't defer forever on a failed card.
+              if (segmentMsgId) creatingCardForMsg.delete(segmentMsgId);
             }
           } else {
             // For non-edit platforms (WeChat), buffer files to send after text.

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -139,7 +139,7 @@ function getErrorRecoveryMarkup(platform: PluginType, errorMessage?: string) {
  * ChannelResponseRouter.
  */
 function stripLarkUnusableImageMarkdown(text: string | undefined, platform: PluginType): string | undefined {
-  if (platform !== 'lark' || !text) return text;
+  if ((platform !== 'lark' && platform !== 'dingtalk') || !text) return text;
   return text
     .replace(/!\[[^\]]*\]\(([^)]+)\)/g, (match, imgPath: string) => {
       if (/^(https?:|data:|file:)/i.test(imgPath)) return match;

--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -67,6 +67,8 @@ interface IAICardSession {
   openSpaceId: string;
   isFinished: boolean;
   inputingStarted: boolean;
+  /** Last full content pushed via streamAICard; used to finishAICard older cards verbatim. */
+  lastContent: string;
 }
 
 export class DingTalkPlugin extends BasePlugin {
@@ -494,6 +496,12 @@ export class DingTalkPlugin extends BasePlugin {
         await this.finishAICard(cardSession.outTrackId, truncatedText);
         this.aiCardSessions.set(messageId, { ...cardSession, isFinished: true });
 
+        // 流结束：把之前各段仍未 finalize 的 card 一并 finalize（停转圈）。
+        // 此时所有 update 已送达，各 card 的 lastContent 即其最终内容，无竞态。
+        // Stream ended: finalize any earlier segment cards that are still loading. All updates
+        // have landed by now, so each card's lastContent is its final text — no race.
+        await this.finalizePendingCards();
+
         // Send extracted local images as separate messages after AI Card is finalized
         if (imagePaths.length > 0) {
           await this.sendLocalImages(chatId, imagePaths);
@@ -653,6 +661,15 @@ export class DingTalkPlugin extends BasePlugin {
    * Returns a synthetic messageId for tracking
    */
   private async createAndDeliverAICard(chatType: 'user' | 'group', id: string, _initialText: string): Promise<string> {
+    // 创建新 card 前 finalize 之前所有未完成的 card（停转圈），让用户看到"上一条消息已完成"。
+    // 安全前提：ActionExecutor 的 msg_id 路由会把建卡 await 窗口内到达的同段 update 暂存
+    // （deferred），不会打到这些刚 finish 的旧 card；上一段被 throttle 的尾内容也由
+    // ActionExecutor 在到达此处之前 flush 到旧 card，故 finalize 时 lastContent 已完整。
+    // Finalize earlier cards before creating a new one so each message stops spinning in turn.
+    // Safe because ActionExecutor's msg_id routing defers same-segment updates during this await,
+    // and flushes the previous segment's throttled tail before reaching here.
+    await this.finalizePendingCards();
+
     const token = await this.getAccessToken();
     const outTrackId = `aion_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
@@ -686,6 +703,7 @@ export class DingTalkPlugin extends BasePlugin {
       openSpaceId,
       isFinished: false,
       inputingStarted: false,
+      lastContent: '',
     });
 
     // Set initial content so the card is not empty
@@ -734,6 +752,13 @@ export class DingTalkPlugin extends BasePlugin {
       isError: false,
       guid: `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     });
+
+    // Record the last full content so finalizePendingCards can finishAICard older cards
+    // with the exact text they currently show (avoids both truncation and the loading spinner).
+    const sessionForContent = this.findCardSessionByTrackId(outTrackId);
+    if (sessionForContent) {
+      sessionForContent.lastContent = content;
+    }
   }
 
   /**
@@ -752,6 +777,24 @@ export class DingTalkPlugin extends BasePlugin {
         },
       },
     });
+  }
+
+  /**
+   * Finalize every still-loading AI Card (flowStatus -> FINISHED) using each card's last
+   * streamed content. Called before creating a new card so prior segment cards stop
+   * showing the loading spinner. Idempotent: already-finished cards are skipped.
+   */
+  private async finalizePendingCards(): Promise<void> {
+    for (const session of this.aiCardSessions.values()) {
+      if (session.isFinished) continue;
+      try {
+        await this.finishAICard(session.outTrackId, session.lastContent || '');
+      } catch (error) {
+        mainWarn('DingTalkPlugin', 'Failed to finalize previous AI Card before creating a new one', error);
+      }
+      // Mark finished regardless of success so we don't retry a failing card on every new card.
+      session.isFinished = true;
+    }
   }
 
   /**

--- a/src/channels/plugins/dingtalk/DingTalkPlugin.ts
+++ b/src/channels/plugins/dingtalk/DingTalkPlugin.ts
@@ -1242,23 +1242,31 @@ export class DingTalkPlugin extends BasePlugin {
 
     const boundary = `----DingTalkBoundary${Date.now()}`;
     const CRLF = '\r\n';
-    const fileData = fileBuffer.toString('binary');
 
-    // Build multipart/form-data body
-    const body =
+    // 钉钉 /media/upload multipart 的 filename 字段若含非 ASCII（如中文），
+    // 服务端会返回 errcode=-1 errmsg=系统繁忙。而 mediaId 与 multipart filename
+    // 不绑定，用户最终看到的 fileName 来自 sendMediaViaAPI 的 msgParam
+    // （走 JSON UTF-8 通道），与此处无关。所以这里用基于扩展名的 ASCII 占位名。
+    const ext = path.extname(fileName) || '';
+    const uploadFileName = `upload${ext}`;
+
+    // 用 Buffer.concat 直接拼接：header / footer UTF-8 编码，文件内容保留原始字节，
+    // 避免历史 `toString('binary')` + `Buffer.from(body, 'binary')` 双重 latin1
+    // 往返路径中任何意外引入的非 ASCII 字符被截断为 0x?? 单字节。
+    const header = Buffer.from(
       `--${boundary}${CRLF}` +
-      `Content-Disposition: form-data; name="media"; filename="${fileName}"${CRLF}` +
-      `Content-Type: application/octet-stream${CRLF}` +
-      CRLF +
-      fileData +
-      CRLF +
-      `--${boundary}--${CRLF}`;
+        `Content-Disposition: form-data; name="media"; filename="${uploadFileName}"${CRLF}` +
+        `Content-Type: application/octet-stream${CRLF}` +
+        CRLF,
+      'utf8',
+    );
+    const footer = Buffer.from(`${CRLF}--${boundary}--${CRLF}`, 'utf8');
 
     const url = `${DingTalkPlugin.DINGTALK_OAPI_BASE}/media/upload?access_token=${encodeURIComponent(token)}&type=${uploadType}`;
 
     return new Promise((resolve, reject) => {
       const urlObj = new URL(url);
-      const bodyBuffer = Buffer.from(body, 'binary');
+      const bodyBuffer = Buffer.concat([header, fileBuffer, footer]);
 
       const options = {
         hostname: urlObj.hostname,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -355,6 +355,13 @@ export interface IUnifiedOutgoingMessage {
   fileName?: string;
   replyToMessageId?: string;
   silent?: boolean;
+  /**
+   * Originating TMessage msg_id (from composeMessage). Used by ActionExecutor to route
+   * streaming updates to the exact AI card that handled the segment's insert, instead of
+   * blindly targeting sentMessageIds[last] (which races with async card creation).
+   * Optional because not every message carries one; plugins do not read it.
+   */
+  msg_id?: string;
 }
 
 /**


### PR DESCRIPTION
Two independent DingTalk channel fixes.

## 1. Image/file delivery: duplicates + CJK filename rejection

- **Dupes**: DingTalk received 2N images for N generated (1→2, 2→4). Root cause: the finalize editMessage re-extracted local `![](path)` from text and re-sent images that `pendingFilesToSend` had already delivered. Fix: extend `stripLarkUnusableImageMarkdown` to dingtalk so the finalize card text no longer carries local image refs.
- **CJK filenames**: DingTalk `/media/upload` rejected non-ASCII filenames with `errcode=-1 系统繁忙`. Root cause: the multipart body was built via `fileBuffer.toString('binary')` + `Buffer.from(body, 'binary')`, truncating multibyte filenames. Fix: rebuild the multipart via `Buffer.concat([header_utf8, fileBuffer, footer_utf8])` with an ASCII placeholder filename; the real (CJK) filename still reaches users via the UTF-8 `msgParam` channel.

## 2. AI Card streaming: per-message spinner + update misrouting

Multi-segment agent replies created one AI Card per text segment but only finished the last at stream end, so earlier cards spun forever; and streaming updates were routed to `sentMessageIds[last]`, which raced with async card creation and dropped/truncated content on the wrong card.

- **types**: add optional `msg_id` to `IUnifiedOutgoingMessage` (plugins ignore it).
- **ActionExecutor**: route streaming updates by `msg_id` via `msgIdToCardId`; defer same-segment updates that arrive during card creation (`creatingCardForMsg` + `deferredByMsgId`); flush the previous segment's throttled tail before creating a new card so it isn't lost when the old card finalizes.
- **DingTalkPlugin**: finalize earlier cards when a new one is created (`finalizePendingCards`, using each card's `lastContent`) and again at `editMessage(isFinal)` as a fallback for the last card; record `lastContent` in `streamAICard`. Each message now stops spinning as soon as the next begins.

Verified manually on DingTalk: image delivery count matches generation, CJK filenames deliver, multi-segment replies stop spinning per message.