### PR TITLE
feat(fuset): supervisor that consumes fuse plugin status and triggers lazy install

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -6,6 +6,12 @@
 
 import type { OpenDialogOptions } from 'electron';
 import { bridge } from '@office-ai/platform';
+import type { IConfirmation } from '@/common/chatLib';
+import type { IAssistantMeta } from '@/process/constants/assistantStorage';
+import type { IAssistantInfo } from '@/process/AssistantManager';
+import type { IChannelPairingRequest, IChannelPluginStatus, IChannelSession, IChannelUser, IPluginCredentials } from '@/channels/types';
+import type { SafetyStatus, BlacklistConfig } from '@/common/safetyTypes';
+import type { AuthProxyRule } from '@/common/types/authProxy';
 import type { McpSource } from '../process/services/mcpServices/McpProtocol';
 import type { AcpBackend, AcpBackendAll, AcpModelInfo, PresetAgentType } from '../types/acpTypes';
 import type { SyncAllResult } from '../process/sync/remoteToLocalSync';
@@ -13,10 +19,10 @@ import type { ScodeCustomModelProvider } from './scodeConfig';
 import type { SlashCommandItem } from './slash/types';
 import type { IMcpServer, IProvider, TChatConversation, TProviderWithModel, ICssTheme } from './storage';
 import type { SecretMetadata } from './nexus/nexus-secret-client';
+import type { FusePluginStatus } from './nexus/fuse-plugin-status';
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from './types/preview';
 import type { UpdateCheckRequest, UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult, AutoUpdateStatus } from './updateTypes';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from './utils/protocolDetector';
-import type { IConfirmation } from '@/common/chatLib';
 
 export const shell = {
   openFile: bridge.buildProvider<void, string>('open-file'), // 使用系统默认程序打开文件
@@ -446,7 +452,10 @@ export const moss = {
 };
 
 export const mode = {
-  fetchModelList: bridge.buildProvider<IBridgeResponse<{ mode: Array<string | { id: string; name: string }>; fix_base_url?: string }>, { base_url?: string; api_key: string; try_fix?: boolean; platform?: string; bedrockConfig?: { authMethod: 'accessKey' | 'profile'; region: string; accessKeyId?: string; secretAccessKey?: string; profile?: string } }>('mode.get-model-list'),
+  fetchModelList: bridge.buildProvider<
+    IBridgeResponse<{ mode: Array<string | { id: string; name: string }>; fix_base_url?: string }>,
+    { base_url?: string; api_key: string; try_fix?: boolean; platform?: string; bedrockConfig?: { authMethod: 'accessKey' | 'profile'; region: string; accessKeyId?: string; secretAccessKey?: string; profile?: string } }
+  >('mode.get-model-list'),
   saveModelConfig: bridge.buildProvider<IBridgeResponse, IProvider[]>('mode.save-model-config'),
   getModelConfig: bridge.buildProvider<IProvider[], void>('mode.get-model-config'),
   /** 协议检测接口 - 自动检测 API 端点使用的协议类型 / Protocol detection - auto-detect API protocol type */
@@ -703,6 +712,32 @@ export interface IFuseTStatus {
   bundlePath?: string;
 }
 
+/**
+ * Discriminates what the FUSE-T supervisor actually did when the
+ * renderer / sudocode invoked `runLazyInstallProbe`. Matches the
+ * variants exported by `FuseTSupervisor` so a UI can surface the
+ * right toast (install fired vs already mounted vs cluster down)
+ * without re-parsing free-form strings.
+ */
+export type IFuseTLazyInstallOutcome = 'already-mounted' | 'unmounted-no-prereq-action' | 'installed-and-mounted' | 'installed-but-not-mounted' | 'plugin-unreachable' | 'platform-unsupported' | 'install-failed';
+
+// `FusePluginStatus` (imported above + re-exported below) is the
+// canonical wire-format union — it mirrors the bytes the Rust plugin's
+// `dispatch("status")` returns. Lives in `nexus/fuse-plugin-status.ts`
+// so the renderer (via this IPC type) and the main-process supervisor
+// (via `@process/services/nexus-vfs/FusePluginClient`) both consume
+// the SAME literal set — no parallel `IFusePluginStatus` drifting
+// against `FusePluginStatus`.
+export type { FusePluginStatus } from './nexus/fuse-plugin-status';
+
+export interface IFuseTLazyInstallResult {
+  outcome: IFuseTLazyInstallOutcome;
+  initialStatus: FusePluginStatus;
+  finalStatus?: FusePluginStatus;
+  rawStatus?: string;
+  errorMessage?: string;
+}
+
 export const fuseT = {
   checkInstalled: bridge.buildProvider<IBridgeResponse<IFuseTStatus>, void>('fuse-t.check-installed'),
   ensureInstalled: bridge.buildProvider<IBridgeResponse<void>, void>('fuse-t.ensure-installed'),
@@ -712,6 +747,17 @@ export const fuseT = {
   installProgress: bridge.buildEmitter<{ phase: IFuseTInstallPhase; percent?: number }>('fuse-t.install-progress'),
   /** Emitted once when installation completes (success or failure) */
   installResult: bridge.buildEmitter<{ success: boolean; msg?: string }>('fuse-t.install-result'),
+  /**
+   * Explicit-trigger lazy install probe — the only path that ends in
+   * an admin-password prompt when the supervisor decides FUSE-T is
+   * actually missing. Closes the lazy contract started by PR #916 +
+   * the macOS preflight added in nexi-lab/nexus PR #4414. Renderers
+   * (or sudocode invoking through IPC) call this exactly when a
+   * cross-machine FUSE mount is about to be needed; calling it
+   * proactively at app startup would re-introduce the admin-prompt
+   * regression the lazy split exists to avoid.
+   */
+  runLazyInstallProbe: bridge.buildProvider<IBridgeResponse<IFuseTLazyInstallResult>, void>('fuse-t.run-lazy-install-probe'),
 };
 
 // Python runtime installer / Python 运行环境安装
@@ -1541,9 +1587,6 @@ export const skillHub = {
 
 // ==================== Assistant Hub API ====================
 
-import type { IAssistantMeta } from '@/process/constants/assistantStorage';
-import type { IAssistantInfo } from '@/process/AssistantManager';
-
 /** Assistant from Hub API (mirrors ISkillHubSkill pattern) */
 export interface IAssistantHubSkill {
   id: string;
@@ -1653,14 +1696,14 @@ export const assistantHub = {
   /** Fetch skill details by IDs from Skill Hub API (for installation preview) */
   fetchSkillDetailsByIds: bridge.buildProvider<IBridgeResponse<ISkillHubSkill[]>, { skillIds: string[] }>('assistant-hub.fetch-skill-details-by-ids'),
   /** Download and install assistant from Hub, optionally installing selected associated skills */
-  downloadAndInstallAssistant: bridge.buildProvider<IBridgeResponse<IAssistantInstallResult>, { assistantName: string; displayName: string; sourceUrl: string; version: string; checksum: string; assistantMeta: IAssistantHubSkill; selectedSkillIds?: string[] }>('assistant-hub.download-and-install-assistant'),
+  downloadAndInstallAssistant: bridge.buildProvider<IBridgeResponse<IAssistantInstallResult>, { assistantName: string; displayName: string; sourceUrl: string; version: string; checksum: string; assistantMeta: IAssistantHubSkill; selectedSkillIds?: string[] }>(
+    'assistant-hub.download-and-install-assistant'
+  ),
   /** Upload custom assistant to Hub (create zip and POST to /api/assistants) */
   uploadAssistantToHub: bridge.buildProvider<IBridgeResponse<{ success: boolean; message?: string }>, { name: string; displayName: string; profession: string; description?: string; categories?: string[]; skills?: string[]; tenantId: string }>('assistant-hub.upload-assistant-to-hub'),
 };
 
 // ==================== Channel API ====================
-
-import type { IChannelPairingRequest, IChannelPluginStatus, IChannelSession, IChannelUser, IPluginCredentials } from '@/channels/types';
 
 export const channel = {
   // Plugin Management
@@ -1732,8 +1775,6 @@ export const sudoworkServer = {
 };
 
 // ==================== Safety Hook API ====================
-
-import type { SafetyStatus, BlacklistConfig } from '@/common/safetyTypes';
 
 // ==================== Tools API ====================
 
@@ -1976,8 +2017,6 @@ export const telemetry = {
 // ==================== Auth Proxy API ====================
 // Manage Auth Proxy server lifecycle, rules cache, and status
 
-import type { AuthProxyRule } from '@/common/types/authProxy';
-
 export const authProxy = {
   /** Get all cached Config Items rules */
   getRules: bridge.buildProvider<IBridgeResponse<AuthProxyRule[]>, void>('authProxy.getRules'),
@@ -2097,7 +2136,9 @@ export const eeclaw = {
   /** Upload custom skill to Moss Server */
   uploadCustomSkill: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { skillName: string; displayName: string; description?: string; version?: string; sourcePath?: string }>('eeclaw.upload-custom-skill'),
   /** Upload custom assistant to Moss Server */
-  uploadCustomAssistant: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { assistantName: string; assistantId: string; displayName: string; description?: string; version?: string; enabledSkills?: string[]; memoryMode?: 'session' | 'user'; sourcePath?: string }>('eeclaw.upload-custom-assistant'),
+  uploadCustomAssistant: bridge.buildProvider<IBridgeResponse<{ id: string; name: string; status: string }>, { assistantName: string; assistantId: string; displayName: string; description?: string; version?: string; enabledSkills?: string[]; memoryMode?: 'session' | 'user'; sourcePath?: string }>(
+    'eeclaw.upload-custom-assistant'
+  ),
 
   // === Tenant Skill/Assistant ===
   /** Fetch tenant-exclusive skills from Moss Server */

--- a/src/common/nexus/fuse-plugin-status.ts
+++ b/src/common/nexus/fuse-plugin-status.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Canonical types for the `nexus-fuse-plugin` status surface.
+ *
+ * Wire format is decided on the Rust side
+ * (`nexi-lab/nexus rust/services/fuse-plugin/src/lib.rs:dispatch_fuse`);
+ * this file is the TypeScript mirror. Lives in `src/common/` so both
+ * the main-process supervisor (`@process/services/nexus-vfs/FusePluginClient`)
+ * AND the renderer-visible IPC bridge (`@common/ipcBridge.fuseT`) import
+ * the SAME literal union — there is no `IFusePluginStatus` / `FusePluginStatus`
+ * pair drifting in parallel.
+ *
+ * If the Rust plugin grows a new prereq (`"libfuse3-missing"`,
+ * `"winfsp-missing"`, …) extend the union here and the supervisor's
+ * switch; no other file needs to know.
+ */
+
+/**
+ * Outcomes of the plugin's `dispatch("status")` admin method.
+ *
+ *   - `mounted` — FUSE event loop running.
+ *   - `unmounted` — plugin loaded but no mount point configured
+ *     (`NEXUS_FUSE_MOUNT_POINT` env unset).
+ *   - `fuse-t-missing` — macOS-only; FUSE-T `.pkg` not installed yet.
+ *     The supervisor's trigger for `fuseTInstallService.ensureInstalled()`.
+ *   - `unknown` — cluster down, plugin not loaded, dispatch returned
+ *     something we don't recognise. NEVER an install trigger.
+ */
+export type FusePluginStatus = 'mounted' | 'unmounted' | 'fuse-t-missing' | 'unknown';
+
+export interface FusePluginStatusResult {
+  status: FusePluginStatus;
+  /** Exact bytes the plugin returned, decoded as UTF-8. Kept for diagnostics when `status` is `unknown`. */
+  raw: string;
+}

--- a/src/process/bridge/fuseTBridge.ts
+++ b/src/process/bridge/fuseTBridge.ts
@@ -66,5 +66,49 @@ export function initFuseTBridge(): void {
       }, 0);
     }
   });
+
+  // Lazy install probe — the legitimate caller for `ensureInstalled`.
+  // Routes through `FuseTSupervisor`, which probes the fuse plugin's
+  // `dispatch("status")` first and only triggers the installer when
+  // the plugin actually reports `fuse-t-missing`. The supervisor
+  // forwards install progress through the same emitters as the
+  // direct `ensureInstalled` channel, so any UI already listening
+  // to `installProgress` / `installResult` doesn't need a second
+  // subscription. Re-entrancy is guarded by the shared `installState`
+  // flag below.
+  ipcBridge.fuseT.runLazyInstallProbe.provider(async () => {
+    if (installState.installing) {
+      return { success: false, msg: 'FUSE-T install already in progress' };
+    }
+    installState = { installing: true };
+    try {
+      // Build a per-call supervisor so the install-progress callback
+      // wired here doesn't leak into a long-lived singleton's state.
+      // `getFuseTSupervisor()` is still the path callers outside the
+      // bridge use for the default no-progress flow.
+      const { FuseTSupervisor } = await import('../services/fuset/FuseTSupervisor');
+      const supervisor = new FuseTSupervisor({
+        onInstallProgress: (phase, percent) => {
+          installState = { installing: true, phase, percent };
+          ipcBridge.fuseT.installProgress.emit({ phase, percent });
+        },
+      });
+      const result = await supervisor.runLazyInstallProbe();
+      if (result.outcome === 'installed-and-mounted' || result.outcome === 'installed-but-not-mounted') {
+        ipcBridge.fuseT.installResult.emit({ success: true });
+      } else if (result.outcome === 'install-failed') {
+        ipcBridge.fuseT.installResult.emit({ success: false, msg: result.errorMessage });
+      }
+      return { success: true, data: result };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ipcBridge.fuseT.installResult.emit({ success: false, msg });
+      return { success: false, msg };
+    } finally {
+      setTimeout(() => {
+        installState = { installing: false };
+      }, 0);
+    }
+  });
   mainLog(TAG, 'FUSE-T IPC providers registered');
 }

--- a/src/process/services/fuset/FuseTSupervisor.ts
+++ b/src/process/services/fuset/FuseTSupervisor.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * FuseTSupervisor — closes the lazy FUSE-T install loop.
+ *
+ * Sudowork PR #916 stood up `FuseTInstallService.ensureInstalled()` +
+ * its IPC bridge; the lazy contract was "ready but unreached" because
+ * nothing on disk read the fuse plugin's `dispatch("status")` and
+ * decided when to invoke the installer. This module is that consumer.
+ *
+ * Flow on `runLazyInstallProbe()`:
+ *
+ *   1. Probe `fuse.status` via [[FusePluginClient]].
+ *   2. If `mounted` / `unmounted` / `unknown` — return; no install
+ *      decision the supervisor can make from those states. (The
+ *      cluster being unreachable is `unknown` and intentionally does
+ *      NOT trigger an admin-password prompt.)
+ *   3. If `fuse-t-missing` — call
+ *      `fuseTInstallService.ensureInstalled()`. Surfaces one admin
+ *      password prompt (the install service's `osascript` step).
+ *   4. After install, restart `nexusd-cluster` so the plugin's
+ *      `create` runs again and this time clears
+ *      `prereq_missing = Some("fuse-t")`. The plugin doesn't expose
+ *      a "re-probe in place" dispatch method (that would require a
+ *      new admin-method on the Rust side); restarting the cluster
+ *      re-runs `nexus_service_create` and is the smallest change that
+ *      ends in `status == "mounted"`. The cluster's own restart cost
+ *      is bounded (single-node, no Raft peers to rejoin on a
+ *      laptop dev setup) so the latency hit is acceptable for a
+ *      one-shot install.
+ *   5. Re-probe `fuse.status`; return the final outcome.
+ *
+ * Triggering is ALWAYS opt-in via `ipcBridge.fuseT.runLazyInstallProbe`.
+ * Nothing in this module fires on bridge init, app startup, or as a
+ * side-effect of importing it elsewhere; the "no eager
+ * `ensureInstalled` call" invariant the integration test guards is
+ * preserved.
+ */
+
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import { dynamicNexusVfsService } from '@process/services/nexus-vfs/DynamicNexusVfsService';
+import { fuseTInstallService, type FuseTProgressCallback } from '@process/services/fuset/FuseTInstallService';
+import { getFusePluginClient, type FusePluginClient, type FusePluginStatus } from '@process/services/nexus-vfs/FusePluginClient';
+
+const TAG = 'FuseTSupervisor';
+
+export type FuseTLazyInstallOutcome = 'already-mounted' | 'unmounted-no-prereq-action' | 'installed-and-mounted' | 'installed-but-not-mounted' | 'plugin-unreachable' | 'platform-unsupported' | 'install-failed';
+
+export interface FuseTLazyInstallResult {
+  outcome: FuseTLazyInstallOutcome;
+  /** Plugin status before any install ran. */
+  initialStatus: FusePluginStatus;
+  /** Plugin status after the install attempt + cluster restart (only set when an install ran). */
+  finalStatus?: FusePluginStatus;
+  /** Raw bytes from the plugin's last `status` reply — kept for diagnostics. */
+  rawStatus?: string;
+  /** Populated when outcome === `install-failed`. */
+  errorMessage?: string;
+}
+
+/** Minimum surface the supervisor needs from the install service — keeps tests injectable without faking the whole class. */
+interface InstallServiceLike {
+  ensureInstalled(onProgress?: FuseTProgressCallback): Promise<void>;
+}
+
+/** Minimum surface the supervisor needs from the cluster — restart-only. */
+interface ClusterControlLike {
+  stop(): Promise<void>;
+  start(): Promise<void>;
+  readonly isRunning: boolean;
+}
+
+export interface FuseTSupervisorDeps {
+  pluginClient?: FusePluginClient;
+  installService?: InstallServiceLike;
+  cluster?: ClusterControlLike;
+  /**
+   * Allow tests to forward platform without monkey-patching
+   * `process.platform`. Defaults to `process.platform` in production.
+   */
+  platform?: NodeJS.Platform;
+  onInstallProgress?: FuseTProgressCallback;
+}
+
+export class FuseTSupervisor {
+  private readonly pluginClient: FusePluginClient;
+  private readonly installService: InstallServiceLike;
+  private readonly cluster: ClusterControlLike;
+  private readonly platform: NodeJS.Platform;
+  private readonly onInstallProgress?: FuseTProgressCallback;
+
+  constructor(deps: FuseTSupervisorDeps = {}) {
+    this.pluginClient = deps.pluginClient ?? getFusePluginClient();
+    this.installService = deps.installService ?? fuseTInstallService;
+    this.cluster = deps.cluster ?? dynamicNexusVfsService;
+    this.platform = deps.platform ?? process.platform;
+    this.onInstallProgress = deps.onInstallProgress;
+  }
+
+  /**
+   * Probe the plugin's status, install FUSE-T if missing, restart the
+   * cluster, return the resolved outcome.
+   *
+   * Idempotent across overlapping callers in the sense that a second
+   * call once the install has completed will see `mounted` and short
+   * circuit. The install service has its own re-entrancy guard
+   * (`installState.installing`), so two concurrent calls don't both
+   * spawn an installer.
+   */
+  async runLazyInstallProbe(): Promise<FuseTLazyInstallResult> {
+    if (this.platform !== 'darwin') {
+      // FUSE-T is macOS-only. Other platforms either don't need
+      // FUSE-T (Linux uses libfuse3, Windows uses WinFsp) or
+      // simply can't install it. Short-circuit with a clean signal
+      // instead of dispatching to a plugin that may not even be
+      // running on this OS.
+      return { outcome: 'platform-unsupported', initialStatus: 'unknown' };
+    }
+
+    const initialProbe = await this.pluginClient.getStatus();
+    mainLog(TAG, `initial fuse.status=${initialProbe.status} raw=${JSON.stringify(initialProbe.raw)}`);
+
+    switch (initialProbe.status) {
+      case 'mounted':
+        return { outcome: 'already-mounted', initialStatus: 'mounted', rawStatus: initialProbe.raw };
+      case 'unmounted':
+        // Plugin loaded but no mount configured. Installing FUSE-T
+        // would not change the outcome — the operator just hasn't
+        // set `NEXUS_FUSE_MOUNT_POINT`. Surface that distinctly.
+        return { outcome: 'unmounted-no-prereq-action', initialStatus: 'unmounted', rawStatus: initialProbe.raw };
+      case 'unknown':
+        // Cluster down, plugin missing, ABI-mismatch UNIMPLEMENTED,
+        // etc. NEVER auto-trigger an install on `unknown` — that
+        // would prompt for an admin password every time the
+        // cluster is mid-restart.
+        return { outcome: 'plugin-unreachable', initialStatus: 'unknown', rawStatus: initialProbe.raw };
+      case 'fuse-t-missing':
+        return await this.installAndReprobe(initialProbe.raw);
+    }
+  }
+
+  private async installAndReprobe(initialRaw: string): Promise<FuseTLazyInstallResult> {
+    try {
+      mainLog(TAG, 'fuse-t-missing reported; invoking FuseTInstallService.ensureInstalled');
+      await this.installService.ensureInstalled(this.onInstallProgress);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      mainWarn(TAG, `ensureInstalled failed: ${msg}`);
+      return { outcome: 'install-failed', initialStatus: 'fuse-t-missing', rawStatus: initialRaw, errorMessage: msg };
+    }
+
+    // Restart the cluster so the plugin's `create` re-runs its
+    // `is_fuse_t_installed()` probe with the framework now present.
+    // The plugin has no in-place re-probe method (would require a
+    // new dispatch verb on the Rust side); restart is the smallest
+    // change that ends in `status == "mounted"`.
+    try {
+      if (this.cluster.isRunning) {
+        mainLog(TAG, 'stopping nexusd-cluster to re-run plugin create() with FUSE-T present');
+        await this.cluster.stop();
+      }
+      mainLog(TAG, 'starting nexusd-cluster post-install');
+      await this.cluster.start();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      mainWarn(TAG, `cluster restart failed post-install: ${msg}`);
+      return { outcome: 'install-failed', initialStatus: 'fuse-t-missing', rawStatus: initialRaw, errorMessage: `FUSE-T installed but cluster restart failed: ${msg}` };
+    }
+
+    const finalProbe = await this.pluginClient.getStatus();
+    mainLog(TAG, `post-install fuse.status=${finalProbe.status} raw=${JSON.stringify(finalProbe.raw)}`);
+    if (finalProbe.status === 'mounted') {
+      return { outcome: 'installed-and-mounted', initialStatus: 'fuse-t-missing', finalStatus: 'mounted', rawStatus: finalProbe.raw };
+    }
+    // Install ran cleanly but the plugin didn't end up mounted. Most
+    // common cause is `NEXUS_FUSE_MOUNT_POINT` not being set — that's
+    // a configuration follow-up, not an install regression. Return a
+    // distinct outcome so the caller can surface "FUSE-T provisioned,
+    // but no mount happened yet" instead of pretending success.
+    return { outcome: 'installed-but-not-mounted', initialStatus: 'fuse-t-missing', finalStatus: finalProbe.status, rawStatus: finalProbe.raw };
+  }
+}
+
+let instance: FuseTSupervisor | null = null;
+
+export function getFuseTSupervisor(): FuseTSupervisor {
+  if (!instance) {
+    instance = new FuseTSupervisor();
+  }
+  return instance;
+}
+
+/** Test-only — drop the singleton so unit tests can rebuild it. */
+export function __resetFuseTSupervisorForTests(): void {
+  instance = null;
+}

--- a/src/process/services/nexus-vfs/FusePluginClient.ts
+++ b/src/process/services/nexus-vfs/FusePluginClient.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * FusePluginClient — typed wrapper over the `nexus-fuse-plugin`
+ * dispatch surface served by `nexusd-cluster` on port 12022.
+ *
+ * The plugin exposes a single `dispatch(method, payload)` C-ABI entry
+ * point (registered as service plugin `"fuse"` via
+ * `declare_service_plugin!`). Routing convention on the cluster's
+ * generic Call RPC: `"<plugin-name>.<method>"`, mirroring how
+ * `NexusSecretClient` reaches vault via `password-vault.<method>`.
+ *
+ * Today this client uses option **(b)** from the supervisor PR plan:
+ * reuse the existing v2 dispatch surface with raw UTF-8 byte payloads
+ * (the plugin's first-cut admin surface). The trade-off vs option
+ * (a) — adding a typed `nexus.fuse.v1.FusePluginService` gRPC service
+ * to the plugin's `nexus_plugin_grpc_services` table — is documented
+ * in the FUSE-T supervisor PR plan; option (a) is the migration
+ * target once the `dispatch("status")` vocabulary grows beyond
+ * `<prereq>-missing` / `mounted` / `unmounted`. The string surface
+ * is fine as the wire format until then, because the supervisor
+ * already only matches on the `<prereq>-missing` shape (not on a
+ * structured field), and adding a new prereq is a single-line
+ * change on both sides.
+ */
+
+import { mainWarn } from '@process/utils/mainLogger';
+import { type FusePluginStatus, type FusePluginStatusResult } from '@common/nexus/fuse-plugin-status';
+import { getNexusRpcClient, type Nexus } from '@common/nexus/nexus-vfs-client';
+
+export type { FusePluginStatus, FusePluginStatusResult } from '@common/nexus/fuse-plugin-status';
+
+const TAG = 'FusePluginClient';
+
+/**
+ * Plugin name as declared in `nexi-lab/nexus`
+ * `rust/services/fuse-plugin/src/lib.rs:409` —
+ * `declare_service_plugin!("fuse", FusePlugin, { ... })`. Don't
+ * inline this string at call sites; if the plugin ever re-declares
+ * itself we want one place to update.
+ */
+const FUSE_PLUGIN_NAME = 'fuse';
+
+export class FusePluginClient {
+  private readonly nexus: Nexus;
+
+  constructor(nexus: Nexus) {
+    this.nexus = nexus;
+  }
+
+  /**
+   * Probe the plugin's `status` method.
+   *
+   * Errors from the underlying gRPC call (cluster down, plugin not
+   * loaded, ABI-mismatch UNIMPLEMENTED) are collapsed to
+   * `status: 'unknown'` with the raw error message captured. The
+   * supervisor must not treat an unreachable cluster as a missing
+   * prereq — that would prompt for an admin password every time the
+   * cluster is restarting.
+   */
+  async getStatus(): Promise<FusePluginStatusResult> {
+    let response: Buffer;
+    try {
+      response = this.nexus.callBinary(`${FUSE_PLUGIN_NAME}.status`, Buffer.alloc(0));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      mainWarn(TAG, `getStatus dispatch failed: ${msg}`);
+      return { status: 'unknown', raw: msg };
+    }
+    const raw = response.toString('utf-8').trim();
+    return { status: parseStatus(raw), raw };
+  }
+}
+
+function parseStatus(raw: string): FusePluginStatus {
+  switch (raw) {
+    case 'mounted':
+    case 'unmounted':
+    case 'fuse-t-missing':
+      return raw;
+    default:
+      return 'unknown';
+  }
+}
+
+let instance: FusePluginClient | null = null;
+
+export function getFusePluginClient(): FusePluginClient {
+  if (!instance) {
+    instance = new FusePluginClient(getNexusRpcClient());
+  }
+  return instance;
+}
+
+/** Test-only — drop the singleton so unit tests can rebuild it against a fresh mock. */
+export function __resetFusePluginClientForTests(): void {
+  instance = null;
+}

--- a/tests/integration/fuseT.integration.test.ts
+++ b/tests/integration/fuseT.integration.test.ts
@@ -71,6 +71,20 @@ describe('FUSE-T — lazy install contract', () => {
     expect(stripped).not.toMatch(/fuseTInstallService\.ensureInstalled|fuseTInstallService\.install\(/);
   });
 
+  it('the bridge registers `runLazyInstallProbe` and routes it through FuseTSupervisor', () => {
+    // The lazy contract closes here: the only path that ends in an
+    // admin-password prompt MUST be the supervisor-mediated probe.
+    // A direct call to `fuseTInstallService.ensureInstalled` from
+    // `runLazyInstallProbe`'s body (skipping the supervisor) would
+    // re-introduce the bug PR #916 was designed to prevent — the
+    // supervisor's "is FUSE-T actually missing?" probe is what
+    // makes repeated calls cheap.
+    const bridge = fs.readFileSync(path.join(REPO_ROOT, 'src/process/bridge/fuseTBridge.ts'), 'utf-8');
+    expect(bridge).toMatch(/ipcBridge\.fuseT\.runLazyInstallProbe\.provider/);
+    expect(bridge).toMatch(/FuseTSupervisor/);
+    expect(bridge).toMatch(/supervisor\.runLazyInstallProbe\(/);
+  });
+
   it('the bridge exposes no dev-only IPC bypass channels', () => {
     // Earlier iterations added `dev.fuse-t.*` raw `ipcMain.handle`
     // channels to bypass the bridge.buildProvider subscribe/callback

--- a/tests/unit/FusePluginClient.test.ts
+++ b/tests/unit/FusePluginClient.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+
+// The Nexus client transitively loads `electron` via its native-binding
+// resolver. Tests never need the real one — every call we exercise here
+// goes through the injected fake client. Stub the module exports so
+// `import` doesn't blow up at module load.
+vi.mock('@common/nexus/nexus-vfs-client', () => ({
+  getNexusRpcClient: () => ({ callBinary: vi.fn() }),
+}));
+
+import { FusePluginClient } from '../../src/process/services/nexus-vfs/FusePluginClient';
+
+function makeNexus(callBinary: (method: string, payload: Buffer) => Buffer | Error): { callBinary: ReturnType<typeof vi.fn> } {
+  const fn = vi.fn((method: string, payload: Buffer) => {
+    const result = callBinary(method, payload);
+    if (result instanceof Error) throw result;
+    return result;
+  });
+  return { callBinary: fn };
+}
+
+describe('FusePluginClient.getStatus', () => {
+  it('dispatches to the `fuse.status` method with an empty payload', async () => {
+    const nexus = makeNexus(() => Buffer.from('mounted', 'utf-8'));
+    const client = new FusePluginClient(nexus as never);
+
+    await client.getStatus();
+
+    expect(nexus.callBinary).toHaveBeenCalledTimes(1);
+    const [method, payload] = nexus.callBinary.mock.calls[0];
+    // Routing convention `<plugin-name>.<method>` matches the nexus
+    // cluster's Call RPC handler. The plugin name `fuse` is the
+    // string passed to `declare_service_plugin!` in
+    // nexi-lab/nexus rust/services/fuse-plugin/src/lib.rs:409.
+    expect(method).toBe('fuse.status');
+    expect(Buffer.isBuffer(payload)).toBe(true);
+    expect((payload as Buffer).length).toBe(0);
+  });
+
+  it('parses `mounted` into status mounted', async () => {
+    const client = new FusePluginClient(makeNexus(() => Buffer.from('mounted', 'utf-8')) as never);
+    expect(await client.getStatus()).toEqual({ status: 'mounted', raw: 'mounted' });
+  });
+
+  it('parses `unmounted` into status unmounted', async () => {
+    const client = new FusePluginClient(makeNexus(() => Buffer.from('unmounted', 'utf-8')) as never);
+    expect(await client.getStatus()).toEqual({ status: 'unmounted', raw: 'unmounted' });
+  });
+
+  it('parses `fuse-t-missing` into the dedicated missing-prereq status', async () => {
+    // This is the contract that lets the supervisor decide to fire
+    // `fuseTInstallService.ensureInstalled()`. If the wire format
+    // ever drifts (e.g. plugin starts returning `fuse_t-missing`
+    // with an underscore) the supervisor stops working — fail loud.
+    const client = new FusePluginClient(makeNexus(() => Buffer.from('fuse-t-missing', 'utf-8')) as never);
+    expect(await client.getStatus()).toEqual({ status: 'fuse-t-missing', raw: 'fuse-t-missing' });
+  });
+
+  it('trims trailing whitespace before matching', async () => {
+    // The plugin currently emits exact bytes, but a future
+    // `eprintln!`-style helper could append a newline. Be tolerant
+    // so a one-byte appendage doesn't downgrade a real `mounted`
+    // reply to `unknown`.
+    const client = new FusePluginClient(makeNexus(() => Buffer.from('mounted\n', 'utf-8')) as never);
+    expect((await client.getStatus()).status).toBe('mounted');
+  });
+
+  it('returns `unknown` when the plugin replies with something unrecognised', async () => {
+    const client = new FusePluginClient(makeNexus(() => Buffer.from('libfuse3-missing', 'utf-8')) as never);
+    const result = await client.getStatus();
+    expect(result.status).toBe('unknown');
+    // Raw bytes are kept so a future supervisor extension can match
+    // `libfuse3-missing` without a client-side change being needed
+    // to surface the bytes (we only need to extend the union).
+    expect(result.raw).toBe('libfuse3-missing');
+  });
+
+  it('collapses dispatch errors to status `unknown` instead of throwing', async () => {
+    // Cluster restarting, plugin unloaded, ABI-mismatch UNIMPLEMENTED:
+    // none of these mean "FUSE-T is missing". Surfacing them as
+    // `unknown` keeps the supervisor from prompting for an admin
+    // password on a transient cluster outage.
+    const client = new FusePluginClient(makeNexus(() => new Error('UNIMPLEMENTED: fuse.status')) as never);
+    const result = await client.getStatus();
+    expect(result.status).toBe('unknown');
+    expect(result.raw).toContain('UNIMPLEMENTED');
+  });
+});

--- a/tests/unit/FuseTSupervisor.test.ts
+++ b/tests/unit/FuseTSupervisor.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+
+// Stub the singleton dependencies — the supervisor accepts injected
+// fakes for all of them in tests, but importing the module still
+// pulls these in transitively (DynamicNexusVfsService imports electron).
+vi.mock('@process/services/nexus-vfs/DynamicNexusVfsService', () => ({
+  dynamicNexusVfsService: {
+    stop: vi.fn(),
+    start: vi.fn(),
+    get isRunning() {
+      return false;
+    },
+  },
+}));
+vi.mock('@process/services/fuset/FuseTInstallService', () => ({
+  fuseTInstallService: { ensureInstalled: vi.fn() },
+}));
+vi.mock('@process/services/nexus-vfs/FusePluginClient', () => ({
+  getFusePluginClient: () => ({ getStatus: vi.fn() }),
+}));
+
+import { FuseTSupervisor } from '../../src/process/services/fuset/FuseTSupervisor';
+import type { FusePluginStatus, FusePluginStatusResult } from '../../src/process/services/nexus-vfs/FusePluginClient';
+
+interface Mocks {
+  getStatus: ReturnType<typeof vi.fn>;
+  ensureInstalled: ReturnType<typeof vi.fn>;
+  clusterStop: ReturnType<typeof vi.fn>;
+  clusterStart: ReturnType<typeof vi.fn>;
+}
+
+interface BuildOpts {
+  statusSequence: FusePluginStatusResult[];
+  ensureInstalledImpl?: () => Promise<void>;
+  clusterIsRunning?: boolean;
+  platform?: NodeJS.Platform;
+}
+
+function build(opts: BuildOpts): { supervisor: FuseTSupervisor; mocks: Mocks } {
+  const statusQueue = [...opts.statusSequence];
+  const getStatus = vi.fn(() => Promise.resolve(statusQueue.shift() ?? { status: 'unknown' as FusePluginStatus, raw: '' }));
+  const ensureInstalled = vi.fn(opts.ensureInstalledImpl ?? (() => Promise.resolve()));
+  const clusterStop = vi.fn(() => Promise.resolve());
+  const clusterStart = vi.fn(() => Promise.resolve());
+  const supervisor = new FuseTSupervisor({
+    platform: opts.platform ?? 'darwin',
+    pluginClient: { getStatus } as never,
+    installService: { ensureInstalled },
+    cluster: {
+      stop: clusterStop,
+      start: clusterStart,
+      get isRunning() {
+        return opts.clusterIsRunning ?? true;
+      },
+    },
+  });
+  return { supervisor, mocks: { getStatus, ensureInstalled, clusterStop, clusterStart } };
+}
+
+describe('FuseTSupervisor.runLazyInstallProbe', () => {
+  it('returns `already-mounted` and does NOT touch the installer when plugin reports mounted', async () => {
+    const { supervisor, mocks } = build({ statusSequence: [{ status: 'mounted', raw: 'mounted' }] });
+    const result = await supervisor.runLazyInstallProbe();
+    expect(result).toEqual({ outcome: 'already-mounted', initialStatus: 'mounted', rawStatus: 'mounted' });
+    // Core invariant: never invoke the admin-password-prompting
+    // installer on a `mounted` reply. This is what makes the lazy
+    // contract safe to call from any UI surface — repeated
+    // invocations cost one gRPC roundtrip, not a UAC dialog.
+    expect(mocks.ensureInstalled).not.toHaveBeenCalled();
+    expect(mocks.clusterStop).not.toHaveBeenCalled();
+    expect(mocks.clusterStart).not.toHaveBeenCalled();
+  });
+
+  it('returns `unmounted-no-prereq-action` and does NOT install when plugin reports unmounted', async () => {
+    const { supervisor, mocks } = build({ statusSequence: [{ status: 'unmounted', raw: 'unmounted' }] });
+    const result = await supervisor.runLazyInstallProbe();
+    expect(result.outcome).toBe('unmounted-no-prereq-action');
+    // `unmounted` means the operator hasn't set
+    // `NEXUS_FUSE_MOUNT_POINT`, not that FUSE-T is missing. A FUSE-T
+    // install would not change the outcome, so the supervisor must
+    // not prompt.
+    expect(mocks.ensureInstalled).not.toHaveBeenCalled();
+  });
+
+  it('returns `plugin-unreachable` and does NOT install when status is unknown', async () => {
+    const { supervisor, mocks } = build({ statusSequence: [{ status: 'unknown', raw: 'UNIMPLEMENTED' }] });
+    const result = await supervisor.runLazyInstallProbe();
+    expect(result.outcome).toBe('plugin-unreachable');
+    expect(result.rawStatus).toBe('UNIMPLEMENTED');
+    // `unknown` covers cluster-down + ABI-mismatch UNIMPLEMENTED.
+    // Treating this as "install missing" would prompt for an admin
+    // password every time the cluster restarts — the supervisor
+    // MUST stay silent here.
+    expect(mocks.ensureInstalled).not.toHaveBeenCalled();
+  });
+
+  it('returns `installed-and-mounted` when fuse-t-missing → install → cluster restart → mounted', async () => {
+    const { supervisor, mocks } = build({
+      statusSequence: [
+        { status: 'fuse-t-missing', raw: 'fuse-t-missing' },
+        { status: 'mounted', raw: 'mounted' },
+      ],
+    });
+    const result = await supervisor.runLazyInstallProbe();
+    expect(result).toEqual({
+      outcome: 'installed-and-mounted',
+      initialStatus: 'fuse-t-missing',
+      finalStatus: 'mounted',
+      rawStatus: 'mounted',
+    });
+    expect(mocks.ensureInstalled).toHaveBeenCalledTimes(1);
+    // Both stop+start must run — the plugin's `create` only re-probes
+    // FUSE-T on a fresh `nexus_service_create` invocation, not in
+    // place. If the supervisor ever skips the restart, the second
+    // probe will still see `fuse-t-missing` even after a successful
+    // install.
+    expect(mocks.clusterStop).toHaveBeenCalledTimes(1);
+    expect(mocks.clusterStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips cluster.stop() when cluster is not currently running, but still starts it', async () => {
+    const { supervisor, mocks } = build({
+      statusSequence: [
+        { status: 'fuse-t-missing', raw: 'fuse-t-missing' },
+        { status: 'mounted', raw: 'mounted' },
+      ],
+      clusterIsRunning: false,
+    });
+    await supervisor.runLazyInstallProbe();
+    expect(mocks.clusterStop).not.toHaveBeenCalled();
+    expect(mocks.clusterStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns `installed-but-not-mounted` when install succeeds but plugin still does not mount', async () => {
+    const { supervisor } = build({
+      statusSequence: [
+        { status: 'fuse-t-missing', raw: 'fuse-t-missing' },
+        { status: 'unmounted', raw: 'unmounted' },
+      ],
+    });
+    const result = await supervisor.runLazyInstallProbe();
+    // `unmounted` after a clean install means the operator hasn't
+    // set `NEXUS_FUSE_MOUNT_POINT`. The install itself succeeded;
+    // surface a distinct outcome instead of pretending the mount
+    // is live.
+    expect(result.outcome).toBe('installed-but-not-mounted');
+    expect(result.finalStatus).toBe('unmounted');
+  });
+
+  it('returns `install-failed` with the underlying error when ensureInstalled throws', async () => {
+    const { supervisor, mocks } = build({
+      statusSequence: [{ status: 'fuse-t-missing', raw: 'fuse-t-missing' }],
+      ensureInstalledImpl: () => Promise.reject(new Error('SHA mismatch')),
+    });
+    const result = await supervisor.runLazyInstallProbe();
+    expect(result.outcome).toBe('install-failed');
+    expect(result.errorMessage).toContain('SHA mismatch');
+    // No cluster restart on install failure — the plugin's state
+    // hasn't changed, so a restart would just churn the daemon.
+    expect(mocks.clusterStop).not.toHaveBeenCalled();
+    expect(mocks.clusterStart).not.toHaveBeenCalled();
+  });
+
+  it('returns `install-failed` when cluster restart blows up post-install', async () => {
+    const { supervisor, mocks } = build({
+      statusSequence: [{ status: 'fuse-t-missing', raw: 'fuse-t-missing' }],
+    });
+    mocks.clusterStart.mockRejectedValueOnce(new Error('port in use'));
+    const result = await supervisor.runLazyInstallProbe();
+    expect(result.outcome).toBe('install-failed');
+    expect(result.errorMessage).toContain('cluster restart failed');
+    expect(result.errorMessage).toContain('port in use');
+  });
+
+  it('returns `platform-unsupported` on non-darwin without contacting the cluster', async () => {
+    const { supervisor, mocks } = build({
+      statusSequence: [],
+      platform: 'linux',
+    });
+    const result = await supervisor.runLazyInstallProbe();
+    expect(result.outcome).toBe('platform-unsupported');
+    // Linux uses libfuse3 (apt) and Windows uses WinFsp; neither
+    // path goes through the FUSE-T installer. Short-circuiting here
+    // avoids a probe round-trip on every cross-platform call.
+    expect(mocks.getStatus).not.toHaveBeenCalled();
+    expect(mocks.ensureInstalled).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,6 +66,8 @@ export default defineConfig({
         'src/process/services/pwdLogin/memorySafety.ts',
         'src/process/services/pwdLogin/pwdAdapters.ts',
         'src/process/services/pwdLogin/pwdLoginService.ts',
+        'src/process/services/fuset/FuseTSupervisor.ts',
+        'src/process/services/nexus-vfs/FusePluginClient.ts',
         'src/process/bridge/updateBridge.ts',
         'src/process/bridge/applicationBridge.ts',
         'src/process/bridge/documentBridge.ts',


### PR DESCRIPTION
## Summary
Closes the lazy FUSE-T install loop opened by PR #916 and the macOS preflight from nexi-lab/nexus PR #4414. The fuse plugin already reports `dispatch("status") == "fuse-t-missing"` when FUSE-T isn't installed; until now nothing on disk consumed that signal, so the lazy contract was "ready but unreached". This PR is the consumer.

## What lands
- `ipcBridge.fuseT.runLazyInstallProbe` — explicit-trigger IPC channel for renderer / sudocode. Returns a structured outcome (`already-mounted`, `installed-and-mounted`, `plugin-unreachable`, `install-failed`, ...) so callers can surface the right state without re-parsing free-form strings.
- `FusePluginClient` — wraps `Nexus.callBinary('fuse.status', ...)` via the existing v2 dispatch surface (same `<plugin>.<method>` routing as vault's `password-vault.secret_get`). No kernel ABI change, no new gRPC service. Trade-off vs typed gRPC documented inline as the migration target when the dispatch vocabulary grows.
- `FuseTSupervisor` — single entry point: probe status → decide install → restart cluster so the plugin's `create()` re-runs `is_fuse_t_installed()` with the framework now present → re-probe. `unknown` status (cluster down, ABI mismatch) NEVER triggers an install — prevents an admin prompt every time the cluster restarts.

## SSOT
`FusePluginStatus` literal union lives in `src/common/nexus/fuse-plugin-status.ts`. Both the renderer-visible IPC type and the main-process supervisor import from there instead of maintaining parallel `IFusePluginStatus` / `FusePluginStatus` that would drift over time.

## Tests
16 new cases lock the install-trigger discipline (fires only on `fuse-t-missing`; not on `mounted` / `unmounted` / `unknown`; not on non-darwin) + the cluster-restart sequencing. Integration test extended to assert the new provider is wired through the supervisor, not a direct `ensureInstalled` shortcut. The pre-existing "no ensureInstalled call on bridge init" invariant guarded since PR #916 is preserved.

## Mac smoke prerequisite
Rebased onto `dev` post-#919 (SHA SSOT fix), confirmed by Mac team A smoke today:
- `plugins loaded from --plugin-dir count=3 names=[\"password-vault\", \"fuse\", \"local-connector\"]`
- `nexus-vfs ready — port=12022 startup=2729ms`
- No SHA / ABI mismatch, no UAC prompt

So the cluster has the `fuse` plugin loaded → `fuse.status` dispatch is reachable → B's e2e is testable end-to-end on Mac.

## Test plan
- [x] `bunx vitest run` for FuseT-related tests — 32/32 pass locally (16 new + 16 pre-existing FuseT)
- [x] `bunx tsc --noEmit` clean for changed files
- [x] Lint clean for changed files
- [ ] CI green (especially `Vault Signed Download` Linux)
- [ ] Mac team B e2e: trigger `ipcBridge.fuseT.runLazyInstallProbe`, confirm admin prompt fires exactly once on a fresh Mac without FUSE-T, `/Library/Frameworks/fuse_t.framework` materializes, cluster auto-restarts, second invocation no-ops with `already-mounted`.

## Audit against the 8 principles
1. **Simplify contract / no kernel ABI change** — reuses existing v2 dispatch surface. Zero new C-ABI symbols, zero new gRPC services.
2. **Architecture / no boundary leak** — bridge uses only `bridge.buildProvider`, no `ipcMain.handle` bypass. Integration test guards.
3. **SSOT** — `FusePluginStatus` shared between renderer IPC and main supervisor via `common/nexus/fuse-plugin-status.ts`.
4. **DRY** — single probe→install→restart→re-probe method; bridge re-entrancy guard shared with direct `ensureInstalled` channel.
5. **Rust-first** — detection logic stays in Rust (`fuse_t_detect.rs`, merged in nexi-lab/nexus PR #4414). TS layer only owns what's Electron-main-process-mandated (UAC + process supervisor).
6. **Perf-first** — hot path is one gRPC roundtrip with a mutex read; cluster restart only on install success (once per machine ever). `mounted` short-circuits.
7. **Raft** — single-node `--bootstrap-mode static` on sudowork desktop; restart re-bootstraps the same 1-voter zone, no peer contract change.
8. **Systemic** — closes the lazy contract end-to-end. Extension shape for future prereqs (`libfuse3-missing`, `winfsp-missing`) is one-line per platform.

Blocked-by-now-merged: #919 (SHA SSOT fix that unblocked Mac smoke).