### PR TITLE
fix(channels): sync workspace skills for IM channels so scode discovers non-builtin skills

### DIFF
--- a/src/channels/agent/ChannelMessageService.ts
+++ b/src/channels/agent/ChannelMessageService.ts
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { mainWarn } from '@process/utils/mainLogger';
+import { composeMessage, transformMessage, type TMessage } from '../../common/chatLib';
+import { uuid } from '../../common/utils';
+import type { IResponseMessage } from '../../common/ipcBridge';
+import { channelEventBus, type IAgentMessageEvent } from './ChannelEventBus';
 import WorkerManage from '@/process/WorkerManage';
 import { getDatabase } from '@/process/database';
 import type BaseAgent from '@/process/task/BaseAgent';
-import { composeMessage, transformMessage, type TMessage } from '../../common/chatLib';
-import { uuid } from '../../common/utils';
-import { channelEventBus, type IAgentMessageEvent } from './ChannelEventBus';
-import type { IResponseMessage } from '../../common/ipcBridge';
+import { queueConversationWorkspaceSkillSync } from '@/process/bridge/conversationBridge';
 
 /**
  * Streaming callback for progress updates
@@ -218,6 +220,14 @@ export class ChannelMessageService {
       const db = getDatabase();
       const dbResult = db.getConversation(conversationId);
       const isFromChannel = dbResult.success && (dbResult.data?.source === 'lark' || dbResult.data?.source === 'telegram' || dbResult.data?.source === 'dingtalk' || dbResult.data?.source === 'wechat');
+
+      if (dbResult.success && dbResult.data) {
+        try {
+          await queueConversationWorkspaceSkillSync(dbResult.data);
+        } catch (syncError) {
+          mainWarn('ChannelMessageService', 'Skill sync failed (non-blocking)', syncError);
+        }
+      }
 
       task = await WorkerManage.getTaskByIdRollbackBuild(conversationId, {
         yoloMode: isFromChannel,

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -7,8 +7,6 @@
 import * as os from 'os';
 import * as path from 'path';
 import { spawn } from 'child_process';
-import type { TChatConversation } from '@/common/storage';
-import type { IDirOrFile, MossSessionAvailableSkill, MossWorkspaceNode } from '@/common/ipcBridge';
 import fs from 'fs/promises';
 import { getDatabase } from '@process/database';
 import { cronService } from '@process/services/cron/CronService';
@@ -27,15 +25,17 @@ import { copyFilesToDirectory, readDirectoryRecursive } from '../utils';
 import { resolveWorkspaceSkillsDir } from '../utils/workspaceSkillsDir';
 import { INTERMEDIATE_DIR_SEGMENTS } from '../task/FileIntentClassifier';
 import WorkerManage from '../WorkerManage';
-import { migrateConversationToDatabase } from './migrationUtils';
-import { closeTerminalsByConversation } from './terminalBridge';
-import { closeBrowserTabsByConversation } from './browserPanelBridge';
 import { skillManager } from '../SkillManager';
 import { ConversationManageWithDB } from '../message';
-import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
 import { startConversationTracking, endConversationSuccess, endConversationError } from '../telemetry';
 import { getConversationProvider, isRemoteProvider } from '../providers';
 import { getMossApi, getMossApiServerUrl, initMossApi } from '../remote/MossSessionApi';
+import { closeBrowserTabsByConversation } from './browserPanelBridge';
+import { closeTerminalsByConversation } from './terminalBridge';
+import { migrateConversationToDatabase } from './migrationUtils';
+import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
+import type { IDirOrFile, MossSessionAvailableSkill, MossWorkspaceNode } from '@/common/ipcBridge';
+import type { TChatConversation } from '@/common/storage';
 import { getSudoworkAcpSlashCommands } from '@/common/slash/sudoworkCommands';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 
@@ -234,7 +234,7 @@ async function syncConversationWorkspaceSkills(conversation: TChatConversation |
   });
 }
 
-function queueConversationWorkspaceSkillSync(conversation: TChatConversation | undefined, requestedSkillNames?: string[]): Promise<void> {
+export function queueConversationWorkspaceSkillSync(conversation: TChatConversation | undefined, requestedSkillNames?: string[]): Promise<void> {
   if (!shouldSyncWorkspaceSkills(conversation, requestedSkillNames)) {
     return Promise.resolve();
   }


### PR DESCRIPTION
ChannelMessageService never invoked queueConversationWorkspaceSkillSync before
sending messages, so the workspace skills directory stayed empty for all IM
channels (lark/dingtalk/telegram/wechat/wecom). AcpAgent reads that directory
on the first message to build the skills hint, meaning non-builtin skills like
image-generation were invisible and scode fell back to drawing SVGs.

- Export queueConversationWorkspaceSkillSync from conversationBridge so the
  channel layer can reuse the existing sync path (no logic change, no new
  module, no import cycle — conversationBridge is not imported elsewhere).
- Call it in ChannelMessageService.sendMessage after fetching the conversation
  and before getTaskByIdRollbackBuild so symlinks exist before scode reads
  them; sync failures only warn and do not block the message.
