### PR TITLE
feat(renderer): dev-mode debug shim for FUSE-T supervisor probes

### DIFF
--- a/src/renderer/bootstrap/devTriggers.ts
+++ b/src/renderer/bootstrap/devTriggers.ts
@@ -1,0 +1,88 @@
+/// <reference types="vite/client" />
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Renderer-side dev-mode debug triggers, attached at
+ * `window.__sudoworkDebug`. Gated by Vite's `import.meta.env.DEV` so the
+ * production renderer bundle ships zero of this code — the entire
+ * module body lives behind a build-time conditional that the bundler
+ * eliminates when DEV is `false`.
+ *
+ * ## Why this lives in the renderer
+ *
+ * The supervisor PR's first e2e attempt tried to test FUSE-T install
+ * from outside the renderer process (CDP `Runtime.evaluate`). The
+ * `bridge.buildProvider` SSOT requires a `subscribe-` emit + a
+ * correlated `subscribe.callback-` listener to round-trip — fine for
+ * the platform's own `.invoke()` wrapper (which renderer TS uses
+ * happily) but hard to drive correctly from outside that wrapper.
+ *
+ * Two paths were rejected before landing this one:
+ *
+ *   * A raw IPC bypass handler in the main bridge + a matching
+ *     preload helper — every channel was a second route to the same
+ *     provider, bypassing `bridge.buildProvider`. Boundary leak. The
+ *     integration test `fuseT.integration.test.ts` (the
+ *     no-dev-IPC-bypass-channels case) exists exactly to catch this
+ *     regression (PR #916 added it the first time the pattern landed +
+ *     had to be ripped out).
+ *
+ *   * A renderer UI button — clean but UX-coupled; CDP wants a
+ *     promise-returning entry point, not a click target.
+ *
+ * This shim is the third option: stay inside the renderer namespace,
+ * delegate to the OFFICIAL `ipcBridge.fuseT.*.invoke()` wrappers (which
+ * already round-trip through `bridge.buildProvider` correctly), and
+ * publish a typed Promise-returning handle on `window.__sudoworkDebug`.
+ *
+ * Net contract:
+ *   - No new IPC channel.
+ *   - No raw electron-renderer / electron-main API imports here.
+ *   - No preload edit.
+ *   - No raw subscribe-channel string literals — those stay hidden
+ *     inside the platform library where they belong.
+ *   - Tree-shaken to zero bytes in the production renderer bundle.
+ *
+ * ## Scoping
+ *
+ * Covers the three FUSE-T providers the supervisor PR introduced
+ * (`runLazyInstallProbe`, `checkInstalled`, `getInstallState`) because
+ * that's the loop Mac e2e drives today. Adding a new debug trigger
+ * for a different provider means appending to the literal below;
+ * never reach for the rejected paths above as a "faster" workaround.
+ */
+
+import { ipcBridge } from '@/common';
+
+declare global {
+  interface Window {
+    /**
+     * Renderer-side debug shim populated only when Vite's `DEV` flag
+     * is on. `undefined` in production builds because the assignment
+     * is dead-code-eliminated.
+     */
+    __sudoworkDebug?: {
+      fuseT: {
+        runLazyInstallProbe: () => ReturnType<typeof ipcBridge.fuseT.runLazyInstallProbe.invoke>;
+        checkInstalled: () => ReturnType<typeof ipcBridge.fuseT.checkInstalled.invoke>;
+        getInstallState: () => ReturnType<typeof ipcBridge.fuseT.getInstallState.invoke>;
+      };
+    };
+  }
+}
+
+if (import.meta.env.DEV) {
+  window.__sudoworkDebug = {
+    fuseT: {
+      runLazyInstallProbe: () => ipcBridge.fuseT.runLazyInstallProbe.invoke(),
+      checkInstalled: () => ipcBridge.fuseT.checkInstalled.invoke(),
+      getInstallState: () => ipcBridge.fuseT.getInstallState.invoke(),
+    },
+  };
+}
+
+export {};

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -6,6 +6,7 @@
 
 import './bootstrap/runtimePatches';
 import './bootstrap/crashHandler';
+import './bootstrap/devTriggers';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
@@ -67,7 +68,12 @@ const arcoLocales: Record<string, typeof enUS> = {
   'en-US': enUS,
 };
 
-const AppProviders: React.FC<PropsWithChildren> = ({ children }) => React.createElement(InitProvider, null, React.createElement(AuthProvider, null, React.createElement(DashboardStatsProvider, null, React.createElement(TenantConfigProvider, null, React.createElement(ThemeProvider, null, React.createElement(PreviewProvider, null, React.createElement(ConversationTabsProvider, null, children)))))));
+const AppProviders: React.FC<PropsWithChildren> = ({ children }) =>
+  React.createElement(
+    InitProvider,
+    null,
+    React.createElement(AuthProvider, null, React.createElement(DashboardStatsProvider, null, React.createElement(TenantConfigProvider, null, React.createElement(ThemeProvider, null, React.createElement(PreviewProvider, null, React.createElement(ConversationTabsProvider, null, children))))))
+  );
 
 const Config: React.FC<PropsWithChildren> = ({ children }) => {
   const {

--- a/tests/integration/fuseT.integration.test.ts
+++ b/tests/integration/fuseT.integration.test.ts
@@ -100,6 +100,32 @@ describe('FUSE-T — lazy install contract', () => {
     const preload = fs.readFileSync(path.join(REPO_ROOT, 'src/preload.ts'), 'utf-8');
     expect(preload).not.toMatch(/devFuseT/);
   });
+
+  it('the renderer dev-trigger shim uses official ipcBridge.*.invoke() and is build-time gated', () => {
+    // The renderer-side debug shim that publishes
+    // `window.__sudoworkDebug.fuseT.*` for CDP-driven Mac smoke MUST:
+    //   (a) only emit code when Vite's DEV flag is true (so the
+    //       production bundle ships zero of it),
+    //   (b) route through the official `ipcBridge.fuseT.*.invoke()`
+    //       wrappers,
+    //   (c) NOT reach for `ipcRenderer` / raw electron / hand-written
+    //       `subscribe-` strings — those would re-introduce the
+    //       boundary leak the bridge above is built to prevent.
+    // Together these mean a Mac-smoke debug session never gets a
+    // second route to the supervisor that bypasses
+    // `bridge.buildProvider`.
+    const shim = fs.readFileSync(path.join(REPO_ROOT, 'src/renderer/bootstrap/devTriggers.ts'), 'utf-8');
+    expect(shim).toMatch(/import\.meta\.env\.DEV/);
+    expect(shim).toMatch(/ipcBridge\.fuseT\.runLazyInstallProbe\.invoke/);
+    expect(shim).not.toMatch(/ipcRenderer/);
+    expect(shim).not.toMatch(/ipcMain/);
+    expect(shim).not.toMatch(/from 'electron'/);
+    expect(shim).not.toMatch(/['"]subscribe-/);
+    // And the renderer entrypoint must actually import it; an
+    // orphan shim ships dead code but solves nothing.
+    const entry = fs.readFileSync(path.join(REPO_ROOT, 'src/renderer/index.ts'), 'utf-8');
+    expect(entry).toMatch(/['"]\.\/bootstrap\/devTriggers['"]/);
+  });
 });
 
 describe('FUSE-T — IPC platform gate', () => {


### PR DESCRIPTION
## Summary
PR #920 closed the lazy-install loop end-to-end but left e2e testing awkward: the `bridge.buildProvider` protocol round-trips through paired `subscribe-` / `subscribe.callback-` channels, which the platform's `.invoke()` wrapper handles transparently for renderer TS but is brittle to drive from outside (CDP, manual DevTools eval).

This PR adds a renderer-side, Vite-`DEV`-gated debug shim that publishes typed Promise-returning handles on `window.__sudoworkDebug.fuseT.*`. The shim internally calls the OFFICIAL `ipcBridge.fuseT.*.invoke()` wrappers — no new IPC channel, no preload edit, no bridge bypass.

## Mac CDP usage
```js
await window.__sudoworkDebug.fuseT.runLazyInstallProbe()
// → { success: true, data: { outcome: '...', initialStatus: '...', ... } }
```

## Why not a raw `ipcMain.handle('dev.fuse-t.*')` bypass?
The integration test from PR #916 explicitly forbids it. Each bypass channel is a second route to the same provider, defeating the `bridge.buildProvider` SSOT. The test caught the pattern once already and would catch it again here.

## Why not a renderer UI button?
Clean, but UX-coupled — CDP wants a promise-returning entry, not a click target. The shim does both: it's promise-returning for CDP, and could later back a button if a UI surface is added.

## Tests
- 12/12 existing fuseT integration tests pass, plus a new invariant case asserting the shim uses `import.meta.env.DEV` + the official `.invoke()` call AND contains no raw electron-renderer / electron-main API tokens / `subscribe-` literals.
- Renderer entrypoint must import the shim — orphan dead code regression is caught too.
- 42/42 FuseT-related tests pass locally.

## Audit (8 principles)
1. **Simplify contract** ✅ Zero IPC channel / kernel ABI change.
2. **Architecture / no boundary leak** ✅ Internally calls the existing bridge SSOT; doesn't add a parallel route.
3. **SSOT** ✅ Channel name + provider unchanged.
4. **DRY** ✅ Three 1-line passthroughs.
5. **Rust-first** ✅ N/A (TS/IPC).
6. **Perf-first** ✅ Same path; tree-shaken in prod.
7. **Raft** ✅ N/A.
8. **Systemic, not patch** ✅ Closes the e2e-trigger gap without re-opening the anti-pattern the integration test guards.

## Test plan
- [x] `bunx vitest run` for FuseT-related tests — 42/42 pass locally
- [x] `bunx tsc --noEmit` clean for changed files
- [x] Lint + prettier clean
- [ ] CI green
- [ ] Mac team B-stage smoke: `await window.__sudoworkDebug.fuseT.runLazyInstallProbe()` in CDP returns the supervisor outcome, UAC fires exactly once when FUSE-T is missing.