### PR TITLE
feat(authProxy): support multi-key injection and auto-sync sudorouter creds

### DIFF
--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -294,6 +294,29 @@ export function mergeCustomProviderIntoScodeConfig(existing: ScodeConfig | null 
   return nextConfig;
 }
 
+/**
+ * Extract sudorouter credentials (baseUrl + apiKey) from a ScodeConfig.
+ * Pure function, no side effects. Returns undefined for any field that is
+ * missing or not a non-empty string. Never throws — invalid input yields `{}`.
+ *
+ * Symmetric with mergeSudorouterIntoScodeConfig: that one writes, this one reads.
+ */
+export function extractSudorouterCreds(config: unknown): { baseUrl?: string; apiKey?: string } {
+  const result: { baseUrl?: string; apiKey?: string } = {};
+  if (!config || typeof config !== 'object') return result;
+  const authModes = (config as ScodeConfig)?.auth_modes;
+  const sudorouter = authModes?.proxy?.[SUDOROUTER_PROVIDER_ID];
+  if (!sudorouter || typeof sudorouter !== 'object') return result;
+  const { baseUrl, apiKey } = sudorouter as { baseUrl?: unknown; apiKey?: unknown };
+  if (typeof baseUrl === 'string' && baseUrl.trim()) {
+    result.baseUrl = baseUrl;
+  }
+  if (typeof apiKey === 'string' && apiKey.trim()) {
+    result.apiKey = apiKey;
+  }
+  return result;
+}
+
 export function removeCustomProviderFromScodeConfig(existing: ScodeConfig | null | undefined, providerId: string): ScodeConfig {
   const normalizedProviderId = providerId.trim();
   const nextApiKeyProviders = { ...(existing?.auth_modes?.['api-key'] || {}) };

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -11,16 +11,17 @@
  * Also exports helper functions for use within the main process.
  */
 
+import fs from 'fs';
+import path from 'path';
+import { SCODE_DIR, isScodeInstalled, getScodeVersionState, ensureScodeInstalled } from '@process/services/scode/ScodeInstallService';
+import { syncUserKeyFromScodeConfig } from '@process/services/authProxy/userKeySync';
+import { readSettings, removeDisabledMcpServersFromSettings, writeSettings } from '@process/services/mcpServices/agents/ScodeMcpAgent';
+import { getDatabase } from '@process/database';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { ipcBridge } from '@/common';
 import { modelInputForModelId } from '@/common/imageUtils';
 import type { ScodeModelEntry } from '@/common/ipcBridge';
 import { addScodeAutoModel, extractCustomProvidersFromScodeConfig, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, type ScodeCustomModelProvider } from '@/common/scodeConfig';
-import { SCODE_DIR, isScodeInstalled, getScodeVersionState, ensureScodeInstalled } from '@process/services/scode/ScodeInstallService';
-import { readSettings, removeDisabledMcpServersFromSettings, writeSettings } from '@process/services/mcpServices/agents/ScodeMcpAgent';
-import { getDatabase } from '@process/database';
-import fs from 'fs';
-import path from 'path';
-import { mainLog, mainWarn } from '@process/utils/mainLogger';
 
 const TAG = 'ScodeBridge';
 const SUDOCODE_CONFIG_PATH = path.join(SCODE_DIR, 'sudocode.json');
@@ -45,6 +46,8 @@ function writeConfig(config: Record<string, unknown>): void {
       /* ignore */
     }
   }
+  // Mirror sudorouter creds into Nexus (fire-and-forget; never throws).
+  void syncUserKeyFromScodeConfig(config);
 }
 
 function getCustomProvidersForUser(userId: string): ScodeCustomModelProvider[] {

--- a/src/process/services/authProxy/AuthProxyServer.ts
+++ b/src/process/services/authProxy/AuthProxyServer.ts
@@ -10,14 +10,15 @@
 import http from 'http';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { URL } from 'url';
-import type { AuthProxyRule } from '@/common/types/authProxy';
-import { resolveSecret } from '@/common/nexus/secret-cache';
 import { mainLog } from '@process/utils/mainLogger';
 import { injectAuth, injectMultiAuth } from './authInjectors';
 import { validateRemoteUrl } from './ssrfGuard';
 import { findRuleForUrl, getRules } from './configItemsLoader';
+import { parseSecretKeys, parseSecretMap } from './secretHeaderParser';
 import { handleSecretsRequest } from './secretsApi';
 import { handlePwdLoginRequest } from './pwdLoginApi';
+import { resolveSecret } from '@/common/nexus/secret-cache';
+import type { AuthProxyRule } from '@/common/types/authProxy';
 
 // ============================================================================
 // Types
@@ -27,7 +28,8 @@ interface ProxyRequestInfo {
   token: string | null;
   remoteUrl: string | null;
   secretNamespace: string | null;
-  secretKey: string | null;
+  secretKey: string[] | null;
+  secretMap: Record<string, string> | null;
   authScheme: string | null;
   authHeader: string | null;
   authPrefix: string | null;
@@ -37,17 +39,7 @@ interface ProxyRequestInfo {
 // Headers to strip before forwarding
 // ============================================================================
 
-const CONTROL_HEADERS = [
-  'authorization',
-  'x-secret-namespace',
-  'x-secret-key',
-  'x-auth-scheme',
-  'x-auth-header',
-  'x-auth-prefix',
-  'x-remote-url',
-  'host',
-  'connection',
-];
+const CONTROL_HEADERS = ['authorization', 'x-secret-namespace', 'x-secret-key', 'x-secret-map', 'x-auth-scheme', 'x-auth-header', 'x-auth-prefix', 'x-remote-url', 'host', 'connection'];
 
 const UPSTREAM_TIMEOUT_MS = 30_000;
 
@@ -228,51 +220,82 @@ export class AuthProxyServer {
   // Auth resolution
   // --------------------------------------------------------------------------
 
-  private async resolveAndInjectAuth(
-    info: ProxyRequestInfo,
-  ): Promise<{ headers: Record<string, string>; url?: string; error?: string; statusCode?: number }> {
+  private async resolveAndInjectAuth(info: ProxyRequestInfo): Promise<{ headers: Record<string, string>; url?: string; error?: string; statusCode?: number }> {
     let secretValue: string;
     let scheme: string | null;
     let bearerPrefix: string | null;
     let rule: AuthProxyRule | null = null;
 
-    // Priority 1: Explicit X-Secret-Namespace + X-Secret-Key
-    if (info.secretNamespace && info.secretKey) {
-      secretValue = resolveSecret(info.secretNamespace, info.secretKey, '');
-      scheme = info.authScheme;
-      bearerPrefix = null;
-    } else {
-      // Priority 2: URL pattern matching
-      rule = findRuleForUrl(info.remoteUrl!, this.minimatchFn);
-      if (!rule) {
-        return { headers: {}, error: 'No matching secret found. Provide X-Secret-Namespace + X-Secret-Key, or configure a URL pattern rule.' };
+    // Priority 1: Explicit X-Secret-Namespace + X-Secret-Key (supports multiple keys)
+    if (info.secretNamespace && info.secretKey && info.secretKey.length > 0) {
+      const keys = info.secretKey;
+
+      // bearer/basic are single-value schemes: only the first key can be injected.
+      // Application layer controls this by passing a single key when it needs them.
+      if (keys.length === 1 || info.authScheme === 'bearer' || info.authScheme === 'basic') {
+        secretValue = resolveSecret(info.secretNamespace, keys[0], '');
+        scheme = info.authScheme;
+        bearerPrefix = null;
+        if (!secretValue) {
+          return { headers: {}, error: `Secret not found: ${info.secretNamespace}/${keys[0]}` };
+        }
+        const prefix = info.authPrefix ?? bearerPrefix ?? 'Bearer';
+        return injectAuth({
+          scheme: scheme ?? 'bearer',
+          secret: secretValue,
+          headerName: info.authHeader,
+          prefix,
+        });
       }
 
-      // Determine scheme: request headers can override server config
-      scheme = info.authScheme ?? rule.scheme;
-      bearerPrefix = rule.bearerPrefix;
-
-      // Single-entry schemes (bearer/basic)
-      if ((scheme === 'bearer' || scheme === 'basic') && rule.entries.length >= 1) {
-        const entry = rule.entries[0];
-        secretValue = resolveSecret(rule.secretNamespace, entry.configKey, '');
-      } else if (scheme === 'header' || scheme === 'query') {
-        // Multi-entry schemes
-        return this.resolveMultiEntryAuth(rule, scheme);
-      } else {
-        // scheme is null or unknown, try single entry
-        if (rule.entries.length >= 1) {
-          secretValue = resolveSecret(rule.secretNamespace, rule.entries[0].configKey, '');
-          scheme = 'bearer';
-        } else {
-          return { headers: {}, error: `Config item "${rule.name}" has no entries with secret values` };
+      // Multiple keys with header/query scheme: aggregate via injectMultiAuth.
+      // Uses X-Secret-Map (vaultKey -> upstreamName) if provided; falls back to vaultKey.
+      const effectiveScheme = info.authScheme ?? 'header';
+      const entries: Array<{ configKey: string; secret: string }> = [];
+      for (const k of keys) {
+        const secret = resolveSecret(info.secretNamespace, k, '');
+        if (!secret) {
+          mainLog('AuthProxy', `Missing secret for ${info.secretNamespace}/${k}, skipping`);
+          continue;
         }
+        entries.push({ configKey: k, secret });
+      }
+      if (entries.length === 0) {
+        return { headers: {}, error: `No secrets found for namespace "${info.secretNamespace}"` };
+      }
+      return injectMultiAuth(effectiveScheme, entries, info.secretMap ?? undefined);
+    }
+
+    // Priority 2: URL pattern matching
+    rule = findRuleForUrl(info.remoteUrl!, this.minimatchFn);
+    if (!rule) {
+      return { headers: {}, error: 'No matching secret found. Provide X-Secret-Namespace + X-Secret-Key, or configure a URL pattern rule.' };
+    }
+
+    // Determine scheme: request headers can override server config
+    scheme = info.authScheme ?? rule.scheme;
+    bearerPrefix = rule.bearerPrefix;
+
+    // Single-entry schemes (bearer/basic)
+    if ((scheme === 'bearer' || scheme === 'basic') && rule.entries.length >= 1) {
+      const entry = rule.entries[0];
+      secretValue = resolveSecret(rule.secretNamespace, entry.configKey, '');
+    } else if (scheme === 'header' || scheme === 'query') {
+      // Multi-entry schemes
+      return this.resolveMultiEntryAuth(rule, scheme);
+    } else {
+      // scheme is null or unknown, try single entry
+      if (rule.entries.length >= 1) {
+        secretValue = resolveSecret(rule.secretNamespace, rule.entries[0].configKey, '');
+        scheme = 'bearer';
+      } else {
+        return { headers: {}, error: `Config item "${rule.name}" has no entries with secret values` };
       }
     }
 
     if (!secretValue) {
-      const missingKey = rule ? rule.entries[0]?.configKey : info.secretKey;
-      return { headers: {}, error: `Secret not found: ${rule ? rule.secretNamespace : info.secretNamespace}/${missingKey}` };
+      const missingKey = rule ? rule.entries[0]?.configKey : undefined;
+      return { headers: {}, error: `Secret not found: ${rule ? rule.secretNamespace : info.secretNamespace}/${missingKey ?? ''}` };
     }
 
     // Inject auth
@@ -285,10 +308,7 @@ export class AuthProxyServer {
     });
   }
 
-  private resolveMultiEntryAuth(
-    rule: AuthProxyRule,
-    scheme: string,
-  ): { headers: Record<string, string>; url?: string; error?: string; statusCode?: number } {
+  private resolveMultiEntryAuth(rule: AuthProxyRule, scheme: string): { headers: Record<string, string>; url?: string; error?: string; statusCode?: number } {
     const entries: Array<{ configKey: string; secret: string }> = [];
 
     for (const entry of rule.entries) {
@@ -318,17 +338,15 @@ export class AuthProxyServer {
       token,
       remoteUrl: req.headers['x-remote-url'] as string | null,
       secretNamespace: req.headers['x-secret-namespace'] as string | null,
-      secretKey: req.headers['x-secret-key'] as string | null,
+      secretKey: parseSecretKeys(req),
+      secretMap: parseSecretMap(req.headers['x-secret-map'] as string | null),
       authScheme: req.headers['x-auth-scheme'] as string | null,
       authHeader: req.headers['x-auth-header'] as string | null,
       authPrefix: req.headers['x-auth-prefix'] as string | null,
     };
   }
 
-  private buildUpstreamHeaders(
-    req: IncomingMessage,
-    authHeaders: Record<string, string>,
-  ): Record<string, string> {
+  private buildUpstreamHeaders(req: IncomingMessage, authHeaders: Record<string, string>): Record<string, string> {
     const headers: Record<string, string> = {};
 
     // Copy original headers, excluding control headers
@@ -355,12 +373,7 @@ export class AuthProxyServer {
     return headers;
   }
 
-  private proxyRequest(
-    targetUrl: string,
-    req: IncomingMessage,
-    res: ServerResponse,
-    headers: Record<string, string>,
-  ): Promise<void> {
+  private proxyRequest(targetUrl: string, req: IncomingMessage, res: ServerResponse, headers: Record<string, string>): Promise<void> {
     return new Promise((resolve) => {
       const parsed = new URL(targetUrl);
 

--- a/src/process/services/authProxy/authInjectors.ts
+++ b/src/process/services/authProxy/authInjectors.ts
@@ -75,20 +75,22 @@ export function injectAuth(params: InjectAuthParams): InjectAuthResult {
 
 /**
  * Inject multiple headers for header/query schemes with multiple entries.
- * Each entry has its own configKey as the header name / query param name.
+ *
+ * @param nameMap - Optional mapping from Vault configKey to the upstream
+ *                  header / query param name. Entries not present in the map
+ *                  (or when the map is omitted) fall back to `entry.configKey`,
+ *                  preserving the URL-pattern path's original behavior.
  */
-export function injectMultiAuth(
-  scheme: string,
-  entries: Array<{ configKey: string; secret: string }>,
-): InjectAuthResult {
+export function injectMultiAuth(scheme: string, entries: Array<{ configKey: string; secret: string }>, nameMap?: Record<string, string>): InjectAuthResult {
   const headers: Record<string, string> = {};
   const queryParts: string[] = [];
 
   for (const entry of entries) {
+    const name = nameMap?.[entry.configKey] ?? entry.configKey;
     if (scheme === 'header') {
-      headers[entry.configKey] = entry.secret;
+      headers[name] = entry.secret;
     } else if (scheme === 'query') {
-      queryParts.push(`${entry.configKey}=${encodeURIComponent(entry.secret)}`);
+      queryParts.push(`${name}=${encodeURIComponent(entry.secret)}`);
     }
   }
 

--- a/src/process/services/authProxy/secretHeaderParser.ts
+++ b/src/process/services/authProxy/secretHeaderParser.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure parsers for Auth Proxy request control headers.
+ *
+ * Extracted from AuthProxyServer so the parsing logic has no Electron / Nexus
+ * dependencies and is unit-testable in isolation. AuthProxyServer delegates to
+ * these via parseRequestInfo().
+ */
+
+import type { IncomingMessage } from 'http';
+
+/**
+ * Collect every X-Secret-Key value from the raw request, supporting both
+ * repeated headers (e.g. two separate `X-Secret-Key: ...` lines) and
+ * comma-separated values within a single header. Empty segments are dropped.
+ * Returns null when no key is present (falls back to URL-pattern matching).
+ */
+export function parseSecretKeys(req: IncomingMessage): string[] | null {
+  const rawValues: string[] = [];
+  for (let i = 0; i < req.rawHeaders.length; i += 2) {
+    if (req.rawHeaders[i]?.toLowerCase() === 'x-secret-key') {
+      const v = req.rawHeaders[i + 1];
+      if (typeof v === 'string') rawValues.push(v);
+    }
+  }
+  if (rawValues.length === 0) return null;
+  const keys = rawValues
+    .flatMap((v) => v.split(','))
+    .map((k) => k.trim())
+    .filter(Boolean);
+  return keys.length > 0 ? keys : null;
+}
+
+/**
+ * Parse X-Secret-Map into a vaultKey -> upstreamName record.
+ * Format: "vaultKey->upstreamName, vaultKey->upstreamName".
+ * Segments missing the `->` separator are silently skipped.
+ * Returns null when the header is absent or produces no valid mappings.
+ */
+export function parseSecretMap(headerValue: string | null): Record<string, string> | null {
+  if (!headerValue) return null;
+  const map: Record<string, string> = {};
+  for (const segment of headerValue.split(',')) {
+    const idx = segment.indexOf('->');
+    if (idx <= 0) continue;
+    const vaultKey = segment.slice(0, idx).trim();
+    const upstreamName = segment.slice(idx + 2).trim();
+    if (vaultKey && upstreamName) {
+      map[vaultKey] = upstreamName;
+    }
+  }
+  return Object.keys(map).length > 0 ? map : null;
+}

--- a/src/process/services/authProxy/userKeySync.ts
+++ b/src/process/services/authProxy/userKeySync.ts
@@ -1,0 +1,97 @@
+/**
+ * User Key Sync — mirrors sudorouter credentials from sudocode.json into Nexus Vault.
+ *
+ * Source : ~/.nexus/sudocode/sudocode.json → auth_modes.proxy.sudorouter.{baseUrl, apiKey}
+ * Target : Nexus secret namespace `service_system:user_info`, keys `base_url` / `api_key`
+ *
+ * Design:
+ * - Pure single-responsibility module: read creds (via scodeConfig) + write Nexus (idempotent).
+ * - Fire-and-forget from callers; never throws (Nexus outages are logged, not propagated).
+ * - Missing fields are skipped with a log line, never deleted from Nexus.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { getNexusSecretClient } from '@common/nexus/nexus-secret-client';
+import { resolveSecret, cachePut } from '@common/nexus/secret-cache';
+import { SCODE_DIR } from '@process/services/scode/ScodeInstallService';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import { extractSudorouterCreds } from '@/common/scodeConfig';
+
+const TAG = 'UserKeySync';
+
+const USER_KEY_NAMESPACE = 'service_system:user_info';
+const KEY_BASE_URL = 'base_url';
+const KEY_API_KEY = 'api_key';
+const SUDOCODE_CONFIG_PATH = path.join(SCODE_DIR, 'sudocode.json');
+
+/**
+ * Sync sudorouter credentials from a parsed sudocode.json config object into Nexus.
+ * Reads `{ baseUrl, apiKey }`; writes whichever are present, skips whichever are missing.
+ * Never throws.
+ */
+export async function syncUserKeyFromScodeConfig(config: unknown): Promise<void> {
+  const creds = extractSudorouterCreds(config);
+
+  if (creds.baseUrl) {
+    await writeSecretIfChanged(KEY_BASE_URL, creds.baseUrl);
+  } else {
+    mainLog(TAG, 'baseUrl missing in sudocode.json, skip sync');
+  }
+
+  if (creds.apiKey) {
+    await writeSecretIfChanged(KEY_API_KEY, creds.apiKey);
+  } else {
+    mainLog(TAG, 'apiKey missing in sudocode.json, skip sync');
+  }
+}
+
+/**
+ * Startup entry point: reads sudocode.json from disk and syncs its sudorouter creds.
+ * Safe to call before the user has logged in (file may be absent/empty).
+ * Never throws.
+ */
+export async function syncUserKeyOnStartup(): Promise<void> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(SUDOCODE_CONFIG_PATH, 'utf-8');
+  } catch {
+    mainLog(TAG, 'sudocode.json not found, skip startup sync');
+    return;
+  }
+
+  let config: unknown;
+  try {
+    config = JSON.parse(raw);
+  } catch (err) {
+    mainWarn(TAG, 'sudocode.json parse failed, skip startup sync', err);
+    return;
+  }
+
+  await syncUserKeyFromScodeConfig(config);
+}
+
+/**
+ * Idempotent single-key write using the standard three-step pattern
+ * (putSecret → restoreSecret → cachePut), mirroring secretsApi.ts.
+ * Skips Nexus round-trip when the cached value already matches.
+ */
+async function writeSecretIfChanged(key: string, value: string): Promise<void> {
+  try {
+    const current = resolveSecret(USER_KEY_NAMESPACE, key, '');
+    if (current === value) {
+      return; // unchanged — avoid bumping Nexus version number on every save
+    }
+    const client = getNexusSecretClient();
+    client.putSecret(USER_KEY_NAMESPACE, key, value);
+    try {
+      client.restoreSecret(USER_KEY_NAMESPACE, key);
+    } catch {
+      // First-time create (no soft-deleted state to clear) reports an error — expected, ignore.
+    }
+    cachePut(USER_KEY_NAMESPACE, key, value);
+    mainLog(TAG, `synced ${USER_KEY_NAMESPACE}/${key}`);
+  } catch (err) {
+    mainWarn(TAG, `failed to sync ${USER_KEY_NAMESPACE}/${key}`, err);
+  }
+}

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -259,6 +259,13 @@ export class ServiceManager {
           } catch (err) {
             mainWarn('ServiceManager', 'Auth Proxy start failed (non-critical):', err);
           }
+          // Sync sudorouter creds from sudocode.json into Nexus (Nexus ready, cache preloaded).
+          try {
+            const { syncUserKeyOnStartup } = await import('@process/services/authProxy/userKeySync');
+            await syncUserKeyOnStartup();
+          } catch (err) {
+            mainWarn('ServiceManager', 'User key sync failed (non-critical):', err);
+          }
           this.secretsReadyResolve?.(true);
         })
         .catch((err) => {


### PR DESCRIPTION
## Changes

- **AuthProxy explicit-header path** now accepts multiple `X-Secret-Key` values (repeated headers or comma-separated) under one namespace.
- **`X-Secret-Map`** (`vaultKey->upstreamName`) for header/query field renaming; bearer/basic fall back to the first key when multiple keys are supplied.
- Extract pure header parsers into `secretHeaderParser.ts`.
- **`userKeySync`**: mirror sudorouter `baseUrl`/`apiKey` from `sudocode.json` into Nexus (`service_system:user_info`) on startup and on every `sudocode.json` write; idempotent, missing fields skipped.

## Files

- `src/common/scodeConfig.ts` — `extractSudorouterCreds` pure helper
- `src/process/services/authProxy/authInjectors.ts` — `injectMultiAuth` optional `nameMap`
- `src/process/services/authProxy/AuthProxyServer.ts` — multi-key + X-Secret-Map wiring
- `src/process/services/authProxy/secretHeaderParser.ts` — new, pure header parsers
- `src/process/services/authProxy/userKeySync.ts` — new, sudocode.json → Nexus sync
- `src/process/bridge/scodeBridge.ts` — writeConfig triggers sync
- `src/process/services/serviceManager/ServiceManager.ts` — startup sync

## Test plan

- [x] Unit: header parsers, injectMultiAuth nameMap, extractSudorouterCreds
- [x] E2E HTTP: AuthProxyServer multi-key injection + control-header stripping
- [x] Real Nexus integration: sudocode.json → `service_system:user_info` write verified against running nexusd-cluster