### PR TITLE
fix(nexus-vfs): single-source SHA256 to unblock Mac install (#918 follow-up)

### DIFF
--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -27,6 +27,7 @@ const https = require('https');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 const runtimeVersions = require('../src/shared/runtime-versions.json');
+const runtimeSha256 = require('../src/shared/runtime-sha256.json');
 
 const VERSION = runtimeVersions['nexus-vfs'];
 const VAULT_VERSION = runtimeVersions['nexus-vault'];
@@ -66,57 +67,16 @@ const FUSE_PLUGIN_GITHUB_URL = `https://github.com/nexi-lab/nexus/releases/downl
 /**
  * Known-good SHA256 sums (mirrors SHA256SUMS.txt in the bucket).
  * A download whose hash is not listed here is rejected — no silent acceptance.
- * Note: there is intentionally NO macos-x86_64 entry (Intel Macs unsupported).
  *
- * nexusd-cluster sums are populated after COS mirror; vault sums from CI artifacts.
+ * Single source of truth lives in `src/shared/runtime-sha256.json` so the
+ * runtime re-installers (DynamicNexusVfsService, VaultPluginInstaller) read
+ * the SAME table — bumping a version in `runtime-versions.json` without a
+ * matched bump here used to leave the runtime stuck on the old SHA while
+ * the script downloaded the new bytes (the #918 → Mac smoke regression).
+ * Strip the `_doc` key so legitimate artifact lookups don't accidentally
+ * match a documentation string.
  */
-const SHA256SUMS = {
-  // nexusd-cluster v0.3.0 — first ABI-v3 cluster release. Adds
-  // `sys_stat_batch` to KernelHandle (#60). The v3 kernel strictly
-  // rejects PLUGIN_API_VERSION mismatch, so EVERY signed plugin pinned
-  // below must also be a v3 rebuild — see the matched v0.2.0 set for
-  // vault / local-connector and the v0.4.0 fuse-plugin (the first
-  // release shipped after vault dogfood signing went green on v3).
-  // Sums lifted from
-  // https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com/nexus-vfs/release/v0.3.0/SHA256SUMS.txt
-  'nexusd-cluster-linux-aarch64.tar.gz': '1afa3e5b0fd239cd8a36a4bd2fd6409890eb5bb8a3d8d3d9a5e8357faec8b610',
-  'nexusd-cluster-linux-x86_64.tar.gz': 'b5589082304cf9cbc693381f3bf52d53554573bee0aa8bbdc23f17ca3a7cf486',
-  'nexusd-cluster-macos-aarch64.tar.gz': '0b07557accd3982ac9823ba8128377ea2e4e8a7ab8aaaf9d243bf9e06688df0e',
-  'nexusd-cluster-macos-x86_64.tar.gz': '7bd7e03a97ba024459503d137d7622e8315a2bb976a5884156a37c2a8d90313d',
-  'nexusd-cluster-windows-aarch64.zip': 'ec97d5ff5fe7b51f29cf5c2b1b0ab7d709df99e10ce3e974aa12cc9e14220ebd',
-  'nexusd-cluster-windows-x86_64.zip': 'c318f749cb1ed5a6dad87559499bf5ae9fbb53ad9decb94e3711060aa8e8050d',
-  // vault plugin v0.2.0 — first ABI-v3 rebuild of the dogfood-signed
-  // vault. Same source as v0.1.4 plus a re-tag against nexus-vfs v0.3.0.
-  // Required so the v3 cluster will actually load the vault dylib — v2
-  // vault gets refused at PluginLoader::load and every gRPC method then
-  // returns UNIMPLEMENTED. Sums computed locally by sha256sum on the
-  // four assets at
-  // https://github.com/nexi-lab/nexus/releases/tag/vault-v0.2.0 — vault
-  // v0.2.0 is not yet mirrored to COS so the downloader falls through
-  // to the GitHub release fallback for this artifact.
-  'nexus-vault-linux-x86_64.tar.gz': 'b209e62e8076d2f567d291f203335009d449683b2199e275d23073a04e59ce30',
-  'nexus-vault-macos-arm64.tar.gz': 'a723b032f119669544156558af3f08425a59a5c95caa87ad9c1cfff1bc876b6d',
-  'nexus-vault-macos-x86_64.tar.gz': '38a7bfed062e34323f83fd6aed03322016976847ea74c90e05bff93f6f8bb874',
-  'nexus-vault-windows-x86_64.zip': 'c89c894f926a0e659364f96bf3192091e58122bbad73ecb3847f70d97a00dc21',
-  // local-connector v0.2.0 — ABI-v3 rebuild of the local-FS driver,
-  // signed by kernel-dogfood-v1.pub. Same source as v0.1.1 plus the
-  // re-tag; needed so the v3 cluster will load it. Sums from
-  // https://github.com/nexi-lab/nexus/releases/tag/local-connector-v0.2.0.
-  'nexus-local-connector-linux-x86_64.tar.gz': '9ff9f574b72241e4b89627b5852effa51042b6c3799d3ce55dcf5bc0910d7ffc',
-  'nexus-local-connector-macos-arm64.tar.gz': 'f5d9abfe0239c9c4c4a49b0154532da64fdd67dda41b07f8490855f7343442f7',
-  'nexus-local-connector-macos-x86_64.tar.gz': '8a589380b276ffcbb425558dcc6baa6b9910d6dd6b53cd81127b5a33e0004f7a',
-  'nexus-local-connector-windows-x86_64.zip': '49078141537918f423d5939d976270dfbe52eb628db677009694ba306be8e9e9',
-  // fuse-plugin v0.4.0 — ABI-v3 rebuild. Adds the macOS preflight that
-  // returns `dispatch("status") == "fuse-t-missing"` instead of crashing
-  // the mount when FUSE-T is not installed; sudowork's supervisor reads
-  // that string to drive `fuseTInstallService.ensureInstalled()` (the
-  // poll wiring lands in a follow-up PR). Aggregates the v0.3.0 WinFsp
-  // adapter that never published a release. Sums from
-  // https://github.com/nexi-lab/nexus/releases/tag/fuse-v0.4.0.
-  'nexus-fuse-plugin-linux-x86_64.tar.gz': '1208d8d3b57d42f6415fa155f7588174eec268a0d2946062fa25bf929805c283',
-  'nexus-fuse-plugin-macos-arm64.tar.gz': '8485c2094bf8714adbd2f8a83d19b95911c3230774e7f84a4b11268c296fe08b',
-  'nexus-fuse-plugin-macos-x86_64.tar.gz': '009245ca9275d64cde92c69003e806a0947b8e2b1a42f78a6a133c132dc8b93d',
-};
+const SHA256SUMS = Object.fromEntries(Object.entries(runtimeSha256).filter(([key]) => !key.startsWith('_')));
 
 
 

--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -11,6 +11,7 @@ import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { processSupervisor } from '@process/ProcessSupervisor';
 import { extractTarGzWithProgress, extractZipWithProgress } from '../archiveProgress';
 import runtimeVersions from '@/shared/runtime-versions.json';
+import runtimeSha256 from '@/shared/runtime-sha256.json';
 import { COS_RUNTIME_BASE, COS_LEGACY_NEXUS_VFS_BASE } from '@/shared/cos';
 import { vaultPluginInstaller } from './VaultPluginInstaller';
 
@@ -49,16 +50,13 @@ const OS_NAME_MAP: Record<string, string> = { darwin: 'macos', win32: 'windows',
 /** Node.js process.arch → artifact arch token (note: arm64 → aarch64). */
 const ARCH_NAME_MAP: Record<string, string> = { arm64: 'aarch64', x64: 'x86_64' };
 
-/** Known-good SHA256 sums for v0.2.2 (mirrors SHA256SUMS.txt in the bucket;
- *  keep in sync with scripts/download-nexus-vfs.js). */
-const NEXUS_VFS_SHA256SUMS: Record<string, string> = {
-  'nexusd-cluster-linux-aarch64.tar.gz': 'fadc8c54c8cca44dc58dbd6194c203354ee282afe2ce9daec8a6056e4683e8c3',
-  'nexusd-cluster-linux-x86_64.tar.gz': 'b5a7730dadd2cbbf47727a3bb6e7989d8facf178fec75076061845867493b0d9',
-  'nexusd-cluster-macos-aarch64.tar.gz': '93eda20acfc5b64135781cc41aff2e4265b1046800967ed4ca85e2321c53175c',
-  'nexusd-cluster-macos-x86_64.tar.gz': 'd6464618413853320ac33103239880a36e564e36f41ff9456e1fa76db89269ec',
-  'nexusd-cluster-windows-aarch64.zip': 'be530516894f4115ad1971f5a6c6a0d4191ba8141f6b213da128381bb552e056',
-  'nexusd-cluster-windows-x86_64.zip': '03e589f7a288a62e0399d4c9dececbb16be342f258842dfb6c6b37b6c3919901',
-};
+/** Known-good SHA256 sums for the cluster binaries. Sourced from
+ *  `src/shared/runtime-sha256.json` so the build-time downloader
+ *  (`scripts/download-nexus-vfs.js`) and this runtime re-installer always
+ *  see the SAME bytes. Pre-#918 these were two parallel hand-maintained
+ *  tables; bumping the script alone left this side stuck on the old
+ *  SHA, which is exactly how the v0.3.0 Mac smoke broke. */
+const NEXUS_VFS_SHA256SUMS: Record<string, string> = runtimeSha256 as Record<string, string>;
 
 export type NexusVfsStage = 'idle' | 'checking' | 'downloading' | 'installing' | 'starting' | 'ready' | 'error';
 

--- a/src/process/services/nexus-vfs/VaultPluginInstaller.ts
+++ b/src/process/services/nexus-vfs/VaultPluginInstaller.ts
@@ -7,6 +7,7 @@ import { app } from 'electron';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { extractTarGzWithProgress, extractZipWithProgress } from '../archiveProgress';
 import runtimeVersions from '@/shared/runtime-versions.json';
+import runtimeSha256 from '@/shared/runtime-sha256.json';
 import { COS_RUNTIME_BASE, COS_LEGACY_NEXUS_VFS_BASE } from '@/shared/cos';
 import type { NexusVfsStage } from './DynamicNexusVfsService';
 
@@ -50,14 +51,13 @@ const VAULT_DYLIB_NAME_MAP: Record<string, string> = {
   win32: 'nexus_vault.dll',
 };
 
-/** Known-good SHA256 sums for vault v0.1.3. Must stay byte-identical to
- *  scripts/download-nexus-vfs.js — U9 unit test enforces this. */
-export const NEXUS_VAULT_SHA256SUMS: Record<string, string> = {
-  'nexus-vault-linux-x86_64.tar.gz': 'ce831d12f55bdd935d928d78df7f4a25078636529d020a1bd0235f68bb8f22f2',
-  'nexus-vault-macos-arm64.tar.gz': '603543170a09208fdd9aa3ce5c6aac6149215726042d51d53db4a083fbe728d6',
-  'nexus-vault-macos-x86_64.tar.gz': '276e1198c55eeed616ba50d5aa5a421ddbb89459a1be1227f44cc5927692e1eb',
-  'nexus-vault-windows-x86_64.zip': '5b91322ddb745c2049e9d675290e3b1a32b2d26bcb67bd96f85dff0f91a3799d',
-};
+/** Known-good SHA256 sums for vault. Sourced from
+ *  `src/shared/runtime-sha256.json` so the build-time downloader
+ *  (`scripts/download-nexus-vfs.js`) and this runtime re-installer always
+ *  see the SAME bytes. The previous hand-maintained table here drifted
+ *  silently when PR #918 bumped vault to v0.2.0 — runtime stayed on the
+ *  v0.1.3 SHA and every Mac install hit a SHA-mismatch error. */
+export const NEXUS_VAULT_SHA256SUMS: Record<string, string> = runtimeSha256 as Record<string, string>;
 
 // ── Module-level pure functions (export so tests can call directly without
 //    poking class internals) ───────────────────────────────────────────────────

--- a/src/shared/runtime-sha256.json
+++ b/src/shared/runtime-sha256.json
@@ -1,0 +1,24 @@
+{
+  "_doc": "Canonical SHA256 sums for every downloadable nexus-vfs runtime artifact. Single source of truth — scripts/download-nexus-vfs.js (build/install-time), DynamicNexusVfsService.ts (runtime cluster re-installer), and VaultPluginInstaller.ts (runtime vault re-installer) all read from this file. Bump versions in runtime-versions.json AND update the matching entry here in one commit; do NOT inline a SHA back into any source file. Verified against the per-release SHA256SUMS.txt in the COS bucket.",
+
+  "nexusd-cluster-linux-aarch64.tar.gz": "1afa3e5b0fd239cd8a36a4bd2fd6409890eb5bb8a3d8d3d9a5e8357faec8b610",
+  "nexusd-cluster-linux-x86_64.tar.gz": "b5589082304cf9cbc693381f3bf52d53554573bee0aa8bbdc23f17ca3a7cf486",
+  "nexusd-cluster-macos-aarch64.tar.gz": "0b07557accd3982ac9823ba8128377ea2e4e8a7ab8aaaf9d243bf9e06688df0e",
+  "nexusd-cluster-macos-x86_64.tar.gz": "7bd7e03a97ba024459503d137d7622e8315a2bb976a5884156a37c2a8d90313d",
+  "nexusd-cluster-windows-aarch64.zip": "ec97d5ff5fe7b51f29cf5c2b1b0ab7d709df99e10ce3e974aa12cc9e14220ebd",
+  "nexusd-cluster-windows-x86_64.zip": "c318f749cb1ed5a6dad87559499bf5ae9fbb53ad9decb94e3711060aa8e8050d",
+
+  "nexus-vault-linux-x86_64.tar.gz": "b209e62e8076d2f567d291f203335009d449683b2199e275d23073a04e59ce30",
+  "nexus-vault-macos-arm64.tar.gz": "a723b032f119669544156558af3f08425a59a5c95caa87ad9c1cfff1bc876b6d",
+  "nexus-vault-macos-x86_64.tar.gz": "38a7bfed062e34323f83fd6aed03322016976847ea74c90e05bff93f6f8bb874",
+  "nexus-vault-windows-x86_64.zip": "c89c894f926a0e659364f96bf3192091e58122bbad73ecb3847f70d97a00dc21",
+
+  "nexus-local-connector-linux-x86_64.tar.gz": "9ff9f574b72241e4b89627b5852effa51042b6c3799d3ce55dcf5bc0910d7ffc",
+  "nexus-local-connector-macos-arm64.tar.gz": "f5d9abfe0239c9c4c4a49b0154532da64fdd67dda41b07f8490855f7343442f7",
+  "nexus-local-connector-macos-x86_64.tar.gz": "8a589380b276ffcbb425558dcc6baa6b9910d6dd6b53cd81127b5a33e0004f7a",
+  "nexus-local-connector-windows-x86_64.zip": "49078141537918f423d5939d976270dfbe52eb628db677009694ba306be8e9e9",
+
+  "nexus-fuse-plugin-linux-x86_64.tar.gz": "1208d8d3b57d42f6415fa155f7588174eec268a0d2946062fa25bf929805c283",
+  "nexus-fuse-plugin-macos-arm64.tar.gz": "8485c2094bf8714adbd2f8a83d19b95911c3230774e7f84a4b11268c296fe08b",
+  "nexus-fuse-plugin-macos-x86_64.tar.gz": "009245ca9275d64cde92c69003e806a0947b8e2b1a42f78a6a133c132dc8b93d"
+}

--- a/tests/integration/fuseT.integration.test.ts
+++ b/tests/integration/fuseT.integration.test.ts
@@ -130,21 +130,23 @@ describe('FUSE-T — eager dylib dispatch in download-nexus-vfs.js', () => {
     expect(script).toContain("'libnexus_fuse_plugin.dylib'");
   });
 
-  it('macOS + Linux fuse-plugin SHA256 sums are filled with 64-hex hashes', () => {
+  it('macOS + Linux fuse-plugin SHA256 sums are filled in the canonical JSON', () => {
     // Earlier in PR #916 these landed commented-out (fail-closed pending the
     // first cross-platform fuse-vX.Y.Z release). v0.2.0 shipped all three
     // archives, so the verifier now has real sums for every platform we
-    // dispatch to. Assert each line is a 64-char hex string — a regression
+    // dispatch to. Assert each entry is a 64-char hex string — a regression
     // like a placeholder or a truncated copy/paste would otherwise let an
     // unverified dylib pass when CI doesn't actually exercise the macOS
     // download path on Linux runners.
-    const expectHexLine = (artifact: string): void => {
-      const re = new RegExp(`'${artifact.replace(/[.]/g, '\\.')}':\\s*'([a-f0-9]{64})'`);
-      expect(script).toMatch(re);
-    };
-    expectHexLine('nexus-fuse-plugin-linux-x86_64.tar.gz');
-    expectHexLine('nexus-fuse-plugin-macos-arm64.tar.gz');
-    expectHexLine('nexus-fuse-plugin-macos-x86_64.tar.gz');
+    //
+    // Sums migrated out of `scripts/download-nexus-vfs.js` into
+    // `src/shared/runtime-sha256.json` to fix the cross-file drift PR
+    // #918 hit on Mac smoke (script bumped, runtime tables not); the
+    // assertion now reads the canonical JSON directly.
+    const sha = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'src/shared/runtime-sha256.json'), 'utf-8')) as Record<string, string>;
+    for (const artifact of ['nexus-fuse-plugin-linux-x86_64.tar.gz', 'nexus-fuse-plugin-macos-arm64.tar.gz', 'nexus-fuse-plugin-macos-x86_64.tar.gz']) {
+      expect(sha[artifact], `missing SHA for ${artifact}`).toMatch(/^[a-f0-9]{64}$/);
+    }
   });
 
   it('FuseTInstallService has a pinned SHA256 for the active fuse-t version (no unverified pkg)', () => {

--- a/tests/integration/nexusVfsSha256Ssot.integration.test.ts
+++ b/tests/integration/nexusVfsSha256Ssot.integration.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration test — nexus-vfs SHA256 SSOT contract.
+ *
+ * Background: pre-#918 the same SHA table lived in three places —
+ * `scripts/download-nexus-vfs.js` (build-time downloader),
+ * `DynamicNexusVfsService.ts` (runtime cluster re-installer), and
+ * `VaultPluginInstaller.ts` (runtime vault re-installer). PR #918
+ * bumped the script's table to ABI v3 SHAs but left the two runtime
+ * tables stuck on the v0.2.2 / v0.1.3 values, so every Mac install
+ * blew up with `nexus-vfs SHA256 mismatch for ...` at the runtime
+ * verifier even though the script had downloaded the correct bytes.
+ *
+ * Fix: move the SHA table into `src/shared/runtime-sha256.json` and
+ * have all three consumers import from there. This test enforces
+ * that contract — no SHA-shaped literal lives in the source files,
+ * the JSON is the single hand-edited source.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SHA_HEX_64 = /\b[a-f0-9]{64}\b/;
+
+const CONSUMERS = ['scripts/download-nexus-vfs.js', 'src/process/services/nexus-vfs/DynamicNexusVfsService.ts', 'src/process/services/nexus-vfs/VaultPluginInstaller.ts'];
+
+describe('nexus-vfs SHA256 SSOT', () => {
+  it('the canonical JSON lives at src/shared/runtime-sha256.json', () => {
+    // The file's existence is half the contract; the other half is
+    // that every other consumer imports from this path. The next
+    // test enforces no inline literals — together that means a SHA
+    // bump touches one file, not three.
+    const jsonPath = path.join(REPO_ROOT, 'src/shared/runtime-sha256.json');
+    expect(fs.existsSync(jsonPath)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(jsonPath, 'utf-8')) as Record<string, string>;
+    // Spot-check: every key (excluding doc keys) is an artifact filename
+    // and every value is a 64-char lowercase hex SHA.
+    for (const [key, value] of Object.entries(parsed)) {
+      if (key.startsWith('_')) continue;
+      expect(key).toMatch(/^(nexusd-cluster|nexus-vault|nexus-local-connector|nexus-fuse-plugin)-.+\.(tar\.gz|zip)$/);
+      expect(value).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  for (const consumer of CONSUMERS) {
+    it(`${consumer} contains no inline 64-char SHA literal — must import from runtime-sha256.json`, () => {
+      // Why a regex over the source: the literals were tolerable when
+      // there was exactly one of them per artifact and they were
+      // co-located with a "keep in sync" comment that nobody enforced.
+      // The class of bug PR #918 introduced is "bump one place, forget
+      // the other two"; the only test that catches that bug is one
+      // that refuses to let SHA literals live in source files at all.
+      const src = fs.readFileSync(path.join(REPO_ROOT, consumer), 'utf-8');
+      const match = src.match(SHA_HEX_64);
+      if (match) {
+        // Surface the first offender so the failure message points at
+        // the literal to delete, not just "this file is dirty".
+        throw new Error(`${consumer} contains inline SHA literal "${match[0]}". Move it to src/shared/runtime-sha256.json and consume via import.`);
+      }
+      // Sanity check: ensure the file actually imports / requires the
+      // canonical JSON (a passing regex check would otherwise be
+      // vacuously true on an empty file).
+      expect(src).toMatch(/runtime-sha256(\.json)?['"]/);
+    });
+  }
+
+  it('every artifact the script knows how to download has a SHA entry in the JSON', () => {
+    const sha = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'src/shared/runtime-sha256.json'), 'utf-8')) as Record<string, string>;
+    const script = fs.readFileSync(path.join(REPO_ROOT, 'scripts/download-nexus-vfs.js'), 'utf-8');
+    // The script names each archive (e.g. `nexusd-cluster-macos-x86_64.tar.gz`)
+    // wherever it builds a download URL. Pull every such occurrence
+    // and confirm we have a SHA for it; missing entries are exactly
+    // what made the v0.1.1 → v0.3.0 transition fail-closed at runtime.
+    const archives = Array.from(script.matchAll(/(nexus(?:d-cluster|-vault|-local-connector|-fuse-plugin)-[a-z0-9_-]+?\.(?:tar\.gz|zip))/g)).map((m) => m[1]);
+    expect(archives.length).toBeGreaterThan(0);
+    const missing = Array.from(new Set(archives)).filter((a) => !(a in sha));
+    expect(missing, `Missing SHA entries for ${missing.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- PR #918 bumped the SHA table in `scripts/download-nexus-vfs.js` but left the two runtime re-installer tables (`DynamicNexusVfsService.ts`, `VaultPluginInstaller.ts`) stuck on the old v0.2.2 / v0.1.3 SHAs. Mac smoke caught the regression: download succeeds with the new bytes, runtime verifier expects the old SHA, fail-closed at every cold start.
- Move all 17 SHA entries to `src/shared/runtime-sha256.json` and have all three consumers import from there. Bumping a version is now a two-file edit (`runtime-versions.json` + `runtime-sha256.json`), not three.
- New integration test refuses any SHA-shaped (64-char hex) literal in the three consumer files — the class of bug that broke #918 is structurally unrepresentable now.

## Mac AI smoke report on #918
- expected: `d6464618...` (stale DynamicNexusVfsService.ts table)
- got: `7bd7e03a...` (COS reality + post-#918 script table)

After this PR both readers see `7bd7e03a...` → SHA passes → marker writes "0.3.0" → next cold start short-circuits. Blocker 2 (markers stuck on v0.1.1) was a downstream artifact of Blocker 1; markers already version-gate correctly, they just never got to write the new version.

## Test plan
- [x] `bunx vitest run tests/integration/nexusVfsSha256Ssot.integration.test.ts tests/integration/fuseT.integration.test.ts tests/unit/FuseTInstallService.test.ts` — 24/24 pass locally
- [x] `bunx tsc --noEmit` clean for changed files (pre-existing unrelated errors only)
- [x] Lint clean for changed files (pre-existing `no-empty` catch warnings only, same count as on `dev`)
- [ ] CI green
- [ ] Mac team re-run cold-start smoke: cluster should install, three signed dylibs present in `~/.nexus-vfs/plugins/`, no UAC prompt, no ABI mismatch in stderr

## Notes
- Blocks the supervisor PR (`feat/fuse-t-supervisor-status-poll`) — that PR's e2e needs a working cluster on Mac, which depends on this hotfix landing first.