### PR TITLE
fix(cron): create scheduled tasks emitted in nested feedback turns

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -3360,11 +3360,18 @@ This identity statement takes priority over the default identity in USER.md.
       }
     }
 
-    // On finish, process any skill commands (cron, channel-info) from accumulated content
-    // Must save content BEFORE reset, then process all command types, then reset at the end
+    // On finish, process any skill commands (cron, channel-info) from accumulated content.
+    // Capture the content, then reset the accumulator IMMEDIATELY — before any await.
+    // Processing a command sends a feedback prompt via sendToConnection, whose ACP
+    // `session/prompt` only resolves when the *nested* feedback turn ends. The skill
+    // mandates LIST-then-CREATE, so the follow-up [CRON_CREATE] always streams inside
+    // that nested turn and accumulates here. If we reset only after the await, the
+    // parent finish wipes the nested turn's freshly-accumulated command before the
+    // nested turn's own finish handler can read it — so the create silently never ran.
     if (v.type === 'finish' && this.cronAccumulator.currentMsgContent) {
       const savedContent = this.cronAccumulator.currentMsgContent;
       const savedMsgId = this.cronAccumulator.currentMsgId;
+      this.cronAccumulator.reset();
 
       // Process cron commands
       if (hasCronCommands(savedContent)) {
@@ -3394,9 +3401,6 @@ This identity statement takes priority over the default identity in USER.md.
           await this.sendToConnection(feedbackMessage);
         }
       }
-
-      // Reset accumulator AFTER all command processing
-      this.cronAccumulator.reset();
     }
 
     ipcBridge.acpConversation.responseStream.emit(v);

--- a/src/process/task/CronCommandDetector.ts
+++ b/src/process/task/CronCommandDetector.ts
@@ -10,12 +10,23 @@
 export type CronCommand = { kind: 'create'; name: string; schedule: string; scheduleDescription: string; message: string } | { kind: 'list' } | { kind: 'delete'; jobId: string };
 
 /**
- * Remove markdown code blocks from content to avoid detecting commands in examples
- * This prevents documentation examples like ```[CRON_LIST]``` from being executed
+ * Normalize markdown code blocks before command detection.
+ *
+ * Documentation/prose fenced blocks are removed so examples don't get executed.
+ * But models (e.g. scode) routinely wrap their REAL multi-line `[CRON_CREATE]`
+ * block in a fence despite the skill telling them not to — deleting those would
+ * silently drop a genuine command. So a fence whose body contains a cron marker
+ * is unwrapped (fence delimiters stripped, command kept) instead of removed.
  */
 function stripCodeBlocks(content: string): string {
-  // Remove fenced code blocks (```...```)
-  return content.replace(/```[\s\S]*?```/g, '');
+  return content.replace(/```[\s\S]*?```/g, (block) => {
+    if (/\[CRON_(?:CREATE|LIST|DELETE)/i.test(block)) {
+      // Strip only the opening (with optional language tag) and closing fence
+      // markers, preserving the command text inside for detection.
+      return block.replace(/^```[a-zA-Z0-9]*[ \t]*\r?\n?/, '').replace(/\r?\n?```$/, '');
+    }
+    return '';
+  });
 }
 
 /**
@@ -26,8 +37,10 @@ function stripCodeBlocks(content: string): string {
  * - [CRON_LIST] - List all scheduled tasks
  * - [CRON_DELETE: task-id] - Delete a scheduled task
  *
- * NOTE: Commands inside markdown code blocks are ignored to prevent
- * documentation examples from being executed.
+ * NOTE: Prose code blocks are ignored to prevent documentation examples from
+ * being executed, but a fenced block whose body is itself a cron command is
+ * unwrapped and honored (see stripCodeBlocks) — models often wrap real commands
+ * in a fence despite being told not to.
  *
  * @param content - The text content to scan
  * @returns Array of detected commands
@@ -152,10 +165,16 @@ export function stripCronCommands(content: string): string {
     return content;
   }
 
-  return content
-    .replace(/\[CRON_CREATE\][\s\S]*?\[\/CRON_CREATE\]/gi, '')
-    .replace(/\[CRON_LIST\]/gi, '')
-    .replace(/\[CRON_DELETE:[^\]]+\]/gi, '')
-    .replace(/\n{3,}/g, '\n\n') // Collapse multiple newlines
-    .trim();
+  return (
+    content
+      .replace(/\[CRON_CREATE\][\s\S]*?\[\/CRON_CREATE\]/gi, '')
+      .replace(/\[CRON_LIST\]/gi, '')
+      .replace(/\[CRON_DELETE:[^\]]+\]/gi, '')
+      // A command the model wrapped in a code fence leaves an empty ``` ``` block
+      // behind after the command text is removed — drop those so the UI doesn't
+      // render a stray empty code block.
+      .replace(/```[a-zA-Z0-9]*[ \t]*\r?\n?\s*```/g, '')
+      .replace(/\n{3,}/g, '\n\n') // Collapse multiple newlines
+      .trim()
+  );
 }

--- a/tests/unit/cronCommandDetector.test.ts
+++ b/tests/unit/cronCommandDetector.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for CronCommandDetector — focused on the code-fence regression where a
+ * model wraps its real `[CRON_CREATE]` block in a markdown fence (ignoring the
+ * skill's "do not wrap in code blocks" instruction). Previously stripCodeBlocks
+ * deleted the whole fence, so detectCronCommands returned [] and no task was
+ * ever created even though the output clearly contained the command.
+ */
+import { describe, expect, it } from 'vitest';
+import { detectCronCommands, hasCronCommands, stripCronCommands } from '@/process/task/CronCommandDetector';
+
+describe('detectCronCommands — fenced commands', () => {
+  it('detects a CRON_CREATE block wrapped in a code fence (real-world scode output)', () => {
+    const content = [
+      '现有任务里有一个"喝水"提醒，和你要的不同，所以我直接创建新任务。',
+      '',
+      '```',
+      '[CRON_CREATE]',
+      'name: 喝水提醒（5分钟后）',
+      'schedule: 35 14 * * *',
+      'schedule_description: 约5分钟后（14:35）提醒一次',
+      'message: 该喝水啦！记得补充水分，保持健康 💧',
+      '[/CRON_CREATE]',
+      '```',
+    ].join('\n');
+
+    expect(hasCronCommands(content)).toBe(true);
+    const commands = detectCronCommands(content);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toEqual({
+      kind: 'create',
+      name: '喝水提醒（5分钟后）',
+      schedule: '35 14 * * *',
+      scheduleDescription: '约5分钟后（14:35）提醒一次',
+      message: '该喝水啦！记得补充水分，保持健康 💧',
+    });
+  });
+
+  it('detects a fenced CRON_CREATE with a language tag', () => {
+    const content = '```text\n[CRON_CREATE]\nname: T\nschedule: 0 9 * * *\nschedule_description: daily 9am\nmessage: hi\n[/CRON_CREATE]\n```';
+    const commands = detectCronCommands(content);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({ kind: 'create', name: 'T', schedule: '0 9 * * *' });
+  });
+
+  it('detects a fenced CRON_LIST', () => {
+    const commands = detectCronCommands('好的，先查询：\n```\n[CRON_LIST]\n```');
+    expect(commands).toEqual([{ kind: 'list' }]);
+  });
+
+  it('detects a fenced CRON_DELETE with a real id', () => {
+    const commands = detectCronCommands('```\n[CRON_DELETE: cron_abc123]\n```');
+    expect(commands).toEqual([{ kind: 'delete', jobId: 'cron_abc123' }]);
+  });
+
+  it('still detects a bare (non-fenced) CRON_CREATE — regression guard', () => {
+    const content = '[CRON_CREATE]\nname: T\nschedule: 0 9 * * MON\nschedule_description: mondays\nmessage: hello\n[/CRON_CREATE]';
+    const commands = detectCronCommands(content);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({ kind: 'create', schedule: '0 9 * * MON' });
+  });
+
+  it('ignores fenced blocks that are prose and contain no cron markers', () => {
+    const content = 'Here is some code:\n```js\nconst x = 1;\n```\nNothing scheduled.';
+    expect(detectCronCommands(content)).toEqual([]);
+  });
+});
+
+describe('stripCronCommands — fenced commands leave no empty code block', () => {
+  it('removes a fenced CRON_CREATE without leaving a stray ``` ``` block', () => {
+    const content = '好的，已创建：\n```\n[CRON_CREATE]\nname: T\nschedule: 0 9 * * *\nschedule_description: daily\nmessage: hi\n[/CRON_CREATE]\n```';
+    const stripped = stripCronCommands(content);
+    expect(stripped).not.toContain('```');
+    expect(stripped).not.toContain('[CRON_CREATE]');
+    expect(stripped).toContain('好的，已创建：');
+  });
+
+  it('removes a fenced CRON_LIST cleanly', () => {
+    const stripped = stripCronCommands('查询中\n```\n[CRON_LIST]\n```');
+    expect(stripped).not.toContain('```');
+    expect(stripped).not.toContain('[CRON_LIST]');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
         'src/agent/acp/AcpConnection.ts',
         'src/agent/acp/modelInfo.ts',
         'src/process/task/acpWorkspaceTracking.ts',
+        'src/process/task/CronCommandDetector.ts',
         // Common
         'src/common/chatLib.ts',
         'src/common/nexusFiles.ts',


### PR DESCRIPTION
The cron skill mandates a LIST-then-CREATE flow, so the follow-up [CRON_CREATE] always streams inside the nested feedback turn that the [CRON_LIST] handler spawns via sendToConnection. ACP's session/prompt only resolves when that nested turn ends, after which the parent finish handler ran cronAccumulator.reset() — wiping the nested turn's freshly accumulated [CRON_CREATE] before its own finish handler could read it. Result: the create silently never ran and no task was created (LIST worked because it is never nested).

Reset the accumulator immediately after capturing the content (before any await) so the nested feedback turn accumulates on a clean buffer and its finish handler detects its own command.

Also harden CronCommandDetector: a code fence whose body is itself a cron command is now unwrapped instead of stripped, since models sometimes wrap real commands in a fence despite the skill telling them not to. Empty fences left after stripping the command are cleaned from the display text.

# Pull Request

## Description

<!-- Provide a clear and concise description of what this PR does. -->

## Related Issues

<!-- Link to related issues using "Closes #123" or "Fixes #123" -->

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- If applicable, add screenshots to help explain your changes. -->

## Additional Context

<!-- Add any other context about the pull request here. -->

---

**Thank you for contributing to Sudowork! 🎉**
