### PR TITLE
ci(dev-shim): CDP smoke + launch-dev fail-fast + getInstallState fix

### DIFF
--- a/.github/workflows/pr-dev-shim-smoke.yml
+++ b/.github/workflows/pr-dev-shim-smoke.yml
@@ -75,6 +75,11 @@ jobs:
         # secrets-grpc-e2e in pr-integration-smoke.yml.
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install uv
+        # `bun run start` chains `hook:build` which builds the Python
+        # safety hook via `uv sync`. Same setup as _build-reusable.yml.
+        uses: astral-sh/setup-uv@v7
+
       - name: Install Linux apt deps (Electron + xvfb)
         if: matrix.platform == 'linux-x64'
         run: |

--- a/.github/workflows/pr-dev-shim-smoke.yml
+++ b/.github/workflows/pr-dev-shim-smoke.yml
@@ -1,0 +1,161 @@
+name: '✓PR Dev Shim Smoke'
+
+# Closes PR #921's regression gap. That PR added the renderer-side
+# dev-trigger shim at `window.__sudoworkDebug.fuseT.*` so Mac CDP-driven
+# smoke can drive the FUSE-T lazy-install loop without re-implementing
+# the bridge.buildProvider subscribe/callback dance. The shim was
+# manually verified on Win local smoke (CDP `Runtime.evaluate` returned
+# `{outcome: 'platform-unsupported', initialStatus: 'unknown'}`) — but
+# nothing in CI exercises it on every PR, so a renderer-entrypoint
+# refactor that drops the `import './bootstrap/devTriggers'` line, or a
+# bridge change that mishandles platform-unsupported, would silently
+# regress.
+#
+# This workflow boots the full Electron dev instance (xvfb on Linux),
+# polls the CDP port, evaluates the shim, and asserts:
+#   (1) runLazyInstallProbe() returns `platform-unsupported` on non-darwin,
+#   (2) getInstallState() returns `installing: false` immediately after.
+# (2) is the regression pin from the 2026-06-24 fuseTBridge.ts setTimeout
+# fix — the bridge previously deferred the install-state reset past the
+# IPC promise resolution.
+#
+# Scope intentionally narrow:
+#   - Linux only this round. macOS deferred behind nexi-lab/nexus#4425
+#     (fuse-plugin libfuse2 hard-link blocks cluster boot on FUSE-T-only
+#     hosts). Windows-on-headless-CI is brittle for full-Electron tests;
+#     re-evaluate once Linux has a confidence baseline.
+#   - No mount data flow, no install path. Those live in the FuseTSupervisor
+#     unit tests (9 cases) and Mac manual smoke.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+concurrency:
+  group: pr-dev-shim-smoke-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+
+jobs:
+  dev-shim-smoke:
+    name: Dev Shim Smoke (${{ matrix.platform }})
+    if: github.event.action != 'edited'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x64
+            os: ubuntu-latest
+            expect_outcome: platform-unsupported
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Rust toolchain
+        # Required for `bun run build:native` (napi-rs builds the
+        # nexus-napi binding from source). Same toolchain as
+        # secrets-grpc-e2e in pr-integration-smoke.yml.
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux apt deps (Electron + xvfb)
+        if: matrix.platform == 'linux-x64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libnss3 libatk-bridge2.0-0 libdrm2 libxkbcommon0 \
+            libxss1 libatspi2.0-0 libgtk-3-0 libxrandr2 libgbm1 \
+            protobuf-compiler pkg-config libssl-dev libsqlite3-dev
+          # asound2 package renamed to libasound2t64 on ubuntu-24.04;
+          # try both so the job survives a runner image refresh.
+          sudo apt-get install -y libasound2t64 || sudo apt-get install -y libasound2
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            native/nexus-napi/target
+          key: ${{ runner.os }}-cargo-napi-${{ hashFiles('native/nexus-napi/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-napi-
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Rebuild native modules for Electron
+        run: bunx electron-builder install-app-deps
+        env:
+          npm_config_runtime: electron
+          npm_config_disturl: https://electronjs.org/headers
+
+      - name: Build nexus-napi native binding
+        run: bun run build:native
+
+      - name: Download nexus-vfs cluster + plugins from COS
+        # Honors src/shared/runtime-versions.json. Even though the smoke
+        # doesn't drive the FUSE mount, the main process initializes
+        # the dynamic nexus-vfs service on bootstrap; without the
+        # binaries it would fall through to a slower error path.
+        run: bun run nexus-vfs:download
+
+      - name: Cold-start + dev-shim smoke (Linux)
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          set -uo pipefail
+          export NEXUS_CDP_PORT=9230
+          LOG=/tmp/sudowork-dev.log
+          : > "$LOG"
+
+          # Background `bun run start` under xvfb so Electron has a display.
+          xvfb-run -a --server-args='-screen 0 1280x1024x24' bun run start > "$LOG" 2>&1 &
+          DEV_PID=$!
+          echo "started bun run start as PID=$DEV_PID"
+
+          # Smoke driver has its own CDP wait window — keeps polling
+          # for up to --wait-seconds before failing.
+          set +e
+          node scripts/cdp-dev-shim-smoke.js \
+            --cdp-port "$NEXUS_CDP_PORT" \
+            --expect-outcome ${{ matrix.expect_outcome }} \
+            --wait-seconds 240
+          RC=$?
+          set -e
+
+          echo "=== sudowork dev log (last 300 lines) ==="
+          tail -300 "$LOG" || true
+          echo "=== end log ==="
+
+          # Best-effort kill — `bun run start` spawns electron-vite which
+          # spawns Electron; SIGTERM the process group to take the tree
+          # down together.
+          kill -TERM -"$DEV_PID" 2>/dev/null || kill -TERM "$DEV_PID" 2>/dev/null || true
+          sleep 3
+          kill -KILL -"$DEV_PID" 2>/dev/null || kill -KILL "$DEV_PID" 2>/dev/null || true
+
+          exit $RC
+
+      - name: Full dev log on failure
+        if: failure()
+        shell: bash
+        run: |
+          echo '=== FULL SUDOWORK DEV LOG ==='
+          cat /tmp/sudowork-dev.log 2>/dev/null || true

--- a/.github/workflows/pr-dev-shim-smoke.yml
+++ b/.github/workflows/pr-dev-shim-smoke.yml
@@ -124,6 +124,12 @@ jobs:
       - name: Cold-start + dev-shim smoke (Linux)
         if: matrix.platform == 'linux-x64'
         shell: bash
+        env:
+          # Force chromium-level logging so a sandbox / GPU init failure
+          # shows up in the log instead of vanishing after "starting
+          # electron app..." (round-2 symptom).
+          ELECTRON_ENABLE_LOGGING: '1'
+          ELECTRON_ENABLE_STACK_DUMPING: '1'
         run: |
           set -uo pipefail
           export NEXUS_CDP_PORT=9230
@@ -131,7 +137,15 @@ jobs:
           : > "$LOG"
 
           # Background `bun run start` under xvfb so Electron has a display.
-          xvfb-run -a --server-args='-screen 0 1280x1024x24' bun run start > "$LOG" 2>&1 &
+          # `-- --no-sandbox --disable-gpu --disable-dev-shm-usage` is
+          # passed through electron-vite to Electron itself. GitHub
+          # runners don't expose user namespaces for chromium's sandbox,
+          # /dev/shm is too small for Electron's default IPC, and there
+          # is no GPU to initialize — without these three Electron
+          # silently aborts before opening CDP.
+          xvfb-run -a --server-args='-screen 0 1280x1024x24' \
+            bun run start -- --no-sandbox --disable-gpu --disable-dev-shm-usage \
+            > "$LOG" 2>&1 &
           DEV_PID=$!
           echo "started bun run start as PID=$DEV_PID"
 

--- a/scripts/cdp-dev-shim-smoke.js
+++ b/scripts/cdp-dev-shim-smoke.js
@@ -85,7 +85,7 @@ async function findPageTarget(cdpPort, waitSeconds) {
 // One-shot Runtime.evaluate. Opens a fresh WS so call N+1 doesn't
 // inherit half-handled callbacks from call N — CDP is happy with this
 // and the cost is negligible compared to the renderer evaluation.
-function evaluateInRenderer(wsUrl, expression) {
+function evaluateInRendererOnce(wsUrl, expression) {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(wsUrl);
     const timeout = setTimeout(() => {
@@ -119,7 +119,9 @@ function evaluateInRenderer(wsUrl, expression) {
       clearTimeout(timeout);
       ws.close();
       if (msg.error) {
-        reject(new Error(`CDP error: ${JSON.stringify(msg.error)}`));
+        const err = new Error(`CDP error: ${JSON.stringify(msg.error)}`);
+        err.cdpError = msg.error;
+        reject(err);
       } else if (msg.result?.exceptionDetails) {
         reject(new Error(`Renderer threw: ${JSON.stringify(msg.result.exceptionDetails)}`));
       } else {
@@ -131,6 +133,29 @@ function evaluateInRenderer(wsUrl, expression) {
       reject(err);
     });
   });
+}
+
+// Retry on transient CDP errors that mean "the page reloaded under us".
+// Vite triggers a renderer reload when it discovers new
+// optimizable deps on first navigation, which destroys the execution
+// context partway through an evaluate. Up to N attempts with brief
+// pauses; refetch the page target each time in case the URL changed
+// (HMR keeps the same target id, but a hard reload may not).
+async function evaluateInRendererResilient(cdpPort, expression, attempts = 5) {
+  let lastErr = null;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const page = await findPageTarget(cdpPort, 30);
+      return await evaluateInRendererOnce(page.webSocketDebuggerUrl, expression);
+    } catch (err) {
+      lastErr = err;
+      const transient = /Execution context was destroyed|Target closed|No target with given id|Cannot find context with specified id/i.test(err.message);
+      if (!transient || i === attempts - 1) throw err;
+      console.log(`[cdp-dev-shim-smoke] transient CDP error (attempt ${i + 1}/${attempts}): ${err.message}; retrying`);
+      await sleep(2000);
+    }
+  }
+  throw lastErr;
 }
 
 // Wrap the renderer-side call in a try/catch that JSON-stringifies the
@@ -146,28 +171,31 @@ function wrap(jsExpr) {
 async function main() {
   const { cdpPort, expectOutcome, waitSeconds } = parseArgs(process.argv.slice(2));
   console.log(`[cdp-dev-shim-smoke] waiting for CDP page target on :${cdpPort} (up to ${waitSeconds}s)`);
-  const page = await findPageTarget(cdpPort, waitSeconds);
-  console.log(`[cdp-dev-shim-smoke] CDP target: ${page.url}`);
-  const wsUrl = page.webSocketDebuggerUrl;
+  const initialPage = await findPageTarget(cdpPort, waitSeconds);
+  console.log(`[cdp-dev-shim-smoke] initial CDP target: ${initialPage.url}`);
 
   // The renderer may still be hydrating when CDP first answers — the
   // shim is attached during `import './bootstrap/devTriggers'` which
-  // can lag the initial page navigation. Spin until it shows up.
+  // can lag the initial page navigation. Vite also reloads the page
+  // shortly after open when it discovers new optimizable deps, which
+  // destroys the execution context. Both are handled by the resilient
+  // evaluate wrapper — it retries on context-destroyed and refetches
+  // the page target each attempt.
   const waitExpr = `(async () => {
     const start = Date.now();
-    while (!window.__sudoworkDebug?.fuseT && Date.now() - start < 60000) {
+    while (!window.__sudoworkDebug?.fuseT && Date.now() - start < 30000) {
       await new Promise((r) => setTimeout(r, 500));
     }
     return !!window.__sudoworkDebug?.fuseT;
   })()`;
-  const waitRes = await evaluateInRenderer(wsUrl, waitExpr);
+  const waitRes = await evaluateInRendererResilient(cdpPort, waitExpr);
   if (!waitRes?.result?.value) {
-    throw new Error('window.__sudoworkDebug.fuseT never appeared on the renderer (60s timeout). devTriggers.ts may not be imported, or this is a production build.');
+    throw new Error('window.__sudoworkDebug.fuseT never appeared on the renderer (30s timeout). devTriggers.ts may not be imported, or this is a production build.');
   }
   console.log('[cdp-dev-shim-smoke] shim ready on window.__sudoworkDebug.fuseT');
 
   // Probe 1: runLazyInstallProbe.
-  const probeRes = await evaluateInRenderer(wsUrl, wrap('window.__sudoworkDebug.fuseT.runLazyInstallProbe()'));
+  const probeRes = await evaluateInRendererResilient(cdpPort, wrap('window.__sudoworkDebug.fuseT.runLazyInstallProbe()'));
   const probeParsed = JSON.parse(probeRes?.result?.value || '{}');
   console.log(`[cdp-dev-shim-smoke] runLazyInstallProbe: ${JSON.stringify(probeParsed)}`);
   if (!probeParsed.ok) throw new Error(`runLazyInstallProbe threw: ${probeParsed.error}`);
@@ -184,7 +212,7 @@ async function main() {
   // Probe 2: getInstallState — back-to-back with probe 1 because that's
   // the timing window that exposed the Win bug. The synchronous-reset
   // fix in fuseTBridge.ts must hold here.
-  const stateRes = await evaluateInRenderer(wsUrl, wrap('window.__sudoworkDebug.fuseT.getInstallState()'));
+  const stateRes = await evaluateInRendererResilient(cdpPort, wrap('window.__sudoworkDebug.fuseT.getInstallState()'));
   const stateParsed = JSON.parse(stateRes?.result?.value || '{}');
   console.log(`[cdp-dev-shim-smoke] getInstallState: ${JSON.stringify(stateParsed)}`);
   if (!stateParsed.ok) throw new Error(`getInstallState threw: ${stateParsed.error}`);

--- a/scripts/cdp-dev-shim-smoke.js
+++ b/scripts/cdp-dev-shim-smoke.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * CDP-driven smoke for the renderer dev-trigger shim
+ * (`src/renderer/bootstrap/devTriggers.ts`, landed in PR #921).
+ *
+ * Connects to a running Electron dev instance's CDP, finds the renderer
+ * page target, waits for the shim to install on `window.__sudoworkDebug`,
+ * then exercises two FUSE-T entry points:
+ *
+ *   1. `runLazyInstallProbe()` — must return the platform-expected
+ *      outcome (`platform-unsupported` on non-darwin CI runners).
+ *   2. `getInstallState()` — must return `{installing: false}`
+ *      immediately after (1) resolves. Pins the regression fix from
+ *      the Win cold-start smoke (the previous bridge `setTimeout(..., 0)`
+ *      pattern leaked `installing: true` into the same-tick read).
+ *
+ * Pure CI infra: no boundary leak, no new IPC channel, no source
+ * changes. Drives the existing official `ipcBridge.fuseT.*.invoke()`
+ * wrappers through the shim.
+ *
+ * Usage:
+ *   node scripts/cdp-dev-shim-smoke.js \
+ *     [--cdp-port 9230] \
+ *     [--expect-outcome platform-unsupported] \
+ *     [--wait-seconds 180]
+ */
+
+const http = require('http');
+const WebSocket = require('ws');
+
+function parseArgs(argv) {
+  const out = {
+    cdpPort: parseInt(process.env.NEXUS_CDP_PORT || '9230', 10),
+    expectOutcome: 'platform-unsupported',
+    waitSeconds: 180,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--cdp-port') out.cdpPort = parseInt(argv[++i], 10);
+    else if (a === '--expect-outcome') out.expectOutcome = argv[++i];
+    else if (a === '--wait-seconds') out.waitSeconds = parseInt(argv[++i], 10);
+  }
+  return out;
+}
+
+function httpGet(url, timeout = 2000) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => resolve(data));
+    });
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('http timeout'));
+    });
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Poll /json/list until a renderer page target appears. Skip
+// devtools:// entries (DevTools self-targets) and chrome-error://
+// frames (sometimes show up during early renderer init).
+async function findPageTarget(cdpPort, waitSeconds) {
+  const deadline = Date.now() + waitSeconds * 1000;
+  let lastErr = null;
+  let portReady = false;
+  while (Date.now() < deadline) {
+    try {
+      const list = JSON.parse(await httpGet(`http://127.0.0.1:${cdpPort}/json/list`));
+      portReady = true;
+      const page = list.find((t) => t.type === 'page' && t.webSocketDebuggerUrl && !t.url.startsWith('devtools://') && !t.url.startsWith('chrome-error://'));
+      if (page) return page;
+    } catch (err) {
+      lastErr = err;
+    }
+    await sleep(1000);
+  }
+  const detail = portReady ? 'CDP port responded but no renderer page target appeared' : `CDP port :${cdpPort} never responded (Electron failed to start?)`;
+  throw new Error(`${detail} within ${waitSeconds}s${lastErr ? ` — last error: ${lastErr.message}` : ''}`);
+}
+
+// One-shot Runtime.evaluate. Opens a fresh WS so call N+1 doesn't
+// inherit half-handled callbacks from call N — CDP is happy with this
+// and the cost is negligible compared to the renderer evaluation.
+function evaluateInRenderer(wsUrl, expression) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    const timeout = setTimeout(() => {
+      try {
+        ws.terminate();
+      } catch {
+        /* ignore */
+      }
+      reject(new Error('Runtime.evaluate timed out after 60s'));
+    }, 60000);
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'Runtime.evaluate',
+          params: { expression, awaitPromise: true, returnByValue: true },
+        }),
+      );
+    });
+    ws.on('message', (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch (err) {
+        clearTimeout(timeout);
+        ws.close();
+        reject(new Error(`CDP returned non-JSON frame: ${err.message}`));
+        return;
+      }
+      if (msg.id !== 1) return;
+      clearTimeout(timeout);
+      ws.close();
+      if (msg.error) {
+        reject(new Error(`CDP error: ${JSON.stringify(msg.error)}`));
+      } else if (msg.result?.exceptionDetails) {
+        reject(new Error(`Renderer threw: ${JSON.stringify(msg.result.exceptionDetails)}`));
+      } else {
+        resolve(msg.result);
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+// Wrap the renderer-side call in a try/catch that JSON-stringifies the
+// result. Avoids depending on returnByValue's handling of nested
+// promises and gives us a uniform parse path on the node side.
+function wrap(jsExpr) {
+  return `(async () => {
+    try { return JSON.stringify({ ok: true, data: await ${jsExpr} }); }
+    catch (e) { return JSON.stringify({ ok: false, error: String(e && e.stack || e) }); }
+  })()`;
+}
+
+async function main() {
+  const { cdpPort, expectOutcome, waitSeconds } = parseArgs(process.argv.slice(2));
+  console.log(`[cdp-dev-shim-smoke] waiting for CDP page target on :${cdpPort} (up to ${waitSeconds}s)`);
+  const page = await findPageTarget(cdpPort, waitSeconds);
+  console.log(`[cdp-dev-shim-smoke] CDP target: ${page.url}`);
+  const wsUrl = page.webSocketDebuggerUrl;
+
+  // The renderer may still be hydrating when CDP first answers — the
+  // shim is attached during `import './bootstrap/devTriggers'` which
+  // can lag the initial page navigation. Spin until it shows up.
+  const waitExpr = `(async () => {
+    const start = Date.now();
+    while (!window.__sudoworkDebug?.fuseT && Date.now() - start < 60000) {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    return !!window.__sudoworkDebug?.fuseT;
+  })()`;
+  const waitRes = await evaluateInRenderer(wsUrl, waitExpr);
+  if (!waitRes?.result?.value) {
+    throw new Error('window.__sudoworkDebug.fuseT never appeared on the renderer (60s timeout). devTriggers.ts may not be imported, or this is a production build.');
+  }
+  console.log('[cdp-dev-shim-smoke] shim ready on window.__sudoworkDebug.fuseT');
+
+  // Probe 1: runLazyInstallProbe.
+  const probeRes = await evaluateInRenderer(wsUrl, wrap('window.__sudoworkDebug.fuseT.runLazyInstallProbe()'));
+  const probeParsed = JSON.parse(probeRes?.result?.value || '{}');
+  console.log(`[cdp-dev-shim-smoke] runLazyInstallProbe: ${JSON.stringify(probeParsed)}`);
+  if (!probeParsed.ok) throw new Error(`runLazyInstallProbe threw: ${probeParsed.error}`);
+  // Bridge wraps supervisor's result in {success, data: <supervisor result>}.
+  const bridgeResp = probeParsed.data;
+  if (!bridgeResp?.success) {
+    throw new Error(`Bridge reported failure: ${JSON.stringify(bridgeResp)}`);
+  }
+  const outcome = bridgeResp.data?.outcome;
+  if (outcome !== expectOutcome) {
+    throw new Error(`Outcome mismatch: got ${outcome}, expected ${expectOutcome}. Full response: ${JSON.stringify(bridgeResp)}`);
+  }
+
+  // Probe 2: getInstallState — back-to-back with probe 1 because that's
+  // the timing window that exposed the Win bug. The synchronous-reset
+  // fix in fuseTBridge.ts must hold here.
+  const stateRes = await evaluateInRenderer(wsUrl, wrap('window.__sudoworkDebug.fuseT.getInstallState()'));
+  const stateParsed = JSON.parse(stateRes?.result?.value || '{}');
+  console.log(`[cdp-dev-shim-smoke] getInstallState: ${JSON.stringify(stateParsed)}`);
+  if (!stateParsed.ok) throw new Error(`getInstallState threw: ${stateParsed.error}`);
+  const stateBridge = stateParsed.data;
+  if (!stateBridge?.success) {
+    throw new Error(`getInstallState bridge failure: ${JSON.stringify(stateBridge)}`);
+  }
+  const installing = stateBridge.data?.installing;
+  if (installing !== false) {
+    throw new Error(`Regression: getInstallState reports installing=${installing} immediately after a ${expectOutcome} probe. Expected false. Full: ${JSON.stringify(stateBridge)}`);
+  }
+
+  console.log(`[cdp-dev-shim-smoke] PASS — outcome=${outcome}, installing=false`);
+}
+
+main().catch((err) => {
+  console.error(`[cdp-dev-shim-smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/launch-dev.js
+++ b/scripts/launch-dev.js
@@ -8,8 +8,11 @@
  */
 
 const { execSync, spawnSync } = require('child_process');
+const fs = require('fs');
 const http = require('http');
 const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
 
 // ── CLI ──
 
@@ -109,9 +112,88 @@ async function stop() {
   }
 }
 
+// ── prereq validation ──
+
+// `bun install` (autorun on fresh clone) does NOT cover three things that
+// `bun run start` silently depends on. Each surfaces as a confusing
+// runtime crash deep inside main-process bootstrap if missing. Detect up
+// front and print a single copy-pasteable fix instead.
+//
+//   (a) napi binding (native/nexus-napi/nexus-napi.node) — built by
+//       `bun run build:native`, requires Rust toolchain.
+//   (b) Electron-ABI-matched native modules (better-sqlite3, node-pty).
+//       Rebuilt by `bunx electron-builder install-app-deps`. The crash
+//       this prevents is `Could not locate the bindings file ...
+//       better_sqlite3.node` after a fresh `bun install` skipped
+//       postinstall on a slow link.
+//   (c) On Windows, MSVC env (vcvars64.bat sourced). Only required when
+//       (a) or (b) need rebuilding; an already-built tree boots fine
+//       without it. Skipped via SUDOWORK_SKIP_PREREQ_CHECK=1 for the
+//       rare case where you know the local tree is good and the
+//       detector is being overcautious.
+function validatePrereqs() {
+  if (process.env.SUDOWORK_SKIP_PREREQ_CHECK === '1') return;
+
+  const missing = [];
+
+  const napiPath = path.join(REPO_ROOT, 'native', 'nexus-napi', 'nexus-napi.node');
+  if (!fs.existsSync(napiPath)) {
+    missing.push({
+      what: 'napi binding',
+      detail: `${path.relative(REPO_ROOT, napiPath)} not found`,
+      fix: 'bun run build:native',
+    });
+  }
+
+  // Electron-ABI native modules: the only reliable existence signal is
+  // the rebuilt `.node` file. Don't compare mtimes against electron's
+  // package.json — `bun install` refreshes package.json mtimes without
+  // touching the rebuild, producing false positives on every clean
+  // tree. Existence catches the actual regression we hit (fresh clone
+  // crashing with `Could not locate the bindings file ...
+  // better_sqlite3.node`); ABI-version skew between an old build and a
+  // bumped electron is rare in practice and would surface as a
+  // runtime crash with a clear message, which is acceptable.
+  const sqliteNode = path.join(REPO_ROOT, 'node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node');
+  if (!fs.existsSync(sqliteNode)) {
+    missing.push({
+      what: 'Electron-ABI native module',
+      detail: `${path.relative(REPO_ROOT, sqliteNode)} not found`,
+      fix: 'bunx electron-builder install-app-deps',
+    });
+  }
+
+  // MSVC env only matters on Windows AND only if (a)/(b) actually
+  // need rebuilding. If the tree is already built, vcvars64.bat being
+  // un-sourced doesn't affect `bun run start`.
+  if (process.platform === 'win32' && missing.length > 0) {
+    const haveMsvc = Boolean(process.env.VCINSTALLDIR) || /\\vc\\/i.test(process.env.INCLUDE || '');
+    if (!haveMsvc) {
+      missing.push({
+        what: 'MSVC env',
+        detail: 'vcvars64.bat not sourced (required to rebuild native modules on Windows)',
+        fix: 'open a "Developer Command Prompt for VS" OR `call <path-to>\\vcvars64.bat` before the rebuild commands',
+      });
+    }
+  }
+
+  if (missing.length === 0) return;
+
+  const lines = ['', 'sudowork: missing prereq(s) for `bun run start`:'];
+  for (const m of missing) lines.push(`  ✗ ${m.what} (${m.detail})`);
+  lines.push('', 'Fix:');
+  for (const m of missing) lines.push(`  - ${m.fix}`);
+  lines.push('  - bun run start  # re-launch after the steps above');
+  lines.push('');
+  lines.push('Bypass (only if you know the tree is already built): SUDOWORK_SKIP_PREREQ_CHECK=1 bun run start');
+  console.error(lines.join('\n'));
+  process.exit(1);
+}
+
 // ── start ──
 
 function start() {
+  validatePrereqs();
   const passthroughArgs = process.argv.slice(3);
   const cleanEnv = { ...process.env };
   delete cleanEnv.ELECTRON_RUN_AS_NODE;

--- a/src/process/bridge/fuseTBridge.ts
+++ b/src/process/bridge/fuseTBridge.ts
@@ -61,9 +61,13 @@ export function initFuseTBridge(): void {
       ipcBridge.fuseT.installResult.emit({ success: false, msg });
       return { success: false, msg };
     } finally {
-      setTimeout(() => {
-        installState = { installing: false };
-      }, 0);
+      // Reset synchronously. A prior setTimeout(..., 0) deferral leaked
+      // `installing: true` to any caller that read `getInstallState()`
+      // in the same tick as the provider resolving — observed in the
+      // 2026-06-24 Win cold-start smoke after a `runLazyInstallProbe()`
+      // returning `platform-unsupported`. Setting in `finally` runs
+      // before the returned promise resolves to the renderer.
+      installState = { installing: false };
     }
   });
 
@@ -105,9 +109,7 @@ export function initFuseTBridge(): void {
       ipcBridge.fuseT.installResult.emit({ success: false, msg });
       return { success: false, msg };
     } finally {
-      setTimeout(() => {
-        installState = { installing: false };
-      }, 0);
+      installState = { installing: false };
     }
   });
   mainLog(TAG, 'FUSE-T IPC providers registered');

--- a/tests/integration/fuseT.integration.test.ts
+++ b/tests/integration/fuseT.integration.test.ts
@@ -85,6 +85,20 @@ describe('FUSE-T — lazy install contract', () => {
     expect(bridge).toMatch(/supervisor\.runLazyInstallProbe\(/);
   });
 
+  it('the bridge resets installing=false synchronously in finally (no setTimeout deferral)', () => {
+    // The 2026-06-24 Win cold-start smoke observed `getInstallState()`
+    // returning `{installing: true}` immediately after a
+    // `runLazyInstallProbe()` resolved with `platform-unsupported`.
+    // Root cause: both providers used `setTimeout(() => { installState
+    // = { installing: false } }, 0)` in their finally blocks. The
+    // setTimeout deferred the reset past the IPC promise resolution,
+    // so any renderer that read state in the same tick saw stale
+    // `installing: true`. A synchronous reset in `finally` runs
+    // before the returned promise resolves to the renderer.
+    const bridge = fs.readFileSync(path.join(REPO_ROOT, 'src/process/bridge/fuseTBridge.ts'), 'utf-8');
+    expect(bridge).not.toMatch(/setTimeout\([^)]*installState/);
+  });
+
   it('the bridge exposes no dev-only IPC bypass channels', () => {
     // Earlier iterations added `dev.fuse-t.*` raw `ipcMain.handle`
     // channels to bypass the bridge.buildProvider subscribe/callback


### PR DESCRIPTION
## Summary

Three commits, one bundled PR per Ethan 2026-06-24:

- **fix(fuse-t-bridge)**: reset `installState` synchronously in `finally`. Removes the `setTimeout(..., 0)` deferral that leaked `installing: true` to any caller reading `getInstallState()` in the same tick as `runLazyInstallProbe()` resolving (observed in 2026-06-24 Win cold-start smoke after a `platform-unsupported` probe). Adds a static-source regression assertion in `tests/integration/fuseT.integration.test.ts`.
- **chore(launch-dev)**: fail-fast on missing prereqs for `bun run start` — napi binding, Electron-ABI-rebuilt better-sqlite3, and (on Win) MSVC env when rebuild is needed. Prints a single copy-pasteable fix instead of crashing deep in main-process bootstrap. Bypass via `SUDOWORK_SKIP_PREREQ_CHECK=1`.
- **ci(dev-shim)**: new `pr-dev-shim-smoke.yml` workflow. Boots full Electron under xvfb on Linux, polls CDP, evaluates `window.__sudoworkDebug.fuseT.runLazyInstallProbe()` + `getInstallState()` via `Runtime.evaluate`, asserts `outcome === 'platform-unsupported'` AND `installing === false`. Closes PR #921's regression gap; pins the fuseTBridge fix in CI.

## What's NOT in this PR (intentional)

- **macos-arm64 cold-start matrix return** (commit D in plan): gated on nexi-lab/nexus#4425 (fuse-plugin libfuse2 hard-link blocks cluster boot on FUSE-T-only hosts). Still OPEN; deferred to a follow-up PR once #4425 closes + fuse-plugin tag bumps.
- **Windows in dev-shim matrix**: Electron-on-Windows-headless-CI is brittle for full-app tests. Linux first for baseline; revisit Win once we have data.
- Pre-existing fuseT integration test failures (2 cases on `'libnexus_fuse_plugin.dylib'` and `'nexus-fuse-plugin-macos-arm64.tar.gz'` substring checks) — tech debt from PR #922's plugin-naming SSOT refactor. Out of scope; these tests need to be ported to `scripts/plugin-naming.js` separately. Doesn't block any PR gate (only `_build-reusable.yml` runs full vitest, and that fires on tag push only, not PR).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx prettier --check` clean on all 5 touched files
- [x] `bunx eslint --fix` clean on touched .ts files
- [x] `bunx vitest run tests/integration/fuseT.integration.test.ts` — new sync-reset assertion green (35/37 cases pass; 2 pre-existing failures unchanged)
- [x] Local smoke: `validatePrereqs()` happy path on current tree passes; missing-napi simulation prints expected fix message
- [x] Local smoke: `scripts/cdp-dev-shim-smoke.js` self-fails cleanly with no CDP target
- [ ] CI: `Dev Shim Smoke (linux-x64)` job green (this PR's empirical baseline)
- [ ] CI: existing `Cold Start Smoke` jobs unchanged