### PR TITLE
fix: persist image generation model selection

### DIFF
--- a/src/common/imageGenerationModelConfig.ts
+++ b/src/common/imageGenerationModelConfig.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_IMAGE_GENERATION_MODEL, type IConfigStorageRefer } from './storage';
+
+/**
+ * Old builds hardcoded this as the default image generation model. It is still a
+ * valid dropdown option, so an explicit user selection must be preserved — only
+ * the legacy *default* is migrated, and only once. See
+ * migrateImageGenerationModelConfig.
+ */
+export const LEGACY_DEFAULT_IMAGE_GENERATION_MODEL = 'gpt-image-1.5';
+
+export type ImageGenerationModelConfig = IConfigStorageRefer['tools.imageGenerationModel'];
+
+/**
+ * Resolve the effective model id from a *complete* config.
+ * Returns null when the feature is off or no model is selected — never infer
+ * "off" from a partial object that simply omits `switch`.
+ */
+export function pickImageGenerationModelId(config: Partial<ImageGenerationModelConfig> | undefined | null): string | null {
+  if (!config) return null;
+  return config.switch && config.useModel ? config.useModel : null;
+}
+
+/**
+ * One-time migration of the legacy hardcoded default (gpt-image-1.5) to the
+ * current default. After the migration flag has been set, an explicit selection
+ * of gpt-image-1.5 is preserved.
+ */
+export function migrateImageGenerationModelConfig(saved: ImageGenerationModelConfig | undefined | null, alreadyMigrated: boolean): { config: ImageGenerationModelConfig; changed: boolean } {
+  if (!saved) {
+    return { config: { useModel: DEFAULT_IMAGE_GENERATION_MODEL, switch: true } as ImageGenerationModelConfig, changed: true };
+  }
+  if (!saved.useModel) {
+    return { config: { ...saved, useModel: DEFAULT_IMAGE_GENERATION_MODEL }, changed: true };
+  }
+  if (!alreadyMigrated && saved.useModel === LEGACY_DEFAULT_IMAGE_GENERATION_MODEL) {
+    return { config: { ...saved, useModel: DEFAULT_IMAGE_GENERATION_MODEL }, changed: true };
+  }
+  return { config: saved, changed: false };
+}
+
+/**
+ * Pick the image model to apply on login: the user's explicit choice when the
+ * feature is enabled, otherwise the current default. Never unconditionally
+ * overrides a user selection.
+ */
+export function resolveLoginImageModelId(saved: ImageGenerationModelConfig | undefined | null): string | null {
+  if (!saved) return DEFAULT_IMAGE_GENERATION_MODEL;
+  if (saved.switch === false) return null;
+  return saved.useModel || DEFAULT_IMAGE_GENERATION_MODEL;
+}

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -71,6 +71,9 @@ export interface IConfigStorageRefer {
   'guid.sessionMode'?: 'remote' | 'local';
   // 迁移标记：修复老版本中助手 enabled 默认值问题 / Migration flag: fix assistant enabled default value issue
   'migration.assistantEnabledFixed'?: boolean;
+  // 迁移标记：旧版硬编码默认图像生成模型（gpt-image-1.5）一次性迁移到当前默认；迁移后用户显式选择不再被覆盖
+  // Migration flag: one-time migration of the legacy hardcoded image generation model (gpt-image-1.5) to the current default; after migration, explicit user selections are preserved
+  'migration.imageGenerationModelDefaultMigrated'?: boolean;
   // 迁移标记：为 cowork 助手添加默认启用的 skills / Migration flag: add default enabled skills for cowork assistant
   /** @deprecated Use migration.builtinDefaultSkillsAdded_v2 instead */
   'migration.coworkDefaultSkillsAdded'?: boolean;

--- a/src/process/bridge/imageGenerationModelSync.ts
+++ b/src/process/bridge/imageGenerationModelSync.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+
+/**
+ * Write agents.defaults.imageGenerationModel into an existing sudoclaw.json.
+ *
+ * The image-generation tool (resolveImageConfig) reads this field first, so the
+ * settings page must keep it in sync — otherwise the running tool keeps using
+ * the previously synced model. The model id is stored plain (no provider prefix),
+ * matching ServiceManager.syncImageModelToSudoclaw; an empty string means "off".
+ *
+ * No-op when the file does not exist yet, to avoid creating a malformed config
+ * before the gateway has written its own.
+ */
+export function writeSudoclawImageGenerationModel(modelId: string, configPath: string): void {
+  if (!fs.existsSync(configPath)) return;
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  if (!config.agents) config.agents = {};
+  if (!config.agents.defaults) config.agents.defaults = {};
+  config.agents.defaults.imageGenerationModel = modelId;
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+}

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -22,9 +22,12 @@ import { ipcBridge } from '@/common';
 import { modelInputForModelId } from '@/common/imageUtils';
 import type { ScodeModelEntry } from '@/common/ipcBridge';
 import { addScodeAutoModel, extractCustomProvidersFromScodeConfig, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, type ScodeCustomModelProvider } from '@/common/scodeConfig';
+import { SUDOCLAW_DIR } from '@process/services/sudoclaw/SudoclawInstallService';
+import { writeSudoclawImageGenerationModel } from '@process/bridge/imageGenerationModelSync';
 
 const TAG = 'ScodeBridge';
 const SUDOCODE_CONFIG_PATH = path.join(SCODE_DIR, 'sudocode.json');
+const SUDOCLAW_CONFIG_PATH = path.join(SUDOCLAW_DIR, 'sudoclaw.json');
 
 /** Read existing sudocode.json, returns empty object on failure */
 function readExistingConfig(): Record<string, unknown> {
@@ -343,9 +346,13 @@ export function registerScodeBridge(): void {
 
   ipcBridge.scode.setImageModel.provider(async ({ modelId }) => {
     try {
-      if (modelId) {
-        writeScodeImageModel(modelId);
-      }
+      // null/empty means the feature is off — clear both stores so the running
+      // tool stops using the last model instead of silently keeping it.
+      const resolved = modelId ?? '';
+      writeScodeImageModel(resolved);
+      // The image-generation tool reads sudoclaw.json first, so keep it in sync
+      // on every save; otherwise the settings change never reaches the tool.
+      writeSudoclawImageGenerationModel(resolved, SUDOCLAW_CONFIG_PATH);
       return { success: true };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/renderer/components/SettingsModal/contents/ToolsModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/ToolsModalContent.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ConfigStorage, DEFAULT_IMAGE_GENERATION_MODEL, type IConfigStorageRefer, type IMcpServer } from '@/common/storage';
+import { migrateImageGenerationModelConfig, pickImageGenerationModelId } from '@/common/imageGenerationModelConfig';
 import { acpConversation, scode } from '@/common/ipcBridge';
 import { Divider, Form, Switch, Tooltip, Message, Button, Dropdown, Menu, Modal } from '@arco-design/web-react';
 import { Help, Down, Plus } from '@icon-park/react';
@@ -18,8 +19,6 @@ import McpServerItem from '@/renderer/pages/settings/McpManagement/McpServerItem
 import { useMcpServers, useMcpAgentStatus, useMcpOperations, useMcpConnection, useMcpModal, useMcpServerCRUD, useMcpOAuth } from '@/renderer/hooks/mcp';
 
 type MessageInstance = ReturnType<typeof Message.useMessage>[0];
-
-const LEGACY_DEFAULT_IMAGE_GENERATION_MODEL = 'gpt-image-1.5';
 
 const IMAGE_GENERATION_MODEL_OPTIONS = [
   { label: 'gemini-3.1-flash-image', value: 'gemini-3.1-flash-image' },
@@ -254,34 +253,26 @@ const ToolsModalContent: React.FC = () => {
       }));
   }, [data]);
 
-  const syncImageGenerationModel = useCallback((modelConfig: Partial<IConfigStorageRefer['tools.imageGenerationModel']>) => {
-    const modelId = modelConfig.switch && modelConfig.useModel ? modelConfig.useModel : null;
-    scode.setImageModel.invoke({ modelId }).catch(console.error);
+  // Sync from a *complete* config — never infer "off" from a partial that just omits `switch`.
+  const syncImageGenerationModel = useCallback((modelConfig: IConfigStorageRefer['tools.imageGenerationModel']) => {
+    const modelId = pickImageGenerationModelId(modelConfig);
+    return scode.setImageModel.invoke({ modelId }).catch(console.error);
   }, []);
 
   useEffect(() => {
     const loadConfigs = async () => {
       try {
         const saved = await ConfigStorage.get('tools.imageGenerationModel');
-        if (saved) {
-          // Always ensure useModel is set
-          if (!saved.useModel || saved.useModel === LEGACY_DEFAULT_IMAGE_GENERATION_MODEL) {
-            const nextConfig = {
-              ...saved,
-              useModel: DEFAULT_IMAGE_GENERATION_MODEL,
-            };
-            setImageGenerationModel(nextConfig);
-            ConfigStorage.set('tools.imageGenerationModel', nextConfig).catch(() => {});
-            syncImageGenerationModel(nextConfig);
-          } else {
-            setImageGenerationModel(saved);
-          }
-        } else {
-          // Default: switch on, hardcoded model
-          const defaultConfig = { useModel: DEFAULT_IMAGE_GENERATION_MODEL, switch: true } as IConfigStorageRefer['tools.imageGenerationModel'];
-          setImageGenerationModel(defaultConfig);
-          ConfigStorage.set('tools.imageGenerationModel', defaultConfig).catch(() => {});
-          syncImageGenerationModel(defaultConfig);
+        const alreadyMigrated = (await ConfigStorage.get('migration.imageGenerationModelDefaultMigrated').catch((): boolean => false)) === true;
+        const { config, changed } = migrateImageGenerationModelConfig(saved, alreadyMigrated);
+
+        setImageGenerationModel(config);
+        if (changed) {
+          await ConfigStorage.set('tools.imageGenerationModel', config).catch(() => {});
+          await syncImageGenerationModel(config);
+        }
+        if (!alreadyMigrated) {
+          await ConfigStorage.set('migration.imageGenerationModelDefaultMigrated', true).catch(() => {});
         }
       } catch (error) {
         console.error('Failed to load image generation model config:', error);
@@ -293,7 +284,7 @@ const ToolsModalContent: React.FC = () => {
 
   const handleImageGenerationModelChange = (value: Partial<IConfigStorageRefer['tools.imageGenerationModel']>) => {
     setImageGenerationModel((prev) => {
-      const newImageGenerationModel = { ...prev, ...value };
+      const newImageGenerationModel = { ...prev, ...value } as IConfigStorageRefer['tools.imageGenerationModel'];
       ConfigStorage.set('tools.imageGenerationModel', newImageGenerationModel).catch((error) => {
         console.error('Failed to update image generation model config:', error);
       });

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { ipcBridge } from '@/common';
 import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
-import { ConfigStorage, DEFAULT_IMAGE_GENERATION_MODEL, type IConfigStorageRefer } from '@/common/storage';
+import { ConfigStorage, type IConfigStorageRefer } from '@/common/storage';
+import { resolveLoginImageModelId } from '@/common/imageGenerationModelConfig';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { withCsrfToken } from '@/webserver/middleware/csrfClient';
 import { getSudorouterPrimaryModelPath, mergeSudorouterProvidersIntoConfig } from '@/common/sudoclawModelConfig';
@@ -305,6 +306,13 @@ function resolveConsumerTenantId(user: Partial<AuthUser> & { tenant_id?: string 
   return resolveString(user.tenant_id) || resolveString(user.enterprise_code) || resolveString(fallbackTenantId);
 }
 
+// 同步图像生成模型到 sudocode/sudoclaw：尊重用户已保存的选择，不再无条件覆盖为默认值
+// Apply the image model on login: respect the user's saved selection instead of unconditionally forcing the default.
+async function applyLoginImageModel(): Promise<void> {
+  const saved = await ConfigStorage.get('tools.imageGenerationModel').catch((): undefined => undefined);
+  await ipcBridge.scode.setImageModel.invoke({ modelId: resolveLoginImageModelId(saved) }).catch(() => {});
+}
+
 // 处理登录成功后的通用逻辑
 async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUser, setStatus: SetAuthStatus, setReady: SetAuthReady, setSyncMessage: SetSyncMessage, tenantIdFallback?: string) {
   const deviceId = getDeviceId();
@@ -390,7 +398,7 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
         console.warn('[Auth] Failed to restore custom scode models:', err);
         return null;
       });
-      await ipcBridge.scode.setImageModel.invoke({ modelId: DEFAULT_IMAGE_GENERATION_MODEL }).catch(() => {});
+      await applyLoginImageModel();
       // Sync settings.json to the merged default model while preserving a user-selected custom model.
       const defaultModel = restoreRes?.data?.default_model || scodeConfig.default_model;
       if (defaultModel) {
@@ -1058,7 +1066,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             console.warn('[Auth] Failed to restore custom scode models on enterprise login:', err);
             return null;
           });
-          await ipcBridge.scode.setImageModel.invoke({ modelId: DEFAULT_IMAGE_GENERATION_MODEL }).catch(() => {});
+          await applyLoginImageModel();
           // Sync settings.json to the merged default model while preserving a user-selected custom model.
           const defaultModel = restoreRes?.data?.default_model || scodeConfig.default_model;
           if (defaultModel) {

--- a/tests/unit/imageGenerationModelConfig.test.ts
+++ b/tests/unit/imageGenerationModelConfig.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_IMAGE_GENERATION_MODEL } from '@/common/storage';
+import { LEGACY_DEFAULT_IMAGE_GENERATION_MODEL, migrateImageGenerationModelConfig, pickImageGenerationModelId, resolveLoginImageModelId, type ImageGenerationModelConfig } from '@/common/imageGenerationModelConfig';
+
+const cfg = (over: Partial<ImageGenerationModelConfig>): ImageGenerationModelConfig => ({ switch: true, useModel: 'gemini-3-pro-image', ...over }) as ImageGenerationModelConfig;
+
+describe('pickImageGenerationModelId', () => {
+  it('returns the model when the switch is on', () => {
+    expect(pickImageGenerationModelId(cfg({ switch: true, useModel: 'gpt-image-1.5' }))).toBe('gpt-image-1.5');
+  });
+
+  it('returns null when the switch is off', () => {
+    expect(pickImageGenerationModelId(cfg({ switch: false, useModel: 'gpt-image-1.5' }))).toBeNull();
+  });
+
+  it('returns null when no model is selected', () => {
+    expect(pickImageGenerationModelId({ switch: true } as ImageGenerationModelConfig)).toBeNull();
+  });
+
+  it('does NOT infer off from a partial that omits switch — returns null only because switch is missing, not because it guessed', () => {
+    // A partial without `switch` must not be treated as enabled.
+    expect(pickImageGenerationModelId({ useModel: 'gpt-image-1.5' })).toBeNull();
+  });
+
+  it('returns null for nullish config', () => {
+    expect(pickImageGenerationModelId(undefined)).toBeNull();
+    expect(pickImageGenerationModelId(null)).toBeNull();
+  });
+});
+
+describe('migrateImageGenerationModelConfig', () => {
+  it('migrates the legacy default exactly once', () => {
+    const saved = cfg({ switch: true, useModel: LEGACY_DEFAULT_IMAGE_GENERATION_MODEL });
+    const first = migrateImageGenerationModelConfig(saved, false);
+    expect(first.changed).toBe(true);
+    expect(first.config.useModel).toBe(DEFAULT_IMAGE_GENERATION_MODEL);
+  });
+
+  it('preserves an explicit gpt-image-1.5 selection after migration has already run', () => {
+    const saved = cfg({ switch: true, useModel: LEGACY_DEFAULT_IMAGE_GENERATION_MODEL });
+    const result = migrateImageGenerationModelConfig(saved, true);
+    expect(result.changed).toBe(false);
+    expect(result.config.useModel).toBe(LEGACY_DEFAULT_IMAGE_GENERATION_MODEL);
+  });
+
+  it('fills in the default when useModel is missing', () => {
+    const result = migrateImageGenerationModelConfig({ switch: true } as ImageGenerationModelConfig, true);
+    expect(result.changed).toBe(true);
+    expect(result.config.useModel).toBe(DEFAULT_IMAGE_GENERATION_MODEL);
+  });
+
+  it('leaves a non-legacy selection untouched', () => {
+    const saved = cfg({ switch: true, useModel: 'doubao-seedream-4-0-250828' });
+    const result = migrateImageGenerationModelConfig(saved, false);
+    expect(result.changed).toBe(false);
+    expect(result.config).toBe(saved);
+  });
+
+  it('returns an enabled default config when nothing is saved', () => {
+    const result = migrateImageGenerationModelConfig(undefined, false);
+    expect(result.changed).toBe(true);
+    expect(result.config).toEqual({ useModel: DEFAULT_IMAGE_GENERATION_MODEL, switch: true });
+  });
+
+  it('preserves the off switch while migrating the legacy model', () => {
+    const saved = cfg({ switch: false, useModel: LEGACY_DEFAULT_IMAGE_GENERATION_MODEL });
+    const result = migrateImageGenerationModelConfig(saved, false);
+    expect(result.config.switch).toBe(false);
+    expect(result.config.useModel).toBe(DEFAULT_IMAGE_GENERATION_MODEL);
+  });
+});
+
+describe('resolveLoginImageModelId', () => {
+  it('respects the user selection when the switch is on — login must not override it', () => {
+    expect(resolveLoginImageModelId(cfg({ switch: true, useModel: 'doubao-seedream-4-0-250828' }))).toBe('doubao-seedream-4-0-250828');
+  });
+
+  it('respects an explicit gpt-image-1.5 selection', () => {
+    expect(resolveLoginImageModelId(cfg({ switch: true, useModel: LEGACY_DEFAULT_IMAGE_GENERATION_MODEL }))).toBe(LEGACY_DEFAULT_IMAGE_GENERATION_MODEL);
+  });
+
+  it('returns null when the user has turned image generation off', () => {
+    expect(resolveLoginImageModelId(cfg({ switch: false, useModel: 'doubao-seedream-4-0-250828' }))).toBeNull();
+  });
+
+  it('falls back to the default when nothing is saved', () => {
+    expect(resolveLoginImageModelId(undefined)).toBe(DEFAULT_IMAGE_GENERATION_MODEL);
+  });
+});

--- a/tests/unit/imageGenerationModelSync.test.ts
+++ b/tests/unit/imageGenerationModelSync.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { writeSudoclawImageGenerationModel } from '@/process/bridge/imageGenerationModelSync';
+
+let tempDir: string | null = null;
+
+function configPath(initial?: unknown): string {
+  tempDir = mkdtempSync(path.join(tmpdir(), 'sudowork-imggen-sync-'));
+  const p = path.join(tempDir, 'sudoclaw.json');
+  if (initial !== undefined) {
+    writeFileSync(p, JSON.stringify(initial, null, 2), 'utf-8');
+  }
+  return p;
+}
+
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+describe('writeSudoclawImageGenerationModel', () => {
+  it('writes agents.defaults.imageGenerationModel into an existing config', () => {
+    const p = configPath({ agents: { defaults: { model: { primary: 'sudorouter/gemini-3-flash' } } } });
+
+    writeSudoclawImageGenerationModel('gpt-image-1.5', p);
+
+    const parsed = JSON.parse(readFileSync(p, 'utf-8'));
+    expect(parsed.agents.defaults.imageGenerationModel).toBe('gpt-image-1.5');
+    // Existing fields are preserved.
+    expect(parsed.agents.defaults.model.primary).toBe('sudorouter/gemini-3-flash');
+  });
+
+  it('clears the model with an empty string when the feature is off', () => {
+    const p = configPath({ agents: { defaults: { imageGenerationModel: 'gpt-image-1.5' } } });
+
+    writeSudoclawImageGenerationModel('', p);
+
+    const parsed = JSON.parse(readFileSync(p, 'utf-8'));
+    expect(parsed.agents.defaults.imageGenerationModel).toBe('');
+  });
+
+  it('creates the agents.defaults path when missing', () => {
+    const p = configPath({ models: { providers: {} } });
+
+    writeSudoclawImageGenerationModel('gemini-3-pro-image', p);
+
+    const parsed = JSON.parse(readFileSync(p, 'utf-8'));
+    expect(parsed.agents.defaults.imageGenerationModel).toBe('gemini-3-pro-image');
+    expect(parsed.models.providers).toEqual({});
+  });
+
+  it('is a no-op when the config file does not exist', () => {
+    const p = configPath(); // no file written
+
+    expect(() => writeSudoclawImageGenerationModel('gpt-image-1.5', p)).not.toThrow();
+    expect(existsSync(p)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve explicit image generation model selections, including `gpt-image-1.5`
- sync image generation model changes to both `sudocode.json` and `sudoclaw.json`
- stop login from overwriting the user-selected image generation model

## Tests
- `node_modules/.bin/vitest run tests/unit/imageGenerationModelConfig.test.ts tests/unit/imageGenerationModelSync.test.ts`
- `node_modules/.bin/tsc --noEmit`