### PR TITLE
ci(cold-start): per-platform smoke for plugin-set + no-admin invariants

### DIFF
--- a/.github/workflows/pr-cold-start-smoke.yml
+++ b/.github/workflows/pr-cold-start-smoke.yml
@@ -68,18 +68,15 @@ jobs:
             node_platform: win32
             node_arch: x64
           # Intentionally NOT in matrix:
-          #   - macos-arm64: blocked on an upstream nexus-fuse-plugin issue.
-          #     libnexus_fuse_plugin.dylib hard-links /usr/local/lib/libfuse.2.dylib
-          #     (a macFUSE path). On a clean macos-14 runner this dlopen fails and
-          #     the cluster correctly skips fuse-plugin → smoke gets count=2 not 3.
-          #     Pre-installing FUSE-T does NOT fix it: FUSE-T 1.2.7's pkg installs
-          #     /Library/Frameworks/fuse_t.framework but does NOT drop a
-          #     /usr/local/lib/libfuse.2.dylib symlink (empirically verified in
-          #     CI run 28080399237 / job 83133769408). The right fix is to relink
-          #     the macOS fuse-plugin build against FUSE-T's framework, which
-          #     belongs in the nexi-lab/nexus fuse-plugin release pipeline.
-          #     Until that lands, manual Mac smoke (via Mac dev session) gates
-          #     mac cold-start regressions; this CI job covers the rest.
+          #   - macos-arm64: blocked on nexi-lab/nexus#4425. Root cause:
+          #     fuse-plugin's macOS dylib hard-links libfuse.2.dylib (macFUSE
+          #     libfuse2), but FUSE-T 1.2.7 ships only libfuse3 at a different
+          #     prefix and no libfuse2 anywhere. Cluster dlopen fails BEFORE
+          #     fuse_t_detect runs, the lazy install supervisor can't probe,
+          #     and the smoke (correctly) flags count=2 not 3. Issue has the
+          #     full pkg payload listing + proposed fix paths. Until it
+          #     closes, manual Mac smoke (via Mac dev session) gates mac
+          #     cold-start regressions; linux + windows here cover the rest.
           #   - macos-x64: cross-build only on macos-14 runner; no native runner.
           #   - windows-arm64: no native plugin artifacts published yet.
           #   - linux-arm64: no plugin artifacts published yet.

--- a/.github/workflows/pr-cold-start-smoke.yml
+++ b/.github/workflows/pr-cold-start-smoke.yml
@@ -1,0 +1,367 @@
+name: '✓PR Cold Start Smoke'
+
+# Pin the "new-user cold start has zero admin/UAC subprocesses AND loads the
+# expected plugin set" invariant cross-platform. PR #919 was caught by a Mac
+# AI's eyeballs (SHA drift between runtime-versions.json and the per-installer
+# SHA tables left lc + fp unloaded). This job catches that entire class of
+# regression before merge.
+#
+# Scope is intentionally narrow:
+#   - Spawns nexusd-cluster directly (no Electron — Electron in headless CI is
+#     brittle, and Electron just wraps the cluster). The cluster's stderr is
+#     the canonical "plugins loaded" gate.
+#   - Watches for admin-prompt subprocess names in parallel. macOS: osascript
+#     "with administrator privileges" + installer -pkg + sudo. Windows: runas
+#     / consent (UAC dialog backend) / UserAccountControlSettings. Linux:
+#     pkexec / kdesudo / polkit-auth-agent (sudo excluded — apt-get is
+#     legitimate noise in setup).
+#   - Asserts the loaded plugin set EQUALS the expected set for this platform,
+#     derived from src/shared/runtime-sha256.json via the
+#     scripts/expected-plugin-set.js helper. Data-driven so a future "publish
+#     fuse-plugin for win" tightens automatically — no YAML edit needed.
+#
+# What this does NOT test (intentional):
+#   - UI rendering (Electron headless is brittle in CI)
+#   - The actual FUSE-T install path (osascript installer -pkg) — that path is
+#     unit-tested in src/process/services/fuset/*.test.ts (9 cases) and
+#     manual-tested on a real Mac with macFUSE coexistence
+#   - Mount data flow
+#
+# Wall budget per platform: ~5min (most is COS download).
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+concurrency:
+  group: pr-cold-start-smoke-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+  # Distinct from the :2028 used by secrets-grpc-e2e so future "run both
+  # together" doesn't break either.
+  CLUSTER_PORT: '2029'
+
+jobs:
+  cold-start-smoke:
+    name: Cold Start Smoke (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ubuntu-latest: full 3-plugin set (vault + local-connector + fuse-plugin).
+          - platform: linux-x64
+            os: ubuntu-latest
+            node_platform: linux
+            node_arch: x64
+          # macos-14: arm64 runner. Full 3-plugin set. THE platform where
+          # the FUSE-T lazy contract could break (eager osascript install).
+          - platform: macos-arm64
+            os: macos-14
+            node_platform: darwin
+            node_arch: arm64
+          # windows-2022: x64. Only 2 plugins published (no Win fuse-plugin —
+          # WinFsp is via separate adapter). UAC contract is the interesting
+          # one here.
+          - platform: windows-x64
+            os: windows-2022
+            node_platform: win32
+            node_arch: x64
+          # Intentionally NOT in matrix:
+          #   - macos-x64: cross-build only on macos-14 runner; no native runner.
+          #   - windows-arm64: no native plugin artifacts published yet.
+          #   - linux-arm64: no plugin artifacts published yet.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Compute expected plugin set
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED=$(node scripts/expected-plugin-set.js \
+            --platform ${{ matrix.node_platform }} \
+            --arch ${{ matrix.node_arch }})
+          echo "expected plugin set: $EXPECTED"
+
+      - name: Download nexus-vfs cluster + plugins from COS
+        # Same step as in secrets-grpc-e2e. Honors src/shared/runtime-versions.json;
+        # SHA mismatches against src/shared/runtime-sha256.json fail fast here.
+        run: bun run nexus-vfs:download
+
+      # ─── Linux smoke ────────────────────────────────────────────────────
+      - name: Cold-start smoke (Linux)
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          CLUSTER_BIN="$HOME/.nexus-vfs/bin/nexusd-cluster"
+          PLUGIN_DIR="$HOME/.nexus-vfs/plugins"
+          CLUSTER_LOG=/tmp/cluster.log
+          ADMIN_LOG=/tmp/admin-procs.log
+          mkdir -p /tmp/cluster-data
+          : > "$ADMIN_LOG"
+
+          # Background watcher — Linux desktop escalation primitives. sudo is
+          # deliberately excluded (apt setup uses passwordless sudo and we
+          # don't want to false-positive on that).
+          (
+            while true; do
+              pgrep -fa 'pkexec|kdesudo|gksu|polkit-.*-authentication-agent' \
+                2>/dev/null >> "$ADMIN_LOG" || true
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
+          RUST_LOG=info,kernel::kernel::plugins=info \
+            nohup "$CLUSTER_BIN" \
+              --bind-addr 0.0.0.0:${CLUSTER_PORT} \
+              --data-dir /tmp/cluster-data \
+              --no-tls \
+              --bootstrap-mode static \
+              --plugin-dir "$PLUGIN_DIR" \
+              > "$CLUSTER_LOG" 2>&1 &
+          CLUSTER_PID=$!
+
+          LISTENING=0
+          for i in $(seq 1 60); do
+            if (echo > /dev/tcp/127.0.0.1/${CLUSTER_PORT}) >/dev/null 2>&1; then
+              echo "cluster listening on :${CLUSTER_PORT} after ${i}s"
+              LISTENING=1
+              break
+            fi
+            sleep 1
+          done
+
+          # Let plugin-load lines flush.
+          sleep 3
+
+          kill "$WATCHER_PID" 2>/dev/null || true
+          kill "$CLUSTER_PID" 2>/dev/null || true
+          sleep 1
+
+          echo "=== cluster log (head -80) ==="
+          head -80 "$CLUSTER_LOG" || true
+          echo "=== admin-procs.log (expected empty) ==="
+          cat "$ADMIN_LOG" || true
+          echo "=== end log dump ==="
+
+          if [ "$LISTENING" -ne 1 ]; then
+            echo "::error::cluster failed to bind :${CLUSTER_PORT} within 60s — see log dump above"
+            exit 1
+          fi
+
+          node scripts/assert-cold-start.js \
+            --cluster-log "$CLUSTER_LOG" \
+            --admin-log "$ADMIN_LOG" \
+            --platform ${{ matrix.node_platform }} \
+            --arch ${{ matrix.node_arch }}
+
+      # ─── macOS smoke ────────────────────────────────────────────────────
+      - name: Cold-start smoke (macOS)
+        if: matrix.platform == 'macos-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          CLUSTER_BIN="$HOME/.nexus-vfs/bin/nexusd-cluster"
+          PLUGIN_DIR="$HOME/.nexus-vfs/plugins"
+          CLUSTER_LOG=/tmp/cluster.log
+          ADMIN_LOG=/tmp/admin-procs.log
+          mkdir -p /tmp/cluster-data
+          : > "$ADMIN_LOG"
+
+          # macOS-specific escalation surface: FuseTInstallService's lazy
+          # install path uses `osascript -e "do shell script ... with
+          # administrator privileges"` which forks `installer -pkg`. If
+          # cluster boot eagerly triggers this, the lazy contract is broken.
+          (
+            while true; do
+              ps -A -o pid=,command= 2>/dev/null \
+                | grep -E '(osascript.*administrator|installer.*-pkg|/usr/bin/sudo|security authorize)' \
+                | grep -v 'grep -E' \
+                >> "$ADMIN_LOG" || true
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
+          RUST_LOG=info,kernel::kernel::plugins=info \
+            nohup "$CLUSTER_BIN" \
+              --bind-addr 0.0.0.0:${CLUSTER_PORT} \
+              --data-dir /tmp/cluster-data \
+              --no-tls \
+              --bootstrap-mode static \
+              --plugin-dir "$PLUGIN_DIR" \
+              > "$CLUSTER_LOG" 2>&1 &
+          CLUSTER_PID=$!
+
+          LISTENING=0
+          for i in $(seq 1 60); do
+            if (echo > /dev/tcp/127.0.0.1/${CLUSTER_PORT}) >/dev/null 2>&1; then
+              echo "cluster listening on :${CLUSTER_PORT} after ${i}s"
+              LISTENING=1
+              break
+            fi
+            sleep 1
+          done
+
+          sleep 3
+
+          kill "$WATCHER_PID" 2>/dev/null || true
+          kill "$CLUSTER_PID" 2>/dev/null || true
+          sleep 1
+
+          echo "=== cluster log (head -80) ==="
+          head -80 "$CLUSTER_LOG" || true
+          echo "=== admin-procs.log (expected empty) ==="
+          cat "$ADMIN_LOG" || true
+          echo "=== end log dump ==="
+
+          if [ "$LISTENING" -ne 1 ]; then
+            echo "::error::cluster failed to bind :${CLUSTER_PORT} within 60s — see log dump above"
+            exit 1
+          fi
+
+          node scripts/assert-cold-start.js \
+            --cluster-log "$CLUSTER_LOG" \
+            --admin-log "$ADMIN_LOG" \
+            --platform ${{ matrix.node_platform }} \
+            --arch ${{ matrix.node_arch }}
+
+      # ─── Windows smoke ──────────────────────────────────────────────────
+      - name: Cold-start smoke (Windows)
+        if: matrix.platform == 'windows-x64'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $clusterBin = Join-Path $env:USERPROFILE '.nexus-vfs\bin\nexusd-cluster.exe'
+          $pluginDir = Join-Path $env:USERPROFILE '.nexus-vfs\plugins'
+          $dataDir = Join-Path $env:TEMP 'cluster-data'
+          $clusterLog = Join-Path $env:TEMP 'cluster.log'
+          $clusterErr = Join-Path $env:TEMP 'cluster.err'
+          $adminLog = Join-Path $env:TEMP 'admin-procs.log'
+          New-Item -ItemType Directory -Force $dataDir | Out-Null
+          if (-not (Test-Path $adminLog)) { New-Item -ItemType File -Force $adminLog | Out-Null }
+          Clear-Content $adminLog -Force
+
+          # Background watcher for the Windows escalation surface. consent.exe
+          # is the UAC dialog backend; runas.exe is direct elevation;
+          # UserAccountControlSettings.exe is the settings panel. None should
+          # spawn during a cold start that respects the lazy contract.
+          $watcher = Start-Job -ScriptBlock {
+            param($adminLogPath)
+            while ($true) {
+              try {
+                $procs = Get-Process -ErrorAction SilentlyContinue |
+                  Where-Object { $_.ProcessName -match '^(runas|consent|UserAccountControlSettings)$' }
+                if ($procs) {
+                  $procs | ForEach-Object {
+                    "PID=$($_.Id) Name=$($_.ProcessName) Path=$($_.Path)" |
+                      Out-File -Append -Encoding utf8 $adminLogPath
+                  }
+                }
+              } catch {}
+              Start-Sleep -Seconds 1
+            }
+          } -ArgumentList $adminLog
+
+          $env:RUST_LOG = 'info,kernel::kernel::plugins=info'
+          $cluster = Start-Process -FilePath $clusterBin `
+            -ArgumentList @(
+              '--bind-addr', "0.0.0.0:$env:CLUSTER_PORT",
+              '--data-dir', $dataDir,
+              '--no-tls',
+              '--bootstrap-mode', 'static',
+              '--plugin-dir', $pluginDir
+            ) `
+            -RedirectStandardOutput $clusterLog `
+            -RedirectStandardError $clusterErr `
+            -PassThru -NoNewWindow
+
+          $listening = $false
+          for ($i = 1; $i -le 60; $i++) {
+            try {
+              $tcp = New-Object System.Net.Sockets.TcpClient
+              $tcp.Connect('127.0.0.1', [int]$env:CLUSTER_PORT)
+              $tcp.Close()
+              Write-Host "cluster listening on :$env:CLUSTER_PORT after $i s"
+              $listening = $true
+              break
+            } catch {
+              Start-Sleep -Seconds 1
+            }
+          }
+
+          Start-Sleep -Seconds 3
+
+          Stop-Job $watcher -ErrorAction SilentlyContinue
+          Remove-Job $watcher -ErrorAction SilentlyContinue
+          if (-not $cluster.HasExited) {
+            Stop-Process -Id $cluster.Id -Force -ErrorAction SilentlyContinue
+          }
+          Start-Sleep -Seconds 1
+
+          # Rust tracing goes to stderr. Concat stderr after stdout for assertion.
+          if (Test-Path $clusterErr) {
+            Get-Content $clusterErr | Add-Content $clusterLog
+          }
+
+          Write-Host '=== cluster log (head 80) ==='
+          Get-Content $clusterLog -TotalCount 80
+          Write-Host '=== admin-procs.log (expected empty) ==='
+          if (Test-Path $adminLog) { Get-Content $adminLog }
+          Write-Host '=== end log dump ==='
+
+          if (-not $listening) {
+            Write-Host "::error::cluster failed to bind :$env:CLUSTER_PORT within 60s — see log dump above"
+            exit 1
+          }
+
+          & node scripts/assert-cold-start.js `
+            --cluster-log $clusterLog `
+            --admin-log $adminLog `
+            --platform win32 `
+            --arch x64
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      # ─── Failure-tail dump (best-effort across platforms) ────────────────
+      - name: Full cluster log on failure (POSIX)
+        if: failure() && matrix.platform != 'windows-x64'
+        shell: bash
+        run: |
+          echo '=== FULL CLUSTER LOG ==='
+          cat /tmp/cluster.log 2>/dev/null || true
+          echo '=== FULL ADMIN-PROCS ==='
+          cat /tmp/admin-procs.log 2>/dev/null || true
+
+      - name: Full cluster log on failure (Windows)
+        if: failure() && matrix.platform == 'windows-x64'
+        shell: pwsh
+        run: |
+          Write-Host '=== FULL CLUSTER LOG ==='
+          $clusterLog = Join-Path $env:TEMP 'cluster.log'
+          if (Test-Path $clusterLog) { Get-Content $clusterLog }
+          Write-Host '=== FULL ADMIN-PROCS ==='
+          $adminLog = Join-Path $env:TEMP 'admin-procs.log'
+          if (Test-Path $adminLog) { Get-Content $adminLog }

--- a/.github/workflows/pr-cold-start-smoke.yml
+++ b/.github/workflows/pr-cold-start-smoke.yml
@@ -109,6 +109,48 @@ jobs:
         # SHA mismatches against src/shared/runtime-sha256.json fail fast here.
         run: bun run nexus-vfs:download
 
+      # ─── macOS-only prereq: install FUSE-T so fuse-plugin's dlopen succeeds.
+      # The macOS build of nexus-fuse-plugin hard-links /usr/local/lib/libfuse.2.dylib
+      # — FUSE-T's PKG installs a libfuse compat shim there. Without this step
+      # the cluster skips fuse-plugin with `dlopen ... Library not loaded:
+      # /usr/local/lib/libfuse.2.dylib` and the smoke would (correctly) fail
+      # with count=2.
+      #
+      # This installs into the runner's system root via the same .pkg path
+      # FuseTInstallService.ts uses at runtime — SHA-pinned for integrity. We
+      # do this BEFORE the smoke step so its `sudo installer` invocation is
+      # not observed by the smoke's admin-watcher (separate step, separate
+      # process scope). Smoke then validates the post-install steady state
+      # cold start, which is the path real users hit on every launch after
+      # their first FUSE mount.
+      #
+      # Why not also test the pre-install path: the lazy-install branch is
+      # already covered by 9 unit tests in src/process/services/fuset/*.test.ts,
+      # and CI runners can't authentically simulate the
+      # "first-mount triggers osascript prompt" scenario anyway.
+      - name: Install FUSE-T prereq (macOS)
+        if: matrix.platform == 'macos-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          FUSE_T_VERSION=$(node -p "require('./src/shared/runtime-versions.json')['fuse-t']")
+          PKG="fuse-t-macos-installer-${FUSE_T_VERSION}.pkg"
+          URL="https://github.com/macos-fuse-t/fuse-t/releases/download/${FUSE_T_VERSION}/${PKG}"
+          # SHA pinned in src/process/services/fuset/FuseTInstallService.ts for v1.2.7.
+          EXPECTED_SHA=6a29c747e61a86a405a189efc3de42812d73147135f93a1bb0624c1e7b90e654
+          DL=/tmp/${PKG}
+          curl -fsSL "$URL" -o "$DL"
+          ACTUAL_SHA=$(shasum -a 256 "$DL" | awk '{print $1}')
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::FUSE-T pkg SHA256 mismatch (got $ACTUAL_SHA expected $EXPECTED_SHA)"
+            exit 1
+          fi
+          sudo installer -pkg "$DL" -target /
+          echo "FUSE-T ${FUSE_T_VERSION} installed; framework at:"
+          ls -lah /Library/Frameworks/fuse_t.framework 2>/dev/null || echo "  (framework path not present)"
+          echo "libfuse compat shim at:"
+          ls -lah /usr/local/lib/libfuse.2.dylib 2>/dev/null || echo "  (no libfuse compat shim)"
+
       # ─── Linux smoke ────────────────────────────────────────────────────
       - name: Cold-start smoke (Linux)
         if: matrix.platform == 'linux-x64'

--- a/.github/workflows/pr-cold-start-smoke.yml
+++ b/.github/workflows/pr-cold-start-smoke.yml
@@ -60,12 +60,6 @@ jobs:
             os: ubuntu-latest
             node_platform: linux
             node_arch: x64
-          # macos-14: arm64 runner. Full 3-plugin set. THE platform where
-          # the FUSE-T lazy contract could break (eager osascript install).
-          - platform: macos-arm64
-            os: macos-14
-            node_platform: darwin
-            node_arch: arm64
           # windows-2022: x64. Only 2 plugins published (no Win fuse-plugin —
           # WinFsp is via separate adapter). UAC contract is the interesting
           # one here.
@@ -74,6 +68,18 @@ jobs:
             node_platform: win32
             node_arch: x64
           # Intentionally NOT in matrix:
+          #   - macos-arm64: blocked on an upstream nexus-fuse-plugin issue.
+          #     libnexus_fuse_plugin.dylib hard-links /usr/local/lib/libfuse.2.dylib
+          #     (a macFUSE path). On a clean macos-14 runner this dlopen fails and
+          #     the cluster correctly skips fuse-plugin → smoke gets count=2 not 3.
+          #     Pre-installing FUSE-T does NOT fix it: FUSE-T 1.2.7's pkg installs
+          #     /Library/Frameworks/fuse_t.framework but does NOT drop a
+          #     /usr/local/lib/libfuse.2.dylib symlink (empirically verified in
+          #     CI run 28080399237 / job 83133769408). The right fix is to relink
+          #     the macOS fuse-plugin build against FUSE-T's framework, which
+          #     belongs in the nexi-lab/nexus fuse-plugin release pipeline.
+          #     Until that lands, manual Mac smoke (via Mac dev session) gates
+          #     mac cold-start regressions; this CI job covers the rest.
           #   - macos-x64: cross-build only on macos-14 runner; no native runner.
           #   - windows-arm64: no native plugin artifacts published yet.
           #   - linux-arm64: no plugin artifacts published yet.
@@ -108,48 +114,6 @@ jobs:
         # Same step as in secrets-grpc-e2e. Honors src/shared/runtime-versions.json;
         # SHA mismatches against src/shared/runtime-sha256.json fail fast here.
         run: bun run nexus-vfs:download
-
-      # ─── macOS-only prereq: install FUSE-T so fuse-plugin's dlopen succeeds.
-      # The macOS build of nexus-fuse-plugin hard-links /usr/local/lib/libfuse.2.dylib
-      # — FUSE-T's PKG installs a libfuse compat shim there. Without this step
-      # the cluster skips fuse-plugin with `dlopen ... Library not loaded:
-      # /usr/local/lib/libfuse.2.dylib` and the smoke would (correctly) fail
-      # with count=2.
-      #
-      # This installs into the runner's system root via the same .pkg path
-      # FuseTInstallService.ts uses at runtime — SHA-pinned for integrity. We
-      # do this BEFORE the smoke step so its `sudo installer` invocation is
-      # not observed by the smoke's admin-watcher (separate step, separate
-      # process scope). Smoke then validates the post-install steady state
-      # cold start, which is the path real users hit on every launch after
-      # their first FUSE mount.
-      #
-      # Why not also test the pre-install path: the lazy-install branch is
-      # already covered by 9 unit tests in src/process/services/fuset/*.test.ts,
-      # and CI runners can't authentically simulate the
-      # "first-mount triggers osascript prompt" scenario anyway.
-      - name: Install FUSE-T prereq (macOS)
-        if: matrix.platform == 'macos-arm64'
-        shell: bash
-        run: |
-          set -euo pipefail
-          FUSE_T_VERSION=$(node -p "require('./src/shared/runtime-versions.json')['fuse-t']")
-          PKG="fuse-t-macos-installer-${FUSE_T_VERSION}.pkg"
-          URL="https://github.com/macos-fuse-t/fuse-t/releases/download/${FUSE_T_VERSION}/${PKG}"
-          # SHA pinned in src/process/services/fuset/FuseTInstallService.ts for v1.2.7.
-          EXPECTED_SHA=6a29c747e61a86a405a189efc3de42812d73147135f93a1bb0624c1e7b90e654
-          DL=/tmp/${PKG}
-          curl -fsSL "$URL" -o "$DL"
-          ACTUAL_SHA=$(shasum -a 256 "$DL" | awk '{print $1}')
-          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
-            echo "::error::FUSE-T pkg SHA256 mismatch (got $ACTUAL_SHA expected $EXPECTED_SHA)"
-            exit 1
-          fi
-          sudo installer -pkg "$DL" -target /
-          echo "FUSE-T ${FUSE_T_VERSION} installed; framework at:"
-          ls -lah /Library/Frameworks/fuse_t.framework 2>/dev/null || echo "  (framework path not present)"
-          echo "libfuse compat shim at:"
-          ls -lah /usr/local/lib/libfuse.2.dylib 2>/dev/null || echo "  (no libfuse compat shim)"
 
       # ─── Linux smoke ────────────────────────────────────────────────────
       - name: Cold-start smoke (Linux)
@@ -197,77 +161,6 @@ jobs:
           done
 
           # Let plugin-load lines flush.
-          sleep 3
-
-          kill "$WATCHER_PID" 2>/dev/null || true
-          kill "$CLUSTER_PID" 2>/dev/null || true
-          sleep 1
-
-          echo "=== cluster log (head -80) ==="
-          head -80 "$CLUSTER_LOG" || true
-          echo "=== admin-procs.log (expected empty) ==="
-          cat "$ADMIN_LOG" || true
-          echo "=== end log dump ==="
-
-          if [ "$LISTENING" -ne 1 ]; then
-            echo "::error::cluster failed to bind :${CLUSTER_PORT} within 60s — see log dump above"
-            exit 1
-          fi
-
-          node scripts/assert-cold-start.js \
-            --cluster-log "$CLUSTER_LOG" \
-            --admin-log "$ADMIN_LOG" \
-            --platform ${{ matrix.node_platform }} \
-            --arch ${{ matrix.node_arch }}
-
-      # ─── macOS smoke ────────────────────────────────────────────────────
-      - name: Cold-start smoke (macOS)
-        if: matrix.platform == 'macos-arm64'
-        shell: bash
-        run: |
-          set -euo pipefail
-          CLUSTER_BIN="$HOME/.nexus-vfs/bin/nexusd-cluster"
-          PLUGIN_DIR="$HOME/.nexus-vfs/plugins"
-          CLUSTER_LOG=/tmp/cluster.log
-          ADMIN_LOG=/tmp/admin-procs.log
-          mkdir -p /tmp/cluster-data
-          : > "$ADMIN_LOG"
-
-          # macOS-specific escalation surface: FuseTInstallService's lazy
-          # install path uses `osascript -e "do shell script ... with
-          # administrator privileges"` which forks `installer -pkg`. If
-          # cluster boot eagerly triggers this, the lazy contract is broken.
-          (
-            while true; do
-              ps -A -o pid=,command= 2>/dev/null \
-                | grep -E '(osascript.*administrator|installer.*-pkg|/usr/bin/sudo|security authorize)' \
-                | grep -v 'grep -E' \
-                >> "$ADMIN_LOG" || true
-              sleep 1
-            done
-          ) &
-          WATCHER_PID=$!
-
-          RUST_LOG=info,kernel::kernel::plugins=info \
-            nohup "$CLUSTER_BIN" \
-              --bind-addr 0.0.0.0:${CLUSTER_PORT} \
-              --data-dir /tmp/cluster-data \
-              --no-tls \
-              --bootstrap-mode static \
-              --plugin-dir "$PLUGIN_DIR" \
-              > "$CLUSTER_LOG" 2>&1 &
-          CLUSTER_PID=$!
-
-          LISTENING=0
-          for i in $(seq 1 60); do
-            if (echo > /dev/tcp/127.0.0.1/${CLUSTER_PORT}) >/dev/null 2>&1; then
-              echo "cluster listening on :${CLUSTER_PORT} after ${i}s"
-              LISTENING=1
-              break
-            fi
-            sleep 1
-          done
-
           sleep 3
 
           kill "$WATCHER_PID" 2>/dev/null || true

--- a/scripts/assert-cold-start.js
+++ b/scripts/assert-cold-start.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Cold Start Smoke assertion: enforces the two invariants the CI job watches
+ *
+ *   1. Plugin set: the cluster loaded EXACTLY the set we publish for this
+ *      (platform, arch). Sourced from runtime-sha256.json via the
+ *      expected-plugin-set helper. Fewer = silent regression (the bug PR
+ *      #919 hit — SHA drift left lc + fp unloaded). More = unexpected
+ *      extra published artifact that the workflow doesn't know about.
+ *
+ *   2. No admin-prompt subprocess: the cold-start path must NOT spawn any
+ *      escalation helper (macOS: osascript / installer / sudo / security;
+ *      Windows: runas / consent / UserAccount*; Linux: pkexec / kdesudo).
+ *      The job's background watcher writes any matches to admin-procs.log;
+ *      this assertion fails if that file has any non-empty content.
+ *
+ * Usage:
+ *   node scripts/assert-cold-start.js --cluster-log <path> --admin-log <path>
+ *                                     [--platform <p>] [--arch <a>]
+ *
+ * Exits 0 on pass, 1 on any failure with a structured diagnostic to stderr.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { expectedPluginsFor } = require(path.join(__dirname, 'expected-plugin-set.js'));
+
+function parseArgs(argv) {
+  const out = { platform: process.platform, arch: process.arch };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--cluster-log') out.clusterLog = argv[++i];
+    else if (a === '--admin-log') out.adminLog = argv[++i];
+    else if (a === '--platform') out.platform = argv[++i];
+    else if (a === '--arch') out.arch = argv[++i];
+  }
+  if (!out.clusterLog || !out.adminLog) {
+    console.error('usage: assert-cold-start.js --cluster-log <path> --admin-log <path>');
+    process.exit(2);
+  }
+  return out;
+}
+
+function readSafe(p) {
+  try {
+    return fs.readFileSync(p, 'utf-8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return '';
+    throw err;
+  }
+}
+
+function main() {
+  const { clusterLog, adminLog, platform, arch } = parseArgs(process.argv.slice(2));
+  const expected = expectedPluginsFor(platform, arch);
+  const clusterText = readSafe(clusterLog);
+  const adminText = readSafe(adminLog).trim();
+
+  const failures = [];
+
+  // Invariant 1a: every expected plugin's dylib name appears somewhere in
+  // the cluster log. Loose match — the cluster's log format varies across
+  // versions; we don't anchor to "signature verified" alone because that
+  // line could be renamed by an upstream cleanup. The dylib filename is
+  // load-bearing identity and ~unchanging.
+  for (const plugin of expected) {
+    if (!clusterText.includes(plugin.dylib)) {
+      failures.push(`expected plugin not seen in cluster log: ${plugin.dylib} (${plugin.name})`);
+    }
+  }
+
+  // Invariant 1b: number of distinct plugin dylibs that appear next to a
+  // load/verify keyword equals the expected count. Strict — catches the
+  // case where an EXTRA plugin got dropped into the plugin-dir (e.g. an
+  // old/stale artifact left behind by a botched install).
+  //
+  // Why dedupe by dylib instead of counting raw "signature verified" lines:
+  // cluster builds emit a per-plugin "plugin loaded" PLUS a summary
+  // "plugins loaded from --plugin-dir count=N names=[...]". A naive line
+  // count double-counts.
+  const verifyKeyword = /signature verified|plugin loaded|plugins? loaded from/i;
+  const loadedDylibs = new Set();
+  for (const line of clusterText.split(/\r?\n/)) {
+    if (!verifyKeyword.test(line)) continue;
+    for (const plugin of expected) {
+      if (line.includes(plugin.dylib)) loadedDylibs.add(plugin.dylib);
+    }
+  }
+  if (loadedDylibs.size !== expected.length) {
+    failures.push(
+      `plugin load count mismatch: expected ${expected.length} (${expected
+        .map((p) => p.dylib)
+        .join(', ')}); saw ${loadedDylibs.size} (${[...loadedDylibs].join(', ') || '<none>'})`,
+    );
+  }
+
+  // Invariant 2: no admin-prompt subprocess observed.
+  if (adminText.length > 0) {
+    failures.push(`admin-prompt subprocess(es) observed during cold start:\n${adminText}`);
+  }
+
+  const report = {
+    platform,
+    arch,
+    expectedPlugins: expected.map((p) => p.dylib),
+    loadedPlugins: [...loadedDylibs],
+    adminPromptObserved: adminText.length > 0,
+    pass: failures.length === 0,
+  };
+
+  if (failures.length > 0) {
+    console.error('Cold Start Smoke FAILED:');
+    for (const f of failures) console.error(`  - ${f}`);
+    console.error('\n--- report ---');
+    console.error(JSON.stringify(report, null, 2));
+    console.error('\n--- cluster log (last 100 lines) ---');
+    console.error(clusterText.split(/\r?\n/).slice(-100).join('\n'));
+    process.exit(1);
+  }
+
+  console.log('Cold Start Smoke PASSED');
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (require.main === module) main();

--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -28,6 +28,15 @@ const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 const runtimeVersions = require('../src/shared/runtime-versions.json');
 const runtimeSha256 = require('../src/shared/runtime-sha256.json');
+const {
+  OS_NAME,
+  CLUSTER_ARCH,
+  getClusterArtifact,
+  getClusterBinary,
+  getPluginArtifact,
+  getPluginDylib,
+  getPluginSig,
+} = require('./plugin-naming.js');
 
 const VERSION = runtimeVersions['nexus-vfs'];
 const VAULT_VERSION = runtimeVersions['nexus-vault'];
@@ -92,68 +101,39 @@ const FUSE_PLUGIN_READY_MARKER = path.join(PLUGIN_DIR, '.nexus-fuse-plugin-ready
 
 const isWindows = process.platform === 'win32';
 
-// Uniform mapping across all three OSes for v0.0.1-rc1.
-const OS_NAME_MAP = { darwin: 'macos', win32: 'windows', linux: 'linux' };
-const ARCH_NAME_MAP = { arm64: 'aarch64', x64: 'x86_64' };
+// Cluster + plugin archive/dylib naming lives in scripts/plugin-naming.js
+// (the SSOT). The wrappers below preserve the original (platform, arch) =
+// defaults from process.platform / process.arch so callers that omit args
+// keep working — that's a stable contract for the install helpers below.
+//
+// Why the per-plugin one-line wrappers stay: they pin a plugin's logical
+// name at the call site (`getVaultArtifactName`) and make a re-grep across
+// the file trivial. Removing them would inline string literals (vault,
+// local-connector, fuse-plugin) into every caller and make the platform
+// matrix harder to audit.
 
 function getBinaryName() {
-  return isWindows ? 'nexusd-cluster.exe' : 'nexusd-cluster';
+  return getClusterBinary(process.platform);
 }
 
 function getArtifactName(platform = process.platform, arch = process.arch) {
-  const osName = OS_NAME_MAP[platform];
-  const archName = ARCH_NAME_MAP[arch];
-  if (!osName || !archName) {
+  const name = getClusterArtifact(platform, arch);
+  if (!name) {
     throw new Error(`Unsupported platform: ${platform}-${arch}`);
   }
-  const ext = platform === 'win32' ? '.zip' : '.tar.gz';
-  return `nexusd-cluster-${osName}-${archName}${ext}`;
+  return name;
 }
 
-/**
- * Vault plugin artifact name. The vault dylib uses different naming from nexusd-cluster:
- * - macOS: libnexus_vault.dylib (arm64 only, no x86_64)
- * - Linux: libnexus_vault.so (x86_64 only in v0.1.0)
- * - Windows: nexus_vault.dll (x86_64 only in v0.1.0)
- *
- * Archive naming: nexus-vault-{os}-{arch}.{tar.gz|zip}
- */
 function getVaultArtifactName(platform = process.platform, arch = process.arch) {
-  const VAULT_PLATFORM_MAP = {
-    'darwin-arm64': 'nexus-vault-macos-arm64',
-    'darwin-x64': 'nexus-vault-macos-x86_64',
-    'linux-x64': 'nexus-vault-linux-x86_64',
-    'win32-x64': 'nexus-vault-windows-x86_64',
-  };
-  const key = `${platform}-${arch}`;
-  const name = VAULT_PLATFORM_MAP[key];
-  if (!name) return null; // not available for this platform
-  const ext = platform === 'win32' ? '.zip' : '.tar.gz';
-  return `${name}${ext}`;
+  return getPluginArtifact(platform, arch, 'nexus_vault');
 }
 
-/** Platform-specific vault dylib filename inside the archive. */
 function getVaultDylibName(platform = process.platform) {
-  if (platform === 'darwin') return 'libnexus_vault.dylib';
-  if (platform === 'linux') return 'libnexus_vault.so';
-  if (platform === 'win32') return 'nexus_vault.dll';
-  return null;
+  return getPluginDylib(platform, 'nexus_vault');
 }
 
-/**
- * Detached-signature filename for a given dylib. Convention is defined by
- * `nexus_plugin_abi::signing::SIGNATURE_FILE_SUFFIX` in nexus-vfs — `.sig`
- * appended to the dylib filename verbatim. The kernel's PluginLoader reads
- * this file alongside the dylib and Ed25519-verifies before any dlopen.
- *
- * Vault releases starting at v0.1.2 ship the `.sig` inside the archive; the
- * v0.1.1 archive predates signing and lacks it (extraction is permissive
- * here so this script keeps working against an old archive — the cluster's
- * own verify path is the binding gate).
- */
 function getVaultSigName(platform = process.platform) {
-  const dylib = getVaultDylibName(platform);
-  return dylib ? `${dylib}.sig` : null;
+  return getPluginSig(platform, 'nexus_vault');
 }
 
 function sha256OfFile(filePath) {
@@ -618,20 +598,11 @@ async function installSignedKernelPlugin(spec, platform, arch, force) {
 
 /** Per-platform archive name for the local-connector release. */
 function getLocalConnectorArtifactName(platform, arch) {
-  const map = {
-    'darwin-arm64': 'nexus-local-connector-macos-arm64.tar.gz',
-    'darwin-x64': 'nexus-local-connector-macos-x86_64.tar.gz',
-    'linux-x64': 'nexus-local-connector-linux-x86_64.tar.gz',
-    'win32-x64': 'nexus-local-connector-windows-x86_64.zip',
-  };
-  return map[`${platform}-${arch}`] || null;
+  return getPluginArtifact(platform, arch, 'nexus_local_connector');
 }
 
 function getLocalConnectorDylibName(platform) {
-  if (platform === 'darwin') return 'libnexus_local_connector.dylib';
-  if (platform === 'linux') return 'libnexus_local_connector.so';
-  if (platform === 'win32') return 'nexus_local_connector.dll';
-  return null;
+  return getPluginDylib(platform, 'nexus_local_connector');
 }
 
 async function installLocalConnectorPlugin(platform, arch, force) {
@@ -660,17 +631,13 @@ function getFusePluginArtifactName(platform, arch) {
   // macOS runs the FUSE protocol via FUSE-T (userspace driver provisioned
   // lazily by `FuseTInstallService`, not eagerly here). Windows stays on
   // the existing WinFsp path — separate adapter, not shipped by this
-  // fuse-plugin release.
-  if (platform === 'linux' && arch === 'x64') return 'nexus-fuse-plugin-linux-x86_64.tar.gz';
-  if (platform === 'darwin' && arch === 'arm64') return 'nexus-fuse-plugin-macos-arm64.tar.gz';
-  if (platform === 'darwin' && arch === 'x64') return 'nexus-fuse-plugin-macos-x86_64.tar.gz';
-  return null;
+  // fuse-plugin release. The `publishedPlatforms` whitelist in
+  // plugin-naming.js is the SSOT for that policy.
+  return getPluginArtifact(platform, arch, 'nexus_fuse_plugin');
 }
 
 function getFusePluginDylibName(platform) {
-  if (platform === 'linux') return 'libnexus_fuse_plugin.so';
-  if (platform === 'darwin') return 'libnexus_fuse_plugin.dylib';
-  return null;
+  return getPluginDylib(platform, 'nexus_fuse_plugin');
 }
 
 async function installFusePlugin(platform, arch, force) {
@@ -717,7 +684,7 @@ async function main() {
   const platform = process.platform;
   const arch = process.arch;
 
-  if (!OS_NAME_MAP[platform] || !ARCH_NAME_MAP[arch]) {
+  if (!OS_NAME[platform] || !CLUSTER_ARCH[arch]) {
     console.warn(`⚠️  Unsupported platform: ${platform}-${arch}; skipping nexus-vfs.`);
     process.exit(0);
   }

--- a/scripts/expected-plugin-set.js
+++ b/scripts/expected-plugin-set.js
@@ -1,65 +1,38 @@
 #!/usr/bin/env node
 /**
  * Derive the expected set of nexus-vfs plugins for a given (platform, arch)
- * from src/shared/runtime-sha256.json. Used by the Cold Start Smoke CI job
- * (.github/workflows/pr-cold-start-smoke.yml) to assert the cluster loads
- * EXACTLY the set we publish for this platform — fewer = regression, more =
- * unexpected extra.
+ * for the Cold Start Smoke CI job (.github/workflows/pr-cold-start-smoke.yml).
  *
- * Why data-driven (vs hardcoded in YAML): the windows-x64 case is a live
- * landmine — vault + local-connector publish there but fuse-plugin doesn't
- * (FUSE-T is mac-only; Win uses WinFsp via a separate adapter). The plan
- * doc claims "Windows: 3 plugins" but the actual table publishes 2. Keeping
- * the count derivation in one place (here) means a future "publish fuse-
- * plugin for win" only requires adding the SHA entry; the smoke assertion
- * tightens automatically.
+ * Two layers of truth combined:
+ *   - `scripts/plugin-naming.js` — SSOT for archive/dylib naming + per-plugin
+ *     publishedPlatforms. Single hand-edited table; consumed by both the
+ *     download script and this helper.
+ *   - `src/shared/runtime-sha256.json` — SSOT for "the bytes we know how to
+ *     verify". A SHA entry is the cryptographic proof we actually publish
+ *     this artifact today.
+ *
+ * The intersection — published-by-naming AND present-in-SHA-table — is the
+ * smoke's expected set. The two layers normally agree, but the AND is
+ * belt-and-suspenders: it catches the case where someone updates the
+ * naming map but forgets the SHA entry (the inverse of the PR #919 bug
+ * the SHA SSOT was designed to prevent).
  *
  * Usage:
  *   node scripts/expected-plugin-set.js                       # current host
  *   node scripts/expected-plugin-set.js --platform linux --arch x64
  *   node scripts/expected-plugin-set.js --format names        # one name per line
+ *   node scripts/expected-plugin-set.js --format dylibs
+ *   node scripts/expected-plugin-set.js --format count
  *
  * Default output is JSON: {"platform":"linux","arch":"x64","plugins":[
- *   {"name":"nexus_vault","dylib":"libnexus_vault.so"},
+ *   {"name":"nexus_vault","dylib":"libnexus_vault.so","artifact":"..."},
  *   ...
  * ],"count":3}
  */
 
 const path = require('path');
 const sha = require(path.join(__dirname, '..', 'src', 'shared', 'runtime-sha256.json'));
-
-// Mirrors download-nexus-vfs.js. Vault/local-connector/fuse-plugin all use
-// arm64/x86_64 in their archive filenames (NOT aarch64 like nexusd-cluster).
-const OS_NAME = { darwin: 'macos', linux: 'linux', win32: 'windows' };
-const PLUGIN_ARCH_NAME = { arm64: 'arm64', x64: 'x86_64' };
-
-const PLUGINS = [
-  {
-    name: 'nexus_vault',
-    artifactPrefix: 'nexus-vault',
-    dylib: { darwin: 'libnexus_vault.dylib', linux: 'libnexus_vault.so', win32: 'nexus_vault.dll' },
-  },
-  {
-    name: 'nexus_local_connector',
-    artifactPrefix: 'nexus-local-connector',
-    dylib: {
-      darwin: 'libnexus_local_connector.dylib',
-      linux: 'libnexus_local_connector.so',
-      win32: 'nexus_local_connector.dll',
-    },
-  },
-  {
-    name: 'nexus_fuse_plugin',
-    artifactPrefix: 'nexus-fuse-plugin',
-    dylib: {
-      darwin: 'libnexus_fuse_plugin.dylib',
-      linux: 'libnexus_fuse_plugin.so',
-      // Intentionally absent: Windows uses WinFsp via separate adapter, not
-      // this fuse-plugin release. Mirrors getFusePluginDylibName() in the
-      // download script.
-    },
-  },
-];
+const { PLUGINS, getPluginDylib, getPluginArtifact } = require(path.join(__dirname, 'plugin-naming.js'));
 
 function parseArgs(argv) {
   const out = { platform: process.platform, arch: process.arch, format: 'json' };
@@ -73,19 +46,14 @@ function parseArgs(argv) {
 }
 
 function expectedPluginsFor(platform, arch) {
-  const osName = OS_NAME[platform];
-  const archName = PLUGIN_ARCH_NAME[arch];
-  if (!osName || !archName) return [];
-  const ext = platform === 'win32' ? '.zip' : '.tar.gz';
-
   const out = [];
   for (const plugin of PLUGINS) {
-    const dylib = plugin.dylib[platform];
+    const dylib = getPluginDylib(platform, plugin.name);
     if (!dylib) continue;
-    const artifact = `${plugin.artifactPrefix}-${osName}-${archName}${ext}`;
-    if (Object.prototype.hasOwnProperty.call(sha, artifact)) {
-      out.push({ name: plugin.name, dylib, artifact });
-    }
+    const artifact = getPluginArtifact(platform, arch, plugin.name);
+    if (!artifact) continue;
+    if (!Object.prototype.hasOwnProperty.call(sha, artifact)) continue;
+    out.push({ name: plugin.name, dylib, artifact });
   }
   return out;
 }

--- a/scripts/expected-plugin-set.js
+++ b/scripts/expected-plugin-set.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Derive the expected set of nexus-vfs plugins for a given (platform, arch)
+ * from src/shared/runtime-sha256.json. Used by the Cold Start Smoke CI job
+ * (.github/workflows/pr-cold-start-smoke.yml) to assert the cluster loads
+ * EXACTLY the set we publish for this platform — fewer = regression, more =
+ * unexpected extra.
+ *
+ * Why data-driven (vs hardcoded in YAML): the windows-x64 case is a live
+ * landmine — vault + local-connector publish there but fuse-plugin doesn't
+ * (FUSE-T is mac-only; Win uses WinFsp via a separate adapter). The plan
+ * doc claims "Windows: 3 plugins" but the actual table publishes 2. Keeping
+ * the count derivation in one place (here) means a future "publish fuse-
+ * plugin for win" only requires adding the SHA entry; the smoke assertion
+ * tightens automatically.
+ *
+ * Usage:
+ *   node scripts/expected-plugin-set.js                       # current host
+ *   node scripts/expected-plugin-set.js --platform linux --arch x64
+ *   node scripts/expected-plugin-set.js --format names        # one name per line
+ *
+ * Default output is JSON: {"platform":"linux","arch":"x64","plugins":[
+ *   {"name":"nexus_vault","dylib":"libnexus_vault.so"},
+ *   ...
+ * ],"count":3}
+ */
+
+const path = require('path');
+const sha = require(path.join(__dirname, '..', 'src', 'shared', 'runtime-sha256.json'));
+
+// Mirrors download-nexus-vfs.js. Vault/local-connector/fuse-plugin all use
+// arm64/x86_64 in their archive filenames (NOT aarch64 like nexusd-cluster).
+const OS_NAME = { darwin: 'macos', linux: 'linux', win32: 'windows' };
+const PLUGIN_ARCH_NAME = { arm64: 'arm64', x64: 'x86_64' };
+
+const PLUGINS = [
+  {
+    name: 'nexus_vault',
+    artifactPrefix: 'nexus-vault',
+    dylib: { darwin: 'libnexus_vault.dylib', linux: 'libnexus_vault.so', win32: 'nexus_vault.dll' },
+  },
+  {
+    name: 'nexus_local_connector',
+    artifactPrefix: 'nexus-local-connector',
+    dylib: {
+      darwin: 'libnexus_local_connector.dylib',
+      linux: 'libnexus_local_connector.so',
+      win32: 'nexus_local_connector.dll',
+    },
+  },
+  {
+    name: 'nexus_fuse_plugin',
+    artifactPrefix: 'nexus-fuse-plugin',
+    dylib: {
+      darwin: 'libnexus_fuse_plugin.dylib',
+      linux: 'libnexus_fuse_plugin.so',
+      // Intentionally absent: Windows uses WinFsp via separate adapter, not
+      // this fuse-plugin release. Mirrors getFusePluginDylibName() in the
+      // download script.
+    },
+  },
+];
+
+function parseArgs(argv) {
+  const out = { platform: process.platform, arch: process.arch, format: 'json' };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--platform') out.platform = argv[++i];
+    else if (a === '--arch') out.arch = argv[++i];
+    else if (a === '--format') out.format = argv[++i];
+  }
+  return out;
+}
+
+function expectedPluginsFor(platform, arch) {
+  const osName = OS_NAME[platform];
+  const archName = PLUGIN_ARCH_NAME[arch];
+  if (!osName || !archName) return [];
+  const ext = platform === 'win32' ? '.zip' : '.tar.gz';
+
+  const out = [];
+  for (const plugin of PLUGINS) {
+    const dylib = plugin.dylib[platform];
+    if (!dylib) continue;
+    const artifact = `${plugin.artifactPrefix}-${osName}-${archName}${ext}`;
+    if (Object.prototype.hasOwnProperty.call(sha, artifact)) {
+      out.push({ name: plugin.name, dylib, artifact });
+    }
+  }
+  return out;
+}
+
+function main() {
+  const { platform, arch, format } = parseArgs(process.argv.slice(2));
+  const plugins = expectedPluginsFor(platform, arch);
+  if (format === 'names') {
+    for (const p of plugins) process.stdout.write(`${p.name}\n`);
+    return;
+  }
+  if (format === 'dylibs') {
+    for (const p of plugins) process.stdout.write(`${p.dylib}\n`);
+    return;
+  }
+  if (format === 'count') {
+    process.stdout.write(`${plugins.length}\n`);
+    return;
+  }
+  process.stdout.write(JSON.stringify({ platform, arch, plugins, count: plugins.length }) + '\n');
+}
+
+if (require.main === module) main();
+
+module.exports = { expectedPluginsFor };

--- a/scripts/plugin-naming.js
+++ b/scripts/plugin-naming.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * SSOT for nexus-vfs runtime artifact NAMING (NOT integrity — SHA values stay
+ * in src/shared/runtime-sha256.json per the contract pinned by PR #919).
+ *
+ * Before this module: `scripts/download-nexus-vfs.js` carried 6 per-plugin
+ * helpers (`getVaultArtifactName`, `getVaultDylibName`, `getVaultSigName`,
+ * `getLocalConnectorArtifactName`, …) each with its own inline platform
+ * matrix, and `scripts/expected-plugin-set.js` had its own parallel PLUGINS
+ * array + OS/arch maps. Same data, two surfaces — exactly the shape that
+ * caused PR #918's SHA drift before the SSOT cleanup.
+ *
+ * After: one PLUGINS array + a single set of OS/arch maps live here.
+ *
+ *   - download-nexus-vfs.js consumes `getClusterArtifact`, `getPluginArtifact`,
+ *     `getPluginDylib`, `getPluginSig` to drive its download loop.
+ *   - expected-plugin-set.js iterates `PLUGINS` and the same helpers to derive
+ *     the per-platform expected set for the CI Cold Start Smoke job.
+ *   - tests/integration/nexusVfsSha256Ssot.integration.test.ts enumerates every
+ *     artifact this module knows how to name and asserts each has a SHA entry
+ *     in runtime-sha256.json — so a future "publish vault for linux-arm64"
+ *     that updates this file but forgets the SHA table fails fast at test time.
+ *
+ * Two important semantic distinctions preserved from the prior code:
+ *
+ *   - **Cluster uses `aarch64`**, plugins use **`arm64`** in archive filenames.
+ *     This is a real upstream naming inconsistency (`nexusd-cluster-macos-aarch64.tar.gz`
+ *     vs `nexus-vault-macos-arm64.tar.gz`). Encoded here as two distinct arch
+ *     maps so consumers can't accidentally cross-wire them.
+ *
+ *   - `publishedPlatforms` per plugin records which (platform, arch) combos
+ *     have a published artifact. fuse-plugin specifically does NOT publish
+ *     for Windows — Win is on WinFsp via a separate adapter, not this release.
+ *     `getPluginArtifact()` returns `null` for unpublished combos, mirroring
+ *     the prior `getXxxArtifactName` return contract.
+ */
+
+const OS_NAME = { darwin: 'macos', linux: 'linux', win32: 'windows' };
+
+// Cluster archives — nexusd-cluster uses LLVM/Rust target-triple style.
+const CLUSTER_ARCH = { arm64: 'aarch64', x64: 'x86_64' };
+
+// Plugin archives — use the human/brand name; not a typo, see header note.
+const PLUGIN_ARCH = { arm64: 'arm64', x64: 'x86_64' };
+
+const PLUGINS = [
+  {
+    name: 'nexus_vault',
+    artifactPrefix: 'nexus-vault',
+    publishedPlatforms: ['darwin-arm64', 'darwin-x64', 'linux-x64', 'win32-x64'],
+    dylib: {
+      darwin: 'libnexus_vault.dylib',
+      linux: 'libnexus_vault.so',
+      win32: 'nexus_vault.dll',
+    },
+  },
+  {
+    name: 'nexus_local_connector',
+    artifactPrefix: 'nexus-local-connector',
+    publishedPlatforms: ['darwin-arm64', 'darwin-x64', 'linux-x64', 'win32-x64'],
+    dylib: {
+      darwin: 'libnexus_local_connector.dylib',
+      linux: 'libnexus_local_connector.so',
+      win32: 'nexus_local_connector.dll',
+    },
+  },
+  {
+    name: 'nexus_fuse_plugin',
+    artifactPrefix: 'nexus-fuse-plugin',
+    // Intentionally no win32 — Windows uses WinFsp via a separate adapter,
+    // not this release. Matches the legacy getFusePluginArtifactName behavior.
+    publishedPlatforms: ['darwin-arm64', 'darwin-x64', 'linux-x64'],
+    dylib: {
+      darwin: 'libnexus_fuse_plugin.dylib',
+      linux: 'libnexus_fuse_plugin.so',
+    },
+  },
+];
+
+// Every (platform, arch) combination the cluster publishes for. Same shape
+// as PLUGINS.publishedPlatforms — enumerated so the integration test can
+// derive the full set of artifact names this module can name without
+// having to enumerate it itself.
+const CLUSTER_PUBLISHED_PLATFORMS = [
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+  'win32-arm64',
+  'win32-x64',
+];
+
+function getArchiveExt(platform) {
+  return platform === 'win32' ? '.zip' : '.tar.gz';
+}
+
+function getClusterArtifact(platform, arch) {
+  const osName = OS_NAME[platform];
+  const archName = CLUSTER_ARCH[arch];
+  if (!osName || !archName) return null;
+  return `nexusd-cluster-${osName}-${archName}${getArchiveExt(platform)}`;
+}
+
+function getClusterBinary(platform) {
+  return platform === 'win32' ? 'nexusd-cluster.exe' : 'nexusd-cluster';
+}
+
+function getPluginByName(name) {
+  return PLUGINS.find((p) => p.name === name) || null;
+}
+
+function getPluginArtifact(platform, arch, pluginName) {
+  const plugin = getPluginByName(pluginName);
+  if (!plugin) return null;
+  if (!plugin.publishedPlatforms.includes(`${platform}-${arch}`)) return null;
+  const osName = OS_NAME[platform];
+  const archName = PLUGIN_ARCH[arch];
+  if (!osName || !archName) return null;
+  return `${plugin.artifactPrefix}-${osName}-${archName}${getArchiveExt(platform)}`;
+}
+
+function getPluginDylib(platform, pluginName) {
+  const plugin = getPluginByName(pluginName);
+  return plugin?.dylib?.[platform] || null;
+}
+
+function getPluginSig(platform, pluginName) {
+  const dylib = getPluginDylib(platform, pluginName);
+  return dylib ? `${dylib}.sig` : null;
+}
+
+/**
+ * Enumerate every archive filename this module can name for any (platform,
+ * arch) combination it knows about. Used by the integration test to assert
+ * every name has a matching SHA entry.
+ */
+function allKnownArchives() {
+  const out = [];
+  for (const combo of CLUSTER_PUBLISHED_PLATFORMS) {
+    const [platform, arch] = combo.split('-');
+    const name = getClusterArtifact(platform, arch);
+    if (name) out.push(name);
+  }
+  for (const plugin of PLUGINS) {
+    for (const combo of plugin.publishedPlatforms) {
+      const [platform, arch] = combo.split('-');
+      const name = getPluginArtifact(platform, arch, plugin.name);
+      if (name) out.push(name);
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  OS_NAME,
+  CLUSTER_ARCH,
+  PLUGIN_ARCH,
+  PLUGINS,
+  CLUSTER_PUBLISHED_PLATFORMS,
+  getArchiveExt,
+  getClusterArtifact,
+  getClusterBinary,
+  getPluginByName,
+  getPluginArtifact,
+  getPluginDylib,
+  getPluginSig,
+  allKnownArchives,
+};

--- a/tests/integration/nexusVfsSha256Ssot.integration.test.ts
+++ b/tests/integration/nexusVfsSha256Ssot.integration.test.ts
@@ -65,16 +65,33 @@ describe('nexus-vfs SHA256 SSOT', () => {
     });
   }
 
-  it('every artifact the script knows how to download has a SHA entry in the JSON', () => {
+  it('every artifact the naming SSOT knows how to name has a SHA entry in the JSON', () => {
     const sha = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'src/shared/runtime-sha256.json'), 'utf-8')) as Record<string, string>;
-    const script = fs.readFileSync(path.join(REPO_ROOT, 'scripts/download-nexus-vfs.js'), 'utf-8');
-    // The script names each archive (e.g. `nexusd-cluster-macos-x86_64.tar.gz`)
-    // wherever it builds a download URL. Pull every such occurrence
-    // and confirm we have a SHA for it; missing entries are exactly
-    // what made the v0.1.1 → v0.3.0 transition fail-closed at runtime.
-    const archives = Array.from(script.matchAll(/(nexus(?:d-cluster|-vault|-local-connector|-fuse-plugin)-[a-z0-9_-]+?\.(?:tar\.gz|zip))/g)).map((m) => m[1]);
+    // Source of truth for "what archives can this codebase ask to download"
+    // is the plugin-naming.js SSOT module. Enumerating from there (rather
+    // than regex-ing the download script's source) lets the assertion stay
+    // accurate after the script was refactored to compute names via helpers
+    // instead of inlining them. The invariant is unchanged: every name the
+    // codebase can produce must have a SHA entry, or runtime verification
+    // will fail-closed on download.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const naming = require(path.join(REPO_ROOT, 'scripts/plugin-naming.js')) as {
+      allKnownArchives: () => string[];
+    };
+    const archives = naming.allKnownArchives();
     expect(archives.length).toBeGreaterThan(0);
     const missing = Array.from(new Set(archives)).filter((a) => !(a in sha));
     expect(missing, `Missing SHA entries for ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('the naming SSOT module itself contains no inline SHA literal', () => {
+    // Symmetric to the CONSUMERS check — plugin-naming.js is a naming SSOT
+    // and must not creep into being a SHA SSOT too. Verifies the boundary
+    // stays clean: names live here, hashes live in runtime-sha256.json.
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/plugin-naming.js'), 'utf-8');
+    const match = src.match(SHA_HEX_64);
+    if (match) {
+      throw new Error(`scripts/plugin-naming.js contains inline SHA literal "${match[0]}". Hashes belong in runtime-sha256.json.`);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-cold-start-smoke.yml` — per-platform Cold Start Smoke (Linux + Windows) that spawns `nexusd-cluster` directly and asserts two invariants on a clean cold start
- Adds `scripts/expected-plugin-set.js` — derives the expected plugin set for a (platform, arch) from `src/shared/runtime-sha256.json`
- Adds `scripts/assert-cold-start.js` — shared assertion: plugin set ≡ expected + no admin-prompt subprocess observed
- Adds `scripts/plugin-naming.js` — SSOT for cluster/plugin archive + dylib naming; consumed by both the download script and the CI helper (no more parallel platform-matrix maps)

## Why

PR #919 (SHA SSOT hotfix) closed a SHA-drift bug that left lc + fp unloaded on Mac cold start. The SSOT refactor made that specific shape structurally unrepresentable, but the more general "cold start broke and we don't notice until a real-machine smoke" failure mode stayed open. This job catches the regression class: plugin count regression, eager-install regression, cluster-bind regression.

## What it asserts (cross-platform)

1. **Plugin set equality** — the cluster loads EXACTLY the dylibs published for this (platform, arch):
   - linux-x64: 3 (vault + local-connector + fuse-plugin)
   - windows-x64: 2 (no fuse-plugin — Win is on WinFsp via separate adapter)
   
   Count is **data-driven from `runtime-sha256.json`** via `expected-plugin-set.js` + `plugin-naming.js`. Adding a future "publish fuse-plugin for win" updates the SSOT, and CI count auto-tightens. YAML names no count.

2. **No admin-prompt subprocess** observed during cluster cold start:
   - Windows: `runas.exe`, `consent.exe` (UAC dialog backend), `UserAccountControlSettings.exe`
   - Linux: `pkexec`, `kdesudo`, `polkit-*-authentication-agent` (sudo excluded — apt setup is legitimate noise)

## DRY refactor

Before: `scripts/download-nexus-vfs.js` carried 6 per-plugin name helpers (`getVaultArtifactName`, `getVaultDylibName`, `getVaultSigName`, plus the local-connector + fuse-plugin pair) each with its own inline platform matrix, and `scripts/expected-plugin-set.js` had its own parallel PLUGINS array + OS/arch maps. Same data, two surfaces — exactly the shape PR #919's SHA SSOT cleanup just eliminated for hashes.

After: one PLUGINS array + one set of OS/arch maps live in `scripts/plugin-naming.js`. Both consumers read from it. The integration test `nexusVfsSha256Ssot.integration.test.ts` now enumerates archives via `plugin-naming.allKnownArchives()` instead of regex-ing the download script source — same invariant, accurate after the names moved out of source-literal form.

## Matrix coverage & gaps

| Platform | Plugins | Status | Why |
|---|---|---|---|
| ubuntu-latest | 3 | ✅ in matrix | linux-x64 baseline |
| windows-2022 (x64) | 2 | ✅ in matrix | UAC contract; fuse-plugin not published for Win |
| macos-arm64 | 3 expected, 2 actual | ⚠️ deferred | nexi-lab/nexus#4425 — fuse-plugin macOS dylib hard-links libfuse.2.dylib (macFUSE libfuse2). FUSE-T 1.2.7 ships only libfuse3 at a different prefix; no libfuse2 anywhere. Cluster dlopen fails before fuse_t_detect runs. Full pkg payload listing + proposed fix paths in the issue. Until it closes, manual Mac smoke gates mac cold-start regressions. |
| macos-x64 | — | skipped | cross-build only; no native runner |
| windows-arm64 | — | skipped | no native plugin artifacts |
| linux-arm64 | — | skipped | no plugin artifacts |

## Findings the smoke surfaced (developing this PR)

1. **macOS fuse-plugin dlopen-time dependency on macFUSE libfuse2** — filed as nexi-lab/nexus#4425. Empirically verified against the FUSE-T 1.2.7 pkg payload (extracted via `xar`/7z) — the FUSE-T pkg installs `/Library/Application Support/fuse-t/lib/libfuse3.4.dylib` (libfuse3) but no libfuse2 anywhere.
2. (Doc-only) Plan's expected "Windows: 3 plugins" was incorrect — the script in `scripts/download-nexus-vfs.js` previously returned `null` for win32 fuse-plugin, and after refactor `plugin-naming.js:nexus_fuse_plugin.publishedPlatforms` makes the policy explicit. Windows publishes only 2 plugins.

## Local Win cold-start smoke (paired with this PR)

Per Ethan's request, I ran the manual Win local cold-start smoke from the project's running plan, against this PR's branch tip on sudowork-win-pc-0:

- ✅ DevTools probe: `await window.__sudoworkDebug.fuseT.runLazyInstallProbe()` → `{outcome:'platform-unsupported', initialStatus:'unknown'}`. Lazy contract honored on Win.
- ✅ UAC observed: NONE during cold-start window (background `Get-Process` poll captured no `runas`/`consent`/`UserAccountControlSettings`).
- ✅ Plugins on disk: nexus_vault.dll + nexus_local_connector.dll. No fuse_plugin.dll (correct — Win not published).
- ⚠️ Dev-mode prereq gap: `bun run start` requires both `bunx electron-builder install-app-deps` AND `bun run build:native` AND an MSVC env (sourced via vcvars64.bat) to launch successfully on a fresh dev clone. None of these are auto-triggered by `bun install`. **The plan's followup B should extend to cover this**: launch-dev.js needs a startup check or auto-install for the Electron-ABI native modules, not just the napi binding.
- ⚠️ `getInstallState()` on Win returns `{installing: true}` despite platform-unsupported — possibly initial-state artifact; worth a code check on FuseTInstallService.ts to confirm intent (not gating this PR).

State backed up + restored cleanly: `.nexus-vfs.backup-pre-smoke-20260624-085457` and `sudowork.backup-pre-smoke-20260624-085457` archives.

## Audit pass (Ethan's 8 principles)

1. **Simplify contract** — no kernel/ABI change, no IPC channels, no new bridge surfaces
2. **Architecture / no boundary leak** — helpers live in `scripts/`, never reach into `src/process/` or `src/renderer/`; the integration test enforces `plugin-naming.js` stays a pure naming SSOT (no SHA leaks)
3. **Data SSOT** — `runtime-sha256.json` for hashes, `plugin-naming.js` for archive/dylib names, `runtime-versions.json` for versions. Three orthogonal SSOTs, one consumer.
4. **DRY** — refactored away the 6-helper + parallel-array duplication. Both consumers iterate the same metadata.
5. Rust-first — N/A (CI infra)
6. **Perf-first** — ~5min/platform; runs only on PR open/sync
7. Raft contract — N/A (`--bootstrap-mode static`)
8. **Systemic** — catches the entire "SHA drift / plugin not loaded / eager install" class. macOS gap deferred to nexi-lab/nexus#4425 (real systemic fix) rather than patched around (e.g., installing macFUSE in CI would defeat the whole FUSE-T-over-macFUSE direction)

## Test plan

- [x] Linux Cold Start Smoke: ✓ on `4f0f4cfa`
- [x] Windows Cold Start Smoke: ✓ on `4f0f4cfa`
- [x] Existing `Vault Signed Download` (Linux): ✓
- [x] Existing `Vault Secrets gRPC E2E`: ✓
- [x] `nexusVfsSha256Ssot.integration.test.ts` (now 6 tests, including new plugin-naming.js no-SHA-leak check): all pass
- [x] tsc --noEmit clean
- [x] Win local dev cold-start smoke (manual, paired with this PR — see above)