### PR TITLE
fix: stabilize workspace refresh and notifications

### DIFF
--- a/src/renderer/pages/conversation/ChatLayout.tsx
+++ b/src/renderer/pages/conversation/ChatLayout.tsx
@@ -216,8 +216,6 @@ const ChatLayout: React.FC<{
       } else {
         if (detail.hasFiles && rightSiderCollapsed) {
           setRightSiderCollapsed(false);
-        } else if (!detail.hasFiles && !rightSiderCollapsed) {
-          setRightSiderCollapsed(true);
         }
       }
     };

--- a/src/renderer/pages/conversation/ChatSider.tsx
+++ b/src/renderer/pages/conversation/ChatSider.tsx
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TChatConversation } from '@/common/storage';
-import { STORAGE_KEYS } from '@/common/storageKeys';
-import { ipcBridge } from '@/common';
-import { useAddEventListener } from '@/renderer/utils/emitter';
 import { Message } from '@arco-design/web-react';
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import ChatWorkspace from './workspace';
 import BrowserPanel from './right-panel/BrowserPanel';
 import DeliverablesPanel from './right-panel/DeliverablesPanel';
 import TerminalPanel from './right-panel/TerminalPanel';
+import { useAddEventListener } from '@/renderer/utils/emitter';
+import { ipcBridge } from '@/common';
+import { STORAGE_KEYS } from '@/common/storageKeys';
+import type { TChatConversation } from '@/common/storage';
 import './workspace/workspace-card.css';
 
 type RightPanelTab = 'workspace' | 'browser' | 'terminal' | 'deliverables';
@@ -82,10 +83,11 @@ const ChatSider: React.FC<{
   } else if (conversation?.type === 'remote-agent') {
     workspaceNode = <ChatWorkspace conversation_id={conversation.id} workspace={workspace || conversation.id} workspaceDisplayName={extra?.workspaceDisplayName} eventPrefix='remote-agent' backend='remote-agent' dataSource='moss-session' readonly messageApi={messageApi} />;
   }
+  const messageContextPortal = typeof document !== 'undefined' ? createPortal(messageContext, document.body) : messageContext;
 
   return (
     <>
-      {messageContext}
+      {messageContextPortal}
       <div className='flex h-full min-h-0 flex-col bg-[var(--color-bg-1)]'>
         <div className='right-panel-tabs'>
           {(['workspace', 'browser', 'terminal', 'deliverables'] as RightPanelTab[]).map((tab) => {

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
-import type { IDirOrFile } from '@/common/ipcBridge';
-import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 import { useEffect, useRef } from 'react';
 import type { ContextMenuState } from '../types';
 import { getAllDirKeys } from '../utils/treeHelpers';
+import { ipcBridge } from '@/common';
+import type { IDirOrFile } from '@/common/ipcBridge';
+import { emitter, useAddEventListener } from '@/renderer/utils/emitter';
 
 interface UseWorkspaceEventsOptions {
   conversation_id: string;
@@ -77,11 +77,10 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
     setContextMenu({ visible: false, x: 0, y: 0, node: null });
     closeRenameModal();
     closeDeleteModal();
-    refreshWorkspace();
     if (eventPrefix === 'acp') {
       emitter.emit('acp.selected.file', []);
     }
-  }, [conversation_id, eventPrefix]); // Only depend on conversation_id to avoid infinite loop
+  }, [closeDeleteModal, closeRenameModal, conversation_id, eventPrefix, setContextMenu, setFiles, setSelected, setTreeKey, selectedKeysRef, selectedNodeRef]);
 
   /**
    * 监听 Agent 响应流 - 自动刷新工作空间
@@ -102,7 +101,7 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
     return () => {
       unsubscribeAcp();
     };
-  }, [dataSource]); // event listeners are stable, refreshWorkspace is captured from closure
+  }, [dataSource, refreshWorkspace]);
 
   useEffect(() => {
     if (dataSource !== 'moss-session') {
@@ -169,7 +168,7 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
       unsubscribeStream();
       unsubscribeConversation();
     };
-  }, [conversation_id, dataSource]);
+  }, [conversation_id, dataSource, refreshWorkspace]);
 
   /**
    * inotify 风格的工作空间目录监听 — 任何文件/子目录变化都会触发刷新
@@ -292,6 +291,20 @@ export function useWorkspaceEvents(options: UseWorkspaceEventsOptions) {
     },
     [eventPrefix, conversation_id, setSelected, selectedKeysRef, selectedNodeRef]
   );
+
+  useEffect(() => {
+    if (!conversation_id || dataSource === 'moss-session') return undefined;
+
+    const unsubscribeRefresh = ipcBridge.conversation.responseStream.on((message) => {
+      if (message.conversation_id !== conversation_id) return;
+      if (message.type !== 'finish') return;
+      refreshRef.current();
+    });
+
+    return () => {
+      unsubscribeRefresh();
+    };
+  }, [conversation_id, dataSource]);
 
   /**
    * 监听搜索工作空间响应

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SelectedNodeRef } from '../types';
+import { ensureDraftsDirectoryNode, filterValidExpandedKeys, getAllDirKeys, getFirstLevelKeys, getLimitedDepthKeys } from '../utils/treeHelpers';
 import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';
 import { emitter } from '@/renderer/utils/emitter';
 import { dispatchWorkspaceHasFilesEvent } from '@/renderer/utils/workspaceEvents';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { SelectedNodeRef } from '../types';
-import { ensureDraftsDirectoryNode, filterValidExpandedKeys, getAllDirKeys, getFirstLevelKeys, getLimitedDepthKeys } from '../utils/treeHelpers';
 
 interface UseWorkspaceTreeOptions {
   workspace: string;
@@ -272,7 +272,7 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix, back
           }
         });
     },
-    [backend, conversation_id, dataSource, eventPrefix, workspace, setLoadingHandler]
+    [backend, conversation_id, dataSource, eventPrefix, getPersistedExpandedKeys, setExpandedKeys, workspace, setLoadingHandler]
   );
 
   /**
@@ -282,6 +282,13 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix, back
   const refreshWorkspace = useCallback(() => {
     return loadWorkspace(workspace);
   }, [workspace, loadWorkspace]);
+
+  // Whenever the active conversation/workspace changes, load the current tree
+  // directly from the latest props instead of relying on external reset hooks.
+  useEffect(() => {
+    if (!workspace) return;
+    void loadWorkspace(workspace);
+  }, [conversation_id, workspace, loadWorkspace]);
 
   /**
    * 确保节点被选中，并可选地发送事件
@@ -362,7 +369,7 @@ export function useWorkspaceTree({ workspace, conversation_id, eventPrefix, back
         }
       }
     },
-    [eventPrefix, conversation_id]
+    [eventPrefix]
   );
 
   /**


### PR DESCRIPTION
本 PR 用于稳定工作空间刷新行为，并将右侧面板的消息宿主移到 body，避免通知被侧边栏布局裁掉。\n\n修改范围：\n- ChatLayout 的自动收起逻辑\n- ChatSider 的消息宿主位置\n- workspace 的刷新事件处理\n- workspace tree 的重载行为