### PR TITLE
feat(telemetry): mirror telemetry and crash events to Sudo Log backend

### DIFF
--- a/src/process/telemetry/CrashReporter.ts
+++ b/src/process/telemetry/CrashReporter.ts
@@ -29,6 +29,7 @@ import { getProductImprovementApiKey } from '../credentialsCache';
 import { getTelemetryEncryptor, initTelemetryEncryptor } from './TelemetryEncryptor';
 import { getUserContextSync } from './UserContext';
 import { ENCRYPTION_CONFIG } from './keys';
+import { getSudoLogTelemetryReporter } from './SudoLogTelemetryReporter';
 
 // ============================================================
 // 常量定义
@@ -240,6 +241,7 @@ export class CrashReporter {
 
     // 缓存事件（如果未初始化）或直接添加到队列
     this.cacheOrAddEvent(storedEvent);
+    getSudoLogTelemetryReporter().enqueueCrashEvent(event);
     mainError('CrashReporter', `Native crash captured: ${crashReason} (process: ${processType})`);
   }
 
@@ -292,6 +294,7 @@ export class CrashReporter {
 
     // 缓存事件（如果未初始化）或直接添加到队列
     this.cacheOrAddEvent(storedEvent);
+    getSudoLogTelemetryReporter().enqueueCrashEvent(event);
     mainError('CrashReporter', `Renderer crash captured: ${crashReason}`);
   }
 
@@ -340,6 +343,7 @@ export class CrashReporter {
 
     // 缓存事件（如果未初始化）或直接添加到队列
     this.cacheOrAddEvent(storedEvent);
+    getSudoLogTelemetryReporter().enqueueCrashEvent(event);
     mainError('CrashReporter', `Exception captured: ${error.name}: ${error.message}`);
   }
 
@@ -387,6 +391,7 @@ export class CrashReporter {
 
     // 缓存事件（如果未初始化）或直接添加到队列
     this.cacheOrAddEvent(storedEvent);
+    getSudoLogTelemetryReporter().enqueueCrashEvent(event);
     mainError('CrashReporter', `Renderer exception captured: ${data.error_name}: ${data.error_message}`);
   }
 

--- a/src/process/telemetry/SudoLogTelemetryReporter.ts
+++ b/src/process/telemetry/SudoLogTelemetryReporter.ts
@@ -13,7 +13,7 @@ import { getLogReportKey } from '@/process/credentialsCache';
 import type { CrashEvent } from '../../shared/types/crash';
 import type { ConversationData, InstallData, PerfData, StepData, TelemetryEvent, TurnData } from '../../shared/types/telemetry';
 import { mainError, mainLog, mainWarn } from '../utils/mainLogger';
-import { SUDO_LOG_API_KEY_HEADER, SUDO_LOG_PRODUCT, SUDO_LOG_TENANT_ID, getSudoworkLogBatchUrl } from '../utils/sudoworkLogUploader';
+import { SUDO_LOG_API_KEY_HEADER, SUDO_LOG_ENVIRONMENT, SUDO_LOG_PRODUCT, SUDO_LOG_TENANT_ID, getSudoworkLogBatchUrl } from '../utils/sudoworkLogUploader';
 import { getUserContextSync } from './UserContext';
 
 type SudoLogLevel = 'info' | 'warn' | 'error';
@@ -271,7 +271,7 @@ function toTelemetryLog(event: TelemetryEvent): SudoLogEntry | null {
     tenant_id: SUDO_LOG_TENANT_ID,
     product: SUDO_LOG_PRODUCT,
     topic: telemetryTopic(event),
-    environment: app.isPackaged ? 'production' : 'development',
+    environment: SUDO_LOG_ENVIRONMENT,
     level,
     component: `qms.telemetry.${event.type}`,
     version: event.version,
@@ -333,7 +333,7 @@ function toCrashLog(event: CrashEvent): SudoLogEntry | null {
     tenant_id: SUDO_LOG_TENANT_ID,
     product: SUDO_LOG_PRODUCT,
     topic: 'error',
-    environment: app.isPackaged ? 'production' : 'development',
+    environment: SUDO_LOG_ENVIRONMENT,
     level: 'error',
     component: `qms.crash.${event.type}`,
     version: event.version,

--- a/src/process/telemetry/SudoLogTelemetryReporter.ts
+++ b/src/process/telemetry/SudoLogTelemetryReporter.ts
@@ -1,0 +1,625 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { app } from 'electron';
+import { isLogReportEnabled } from '@/common/systemConfig';
+import { getLogReportKey } from '@/process/credentialsCache';
+import type { CrashEvent } from '../../shared/types/crash';
+import type { ConversationData, InstallData, PerfData, StepData, TelemetryEvent, TurnData } from '../../shared/types/telemetry';
+import { mainError, mainLog, mainWarn } from '../utils/mainLogger';
+import { SUDO_LOG_API_KEY_HEADER, SUDO_LOG_PRODUCT, SUDO_LOG_TENANT_ID, getSudoworkLogBatchUrl } from '../utils/sudoworkLogUploader';
+import { getUserContextSync } from './UserContext';
+
+type SudoLogLevel = 'info' | 'warn' | 'error';
+
+type SudoLogEntry = {
+  timestamp: string;
+  tenant_id: string;
+  product: string;
+  topic: 'app' | 'audit' | 'error' | 'perf';
+  environment: 'development' | 'production';
+  level: SudoLogLevel;
+  component: string;
+  version: string;
+  platform: string;
+  arch: string;
+  user_identifier_hash: string;
+  user_id_hash?: string;
+  session_id?: string;
+  trace_id?: string;
+  message: string;
+  error?: {
+    name: string;
+    message: string;
+    stack: string;
+  };
+  tags: Record<string, string | number | boolean>;
+  attributes: Record<string, unknown>;
+};
+
+type SudoLogBatchResponse = {
+  success: boolean;
+  accepted?: boolean;
+  received?: number;
+  error?: string;
+  message?: string;
+  retryable?: boolean;
+};
+
+type StoredSudoLogTelemetryEntry = {
+  id: string;
+  storedAt: number;
+  retryCount: number;
+  log: SudoLogEntry;
+};
+
+const CACHE_FILE_NAME = 'sudowork-log-telemetry-cache.json';
+const MAX_QUEUE_SIZE = 500;
+const MAX_BATCH_SIZE = 50;
+const MAX_RETRIES = 3;
+const MAX_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const FLUSH_INTERVAL_MS = 30000;
+const SEND_TIMEOUT_MS = 5000;
+const MAX_STRING_LENGTH = 8000;
+const MAX_TAG_VALUE_LENGTH = 256;
+const MAX_ATTRIBUTE_STRING_LENGTH = 2000;
+const MAX_ARRAY_ITEMS = 30;
+const MAX_OBJECT_KEYS = 80;
+const MAX_OBJECT_DEPTH = 5;
+
+function isPersonalMode(): boolean {
+  return getUserContextSync().login_mode === 'personal';
+}
+
+function hashIdentifier(value?: unknown): string | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const normalized = String(value).trim();
+  if (!normalized) return undefined;
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...[truncated]`;
+}
+
+function limitString(value: unknown, maxLength = MAX_STRING_LENGTH): string {
+  if (value === undefined || value === null) return '';
+  return truncate(String(value), maxLength);
+}
+
+function addTag(tags: Record<string, string | number | boolean>, key: string, value: unknown): void {
+  if (value === undefined || value === null) return;
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) tags[key] = value;
+    return;
+  }
+  if (typeof value === 'boolean') {
+    tags[key] = value;
+    return;
+  }
+  const normalized = String(value).trim();
+  if (!normalized) return;
+  tags[key] = truncate(normalized, MAX_TAG_VALUE_LENGTH);
+}
+
+function maskedPhone(value?: unknown): string | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const digits = String(value).replace(/\D/g, '');
+  if (digits.length < 7) return undefined;
+  return `${digits.slice(0, 3)}****${digits.slice(-4)}`;
+}
+
+function userLabel(event: Pick<TelemetryEvent | CrashEvent, 'user_id' | 'user_nickname' | 'user_phone'>): string | undefined {
+  const nickname = typeof event.user_nickname === 'string' ? event.user_nickname.trim() : '';
+  if (nickname) return nickname;
+
+  const masked = maskedPhone(event.user_phone);
+  if (masked) return masked;
+
+  const userKey = hashIdentifier(event.user_id);
+  return userKey ? `user_${userKey.slice(0, 8)}` : undefined;
+}
+
+function addUserTags(tags: Record<string, string | number | boolean>, event: Pick<TelemetryEvent | CrashEvent, 'user_id' | 'user_nickname' | 'user_phone'>): void {
+  const userKey = hashIdentifier(event.user_id) || hashIdentifier(event.user_phone);
+  addTag(tags, 'sw_user_key', userKey);
+  addTag(tags, 'sw_user', userLabel(event));
+}
+
+function limitValue(value: unknown, depth = 0): unknown {
+  if (depth > MAX_OBJECT_DEPTH) return '[MaxDepth]';
+  if (value === null || value === undefined) return value;
+  if (value instanceof Error) {
+    return {
+      name: limitString(value.name, MAX_ATTRIBUTE_STRING_LENGTH),
+      message: limitString(value.message, MAX_ATTRIBUTE_STRING_LENGTH),
+      stack: value.stack ? limitString(value.stack, MAX_STRING_LENGTH) : undefined,
+    };
+  }
+  if (typeof value === 'string') return limitString(value, MAX_ATTRIBUTE_STRING_LENGTH);
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function' || typeof value === 'symbol') return `[${typeof value}]`;
+  if (Array.isArray(value)) return value.slice(0, MAX_ARRAY_ITEMS).map((item) => limitValue(item, depth + 1));
+
+  if (typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    let count = 0;
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      if (count >= MAX_OBJECT_KEYS) {
+        result.__truncated_keys = true;
+        break;
+      }
+      result[key] = limitValue(nestedValue, depth + 1);
+      count += 1;
+    }
+    return result;
+  }
+  return String(value);
+}
+
+function getCachePath(): string {
+  return path.join(app.getPath('userData'), CACHE_FILE_NAME);
+}
+
+function timestampToIso(value: number): string {
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : new Date().toISOString();
+}
+
+function dataSessionId(data: TelemetryEvent['data']): string | undefined {
+  return 'session_id' in data ? data.session_id : undefined;
+}
+
+function dataTraceId(data: TelemetryEvent['data']): string | undefined {
+  if ('turn_id' in data && typeof data.turn_id === 'string') return data.turn_id;
+  if ('step_id' in data && typeof data.step_id === 'string') return data.step_id;
+  if ('install_id' in data && typeof data.install_id === 'string') return data.install_id;
+  return undefined;
+}
+
+function telemetryLevel(event: TelemetryEvent): SudoLogLevel {
+  const data = event.data as { status?: unknown };
+  if (data.status === 'error' || data.status === 'failed') return 'error';
+  return 'info';
+}
+
+function telemetryTopic(event: TelemetryEvent): SudoLogEntry['topic'] {
+  if (event.type === 'perf') return 'perf';
+  if (event.type === 'install') return 'audit';
+  if (telemetryLevel(event) === 'error') return 'error';
+  return 'app';
+}
+
+function telemetryError(event: TelemetryEvent): SudoLogEntry['error'] | undefined {
+  if (telemetryLevel(event) !== 'error') return undefined;
+  const data = event.data as { error_code?: unknown; error_message?: unknown; status?: unknown };
+  const name = limitString(data.error_code || `${event.type}_error`, MAX_ATTRIBUTE_STRING_LENGTH);
+  const message = limitString(data.error_message || `QMS telemetry ${event.type} reported ${data.status || 'error'}`, MAX_STRING_LENGTH);
+  return {
+    name,
+    message,
+    stack: `${name}: ${message}\n    at qms.telemetry.${event.type}`,
+  };
+}
+
+function buildTelemetryTags(event: TelemetryEvent): Record<string, string | number | boolean> {
+  const tags: Record<string, string | number | boolean> = {};
+  addTag(tags, 'sw_signal', 'telemetry');
+  addTag(tags, 'sw_event_type', event.type);
+  addTag(tags, 'sw_login_mode', event.login_mode);
+  addTag(tags, 'sw_agent_type', event.agent_type);
+  addUserTags(tags, event);
+
+  if (event.type === 'perf') {
+    const data = event.data as PerfData;
+    addTag(tags, 'sw_perf_metric', data.metric);
+    addTag(tags, 'value_ms', data.value_ms);
+  } else if (event.type === 'conversation') {
+    const data = event.data as ConversationData;
+    addTag(tags, 'sw_status', data.status);
+    addTag(tags, 'sw_model_id', data.model_id);
+    addTag(tags, 'sw_model_provider', data.model_provider);
+    addTag(tags, 'sw_error_code', data.error_code);
+    addTag(tags, 'duration_ms', data.duration_ms);
+    addTag(tags, 'tokens_used', data.tokens_used);
+    addTag(tags, 'input_tokens', data.input_tokens);
+    addTag(tags, 'output_tokens', data.output_tokens);
+  } else if (event.type === 'install') {
+    const data = event.data as InstallData;
+    addTag(tags, 'sw_install_status', data.status);
+    addTag(tags, 'sw_install_type', data.install_type);
+    addTag(tags, 'duration_ms', data.duration_ms);
+  } else if (event.type === 'turn') {
+    const data = event.data as TurnData;
+    addTag(tags, 'sw_status', data.status);
+    addTag(tags, 'sw_model_id', data.model_id);
+    addTag(tags, 'sw_model_provider', data.model_provider);
+    addTag(tags, 'sw_error_code', data.error_code);
+    addTag(tags, 'duration_ms', data.duration_ms);
+    addTag(tags, 'input_tokens', data.input_tokens);
+    addTag(tags, 'output_tokens', data.output_tokens);
+    addTag(tags, 'total_tokens', data.total_tokens);
+  } else {
+    const data = event.data as StepData;
+    addTag(tags, 'sw_step_type', data.step_type);
+    addTag(tags, 'sw_step_status', data.status);
+    addTag(tags, 'sw_tool_name', data.tool_name);
+    addTag(tags, 'sw_tool_kind', data.tool_kind);
+    addTag(tags, 'sw_permission_kind', data.permission_kind);
+    addTag(tags, 'duration_ms', data.duration_ms);
+    addTag(tags, 'thinking_tokens', data.thinking_tokens);
+  }
+
+  return tags;
+}
+
+function toTelemetryLog(event: TelemetryEvent): SudoLogEntry | null {
+  const userIdentifierHash = hashIdentifier(event.user_phone) || hashIdentifier(event.user_id);
+  if (!userIdentifierHash) return null;
+
+  const level = telemetryLevel(event);
+  return {
+    timestamp: timestampToIso(event.timestamp),
+    tenant_id: SUDO_LOG_TENANT_ID,
+    product: SUDO_LOG_PRODUCT,
+    topic: telemetryTopic(event),
+    environment: app.isPackaged ? 'production' : 'development',
+    level,
+    component: `qms.telemetry.${event.type}`,
+    version: event.version,
+    platform: event.platform,
+    arch: event.arch,
+    user_identifier_hash: userIdentifierHash,
+    user_id_hash: hashIdentifier(event.user_id),
+    session_id: dataSessionId(event.data),
+    trace_id: dataTraceId(event.data),
+    message: `QMS telemetry ${event.type}`,
+    error: telemetryError(event),
+    tags: buildTelemetryTags(event),
+    attributes: {
+      qms_event: limitValue(event),
+    },
+  };
+}
+
+function crashError(event: CrashEvent): SudoLogEntry['error'] {
+  if (event.type === 'js_exception') {
+    return {
+      name: limitString(event.error_name || 'JsException', MAX_ATTRIBUTE_STRING_LENGTH),
+      message: limitString(event.error_message || 'JavaScript exception', MAX_STRING_LENGTH),
+      stack: limitString(event.stack_trace || `${event.error_name}: ${event.error_message}`, MAX_STRING_LENGTH),
+    };
+  }
+
+  const message = `Crash reason: ${event.crash_reason}`;
+  return {
+    name: limitString(event.crash_reason || event.type, MAX_ATTRIBUTE_STRING_LENGTH),
+    message,
+    stack: `${event.type}: ${message}\n    at qms.crash.${event.process_type}`,
+  };
+}
+
+function buildCrashTags(event: CrashEvent): Record<string, string | number | boolean> {
+  const tags: Record<string, string | number | boolean> = {};
+  addTag(tags, 'sw_signal', 'crash');
+  addTag(tags, 'sw_event_type', event.type);
+  addTag(tags, 'sw_login_mode', event.login_mode);
+  addTag(tags, 'sw_agent_type', event.agent_type);
+  addUserTags(tags, event);
+  addTag(tags, 'sw_process_type', event.process_type);
+  if (event.type === 'js_exception') {
+    addTag(tags, 'sw_error_name', event.error_name);
+  } else {
+    addTag(tags, 'sw_crash_reason', event.crash_reason);
+    addTag(tags, 'exit_code', event.exit_code);
+  }
+  return tags;
+}
+
+function toCrashLog(event: CrashEvent): SudoLogEntry | null {
+  const userIdentifierHash = hashIdentifier(event.user_phone) || hashIdentifier(event.user_id);
+  if (!userIdentifierHash) return null;
+
+  return {
+    timestamp: timestampToIso(event.timestamp),
+    tenant_id: SUDO_LOG_TENANT_ID,
+    product: SUDO_LOG_PRODUCT,
+    topic: 'error',
+    environment: app.isPackaged ? 'production' : 'development',
+    level: 'error',
+    component: `qms.crash.${event.type}`,
+    version: event.version,
+    platform: event.platform,
+    arch: event.arch,
+    user_identifier_hash: userIdentifierHash,
+    user_id_hash: hashIdentifier(event.user_id),
+    session_id: event.context?.session_id,
+    message: `QMS crash ${event.type}`,
+    error: crashError(event),
+    tags: buildCrashTags(event),
+    attributes: {
+      qms_event: limitValue(event),
+    },
+  };
+}
+
+export class SudoLogTelemetryReporter {
+  private static instance: SudoLogTelemetryReporter | null = null;
+
+  private queue: StoredSudoLogTelemetryEntry[] = [];
+  private initialized = false;
+  private enabled = false;
+  private cacheLoaded = false;
+  private isFlushing = false;
+  private flushTimer: NodeJS.Timeout | null = null;
+  private enqueueChain: Promise<void> = Promise.resolve();
+
+  private constructor() {}
+
+  public static getInstance(): SudoLogTelemetryReporter {
+    if (!SudoLogTelemetryReporter.instance) {
+      SudoLogTelemetryReporter.instance = new SudoLogTelemetryReporter();
+    }
+    return SudoLogTelemetryReporter.instance;
+  }
+
+  public async initialize(enabled: boolean): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.enabled = enabled && isPersonalMode() && isLogReportEnabled();
+
+    if (!this.enabled) {
+      await this.dropAndClear();
+      return;
+    }
+
+    await this.loadCachedQueue();
+    if (this.queue.length > 0) {
+      this.startFlushTimer();
+      void this.flush();
+    }
+    mainLog('SudoLogTelemetry', `Initialized, queue: ${this.queue.length}, endpoint: ${getSudoworkLogBatchUrl()}`);
+  }
+
+  public async setEnabled(enabled: boolean): Promise<void> {
+    this.enabled = enabled && isPersonalMode() && isLogReportEnabled();
+    if (!this.enabled) {
+      await this.dropAndClear();
+      return;
+    }
+    this.startFlushTimer();
+  }
+
+  public enqueueTelemetryEvent(event: TelemetryEvent): void {
+    this.enqueueLog(toTelemetryLog(event));
+  }
+
+  public enqueueCrashEvent(event: CrashEvent): void {
+    this.enqueueLog(toCrashLog(event));
+  }
+
+  public async flushAll(): Promise<void> {
+    await this.flush();
+  }
+
+  public resetForTest(): void {
+    this.queue = [];
+    this.initialized = false;
+    this.enabled = false;
+    this.cacheLoaded = false;
+    this.isFlushing = false;
+    this.stopFlushTimer();
+    this.enqueueChain = Promise.resolve();
+  }
+
+  private enqueueLog(log: SudoLogEntry | null): void {
+    if (!log) return;
+    if (this.initialized && (!this.enabled || !isPersonalMode() || !isLogReportEnabled())) return;
+
+    this.enqueueChain = this.enqueueChain
+      .then(async () => {
+        await this.loadCachedQueue();
+        await this.addToQueue({
+          id: this.generateId(),
+          storedAt: Date.now(),
+          retryCount: 0,
+          log,
+        });
+        if (this.enabled) {
+          this.startFlushTimer();
+          if (this.queue.length >= MAX_BATCH_SIZE) {
+            void this.flush();
+          }
+        }
+      })
+      .catch((error) => {
+        mainWarn('SudoLogTelemetry', 'Failed to enqueue event:', error);
+      });
+  }
+
+  private generateId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+
+  private async addToQueue(entry: StoredSudoLogTelemetryEntry): Promise<void> {
+    if (this.queue.length >= MAX_QUEUE_SIZE) {
+      this.queue.shift();
+    }
+    this.queue.push(entry);
+    await this.persistCache();
+  }
+
+  private async loadCachedQueue(): Promise<void> {
+    if (this.cacheLoaded) return;
+    this.cacheLoaded = true;
+    try {
+      const content = await fs.readFile(getCachePath(), 'utf-8').catch(() => '');
+      if (!content.trim()) return;
+      const cached = JSON.parse(content) as StoredSudoLogTelemetryEntry[];
+      const now = Date.now();
+      this.queue = cached.filter((entry) => entry.retryCount < MAX_RETRIES && now - entry.storedAt < MAX_EVENT_AGE_MS);
+      if (this.queue.length !== cached.length) {
+        await this.persistOrClearCache();
+      }
+    } catch (error) {
+      mainWarn('SudoLogTelemetry', 'Failed to load cache:', error);
+      this.queue = [];
+    }
+  }
+
+  private async persistCache(): Promise<void> {
+    try {
+      await fs.writeFile(getCachePath(), JSON.stringify(this.queue), 'utf-8');
+    } catch (error) {
+      mainWarn('SudoLogTelemetry', 'Failed to persist cache:', error);
+    }
+  }
+
+  private async clearCacheFile(): Promise<void> {
+    await fs.unlink(getCachePath()).catch(() => {});
+  }
+
+  private async persistOrClearCache(): Promise<void> {
+    if (this.queue.length === 0) {
+      await this.clearCacheFile();
+    } else {
+      await this.persistCache();
+    }
+  }
+
+  private async dropAndClear(): Promise<void> {
+    this.queue = [];
+    this.cacheLoaded = true;
+    this.stopFlushTimer();
+    await this.clearCacheFile();
+  }
+
+  private startFlushTimer(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setInterval(() => {
+      void this.flush();
+    }, FLUSH_INTERVAL_MS);
+    this.flushTimer.unref?.();
+  }
+
+  private stopFlushTimer(): void {
+    if (!this.flushTimer) return;
+    clearInterval(this.flushTimer);
+    this.flushTimer = null;
+  }
+
+  private async flush(): Promise<void> {
+    if (!this.enabled || !isPersonalMode() || !isLogReportEnabled()) {
+      await this.dropAndClear();
+      return;
+    }
+
+    await this.enqueueChain;
+    await this.loadCachedQueue();
+    if (this.isFlushing || this.queue.length === 0) return;
+
+    this.isFlushing = true;
+    try {
+      const batch = this.queue.slice(0, MAX_BATCH_SIZE);
+      const response = await this.sendBatch(batch.map((entry) => entry.log));
+
+      if (response.success && response.accepted !== false) {
+        this.queue = this.queue.slice(batch.length);
+        await this.persistOrClearCache();
+        if (this.queue.length === 0) this.stopFlushTimer();
+        mainLog('SudoLogTelemetry', `Flushed ${response.received ?? batch.length} event(s), pending: ${this.queue.length}`);
+        return;
+      }
+
+      const reason = response.error || response.message || 'Upload rejected';
+      if (response.retryable === false) {
+        this.queue = this.queue.slice(batch.length);
+        await this.persistOrClearCache();
+        mainWarn('SudoLogTelemetry', `Dropped non-retryable batch: ${reason}, pending: ${this.queue.length}`);
+        return;
+      }
+
+      await this.markBatchFailed(batch, reason);
+    } catch (error) {
+      mainError('SudoLogTelemetry', 'Flush error:', error);
+    } finally {
+      this.isFlushing = false;
+    }
+  }
+
+  private async markBatchFailed(batch: StoredSudoLogTelemetryEntry[], reason: string): Promise<void> {
+    for (const entry of batch) {
+      entry.retryCount += 1;
+    }
+    const now = Date.now();
+    this.queue = this.queue.filter((entry) => entry.retryCount < MAX_RETRIES && now - entry.storedAt < MAX_EVENT_AGE_MS);
+    await this.persistOrClearCache();
+    mainWarn('SudoLogTelemetry', `Upload failed: ${reason}, pending: ${this.queue.length}`);
+  }
+
+  private async sendBatch(logs: SudoLogEntry[]): Promise<SudoLogBatchResponse> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
+    try {
+      const apiKey = getLogReportKey();
+      if (!apiKey) {
+        mainError('SudoLogTelemetry', 'log_report key not provisioned, skip sendBatch');
+        return { success: false, received: 0, error: 'log_report key missing', retryable: false };
+      }
+
+      const response = await fetch(getSudoworkLogBatchUrl(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [SUDO_LOG_API_KEY_HEADER]: apiKey,
+        },
+        body: JSON.stringify({ logs }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        return {
+          success: false,
+          received: 0,
+          error: `HTTP ${response.status}: ${response.statusText}`,
+          retryable: response.status >= 500,
+        };
+      }
+
+      return (await response.json()) as SudoLogBatchResponse;
+    } catch (error) {
+      return {
+        success: false,
+        received: 0,
+        error: error instanceof Error ? error.message : 'Network error',
+        retryable: true,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export const getSudoLogTelemetryReporter = (): SudoLogTelemetryReporter => {
+  return SudoLogTelemetryReporter.getInstance();
+};
+
+export const initSudoLogTelemetryReporter = async (enabled: boolean): Promise<void> => {
+  await getSudoLogTelemetryReporter().initialize(enabled);
+};
+
+export const flushSudoLogTelemetryReporter = async (): Promise<void> => {
+  await getSudoLogTelemetryReporter().flushAll();
+};
+
+export const resetSudoLogTelemetryReporterForTest = (): void => {
+  getSudoLogTelemetryReporter().resetForTest();
+};

--- a/src/process/telemetry/TelemetryBatchReporter.ts
+++ b/src/process/telemetry/TelemetryBatchReporter.ts
@@ -43,6 +43,7 @@ import { getProductImprovementApiKey } from '../credentialsCache';
 import { getTelemetryEncryptor, initTelemetryEncryptor, isEncryptionAvailable } from './TelemetryEncryptor';
 import { ENCRYPTION_CONFIG } from './keys';
 import { getUserContextSync } from './UserContext';
+import { getSudoLogTelemetryReporter } from './SudoLogTelemetryReporter';
 
 // ============================================================
 // 类型定义
@@ -229,6 +230,8 @@ export class TelemetryBatchReporter {
     // 添加到队列
     this.addToQueue(storedEvent);
 
+    getSudoLogTelemetryReporter().enqueueTelemetryEvent(this.toTelemetryEvent(storedEvent));
+
     // 如果队列满了，立即上报
     if (this.eventQueue.length >= this.config.batchSize) {
       void this.flush();
@@ -271,6 +274,7 @@ export class TelemetryBatchReporter {
     }
 
     this.enabled = enabled;
+    await getSudoLogTelemetryReporter().setEnabled(enabled);
 
     if (enabled && !this.flushTimer) {
       this.startFlushTimer();
@@ -313,6 +317,56 @@ export class TelemetryBatchReporter {
   /** 判断事件是否满足上报身份要求 */
   private isReportableEvent(event: StoredTelemetryEvent): boolean {
     return Boolean(event.user_id && event.tenant_id);
+  }
+
+  private toTelemetryEvent(stored: StoredTelemetryEvent): TelemetryEvent {
+    const baseEvent = {
+      timestamp: stored.timestamp,
+      version: stored.version,
+      platform: stored.platform,
+      arch: stored.arch,
+      org_id: stored.org_id,
+      user_id: stored.user_id,
+      tenant_id: stored.tenant_id,
+      login_mode: stored.login_mode,
+      agent_type: stored.agent_type,
+      user_nickname: stored.user_nickname,
+      user_phone: stored.user_phone,
+    };
+
+    if (stored.type === 'perf') {
+      return {
+        type: 'perf',
+        ...baseEvent,
+        data: stored.data as PerfData,
+      } as PerfTelemetryEvent;
+    }
+    if (stored.type === 'conversation') {
+      return {
+        type: 'conversation',
+        ...baseEvent,
+        data: stored.data as ConversationData,
+      } as ConversationTelemetryEvent;
+    }
+    if (stored.type === 'install') {
+      return {
+        type: 'install',
+        ...baseEvent,
+        data: stored.data as InstallData,
+      } as InstallTelemetryEvent;
+    }
+    if (stored.type === 'turn') {
+      return {
+        type: 'turn',
+        ...baseEvent,
+        data: stored.data as TurnData,
+      } as TurnTelemetryEvent;
+    }
+    return {
+      type: 'step',
+      ...baseEvent,
+      data: stored.data as StepData,
+    } as StepTelemetryEvent;
   }
 
   /** 添加事件到队列 */
@@ -375,55 +429,7 @@ export class TelemetryBatchReporter {
       // 取出一批事件
       const batch = this.eventQueue.slice(0, this.config.batchSize);
       // Convert stored events to TelemetryEvent format
-      const events: TelemetryEvent[] = batch.map((stored): TelemetryEvent => {
-        // 基础字段
-        const baseEvent = {
-          timestamp: stored.timestamp,
-          version: stored.version,
-          platform: stored.platform,
-          arch: stored.arch,
-          org_id: stored.org_id,
-          user_id: stored.user_id,
-          tenant_id: stored.tenant_id,
-          login_mode: stored.login_mode,
-          agent_type: stored.agent_type,
-          user_nickname: stored.user_nickname,
-          user_phone: stored.user_phone,
-        };
-
-        // Create specific event type based on stored.type
-        if (stored.type === 'perf') {
-          return {
-            type: 'perf',
-            ...baseEvent,
-            data: stored.data as PerfData,
-          } as PerfTelemetryEvent;
-        } else if (stored.type === 'conversation') {
-          return {
-            type: 'conversation',
-            ...baseEvent,
-            data: stored.data as ConversationData,
-          } as ConversationTelemetryEvent;
-        } else if (stored.type === 'install') {
-          return {
-            type: 'install',
-            ...baseEvent,
-            data: stored.data as InstallData,
-          } as InstallTelemetryEvent;
-        } else if (stored.type === 'turn') {
-          return {
-            type: 'turn',
-            ...baseEvent,
-            data: stored.data as TurnData,
-          } as TurnTelemetryEvent;
-        } else {
-          return {
-            type: 'step',
-            ...baseEvent,
-            data: stored.data as StepData,
-          } as StepTelemetryEvent;
-        }
-      });
+      const events: TelemetryEvent[] = batch.map((stored): TelemetryEvent => this.toTelemetryEvent(stored));
 
       const request: TelemetryBatchRequest = { events };
 

--- a/src/process/telemetry/index.ts
+++ b/src/process/telemetry/index.ts
@@ -14,47 +14,15 @@
 // 内部导入 (用于 initializeTelemetry/shutdownTelemetry)
 // ============================================================
 
-import { getTelemetryReporter } from './TelemetryBatchReporter';
-import { markAppStart } from './PerfTracker';
+import { getTelemetryReporter, flushTelemetry } from './TelemetryBatchReporter';
 import { initInstallTracking, markInstallSuccess } from './InstallTracker';
-import { flushTelemetry } from './TelemetryBatchReporter';
+import { getSudoLogTelemetryReporter } from './SudoLogTelemetryReporter';
 
 // ============================================================
 // 类型导出
 // ============================================================
 
-export type {
-  TelemetryPlatform,
-  TelemetryArch,
-  TelemetryEventType,
-  PerfMetricType,
-  ConversationStatus,
-  TurnStatus,
-  StepStatus,
-  StepType,
-  InstallStatus,
-  InstallType,
-  ModelProvider,
-  AgentType,
-  LoginMode,
-  TelemetryErrorCode,
-  PerfData,
-  ConversationData,
-  TurnData,
-  StepData,
-  InstallData,
-  TelemetryEventBase,
-  PerfTelemetryEvent,
-  ConversationTelemetryEvent,
-  TurnTelemetryEvent,
-  StepTelemetryEvent,
-  InstallTelemetryEvent,
-  TelemetryEvent,
-  TelemetryBatchRequest,
-  TelemetryBatchResponse,
-  TelemetryConfig,
-  StoredTelemetryEvent,
-} from '../../shared/types/telemetry';
+export type { TelemetryPlatform, TelemetryArch, TelemetryEventType, PerfMetricType, ConversationStatus, TurnStatus, StepStatus, StepType, InstallStatus, InstallType, ModelProvider, AgentType, LoginMode, TelemetryErrorCode, PerfData, ConversationData, TurnData, StepData, InstallData, TelemetryEventBase, PerfTelemetryEvent, ConversationTelemetryEvent, TurnTelemetryEvent, StepTelemetryEvent, InstallTelemetryEvent, TelemetryEvent, TelemetryBatchRequest, TelemetryBatchResponse, TelemetryConfig, StoredTelemetryEvent } from '../../shared/types/telemetry';
 
 export { DEFAULT_TELEMETRY_CONFIG, ERROR_CODE_DESCRIPTION, mapElectronArch } from '../../shared/types/telemetry';
 
@@ -63,6 +31,8 @@ export { DEFAULT_TELEMETRY_CONFIG, ERROR_CODE_DESCRIPTION, mapElectronArch } fro
 // ============================================================
 
 export { TelemetryBatchReporter, getTelemetryReporter, initTelemetry, recordTelemetry, flushTelemetry } from './TelemetryBatchReporter';
+
+export { SudoLogTelemetryReporter, getSudoLogTelemetryReporter, initSudoLogTelemetryReporter, flushSudoLogTelemetryReporter } from './SudoLogTelemetryReporter';
 
 export { PerfTracker, getPerfTracker, markAppStart, markFirstWindowShow, markRendererReady, startPerfTiming, endPerfTiming, recordFirstToken, flushPerfCachedMetrics, PERF_METRICS } from './PerfTracker';
 
@@ -89,6 +59,8 @@ export async function initializeTelemetry(): Promise<void> {
   // 初始化批量上报器
   await getTelemetryReporter().initialize();
 
+  await getSudoLogTelemetryReporter().initialize(getTelemetryReporter().getStatus().enabled);
+
   // 初始化安装追踪器
   await initInstallTracking();
 
@@ -111,6 +83,8 @@ export async function shutdownTelemetry(): Promise<void> {
   // 上报剩余 crash 事件
   const { flushCrashReporter } = await import('./CrashReporter');
   await flushCrashReporter();
+
+  await getSudoLogTelemetryReporter().flushAll();
 }
 
 // ============================================================

--- a/src/process/utils/sudoworkLogUploader.ts
+++ b/src/process/utils/sudoworkLogUploader.ts
@@ -84,6 +84,7 @@ type PersonalConfigSnapshot = {
 export const SUDO_LOG_TENANT_ID = 'sudo';
 export const SUDO_LOG_PRODUCT = 'sudowork';
 export const SUDO_LOG_API_KEY_HEADER = 'X-API-Key';
+export const SUDO_LOG_ENVIRONMENT: SudoworkLogEntry['environment'] = 'production';
 const CACHE_FILE_NAME = 'sudowork-log-error-cache.json';
 const MAX_QUEUE_SIZE = 500;
 const MAX_BATCH_SIZE = 50;
@@ -296,7 +297,7 @@ function toLogEntry(entry: LogUploadErrorEntry, config: PersonalConfigSnapshot):
     tenant_id: SUDO_LOG_TENANT_ID,
     product: SUDO_LOG_PRODUCT,
     topic: 'error',
-    environment: app.isPackaged ? 'production' : 'development',
+    environment: SUDO_LOG_ENVIRONMENT,
     level: 'error',
     component: limitString(entry.tag || 'main', MAX_ATTRIBUTE_STRING_LENGTH),
     version: buildVersion,

--- a/src/process/utils/sudoworkLogUploader.ts
+++ b/src/process/utils/sudoworkLogUploader.ts
@@ -81,9 +81,9 @@ type PersonalConfigSnapshot = {
   installId?: string;
 };
 
-const SUDO_LOG_TENANT_ID = 'sudo';
-const LOG_PRODUCT = 'sudowork';
-const API_KEY_HEADER = 'X-API-Key';
+export const SUDO_LOG_TENANT_ID = 'sudo';
+export const SUDO_LOG_PRODUCT = 'sudowork';
+export const SUDO_LOG_API_KEY_HEADER = 'X-API-Key';
 const CACHE_FILE_NAME = 'sudowork-log-error-cache.json';
 const MAX_QUEUE_SIZE = 500;
 const MAX_BATCH_SIZE = 50;
@@ -171,6 +171,10 @@ function getBatchUrl(): string {
   }
 
   return `${getLogReportBaseUrl()}/v1/logs/batch`;
+}
+
+export function getSudoworkLogBatchUrl(): string {
+  return getBatchUrl();
 }
 
 function hashIdentifier(value?: unknown): string | undefined {
@@ -290,7 +294,7 @@ function toLogEntry(entry: LogUploadErrorEntry, config: PersonalConfigSnapshot):
   return {
     timestamp: new Date(entry.timestampMs).toISOString(),
     tenant_id: SUDO_LOG_TENANT_ID,
-    product: LOG_PRODUCT,
+    product: SUDO_LOG_PRODUCT,
     topic: 'error',
     environment: app.isPackaged ? 'production' : 'development',
     level: 'error',
@@ -321,7 +325,7 @@ function normalizeStoredLogEntry(entry: StoredLogEntry, config: PersonalConfigSn
     log: {
       ...entry.log,
       tenant_id: SUDO_LOG_TENANT_ID,
-      product: LOG_PRODUCT,
+      product: SUDO_LOG_PRODUCT,
       user_identifier_hash: userIdentifierHash,
       tags: buildTags(config),
       attributes,
@@ -559,7 +563,7 @@ class SudoworkLogUploader {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          [API_KEY_HEADER]: apiKey,
+          [SUDO_LOG_API_KEY_HEADER]: apiKey,
         },
         body: JSON.stringify(request),
         signal: controller.signal,

--- a/tests/unit/sudoLogTelemetryReporter.test.ts
+++ b/tests/unit/sudoLogTelemetryReporter.test.ts
@@ -33,7 +33,7 @@ describe('SudoLogTelemetryReporter', () => {
           if (name === 'userData') return userDataDir;
           return userDataDir;
         }),
-        isPackaged: true,
+        isPackaged: false,
       },
     }));
     vi.doMock('@/common/buildInfo', () => ({ buildVersion: '9.9.9-test' }));
@@ -118,6 +118,7 @@ describe('SudoLogTelemetryReporter', () => {
       tenant_id: 'sudo',
       product: 'sudowork',
       topic: 'app',
+      environment: 'production',
       level: 'info',
       component: 'qms.telemetry.turn',
       session_id: 'session_1',

--- a/tests/unit/sudoLogTelemetryReporter.test.ts
+++ b/tests/unit/sudoLogTelemetryReporter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const BATCH_URL = 'https://logs.test/v1/logs/batch';
+const TEST_LOG_REPORT_KEY = 'test-log-report-key';
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+describe('SudoLogTelemetryReporter', () => {
+  let userDataDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    userDataDir = mkdtempSync(join(tmpdir(), 'sudowork-log-telemetry-test-'));
+    process.env.SUDOWORK_LOG_BATCH_URL = BATCH_URL;
+
+    vi.doMock('electron', () => ({
+      app: {
+        getPath: vi.fn((name: string) => {
+          if (name === 'userData') return userDataDir;
+          return userDataDir;
+        }),
+        isPackaged: true,
+      },
+    }));
+    vi.doMock('@/common/buildInfo', () => ({ buildVersion: '9.9.9-test' }));
+    vi.doMock('@/process/initStorage', () => ({
+      ProcessConfig: {
+        getSync: vi.fn((key: string) => {
+          if (key === 'system.appMode') return 'c';
+          if (key === 'consumer.userInfo') return { id: 'user-123', phone: '13800138000', tenant_id: 'sudo' };
+          return undefined;
+        }),
+      },
+    }));
+    vi.doMock('@/common/systemConfig', () => ({
+      getLogReportBaseUrl: vi.fn(() => 'https://sudolog.sudoprivacy.com'),
+      isLogReportEnabled: vi.fn(() => true),
+    }));
+    vi.doMock('@/process/credentialsCache', () => ({
+      getLogReportKey: vi.fn(() => TEST_LOG_REPORT_KEY),
+    }));
+
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ success: true, accepted: true, received: 1, event_ids: ['evt_1'] }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(async () => {
+    const { resetSudoLogTelemetryReporterForTest } = await import('@/process/telemetry/SudoLogTelemetryReporter');
+    resetSudoLogTelemetryReporterForTest();
+    vi.unstubAllGlobals();
+    vi.unmock('electron');
+    vi.unmock('@/common/buildInfo');
+    vi.unmock('@/process/initStorage');
+    vi.unmock('@/common/systemConfig');
+    vi.unmock('@/process/credentialsCache');
+    delete process.env.SUDOWORK_LOG_BATCH_URL;
+    rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it('converts QMS turn telemetry into a sudolog batch with metric-like numeric tags', async () => {
+    mkdirSync(userDataDir, { recursive: true });
+    const { getSudoLogTelemetryReporter } = await import('@/process/telemetry/SudoLogTelemetryReporter');
+    const reporter = getSudoLogTelemetryReporter();
+
+    await reporter.initialize(true);
+    reporter.enqueueTelemetryEvent({
+      type: 'turn',
+      timestamp: 1781654400000,
+      version: '9.9.9-test',
+      platform: 'darwin',
+      arch: 'arm64',
+      user_id: 'user-123',
+      tenant_id: 'sudo',
+      login_mode: 'personal',
+      agent_type: 'codex',
+      user_nickname: 'Alice',
+      user_phone: '13800138000',
+      data: {
+        turn_id: 'turn_1',
+        session_id: 'session_1',
+        model_id: 'gpt-4.1',
+        model_provider: 'openai',
+        input_tokens: 100,
+        output_tokens: 800,
+        total_tokens: 900,
+        duration_ms: 1234,
+        status: 'success',
+      },
+    });
+    await reporter.flushAll();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(BATCH_URL);
+    expect(fetchMock.mock.calls[0][1].headers['X-API-Key']).toBe(TEST_LOG_REPORT_KEY);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const [log] = body.logs;
+
+    expect(log).toMatchObject({
+      tenant_id: 'sudo',
+      product: 'sudowork',
+      topic: 'app',
+      level: 'info',
+      component: 'qms.telemetry.turn',
+      session_id: 'session_1',
+      trace_id: 'turn_1',
+    });
+    expect(log.tags).toMatchObject({
+      sw_signal: 'telemetry',
+      sw_event_type: 'turn',
+      sw_agent_type: 'codex',
+      sw_user_key: hash('user-123'),
+      sw_user: 'Alice',
+      sw_status: 'success',
+      sw_model_id: 'gpt-4.1',
+      sw_model_provider: 'openai',
+      duration_ms: 1234,
+      input_tokens: 100,
+      output_tokens: 800,
+      total_tokens: 900,
+    });
+    expect(log.attributes.qms_event.data.total_tokens).toBe(900);
+  });
+
+  it('keeps failed uploads in the telemetry cache without using the error-log cache', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      json: async () => ({ success: false }),
+    });
+    const { getSudoLogTelemetryReporter } = await import('@/process/telemetry/SudoLogTelemetryReporter');
+    const reporter = getSudoLogTelemetryReporter();
+    await reporter.initialize(true);
+    reporter.enqueueTelemetryEvent({
+      type: 'perf',
+      timestamp: 1781654400000,
+      version: '9.9.9-test',
+      platform: 'darwin',
+      arch: 'arm64',
+      user_id: 'user-123',
+      tenant_id: 'sudo',
+      login_mode: 'personal',
+      user_phone: '13800138000',
+      data: { metric: 'first_token', value_ms: 456, session_id: 'session_1' },
+    });
+    await reporter.flushAll();
+
+    const telemetryCache = readFileSync(join(userDataDir, 'sudowork-log-telemetry-cache.json'), 'utf-8');
+    expect(JSON.parse(telemetryCache)).toHaveLength(1);
+  });
+});

--- a/tests/unit/sudoworkLogUploader.test.ts
+++ b/tests/unit/sudoworkLogUploader.test.ts
@@ -54,7 +54,7 @@ describe('Sudowork Log personal error upload sink', () => {
           if (name === 'home') return homeDir;
           return homeDir;
         }),
-        isPackaged: true,
+        isPackaged: false,
       },
     }));
 

--- a/tests/unit/sudoworkLogUploader.test.ts
+++ b/tests/unit/sudoworkLogUploader.test.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const BATCH_URL = 'https://logs.test/v1/logs/batch';
+const TEST_LOG_REPORT_KEY = 'test-log-report-key';
 
 function encodeConfig(data: Record<string, unknown>): string {
   return Buffer.from(encodeURIComponent(JSON.stringify(data)), 'utf-8').toString('base64');
@@ -66,6 +67,13 @@ describe('Sudowork Log personal error upload sink', () => {
         },
       },
     }));
+    vi.doMock('@/common/systemConfig', () => ({
+      getLogReportBaseUrl: vi.fn(() => 'https://sudolog.sudoprivacy.com'),
+      isLogReportEnabled: vi.fn(() => true),
+    }));
+    vi.doMock('@/process/credentialsCache', () => ({
+      getLogReportKey: vi.fn(() => TEST_LOG_REPORT_KEY),
+    }));
 
     fetchMock = vi.fn(async () => ({
       ok: true,
@@ -81,6 +89,8 @@ describe('Sudowork Log personal error upload sink', () => {
     uploader.resetSudoworkLogUploaderForTest();
     consoleInfoSpy.mockRestore();
     vi.unstubAllGlobals();
+    vi.unmock('@/common/systemConfig');
+    vi.unmock('@/process/credentialsCache');
     delete process.env.SUDOWORK_LOG_BATCH_URL;
     delete process.env.SUDOWORK_LOG_BASE_URL;
     rmSync(homeDir, { recursive: true, force: true });
@@ -186,7 +196,7 @@ describe('Sudowork Log personal error upload sink', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, request] = fetchMock.mock.calls[0];
     expect(url).toBe(BATCH_URL);
-    expect(request.headers['X-API-Key']).toBeTruthy();
+    expect(request.headers['X-API-Key']).toBe(TEST_LOG_REPORT_KEY);
 
     const body = JSON.parse(request.body);
     expect(body.logs).toHaveLength(1);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
         'src/process/services/pwdLogin/pwdLoginService.ts',
         'src/process/services/fuset/FuseTSupervisor.ts',
         'src/process/services/nexus-vfs/FusePluginClient.ts',
+        'src/process/telemetry/SudoLogTelemetryReporter.ts',
         'src/process/bridge/updateBridge.ts',
         'src/process/bridge/applicationBridge.ts',
         'src/process/bridge/documentBridge.ts',


### PR DESCRIPTION
## Summary
- Introduces `SudoLogTelemetryReporter` that forwards telemetry events (perf/conversation/turn/step/install) and crash events to the Sudo Log backend, running alongside the existing `TelemetryBatchReporter`.
- Wires the reporter into `CrashReporter` capture paths and `TelemetryBatchReporter.recordEvent` so all events are mirrored, with shared enable/flush lifecycle via `initializeTelemetry` / `shutdownTelemetry`.
- Exposes Sudo Log constants (`SUDO_LOG_PRODUCT`, `SUDO_LOG_TENANT_ID`, batch URL, API key header) and adds `SUDOWORK_LOG_API_KEY` env override so the new reporter can reuse the same transport configuration.

## Test plan
- [ ] `bunx vitest run tests/unit/sudoLogTelemetryReporter.test.ts`
- [ ] `bunx vitest run tests/unit/sudoworkLogUploader.test.ts`
- [ ] `bunx tsc --noEmit`
- [ ] Manual smoke: run app and verify telemetry/crash events appear in Sudo Log dashboard