### PR TITLE
feat: server-driven endpoints + back-to-mode-select on password auth panel

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -19,6 +19,10 @@ on:
         description: 'Append short commit hash to artifact names'
         type: boolean
         default: false
+      server_base_url:
+        description: 'Optional sudowork-server base URL injected via Vite define (empty = use literal fallback)'
+        type: string
+        default: ''
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
@@ -66,6 +70,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: code-quality
     if: ${{ always() && (inputs.skip_code_quality || needs.code-quality.result == 'success') }}
+
+    # Job-level env propagates to every step in this job AND to subprocesses spawned by those steps
+    # (e.g. build-with-builder.js → electron-vite). Existing release/nightly callers do not pass
+    # `server_base_url`, so this resolves to '' and the runtime helper falls back to the literal default.
+    env:
+      BUILD_SERVER_BASE_URL: ${{ inputs.server_base_url }}
 
     outputs:
       commit-short: ${{ steps.commit.outputs.short }}

--- a/.github/workflows/build-custom-server.yml
+++ b/.github/workflows/build-custom-server.yml
@@ -1,0 +1,75 @@
+name: Build with Custom sudowork-server URL
+
+# Manually-triggered build pipeline that injects a user-supplied sudowork-server
+# base URL into the bundle via Vite `define` (__SUDOWORK_SERVER_BASE_URL__).
+# Produces the SAME platforms/artifact types as the standard dev-manual build
+# in build-and-release.yml (mac-arm64, mac-x64, windows-x64, windows-arm64).
+#
+# Use this when you need a build pointing at a different sudowork-server
+# (staging, customer-specific, on-prem, etc.). The standard release / nightly
+# pipelines remain untouched and continue to ship the literal fallback address.
+
+permissions:
+  contents: read
+  actions: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_base_url:
+        description: 'sudowork-server base URL to inject (REQUIRED, e.g. https://sudowork-staging.example.com)'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to checkout (branch or commit; leave empty for the default branch)'
+        required: false
+        type: string
+        default: ''
+      skip_code_quality:
+        description: 'Skip code quality checks (faster builds for debugging)'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+
+jobs:
+  prepare-matrix:
+    name: Prepare Build Matrix (all 4 platforms)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - name: Generate build matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          # Same 4 platforms as the IS_MANUAL_DEV branch in build-and-release.yml
+          MACOS_ARM64='{"platform":"macos-arm64","os":"macos-14","command":"node scripts/build-with-builder.js arm64 --mac --arm64","artifact-name":"macos-build-arm64","arch":"arm64"}'
+          MACOS_X64='{"platform":"macos-x64","os":"macos-15-intel","command":"node scripts/build-with-builder.js x64 --mac --x64","artifact-name":"macos-build-x64","arch":"x64"}'
+          WINDOWS_X64='{"platform":"windows-x64","os":"windows-2022","command":"node scripts/build-with-builder.js x64 --win --x64","artifact-name":"windows-build-x64","arch":"x64"}'
+          WINDOWS_ARM64='{"platform":"windows-arm64","os":"windows-2022","command":"node scripts/build-with-builder.js arm64 --win --arm64","artifact-name":"windows-build-arm64","arch":"arm64"}'
+
+          MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64]}"
+
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "Generated matrix:"
+          echo "$MATRIX" | python3 -m json.tool
+
+      - name: Echo injected sudowork-server URL
+        shell: bash
+        run: |
+          echo "::notice title=Custom sudowork-server URL::Will inject: ${{ inputs.server_base_url }}"
+
+  build-pipeline:
+    name: Build Pipeline
+    needs: prepare-matrix
+    uses: ./.github/workflows/_build-reusable.yml
+    with:
+      matrix: ${{ needs.prepare-matrix.outputs.matrix }}
+      ref: ${{ inputs.ref }}
+      skip_code_quality: ${{ inputs.skip_code_quality }}
+      server_base_url: ${{ inputs.server_base_url }}
+    secrets: inherit

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -78,6 +78,11 @@ export default defineConfig(({ mode }) => {
     // Optional sudowork-server base URL injection. Empty string means "not injected"
     // so the runtime helper falls back to the literal default.
     __SUDOWORK_SERVER_BASE_URL__: JSON.stringify(process.env.BUILD_SERVER_BASE_URL ?? ''),
+    // Server-driven endpoint base URLs (system-config). Same convention: empty = not injected.
+    __SUDOROUTER_BASE_URL__: JSON.stringify(process.env.BUILD_SUDOROUTER_BASE_URL ?? ''),
+    __SKILLHUB_BASE_URL__: JSON.stringify(process.env.BUILD_SKILLHUB_BASE_URL ?? ''),
+    __LOG_REPORT_BASE_URL__: JSON.stringify(process.env.BUILD_LOG_REPORT_BASE_URL ?? ''),
+    __COS_RELEASE_BASE__: JSON.stringify(process.env.BUILD_COS_RELEASE_BASE ?? ''),
   };
 
   return {

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -75,6 +75,9 @@ export default defineConfig(({ mode }) => {
     __BUILD_DATE__: JSON.stringify(buildMeta.date),
     __BUILD_COMMIT__: JSON.stringify(buildMeta.commit),
     __BUILD_IS_NIGHTLY__: JSON.stringify(buildMeta.isNightly),
+    // Optional sudowork-server base URL injection. Empty string means "not injected"
+    // so the runtime helper falls back to the literal default.
+    __SUDOWORK_SERVER_BASE_URL__: JSON.stringify(process.env.BUILD_SERVER_BASE_URL ?? ''),
   };
 
   return {

--- a/skills/_builtin/sudoclaw-skill-installer/scripts/sudoclaw-skill.mjs
+++ b/skills/_builtin/sudoclaw-skill-installer/scripts/sudoclaw-skill.mjs
@@ -25,9 +25,13 @@ try {
   JSZip = require('jszip');
 }
 
-const SKILL_HUB_BASE_URL = 'https://sudoworkhub.sudoprivacy.com/api/skills';
-const SKILL_HUB_CURSOR_URL = 'https://sudoworkhub.sudoprivacy.com/api/skills/cursor';
-const AUTHORIZATION = 'sud0@sudo';
+// Server-driven hub root + token: env-injected when run under the app
+// (SKILLHUB_BASE_URL / SKILLHUB_AUTHORIZATION); fallback to the hardcoded defaults for
+// standalone CLI use so old resources keep working.
+const HUB_ROOT = process.env.SKILLHUB_BASE_URL?.trim() || 'https://sudoworkhub.sudoprivacy.com';
+const SKILL_HUB_BASE_URL = `${HUB_ROOT}/api/skills`;
+const SKILL_HUB_CURSOR_URL = `${HUB_ROOT}/api/skills/cursor`;
+const AUTHORIZATION = process.env.SKILLHUB_AUTHORIZATION?.trim() || 'sud0@sudo';
 
 const NEXUS_DIR = path.join(os.homedir(), '.nexus');
 const SKILLS_DIR = path.join(NEXUS_DIR, 'skills');

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -23,6 +23,7 @@ import type { FusePluginStatus } from './nexus/fuse-plugin-status';
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from './types/preview';
 import type { UpdateCheckRequest, UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult, AutoUpdateStatus } from './updateTypes';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from './utils/protocolDetector';
+import type { SystemConfig } from '@/common/systemConfig';
 
 export const shell = {
   openFile: bridge.buildProvider<void, string>('open-file'), // 使用系统默认程序打开文件
@@ -1782,6 +1783,15 @@ export const sudoworkServer = {
 export const systemConfig = {
   /** Decrypt + cache the credentials envelope; triggers CrashReporter.flushAll() backfill. */
   cacheCredentials: bridge.buildProvider<IBridgeResponse<{ cached: boolean }>, { nonce: string; ciphertext: string }>('system-config.cache-credentials'),
+  /**
+   * Sync a renderer-fetched systemConfig snapshot into the main-process cache.
+   * The `systemConfig` module has ONE instance per process; without this channel, a
+   * renderer-side fetchSystemConfig only fills the renderer's copy and main-process
+   * readers (skillHubBridge / sudorouter / log-report) keep seeing the stale fallback.
+   * Payload is non-null SystemConfig — callers MUST NOT invoke when fetchSystemConfig
+   * returned null (renderer fetch failure), as that would wipe main-side cache.
+   */
+  syncFromRenderer: bridge.buildProvider<IBridgeResponse<void>, { data: SystemConfig }>('system-config.sync-from-renderer'),
 };
 
 // ==================== Safety Hook API ====================

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1774,6 +1774,16 @@ export const sudoworkServer = {
   updateConfig: bridge.buildProvider<void, Partial<ISudoworkServerConfig>>('sudowork-server.update-config'),
 };
 
+// ==================== System Config (server-driven) ====================
+// Renderer fetches the AES-256-GCM credentials envelope with the user's JWT and forwards
+// {nonce, ciphertext} here; the main process decrypts + caches the plaintext (main-only)
+// and triggers CrashReporter backfill. JWT never leaves the renderer.
+
+export const systemConfig = {
+  /** Decrypt + cache the credentials envelope; triggers CrashReporter.flushAll() backfill. */
+  cacheCredentials: bridge.buildProvider<IBridgeResponse<{ cached: boolean }>, { nonce: string; ciphertext: string }>('system-config.cache-credentials'),
+};
+
 // ==================== Safety Hook API ====================
 
 // ==================== Tools API ====================

--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -1,5 +1,6 @@
 import { modelInputForModelId } from './imageUtils';
 import type { ScodeConfig, ScodeModelEntry } from './ipcBridge';
+import { getSudorouterBaseUrl } from './systemConfig';
 
 export type LoginSudoclawPayload = {
   sudorouterKey?: string;
@@ -237,7 +238,7 @@ export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | un
     web_search: {
       ...(existing?.web_search || {}),
       provider: existing?.web_search?.provider || 'tavily',
-      apiUrl: existing?.web_search?.apiUrl || 'https://hk.sudorouter.ai/search/tavily/search',
+      apiUrl: existing?.web_search?.apiUrl || `${getSudorouterBaseUrl()}/search/tavily/search`,
       apiKey: existing?.web_search?.apiKey || payload.sudorouterKey || '',
     },
   };

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -491,9 +491,6 @@ export interface IProvider {
 
 export type TProviderWithModel = Omit<IProvider, 'model'> & { useModel: string };
 
-/** Default base URL for SudoRouter image generation */
-export const DEFAULT_IMAGE_BASE_URL = 'https://hk.sudorouter.ai/v1';
-
 /** Default model used for image parsing/understanding (看图) via SudoRouter */
 export const DEFAULT_IMAGE_PARSING_MODEL = 'gemini-3.5-flash';
 

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -103,13 +103,23 @@ export interface IConfigStorageRefer {
   // 内置资源最后复制的版本号，用于优化启动速度 / Last copied version of builtin resources for startup optimization
   'system.lastBuiltinResourcesVersion'?: string;
   /**
-   * @deprecated Server URL is now hardcoded in src/common/sudoworkServer.ts.
-   * This config key is kept for backward compatibility but is no longer used.
+   * @deprecated Superseded by `system.sudoworkServerUrl` below. The current sudowork-server URL
+   * is resolved at runtime via `src/common/sudoworkServer.ts` (renderer `getSudoworkServerBaseUrl`)
+   * and `src/process/initStorage.ts#getSudoworkServerBaseUrlSync` (main), with priority:
+   * user setting > build-time `__SUDOWORK_SERVER_BASE_URL__` define > literal fallback.
+   * This key is kept for backward compatibility but is no longer read or written.
    */
   'sudowork.server'?: {
     baseUrl: string;
     enterpriseCode?: string;
   };
+  /**
+   * User-configured sudowork-server base URL (optional override).
+   * Resolved by helpers in `src/common/sudoworkServer.ts` (renderer) and
+   * `src/process/initStorage.ts#getSudoworkServerBaseUrlSync` (main).
+   * Empty / absent → fall back to build-time define, then to literal.
+   */
+  'system.sudoworkServerUrl'?: string;
   // Telegram assistant default model / Telegram 助手默认模型
   'assistant.telegram.defaultModel'?: {
     id: string;

--- a/src/common/sudoclawModelConfig.ts
+++ b/src/common/sudoclawModelConfig.ts
@@ -1,6 +1,6 @@
 import type { SudoclawConfig, SudoclawProvider, SudoclawProviderModel } from './ipcBridge';
+import { getSudorouterBaseUrl } from './systemConfig';
 
-const SUDOROUTER_BASE_URL = 'https://hk.sudorouter.ai/v1';
 const DEFAULT_PRIMARY_MODEL = 'gemini-3.5-flash';
 
 type MergeSudorouterProvidersParams = {
@@ -46,7 +46,7 @@ export function buildSudorouterProviderModel(modelId: string): SudoclawProviderM
 export function buildSudorouterProvider(modelId: string, apiKey?: string, existingProvider?: SudoclawProvider): SudoclawProvider {
   const provider: SudoclawProvider = {
     ...existingProvider,
-    baseUrl: SUDOROUTER_BASE_URL,
+    baseUrl: `${getSudorouterBaseUrl()}/v1`,
     api: getSudorouterApiType(modelId),
     models: [buildSudorouterProviderModel(modelId)],
   };
@@ -95,7 +95,7 @@ export function mergeSudorouterProvidersIntoConfig(config: SudoclawConfig | null
   const existingCanonicalProvider = existingProviders.sudorouter;
   mergedProviders.sudorouter = {
     ...existingCanonicalProvider,
-    baseUrl: params.baseUrl?.trim() || existingCanonicalProvider?.baseUrl || SUDOROUTER_BASE_URL,
+    baseUrl: params.baseUrl?.trim() || existingCanonicalProvider?.baseUrl || `${getSudorouterBaseUrl()}/v1`,
     api: existingCanonicalProvider?.api || getSudorouterApiType(getPreferredSudorouterPrimaryModel(modelIds)),
     models: canonicalSudorouterModels,
   };

--- a/src/common/sudoworkServer.ts
+++ b/src/common/sudoworkServer.ts
@@ -5,16 +5,49 @@
  */
 
 /**
- * Sudowork Server constants
- * Sudowork 中控服务器常量配置
+ * Sudowork Server base URL resolver.
+ *
+ * Priority (highest to lowest):
+ *   1. User setting in ConfigStorage / ProcessConfig (`system.sudoworkServerUrl`)
+ *   2. Build-time injected value (`__SUDOWORK_SERVER_BASE_URL__` via Vite `define`)
+ *   3. Hardcoded fallback (`FALLBACK_SUDOWORK_SERVER_BASE_URL`)
+ *
+ * All call sites must resolve the URL on every use (no caching of the value
+ * inside Reporter / module-level constants) so that user updates take effect
+ * on the next call without any reload/relaunch.
  */
 
+import { ConfigStorage } from '@/common/storage';
+
+// Vite `define` injects this as a string literal at build time.
+// Empty string when the env var BUILD_SERVER_BASE_URL was not set during build.
+declare const __SUDOWORK_SERVER_BASE_URL__: string | undefined;
+
+/** Hardcoded fallback (the historical production address). */
+export const FALLBACK_SUDOWORK_SERVER_BASE_URL = 'https://sudowork-server.sudoprivacy.com';
+
 /**
- * Default Sudowork server base URL
- * Sudowork 中控服务器默认地址
- *
- * This is hardcoded to avoid issues where old config values persist
- * after code updates. The server URL should be controlled by code,
- * not by user configuration.
+ * Build-time injected base URL, or fallback when not injected.
+ * Resolved synchronously at module load (the define is a compile-time string literal).
  */
-export const SUDOWORK_SERVER_BASE_URL = 'https://sudowork-server.sudoprivacy.com';
+export const BUILD_SUDOWORK_SERVER_BASE_URL: string = (typeof __SUDOWORK_SERVER_BASE_URL__ !== 'undefined' && __SUDOWORK_SERVER_BASE_URL__) || FALLBACK_SUDOWORK_SERVER_BASE_URL;
+
+/**
+ * Normalize a raw URL string: trim whitespace and strip trailing slashes.
+ * Returns null for empty / null / undefined / non-string inputs so callers can
+ * `?? BUILD_SUDOWORK_SERVER_BASE_URL` to fall back cleanly.
+ */
+export function normalizeSudoworkServerUrl(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().replace(/\/+$/, '');
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Resolve the current sudowork-server base URL (renderer / async context).
+ * Reads the user setting on every call — no caching.
+ */
+export async function getSudoworkServerBaseUrl(): Promise<string> {
+  const raw = await ConfigStorage.get('system.sudoworkServerUrl').catch(() => undefined as unknown as string | undefined);
+  return normalizeSudoworkServerUrl(raw) ?? BUILD_SUDOWORK_SERVER_BASE_URL;
+}

--- a/src/common/systemConfig.ts
+++ b/src/common/systemConfig.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Sudowork-server system-config client.
+ *
+ * Fetches the public system-config (`GET /api/v1/system-config`) and decrypts the
+ * credentials envelope (`GET /api/v1/system-config/credentials`, AES-256-GCM), and
+ * exposes synchronous base-url helpers + feature switches that every call site reads
+ * on every use.
+ *
+ * Module placement: this lives in `src/common/` (shared by main + renderer). Per the
+ * Electron bundling model, this module has ONE instance per process; each process fills
+ * its own module-level cache at startup (main: `src/index.ts`, renderer:
+ * `useSystemLoginMethod`), so synchronous helpers read the in-process instance without
+ * any reverse dependency on `src/process/`.
+ *
+ * Sensitivity boundary: only NON-sensitive data (base urls + feature switches) is held
+ * in this module-level cache. Decrypted credential plaintext (keys/tokens) is stored in
+ * the main process only (`src/process/`) and never enters this module or the renderer.
+ */
+
+import { getSudoworkServerBaseUrl, normalizeSudoworkServerUrl } from '@/common/sudoworkServer';
+import { COS_RELEASE_BASE } from '@/shared/cos';
+
+// ---- build-time injected base URLs (Vite `define`; empty string = not injected) ----
+declare const __SUDOROUTER_BASE_URL__: string | undefined;
+declare const __SKILLHUB_BASE_URL__: string | undefined;
+declare const __LOG_REPORT_BASE_URL__: string | undefined;
+declare const __COS_RELEASE_BASE__: string | undefined;
+
+/** Hardcoded fallbacks (the historical production addresses). */
+export const FALLBACK_SUDOROUTER_BASE_URL = 'https://hk.sudorouter.ai';
+export const FALLBACK_SKILLHUB_BASE_URL = 'https://sudoworkhub.sudoprivacy.com';
+export const FALLBACK_LOG_REPORT_BASE_URL = 'https://sudolog.sudoprivacy.com';
+
+/** Build-time injected value, or fallback when not injected (mirrors sudoworkServer.ts:33). */
+export const BUILD_SUDOROUTER_BASE_URL: string = (typeof __SUDOROUTER_BASE_URL__ !== 'undefined' && __SUDOROUTER_BASE_URL__) || FALLBACK_SUDOROUTER_BASE_URL;
+export const BUILD_SKILLHUB_BASE_URL: string = (typeof __SKILLHUB_BASE_URL__ !== 'undefined' && __SKILLHUB_BASE_URL__) || FALLBACK_SKILLHUB_BASE_URL;
+export const BUILD_LOG_REPORT_BASE_URL: string = (typeof __LOG_REPORT_BASE_URL__ !== 'undefined' && __LOG_REPORT_BASE_URL__) || FALLBACK_LOG_REPORT_BASE_URL;
+export const BUILD_COS_RELEASE_BASE: string = (typeof __COS_RELEASE_BASE__ !== 'undefined' && __COS_RELEASE_BASE__) || COS_RELEASE_BASE;
+
+// ---- typed system-config shape (interface doc 1.4) ----
+export interface SystemConfig {
+  login_method?: number;
+  log_report?: { enabled: number; baseurl?: string };
+  version_update?: { enabled: number; cos_domain?: string };
+  product_improvement?: { enabled: number; encryption_required?: boolean };
+  sudorouter_baseurl?: string;
+  skillhub_baseurl?: string;
+}
+
+/** Decrypted credentials plaintext (interface doc 2.4.3 — fields are conditional). */
+export interface DecryptedCredentials {
+  skillhub?: { token: string };
+  log_report?: { key: string };
+  product_improvement?: { api_key: string; public_key?: string };
+}
+
+// ---- module-level cache (per-process instance, 5 min TTL, mirrors useSystemLoginMethod) ----
+const CACHE_TTL_MS = 5 * 60 * 1000;
+let cachedConfig: SystemConfig | null = null;
+let cachedAt = 0;
+
+/** Fill/replace the in-process cache (called by main `index.ts` and renderer `useSystemLoginMethod`). */
+export function setSystemConfigCache(data: SystemConfig | null): void {
+  cachedConfig = data;
+  cachedAt = data ? Date.now() : 0;
+}
+
+/** Read the in-process cache; null when empty or expired (caller then falls back). */
+export function getSystemConfigCache(): SystemConfig | null {
+  if (cachedConfig && Date.now() - cachedAt < CACHE_TTL_MS) return cachedConfig;
+  return null;
+}
+
+// ---- fetch (public, no auth; fetch + res.json() work in both processes) ----
+export async function fetchSystemConfig(): Promise<SystemConfig | null> {
+  try {
+    const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/system-config`);
+    const json = (await res.json()) as { success?: boolean; data?: SystemConfig };
+    if (json?.success && json.data) {
+      setSystemConfigCache(json.data);
+      return json.data;
+    }
+    return null;
+  } catch (err) {
+    console.warn('[systemConfig] fetch system-config failed:', err);
+    return null;
+  }
+}
+
+// ---- AES-256-GCM decryption of the credentials envelope (interface doc 2.4.2 / 2.5.5) ----
+// Fixed shared key. atob + crypto.subtle are available in both Node (>=16) and browser,
+// so this pure function is safe to keep in src/common/ (only ever invoked from main).
+const CREDENTIALS_KEY_B64 = 'L7CbnQlwVrzWlaehCWSIiKuwBxFDh9i1AFaifYv7UXE=';
+
+function base64ToBytes(b64: string): BufferSource {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+export async function decryptCredentials(nonceB64: string, ciphertextB64: string): Promise<DecryptedCredentials> {
+  const key = await crypto.subtle.importKey('raw', base64ToBytes(CREDENTIALS_KEY_B64), { name: 'AES-GCM' }, false, ['decrypt']);
+  // GCM tag is appended to the ciphertext (interface doc 2.4.2); no AAD.
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: base64ToBytes(nonceB64) }, key, base64ToBytes(ciphertextB64));
+  return JSON.parse(new TextDecoder().decode(plain)) as DecryptedCredentials;
+}
+
+// ---- synchronous base-url helpers (read module cache; 3-level fallback) ----
+// Precedence: dispatched value > build-time define > hardcoded fallback.
+function resolve(raw: string | null | undefined, buildValue: string): string {
+  return normalizeSudoworkServerUrl(raw) ?? buildValue;
+}
+
+/** Sudorouter root address (call sites append `/v1`, `/search/tavily`, `/api/specific_pricing`, …). */
+export function getSudorouterBaseUrl(): string {
+  return resolve(getSystemConfigCache()?.sudorouter_baseurl, BUILD_SUDOROUTER_BASE_URL);
+}
+
+/**
+ * Stable sudorouter identity check by host (NOT a `includes('sudorouter.ai')` substring test).
+ * Matches the host of the current dispatched sudorouter base URL, so the check stays valid
+ * after the domain is re-dispatched to a different company's deployment.
+ */
+export function isSudorouterBaseUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    return new URL(url).host === new URL(getSudorouterBaseUrl()).host;
+  } catch {
+    return false;
+  }
+}
+
+export function getSkillHubBaseUrl(): string {
+  return resolve(getSystemConfigCache()?.skillhub_baseurl, BUILD_SKILLHUB_BASE_URL);
+}
+
+export function getLogReportBaseUrl(): string {
+  return resolve(getSystemConfigCache()?.log_report?.baseurl, BUILD_LOG_REPORT_BASE_URL);
+}
+
+export function getCosReleaseBase(): string {
+  return resolve(getSystemConfigCache()?.version_update?.cos_domain, BUILD_COS_RELEASE_BASE);
+}
+
+// ---- feature-switch helpers (fail-open: cache empty => keep current behavior) ----
+// `enabled === 0` is the explicit "off" signal; anything else (including cache miss) keeps
+// the historical behavior, so a transient fetch failure cannot silently disable features.
+export function isVersionUpdateEnabled(): boolean {
+  const cache = getSystemConfigCache();
+  return cache ? cache.version_update?.enabled !== 0 : true;
+}
+
+export function isProductImprovementEnabled(): boolean {
+  const cache = getSystemConfigCache();
+  return cache ? cache.product_improvement?.enabled !== 0 : true;
+}
+
+export function isLogReportEnabled(): boolean {
+  const cache = getSystemConfigCache();
+  return cache ? cache.log_report?.enabled !== 0 : true;
+}

--- a/src/common/systemConfig.ts
+++ b/src/common/systemConfig.ts
@@ -60,21 +60,23 @@ export interface DecryptedCredentials {
   product_improvement?: { api_key: string; public_key?: string };
 }
 
-// ---- module-level cache (per-process instance, 5 min TTL, mirrors useSystemLoginMethod) ----
-const CACHE_TTL_MS = 5 * 60 * 1000;
+// ---- module-level cache (per-process instance; resides for the process lifetime) ----
+// No TTL: once filled (by startup bootstrap, autoUpdater branch, or renderer push), the
+// cache stays put until the process exits. A time-based expiry would force every consumer
+// to fall back to the hardcoded URL whenever no refresh path happened to fire — and there
+// is no consumer or scheduler that re-fetches on expiry, so an expired cache was silently
+// equivalent to a permanently absent cache. server-side dispatch changes are picked up on
+// the next startup / re-login (the same windows that fill the cache in the first place).
 let cachedConfig: SystemConfig | null = null;
-let cachedAt = 0;
 
 /** Fill/replace the in-process cache (called by main `index.ts` and renderer `useSystemLoginMethod`). */
 export function setSystemConfigCache(data: SystemConfig | null): void {
   cachedConfig = data;
-  cachedAt = data ? Date.now() : 0;
 }
 
-/** Read the in-process cache; null when empty or expired (caller then falls back). */
+/** Read the in-process cache; null only when never filled. */
 export function getSystemConfigCache(): SystemConfig | null {
-  if (cachedConfig && Date.now() - cachedAt < CACHE_TTL_MS) return cachedConfig;
-  return null;
+  return cachedConfig;
 }
 
 // ---- fetch (public, no auth; fetch + res.json() work in both processes) ----

--- a/src/index.ts
+++ b/src/index.ts
@@ -684,24 +684,29 @@ const createWindow = (): void => {
   const isCiRuntime = process.env.CI === 'true' || process.env.CI === '1' || process.env.GITHUB_ACTIONS === 'true';
   const disableAutoUpdater = process.env.NEXUS_DISABLE_AUTO_UPDATE === '1' || process.env.NEXUS_E2E_TEST === '1' || isCiRuntime;
   if (!disableAutoUpdater) {
-    Promise.all([import('./process/services/autoUpdaterService'), import('./process/bridge/updateBridge')])
-      .then(([{ autoUpdaterService }, { createAutoUpdateStatusBroadcast }]) => {
+    Promise.all([import('./process/services/autoUpdaterService'), import('./process/bridge/updateBridge'), import('./common/systemConfig')])
+      .then(([{ autoUpdaterService }, { createAutoUpdateStatusBroadcast }, { fetchSystemConfig, isVersionUpdateEnabled }]) => {
         // Create status broadcast callback that emits via ipcBridge (pure emitter, no window binding)
         const statusBroadcast = createAutoUpdateStatusBroadcast();
         autoUpdaterService.initialize(statusBroadcast);
-        // Skip auto-update check for nightly builds – nightly versions should only be
-        // updated manually via the in-app update modal which already handles nightly isolation.
-        // nightly 版本跳过自动更新检查，避免弹出指向正式 release 版本的更新提醒。
-        // nightly 版本的更新应通过应用内手动检查完成（UpdateModal 已实现 nightly 隔离逻辑）。
-        if (isNightlyBuild) {
-          mainLog('App', 'Nightly build detected, skipping auto-update check');
-        } else {
-          // Check for updates after 3 seconds delay
-          // 3秒后检查更新
-          setTimeout(() => {
-            void autoUpdaterService.checkForUpdatesAndNotify();
-          }, 3000);
-        }
+        // §4.1(3)/§4.4: fill the main-process system-config cache first (eliminates the startup
+        // race where version_update.enabled is read before the cache is populated), then gate.
+        void fetchSystemConfig().then(() => {
+          // Skip auto-update check for nightly builds – nightly versions should only be
+          // updated manually via the in-app update modal which already handles nightly isolation.
+          if (isNightlyBuild) {
+            mainLog('App', 'Nightly build detected, skipping auto-update check');
+          } else if (!isVersionUpdateEnabled()) {
+            // §4.4: server disabled auto-update — skip the check entirely.
+            mainLog('App', 'version_update disabled by server config, skipping auto-update check');
+          } else {
+            // Check for updates after 3 seconds delay
+            // 3秒后检查更新
+            setTimeout(() => {
+              void autoUpdaterService.checkForUpdatesAndNotify();
+            }, 3000);
+          }
+        });
       })
       .catch((error) => {
         console.error('[App] Failed to initialize autoUpdaterService:', error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { SERVER_CONFIG } from './webserver/config/constants';
 import { applyZoomToWindow } from './process/utils/zoom';
 import i18n from '@process/i18n';
 import { mainLog, mainError } from './process/utils/mainLogger';
+import { ensureMainSystemConfig } from './process/services/systemConfigBootstrap';
 import { isNightlyBuild } from './common/buildInfo';
 // @ts-expect-error - electron-squirrel-startup doesn't have types
 import electronSquirrelStartup from 'electron-squirrel-startup';
@@ -891,6 +892,8 @@ const handleAppReady = async (): Promise<void> => {
       return;
     }
 
+    await ensureMainSystemConfig();
+
     const userConfigInfo = loadUserWebUIConfig();
     if (userConfigInfo.exists && userConfigInfo.path) {
       // Config file loaded from user directory
@@ -926,6 +929,8 @@ const handleAppReady = async (): Promise<void> => {
 
     // Wait for backend initialization to complete before proceeding with tray/settings
     await initDone;
+
+    await ensureMainSystemConfig();
 
     // Telemetry: initialize telemetry modules after process config is ready
     try {

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -3,6 +3,13 @@
  * Hub API calls for fetching assistants, categories, and installing from Hub.
  */
 
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import path from 'path';
+import https from 'node:https';
+import http from 'node:http';
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import JSZip from 'jszip';
 import { ipcBridge } from '@/common';
 import type { IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill, IBridgeResponse, IAssistantHubVersionLike } from '@/common/ipcBridge';
 import { assistantManager } from '@/process/AssistantManager';
@@ -10,23 +17,13 @@ import { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCusto
 import { skillManager } from '@/process/SkillManager';
 import { getDatabase } from '@/process/database';
 import { DEFAULT_PRESET_AGENT_TYPE, normalizePresetAgentType } from '@/types/acpTypes';
-import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS } from '@/process/constants/enterpriseStorage';
-import fs from 'fs/promises';
-import fsSync from 'fs';
-import path from 'path';
-import https from 'node:https';
-import http from 'node:http';
-import JSZip from 'jszip';
+import { getSkillHubBaseUrl } from '@/common/systemConfig';
+import { getSkillhubToken } from '@/process/credentialsCache';
 
 const { existsSync } = fsSync;
 
-// Hub API constants (same service as Skill Hub)
-const ASSISTANT_HUB_BASE_URL = 'https://sudoworkhub.sudoprivacy.com/api/assistants';
-const ASSISTANT_HUB_CURSOR_URL = 'https://sudoworkhub.sudoprivacy.com/api/assistants/cursor';
-const ASSISTANT_CATEGORY_URL = 'https://sudoworkhub.sudoprivacy.com/api/categories';
-const AUTHORIZATION = 'sud0@sudo';
 const ASSISTANT_META_FILE = '_sudowork_meta.json';
 const MOSS_ASSISTANT_META_FILE = '_moss_meta.json';
 
@@ -431,8 +428,13 @@ export function initAssistantHubBridge(): void {
       if (category) params.set('category', category);
       if (typeof tenantId === 'string' && tenantId.trim()) params.set('tenant_id', tenantId.trim());
 
-      const response = await fetch(`${ASSISTANT_HUB_CURSOR_URL}?${params}`, {
-        headers: { Authorization: AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('AssistantHub', 'skillhub token not provisioned, skip fetchAssistants');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/assistants/cursor?${params}`, {
+        headers: { Authorization: token },
       });
       const result = await response.json();
 
@@ -522,8 +524,13 @@ export function initAssistantHubBridge(): void {
       }
 
       // 个人模式：从 SudoPrivacy Assistant Hub API 获取分类
-      const response = await fetch(`${ASSISTANT_CATEGORY_URL}?type=1`, {
-        headers: { Authorization: AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('AssistantHub', 'skillhub token not provisioned, skip fetchCategories');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/categories?type=1`, {
+        headers: { Authorization: token },
       });
       const data = await response.json();
       return { success: true, data: data.data || [] };
@@ -583,9 +590,16 @@ export function initAssistantHubBridge(): void {
       }
 
       // 个人模式：从 SudoPrivacy Assistant Hub API 获取详情
-      const url = `${ASSISTANT_HUB_BASE_URL}/${assistantId}`;
+      const token = getSkillhubToken();
+      if (!token) {
+        if (!silent) {
+          mainError('AssistantHub', 'skillhub token not provisioned, skip fetchAssistantDetail');
+        }
+        return { success: false, msg: 'skillhub token missing' };
+      }
+      const url = `${getSkillHubBaseUrl()}/api/assistants/${assistantId}`;
       const response = await fetch(url, {
-        headers: { Authorization: AUTHORIZATION },
+        headers: { Authorization: token },
       });
       const data = await response.json();
       return { success: true, data: data.data };
@@ -604,12 +618,18 @@ export function initAssistantHubBridge(): void {
         return { success: true, data: [] };
       }
 
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('AssistantHub', 'skillhub token not provisioned, skip fetchSkillDetailsByIds');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+
       // Fetch all skills in parallel
       const responses = await Promise.all(
         skillIds.map(async (id) => {
           try {
-            const response = await fetch(`https://sudoworkhub.sudoprivacy.com/api/skills/${id}`, {
-              headers: { Authorization: AUTHORIZATION },
+            const response = await fetch(`${getSkillHubBaseUrl()}/api/skills/${id}`, {
+              headers: { Authorization: token },
             });
             const data = await response.json();
             if (data.success && data.data?.skill) {
@@ -633,6 +653,12 @@ export function initAssistantHubBridge(): void {
   // Download and install assistant from Hub, optionally installing selected associated skills
   ipcBridge.assistantHub.downloadAndInstallAssistant.provider(async ({ assistantName, displayName, sourceUrl, version, checksum, assistantMeta, selectedSkillIds }) => {
     try {
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('AssistantHub', 'skillhub token not provisioned, skip downloadAndInstallAssistant');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+
       // Download zip file
       const zipBuffer = await downloadFile(sourceUrl);
 
@@ -699,8 +725,8 @@ export function initAssistantHubBridge(): void {
 
           // Fetch skill detail from Hub to get name and download URL (for non-builtin skills)
           try {
-            const skillDetailResponse = await fetch(`https://sudoworkhub.sudoprivacy.com/api/skills/${skillId}`, {
-              headers: { Authorization: AUTHORIZATION },
+            const skillDetailResponse = await fetch(`${getSkillHubBaseUrl()}/api/skills/${skillId}`, {
+              headers: { Authorization: token },
             });
             const skillDetailData = await skillDetailResponse.json();
 
@@ -887,6 +913,12 @@ export function registerUploadAssistantToHubBridge() {
     }
 
     try {
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('AssistantHub', 'skillhub token not provisioned, skip uploadAssistantToHub');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+
       // Get custom assistants directory
       const assistantsDir = getCustomAssistantsDir();
       const assistantDir = path.join(assistantsDir, name);
@@ -993,13 +1025,13 @@ export function registerUploadAssistantToHubBridge() {
       formData.append('source_url', zipBlob, zipFileName);
 
       // Upload to Hub API
-      const uploadUrl = ASSISTANT_HUB_BASE_URL;
+      const uploadUrl = `${getSkillHubBaseUrl()}/api/assistants`;
 
       // Real API call
       const response = await fetch(uploadUrl, {
         method: 'POST',
         headers: {
-          Authorization: AUTHORIZATION,
+          Authorization: token,
         },
         body: formData,
       });

--- a/src/process/bridge/imageGenerationBridge.ts
+++ b/src/process/bridge/imageGenerationBridge.ts
@@ -8,7 +8,7 @@ import fs from 'fs/promises';
 import fsSync from 'fs';
 import path from 'path';
 import { app } from 'electron';
-import { DEFAULT_IMAGE_BASE_URL } from '../../common/storage';
+import { getSudorouterBaseUrl, isSudorouterBaseUrl } from '../../common/systemConfig';
 import { detectImageMimeType, IMAGE_TARGET_RAW_SIZE } from '../../common/imageUtils';
 import { ipcBridge } from '../../common';
 import type { IBridgeResponse } from '../../common/ipcBridge';
@@ -95,7 +95,7 @@ export function readSudorouterCredentials(): { baseUrl: string; apiKey: string }
     const config = JSON.parse(raw) as { auth_modes?: { proxy?: Record<string, { baseUrl?: string; apiKey?: string }> } };
     const sr = config?.auth_modes?.proxy?.sudorouter;
     if (sr?.apiKey) {
-      const baseUrl = (sr.baseUrl || DEFAULT_IMAGE_BASE_URL).replace(/\/+$/, '');
+      const baseUrl = (sr.baseUrl || `${getSudorouterBaseUrl()}/v1`).replace(/\/+$/, '');
       return { baseUrl, apiKey: sr.apiKey };
     }
   } catch {
@@ -106,7 +106,7 @@ export function readSudorouterCredentials(): { baseUrl: string; apiKey: string }
     const config = JSON.parse(raw) as { models?: { providers?: Record<string, { baseUrl?: string; apiKey?: string }> } };
     const sr = config?.models?.providers?.sudorouter;
     if (sr?.apiKey) {
-      const baseUrl = (sr.baseUrl || DEFAULT_IMAGE_BASE_URL).replace(/\/+$/, '');
+      const baseUrl = (sr.baseUrl || `${getSudorouterBaseUrl()}/v1`).replace(/\/+$/, '');
       return { baseUrl, apiKey: sr.apiKey };
     }
   } catch (e) {
@@ -147,7 +147,7 @@ export async function resolveImageConfig(): Promise<{ baseUrl: string; apiKey: s
   // Fall back to model.config sudorouter provider
   const providers = (await ProcessConfig.get('model.config').catch((): null => null)) || [];
   for (const provider of providers) {
-    if (provider.baseUrl?.includes('sudorouter.ai') && provider.apiKey) {
+    if (isSudorouterBaseUrl(provider.baseUrl) && provider.apiKey) {
       const baseUrl = provider.baseUrl.replace(/\/+$/, '');
       console.log('[ImageGen] routing user model via model.config sudorouter:', imageModelId);
       return { baseUrl, apiKey: provider.apiKey, model: imageModelId };

--- a/src/process/bridge/index.ts
+++ b/src/process/bridge/index.ts
@@ -38,6 +38,7 @@ import { initAssistantHubBridge } from './assistantHubBridge';
 import { initSudoclawBridge } from './sudoclawBridge';
 import { initInitBridge } from './initBridge';
 import { initSudoworkServerBridge } from './sudoworkServerBridge';
+import { initSystemConfigBridge } from './systemConfigBridge';
 import { initNodeRuntimeBridge } from './nodeRuntimeBridge';
 import { initPythonRuntimeBridge } from './pythonRuntimeBridge';
 import { initFuseTBridge } from './fuseTBridge';
@@ -104,6 +105,7 @@ export function initAllBridges(): void {
   initPythonRuntimeBridge();
   initFuseTBridge();
   initSudoworkServerBridge();
+  initSystemConfigBridge();
   // Safety hook IPC is hidden while the feature is disabled.
   // initSafetyBridge();
   initBdpanBridge();

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -18,12 +18,13 @@ import { syncUserKeyFromScodeConfig } from '@process/services/authProxy/userKeyS
 import { readSettings, removeDisabledMcpServersFromSettings, writeSettings } from '@process/services/mcpServices/agents/ScodeMcpAgent';
 import { getDatabase } from '@process/database';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import { SUDOCLAW_DIR } from '@process/services/sudoclaw/SudoclawInstallService';
+import { writeSudoclawImageGenerationModel } from '@process/bridge/imageGenerationModelSync';
 import { ipcBridge } from '@/common';
 import { modelInputForModelId } from '@/common/imageUtils';
 import type { ScodeModelEntry } from '@/common/ipcBridge';
 import { addScodeAutoModel, extractCustomProvidersFromScodeConfig, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, type ScodeCustomModelProvider } from '@/common/scodeConfig';
-import { SUDOCLAW_DIR } from '@process/services/sudoclaw/SudoclawInstallService';
-import { writeSudoclawImageGenerationModel } from '@process/bridge/imageGenerationModelSync';
+import { getSudorouterBaseUrl } from '@/common/systemConfig';
 
 const TAG = 'ScodeBridge';
 const SUDOCODE_CONFIG_PATH = path.join(SCODE_DIR, 'sudocode.json');
@@ -97,9 +98,6 @@ export function writeScodeImageModel(modelId: string): void {
   mainLog(TAG, `Updated tools.imageGenerationModel to "${modelId}"`);
 }
 
-/** Live model-list endpoint for proxy model discovery. */
-const SPECIFIC_PRICING_URL = 'https://hk.sudorouter.ai/api/specific_pricing';
-
 type SpecificPricingResponse = {
   success?: boolean;
   data?: Array<{ model_id?: string }>;
@@ -117,7 +115,7 @@ type SpecificPricingResponse = {
 export async function syncScodeModelsFromPricing(): Promise<void> {
   let json: SpecificPricingResponse;
   try {
-    const response = await fetch(SPECIFIC_PRICING_URL, { signal: AbortSignal.timeout(15000) });
+    const response = await fetch(`${getSudorouterBaseUrl()}/api/specific_pricing`, { signal: AbortSignal.timeout(15000) });
     json = (await response.json()) as SpecificPricingResponse;
   } catch (err) {
     mainWarn(TAG, `specific_pricing fetch failed, keeping existing models: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
 import fsSync, { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
@@ -13,21 +12,21 @@ import https from 'node:https';
 import http from 'node:http';
 import { app } from 'electron';
 import JSZip from 'jszip';
-import { clearSkillsCache, getSkillsDir, getHubSkillsDir, getCustomSkillsDir, getBuiltinSkillsDir, SKILL_SUBDIRS, ProcessConfig } from '@/process/initStorage';
-import { skillManager, SkillCategory, SkillStatus, ISkillMeta } from '@/process/SkillManager';
 import WorkerManage from '@process/WorkerManage';
 import { serviceManager } from '@process/services/serviceManager';
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { clearSkillsCache, getSkillsDir, getHubSkillsDir, getCustomSkillsDir, getBuiltinSkillsDir, SKILL_SUBDIRS, ProcessConfig } from '@/process/initStorage';
+import { skillManager, SkillCategory, SkillStatus, ISkillMeta } from '@/process/SkillManager';
 import { toAssetUrl } from '@/extensions/assetProtocol';
 import { AcpSkillManager } from '@/process/task/AcpSkillManager';
-import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { ipcBridge } from '@/common';
 import { buildSkillDisplayName, canonicalizeSkillMarkdownPath, findRootSkillMarkdownFileName, isSkillMarkdownFileName, parseSkillFrontmatter, resolveSkillIconFromFiles } from '@/process/utils/skillPackage';
 import { scanSkillDirectory, readAuditReport } from '@/process/services/safety/SkillAuditScanner';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { SKILLS_ROOT_DIR, ENTERPRISE_SKILL_SUBDIRS } from '@/process/constants/enterpriseStorage';
+import { getSkillHubBaseUrl } from '@/common/systemConfig';
+import { getSkillhubToken } from '@/process/credentialsCache';
 
-const SKILL_HUB_BASE_URL = 'https://sudoworkhub.sudoprivacy.com/api/skills';
-const SKILL_HUB_CURSOR_URL = 'https://sudoworkhub.sudoprivacy.com/api/skills/cursor';
-const AUTHORIZATION = 'sud0@sudo';
 const VERSION_FILE_NAME = 'sudowork-version';
 /** Metadata file saved alongside installed hub skills. Prefixed to avoid conflicts with skill content. */
 const SKILL_HUB_META_FILE = '_sudowork_meta.json';
@@ -710,8 +709,13 @@ export function initSkillHubBridge(): void {
       if (query) params.set('query', query);
       if (category) params.set('categories', category);
       if (typeof tenantId === 'string' && tenantId.trim()) params.set('tenant_id', tenantId.trim());
-      const response = await fetch(`${SKILL_HUB_CURSOR_URL}?${params}`, {
-        headers: { Authorization: AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('SkillHub', 'skillhub token not provisioned, skip fetchSkills');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/skills/cursor?${params}`, {
+        headers: { Authorization: token },
       });
       const result = await response.json();
       // API returns { success, message, data: { skills, next_cursor, has_more } }
@@ -758,8 +762,13 @@ export function initSkillHubBridge(): void {
       }
 
       // 个人模式：从 SudoPrivacy Skill Hub API 获取分类
-      const response = await fetch('https://sudoworkhub.sudoprivacy.com/api/categories', {
-        headers: { Authorization: AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('SkillHub', 'skillhub token not provisioned, skip fetchCategories');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/categories`, {
+        headers: { Authorization: token },
       });
       const data = await response.json();
       return { success: true, data: data.data || [] };
@@ -822,8 +831,13 @@ export function initSkillHubBridge(): void {
       }
 
       // 个人模式：从 SudoPrivacy Skill Hub API 获取详情
-      const response = await fetch(`${SKILL_HUB_BASE_URL}/${skillId}`, {
-        headers: { Authorization: AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        mainError('SkillHub', 'skillhub token not provisioned, skip fetchSkillDetail');
+        return { success: false, msg: 'skillhub token missing' };
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/skills/${skillId}`, {
+        headers: { Authorization: token },
       });
       const data = await response.json();
       return { success: true, data: data.data };
@@ -1005,23 +1019,23 @@ export function initSkillHubBridge(): void {
         category: skill.category,
         meta: skill.meta
           ? {
-            ...skill.meta,
-            // 补充 ISkillHubMeta 必填字段
-            name: skill.meta.name || skill.name,
-            id: skill.meta.id || skill.name,
-            display_name: skill.meta.display_name || skill.name,
-            description: skill.meta.description || '',
-            icon: skill.meta.icon || '',
-            emoji: skill.meta.emoji ?? null,
-            category: skill.meta.category || '',
-            categories: skill.meta.categories || [],
-            applicable_scenarios: skill.meta.applicable_scenarios ?? null,
-            core_features: skill.meta.core_features ?? null,
-            homepage: skill.meta.homepage ?? null,
-            author_id: skill.meta.author_id || '',
-            installed_version: skill.meta.installed_version || skill.version,
-            installed_at: skill.meta.installed_at || '',
-          }
+              ...skill.meta,
+              // 补充 ISkillHubMeta 必填字段
+              name: skill.meta.name || skill.name,
+              id: skill.meta.id || skill.name,
+              display_name: skill.meta.display_name || skill.name,
+              description: skill.meta.description || '',
+              icon: skill.meta.icon || '',
+              emoji: skill.meta.emoji ?? null,
+              category: skill.meta.category || '',
+              categories: skill.meta.categories || [],
+              applicable_scenarios: skill.meta.applicable_scenarios ?? null,
+              core_features: skill.meta.core_features ?? null,
+              homepage: skill.meta.homepage ?? null,
+              author_id: skill.meta.author_id || '',
+              installed_version: skill.meta.installed_version || skill.version,
+              installed_at: skill.meta.installed_at || '',
+            }
           : undefined,
       }));
       return { success: true, data: result };

--- a/src/process/bridge/sudoclawBridge.ts
+++ b/src/process/bridge/sudoclawBridge.ts
@@ -4,19 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
-import type { SudoclawConfig } from '@/common/ipcBridge';
-import { cachePut } from '@common/nexus/secret-cache';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { spawn } from 'child_process';
+import { cachePut } from '@common/nexus/secret-cache';
 import WorkerManage from '../WorkerManage';
 import { SUDOCLAW_DIR, getSudoclawInstalledVersion, isSudoclawInstalled, SUDOCLAW_DEFAULT_PORT, installSudoclawManually, removeSudoclawCli } from '../services/sudoclaw/SudoclawInstallService';
 import { syncSudoclawRuntimeState } from '../services/sudoclaw/sudoclawRuntimeSync';
 import { checkSudoclawHealth, SUDOCLAW_HEALTH_TIMEOUT_MS } from '../services/sudoclaw/sudoclawHealth';
 import { getNodeBinaryPath } from '../services/claudeCli/NodeRuntimeService';
 import { mainError, mainLog, mainWarn } from '../utils/mainLogger';
+import { getSudorouterBaseUrl } from '@/common/systemConfig';
+import type { SudoclawConfig } from '@/common/ipcBridge';
+import { ipcBridge } from '@/common';
 
 interface InstallState {
   installing: boolean;
@@ -90,7 +91,7 @@ function syncToClaudeSettings(config: SudoclawConfig): void {
   // Create new settings with fixed values
   const settings: Record<string, unknown> = {
     env: {
-      ANTHROPIC_BASE_URL: 'https://hk.sudorouter.ai',
+      ANTHROPIC_BASE_URL: getSudorouterBaseUrl(),
       ANTHROPIC_AUTH_TOKEN: apiKey,
       ANTHROPIC_MODEL: modelId || 'gemini-3.5-flash',
     },

--- a/src/process/bridge/sudoworkServerBridge.ts
+++ b/src/process/bridge/sudoworkServerBridge.ts
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getSudoworkServerBaseUrlSync } from '@process/initStorage';
 import { sudoworkServer } from '@/common/ipcBridge';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
 
 export function initSudoworkServerBridge(): void {
   sudoworkServer.getConfig.provider(async () => {
-    // Always return hardcoded URL, ignore any saved config
-    return { baseUrl: SUDOWORK_SERVER_BASE_URL };
+    // Resolve on every call so user-updated `system.sudoworkServerUrl` takes effect immediately.
+    return { baseUrl: getSudoworkServerBaseUrlSync() };
   });
 
   sudoworkServer.updateConfig.provider(async (_config) => {
-    // No-op: server URL is now hardcoded and cannot be changed via config
-    // This handler exists for backward compatibility but does nothing
+    // No-op: this legacy IPC channel does not own writes to the new
+    // `system.sudoworkServerUrl` setting (ModeSetup writes ConfigStorage directly).
+    // Kept for backward compatibility with renderer code that may still invoke it.
   });
 }

--- a/src/process/bridge/systemConfigBridge.ts
+++ b/src/process/bridge/systemConfigBridge.ts
@@ -16,7 +16,7 @@
 
 import { mainError } from '@process/utils/mainLogger';
 import { systemConfig } from '@/common/ipcBridge';
-import { decryptCredentials } from '@/common/systemConfig';
+import { decryptCredentials, setSystemConfigCache } from '@/common/systemConfig';
 import { setCredentialsCache } from '@/process/credentialsCache';
 import { flushCrashReporter } from '@/process/telemetry/CrashReporter';
 import { reinitTelemetryEncryptor } from '@/process/telemetry/TelemetryEncryptor';
@@ -38,5 +38,13 @@ export function initSystemConfigBridge(): void {
       mainError('systemConfig', 'decrypt/cache credentials failed:', err);
       return { success: true, data: { cached: false } };
     }
+  });
+
+  // Sync renderer-fetched systemConfig snapshot into the main-process cache.
+  // See channel doc in src/common/ipcBridge.ts for the rationale (per-process module
+  // cache means renderer fills do NOT propagate to main without this hop).
+  systemConfig.syncFromRenderer.provider(async ({ data }) => {
+    setSystemConfigCache(data);
+    return { success: true };
   });
 }

--- a/src/process/bridge/systemConfigBridge.ts
+++ b/src/process/bridge/systemConfigBridge.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * System Config Bridge — main-side handler for the server-driven credentials envelope.
+ *
+ * The renderer holds the JWT and fetches the AES-256-GCM envelope itself, then forwards
+ * {nonce, ciphertext} here. The main process decrypts it, caches the plaintext in the
+ * main-only `credentialsCache`, and triggers CrashReporter backfill. Because both login
+ * paths (active login `handleLoginSuccess` + restart restore `refresh`) route through
+ * this handler, the CrashReporter backfill naturally covers both (decision D8 + §6.3).
+ */
+
+import { mainError } from '@process/utils/mainLogger';
+import { systemConfig } from '@/common/ipcBridge';
+import { decryptCredentials } from '@/common/systemConfig';
+import { setCredentialsCache } from '@/process/credentialsCache';
+import { flushCrashReporter } from '@/process/telemetry/CrashReporter';
+import { reinitTelemetryEncryptor } from '@/process/telemetry/TelemetryEncryptor';
+
+export function initSystemConfigBridge(): void {
+  systemConfig.cacheCredentials.provider(async ({ nonce, ciphertext }) => {
+    try {
+      const credentials = await decryptCredentials(nonce, ciphertext);
+      setCredentialsCache(credentials);
+      // Re-init the qms encryptor so an encryption_required=true dispatch swaps in the
+      // server's public key (D6); no-op effect when encryption_required is false.
+      void reinitTelemetryEncryptor().catch((err) => mainError('systemConfig', 'encryptor reinit failed:', err));
+      // Credentials ready — flush any crash events queued before login (§6.3 backfill).
+      void flushCrashReporter().catch((err) => mainError('systemConfig', 'post-credentials crash flush failed:', err));
+      return { success: true, data: { cached: true } };
+    } catch (err) {
+      // D8: never block login on credential failure. Reporters skip via identity gating
+      // (§6.1) when keys are absent, so a decrypt failure just logs and continues.
+      mainError('systemConfig', 'decrypt/cache credentials failed:', err);
+      return { success: true, data: { cached: false } };
+    }
+  });
+}

--- a/src/process/bridge/updateBridge.ts
+++ b/src/process/bridge/updateBridge.ts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ipcBridge } from '@/common';
-import type { UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult, UpdateReleaseInfo, GitHubReleaseAsset } from '@/common/updateTypes';
-import { uuid } from '@/common/utils';
 import { app } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import semver from 'semver';
-import { autoUpdaterService } from '../services/autoUpdaterService';
 import { mainLog, mainError } from '@process/utils/mainLogger';
+import { autoUpdaterService } from '../services/autoUpdaterService';
+import { uuid } from '@/common/utils';
+import type { UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult, UpdateReleaseInfo, GitHubReleaseAsset } from '@/common/updateTypes';
+import { ipcBridge } from '@/common';
 import { isNightlyBuild, buildDate, buildCommit, isNightlyTag, parseNightlyDate, parseNightlyCommit, compareNightlyTags } from '@/common/buildInfo';
-import { COS_RELEASE_BASE } from '@/shared/cos';
+import { getCosReleaseBase } from '@/common/systemConfig';
 
 type GitHubReleaseApiAsset = {
   name: string;
@@ -57,8 +57,18 @@ const ALLOWED_DOWNLOAD_HOSTS = new Set<string>([
 ]);
 const MAX_REDIRECTS = 8;
 
-/** COS mirror base URL for Chinese users (role-based release bucket) */
-const COS_MIRROR_BASE = `${COS_RELEASE_BASE}/sudowork/release/latest`;
+/** COS mirror base URL (release bucket; server-driven cos_domain). */
+const getCosMirrorBase = (): string => `${getCosReleaseBase()}/sudowork/release/latest`;
+
+/** Whether a download host is allowlisted: the static set, or the server-dispatched cos release host (§4.4). */
+const isAllowedDownloadHost = (hostname: string): boolean => {
+  if (ALLOWED_DOWNLOAD_HOSTS.has(hostname)) return true;
+  try {
+    return new URL(getCosReleaseBase()).host === hostname;
+  } catch {
+    return false;
+  }
+};
 
 /** COS yml file structure */
 interface COSYmlInfo {
@@ -139,13 +149,13 @@ const buildReleaseInfoFromCOS = (ymlInfo: COSYmlInfo): UpdateReleaseInfo => {
     assets: [
       {
         name: fileName,
-        url: `${COS_MIRROR_BASE}/${fileName}`,
+        url: `${getCosMirrorBase()}/${fileName}`,
         size: ymlInfo.files?.[0]?.size || 0,
       },
     ],
     recommendedAsset: {
       name: fileName,
-      url: `${COS_MIRROR_BASE}/${fileName}`,
+      url: `${getCosMirrorBase()}/${fileName}`,
       size: ymlInfo.files?.[0]?.size || 0,
     },
   };
@@ -156,7 +166,7 @@ const buildReleaseInfoFromCOS = (ymlInfo: COSYmlInfo): UpdateReleaseInfo => {
  */
 const checkUpdateFromCOS = async (): Promise<UpdateReleaseInfo | null> => {
   const ymlFileName = getCOSYmlFileName();
-  const ymlUrl = `${COS_MIRROR_BASE}/${ymlFileName}`;
+  const ymlUrl = `${getCosMirrorBase()}/${ymlFileName}`;
 
   mainLog('Update', `Checking update from COS mirror: ${ymlUrl}`);
 
@@ -326,7 +336,7 @@ const selectDownloadSource = async (originalUrl: string, originalName: string): 
   }
 
   // Use COS mirror
-  const cosUrl = `${COS_MIRROR_BASE}/${convertToCOSName(originalName)}`;
+  const cosUrl = `${getCosMirrorBase()}/${convertToCOSName(originalName)}`;
   mainLog('Update', `GitHub unreachable, using COS mirror: ${cosUrl}`);
   return cosUrl;
 };
@@ -342,7 +352,7 @@ const assertAllowedUrl = (rawUrl: string) => {
   if (parsed.protocol !== 'https:') {
     throw new Error('Only https download URLs are allowed');
   }
-  if (!ALLOWED_DOWNLOAD_HOSTS.has(parsed.hostname)) {
+  if (!isAllowedDownloadHost(parsed.hostname)) {
     throw new Error(`Download host not allowed: ${parsed.hostname}`);
   }
 };

--- a/src/process/credentialsCache.ts
+++ b/src/process/credentialsCache.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Main-process-only cache for decrypted credentials plaintext.
+ *
+ * Sensitivity boundary: the decrypted credential plaintext (keys/tokens) lives ONLY in the
+ * main process — it never enters `src/common/` (which the renderer also bundles) or the
+ * renderer itself. Only the encrypted envelope crosses the IPC boundary; decryption happens
+ * here (see `decryptCredentials` in `src/common/systemConfig.ts`, invoked from the main-side
+ * IPC handler).
+ *
+ * Callers read keys via the helpers below; a missing/empty value resolves to `null`, which
+ * callers treat as "credential absent" → skip the request/report + log an error (decision D8),
+ * never silently falling back to a hardcoded key.
+ */
+
+import type { DecryptedCredentials } from '@/common/systemConfig';
+
+let cached: DecryptedCredentials | null = null;
+
+/** Store/replace the decrypted credentials (called from the main-side IPC handler after decryption). */
+export function setCredentialsCache(credentials: DecryptedCredentials | null): void {
+  cached = credentials;
+}
+
+export function getCredentialsCache(): DecryptedCredentials | null {
+  return cached;
+}
+
+function nonEmpty(value: string | undefined | null): string | null {
+  return value && value.trim() ? value : null;
+}
+
+/** Skillhub bearer token (header `Authorization`); null when not provisioned. */
+export function getSkillhubToken(): string | null {
+  return nonEmpty(cached?.skillhub?.token);
+}
+
+/** qms product-improvement `X-API-Key`; null when not provisioned. */
+export function getProductImprovementApiKey(): string | null {
+  return nonEmpty(cached?.product_improvement?.api_key);
+}
+
+/** qms product-improvement encryption public key (PEM); null unless `encryption_required=true` + provisioned. */
+export function getProductImprovementPublicKey(): string | null {
+  return nonEmpty(cached?.product_improvement?.public_key);
+}
+
+/** Log-upload `X-API-Key`; null when not provisioned. */
+export function getLogReportKey(): string | null {
+  return nonEmpty(cached?.log_report?.key);
+}

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -9,17 +9,18 @@ import fs from 'fs/promises';
 import path from 'path';
 import { app } from 'electron';
 import { application } from '../common/ipcBridge';
-import type { TMessage } from '@/common/chatLib';
-import { ASSISTANT_PRESETS } from '@/common/presets/assistantPresets';
 import type { IChatConversationRefer, IConfigStorageRefer, IEnvStorageRefer, IMcpServer } from '../common/storage';
 import { ChatMessageStorage, ChatStorage, ConfigStorage, EnvStorage } from '../common/storage';
 import { copyDirectoryRecursively, ensureDirectory, getConfigPath, getDataPath, getTempPath, verifyDirectoryFiles } from './utils';
 import { getDatabase } from './database/export';
-import type { AcpBackendConfig } from '@/types/acpTypes';
 import { perfLog, mainLog, mainWarn, mainError } from './utils/mainLogger';
 import { SKILL_SUBDIRS, ENTERPRISE_SKILL_SUBDIRS } from './constants/skillStorage';
 import { ASSISTANT_SUBDIRS, ENTERPRISE_ASSISTANT_SUBDIRS } from './constants/assistantStorage';
+import type { AcpBackendConfig } from '@/types/acpTypes';
+import { ASSISTANT_PRESETS } from '@/common/presets/assistantPresets';
+import type { TMessage } from '@/common/chatLib';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { BUILD_SUDOWORK_SERVER_BASE_URL, normalizeSudoworkServerUrl } from '@/common/sudoworkServer';
 // Platform and architecture types (moved from deleted updateConfig)
 type PlatformType = 'win32' | 'darwin' | 'linux';
 type ArchitectureType = 'x64' | 'arm64' | 'ia32' | 'arm';
@@ -1172,6 +1173,20 @@ export const ProcessChat = chatFile;
 export const ProcessChatMessage = chatMessageFile;
 
 export const ProcessEnv = envFile;
+
+/**
+ * Main-process sync resolver for the sudowork-server base URL.
+ *
+ * Mirrors the renderer-side `getSudoworkServerBaseUrl()` priority chain
+ * (user setting > build define > literal fallback), but reads `ProcessConfig`
+ * synchronously since main-process call sites are not necessarily async.
+ *
+ * Read on every call — do NOT cache the result.
+ */
+export function getSudoworkServerBaseUrlSync(): string {
+  const raw = configFile.getSync('system.sudoworkServerUrl');
+  return normalizeSudoworkServerUrl(raw) ?? BUILD_SUDOWORK_SERVER_BASE_URL;
+}
 
 export const getSystemDir = () => {
   return {

--- a/src/process/services/authProxy/configItemsLoader.ts
+++ b/src/process/services/authProxy/configItemsLoader.ts
@@ -3,18 +3,16 @@
  * and maintains an in-memory cache for Auth Proxy URL matching.
  */
 
-import type { AuthProxyRule } from '@/common/types/authProxy';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { getSudoworkServerBaseUrlSync } from '@process/initStorage';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { adaptConfigItems, adaptConfigItem } from './configItemsAdapter';
+import type { AuthProxyRule } from '@/common/types/authProxy';
 
 // ============================================================================
 // Cache
 // ============================================================================
 
-const CONFIG_ITEMS_API = `${SUDOWORK_SERVER_BASE_URL}/api/v1/config/items`;
-
-let rulesCache: Map<number, AuthProxyRule> = new Map();
+const rulesCache: Map<number, AuthProxyRule> = new Map();
 let lastSuccessfulRules: AuthProxyRule[] = [];
 let rawConfigItemsCache: RawConfigItem[] = [];
 
@@ -80,12 +78,9 @@ export function findRuleForUrl(url: string, minimatchFn: (str: string, pattern: 
  * @param accessToken - User's access token for sudowork-server API
  * @param enabledConfigItemIds - IDs of config items the user has enabled
  */
-export async function refreshRules(
-  accessToken: string,
-  enabledConfigItemIds: number[],
-): Promise<AuthProxyRule[]> {
+export async function refreshRules(accessToken: string, enabledConfigItemIds: number[]): Promise<AuthProxyRule[]> {
   try {
-    const response = await fetch(CONFIG_ITEMS_API, {
+    const response = await fetch(`${getSudoworkServerBaseUrlSync()}/api/v1/config/items`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 

--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { EventEmitter } from 'events';
 import { autoUpdater } from 'electron-updater';
 import type { ProgressInfo, UpdateInfo } from 'electron-updater';
 import log from 'electron-log';
-import { EventEmitter } from 'events';
-import { COS_RELEASE_BASE } from '@/shared/cos';
+import { getCosReleaseBase, isVersionUpdateEnabled } from '@/common/systemConfig';
 
-/** COS mirror base URL for Chinese users (role-based release bucket) */
-const COS_MIRROR_BASE = `${COS_RELEASE_BASE}/sudowork/release/latest`;
+/** COS mirror base URL for Chinese users (release bucket, server-driven cos_domain) */
+const getCosMirrorBase = (): string => `${getCosReleaseBase()}/sudowork/release/latest`;
 
 /** Timeout for GitHub API accessibility check */
 const GITHUB_API_TIMEOUT = 5000; // 5 seconds
@@ -248,11 +248,11 @@ class AutoUpdaterService extends EventEmitter {
   async switchToMirror(): Promise<void> {
     autoUpdater.setFeedURL({
       provider: 'generic',
-      url: COS_MIRROR_BASE,
+      url: getCosMirrorBase(),
     });
 
     this._mirrorStatus = { useMirror: true, reason: 'github_unreachable' };
-    log.info(`Switched to COS mirror: ${COS_MIRROR_BASE}/${this.getYmlFileName()}`);
+    log.info(`Switched to COS mirror: ${getCosMirrorBase()}/${this.getYmlFileName()}`);
   }
 
   private setupEventHandlers(): void {
@@ -327,6 +327,9 @@ class AutoUpdaterService extends EventEmitter {
   }
 
   async checkForUpdates(): Promise<{ success: boolean; updateInfo?: UpdateInfo; error?: string }> {
+    if (!isVersionUpdateEnabled()) {
+      return { success: false, error: 'version_update disabled by server config' };
+    }
     try {
       if (!this._isInitialized) {
         throw new Error('AutoUpdaterService not initialized');
@@ -355,6 +358,9 @@ class AutoUpdaterService extends EventEmitter {
   }
 
   async downloadUpdate(): Promise<{ success: boolean; error?: string }> {
+    if (!isVersionUpdateEnabled()) {
+      return { success: false, error: 'version_update disabled by server config' };
+    }
     try {
       if (!this._isInitialized) {
         throw new Error('AutoUpdaterService not initialized');
@@ -391,6 +397,9 @@ class AutoUpdaterService extends EventEmitter {
    * Check for updates and notify (for startup)
    */
   async checkForUpdatesAndNotify(): Promise<void> {
+    if (!isVersionUpdateEnabled()) {
+      return;
+    }
     try {
       // Ensure clean state: prevent stale allowDowngrade=true from prior setAllowPrerelease(true) calls
       autoUpdater.allowDowngrade = false;

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -12,6 +12,8 @@ import { initStatusManager } from '../initStatus';
 import { isSudoclawHealthPayload, SUDOCLAW_HEALTH_TIMEOUT_MS, type SudoclawHealthPayload } from '../sudoclaw/sudoclawHealth';
 import { AdbResultSidechannel } from '../sudoclaw/AdbResultSidechannel';
 import { runtimeInstaller } from './RuntimeInstaller';
+import { getSkillHubBaseUrl } from '@/common/systemConfig';
+import { getSkillhubToken } from '@/process/credentialsCache';
 
 type SudoclawGateway = import('@/agent/sudoclaw/SudoclawGatewayManager').OpenClawGatewayManager;
 
@@ -522,6 +524,15 @@ export class ServiceManager {
         mainWarn('ServiceManager', 'Could not read sudorouter provider creds from sudoclaw.json', err);
       }
 
+      // Server-driven skillhub address + token injected into the gateway subprocess env so
+      // child scripts (e.g. skills/_builtin/.../sudoclaw-skill.mjs) follow the dispatched
+      // values instead of their hardcoded fallbacks (§4.3).
+      const skillhubEnv: Record<string, string> = {};
+      const skillhubBase = getSkillHubBaseUrl();
+      const skillhubToken = getSkillhubToken();
+      if (skillhubBase) skillhubEnv.SKILLHUB_BASE_URL = skillhubBase;
+      if (skillhubToken) skillhubEnv.SKILLHUB_AUTHORIZATION = skillhubToken;
+
       this.gateway = new OpenClawGatewayManager({
         port: SUDOCLAW_DEFAULT_PORT,
         stateDir: SUDOCLAW_DIR,
@@ -532,6 +543,7 @@ export class ServiceManager {
           ...pythonPathEnv,
           ...sudoworkBinEnv,
           ...sudorouterEnv,
+          ...skillhubEnv,
         },
         forceSubprocessGateway: true,
       });

--- a/src/process/services/sudoclaw/SudoclawInstallService.ts
+++ b/src/process/services/sudoclaw/SudoclawInstallService.ts
@@ -22,9 +22,10 @@ import * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
-import runtimeVersions from '@/shared/runtime-versions.json';
 import { extractTarGzWithProgress } from '../archiveProgress';
+import runtimeVersions from '@/shared/runtime-versions.json';
 import { buildVersion } from '@/common/buildInfo';
+import { getSudorouterBaseUrl } from '@/common/systemConfig';
 
 type SudoclawInstallResult = {
   installed: boolean;
@@ -72,7 +73,6 @@ export const SUDOCLAW_CONFIG_PATH = path.join(SUDOCLAW_DIR, CONFIG_FILENAME);
 const SUDOCLAW_DEFAULT_GATEWAY_RELOAD = {
   mode: 'hot' as const,
 };
-const SUDOCLAW_TAVILY_WEB_SEARCH_BASE_URL = 'https://hk.sudorouter.ai/search/tavily';
 
 /** Remove only the extracted Sudoclaw CLI runtime, preserving user config and workspace data. */
 export function removeSudoclawCli(): void {
@@ -470,7 +470,7 @@ export function repairSudoclawConfig(): void {
               webSearch: {
                 ...existingWebSearch,
                 ...(shouldBackfillApiKey ? { apiKey: sudorouterApiKey } : {}),
-                ...(shouldBackfillBaseUrl ? { baseUrl: SUDOCLAW_TAVILY_WEB_SEARCH_BASE_URL } : {}),
+                ...(shouldBackfillBaseUrl ? { baseUrl: `${getSudorouterBaseUrl()}/search/tavily` } : {}),
               },
             },
           };
@@ -646,12 +646,12 @@ export function ensureDefaultConfig(): void {
       mode: 'merge' as const,
       providers: {
         sudorouter: {
-          baseUrl: 'https://hk.sudorouter.ai/v1',
+          baseUrl: `${getSudorouterBaseUrl()}/v1`,
           api: 'google-generative-ai',
           models: [{ id: 'gemini-3.5-flash', name: 'gemini-3.5-flash', input: ['text', 'image'] }],
         },
         'sudorouter-gemini-3.5-flash': {
-          baseUrl: 'https://hk.sudorouter.ai/v1',
+          baseUrl: `${getSudorouterBaseUrl()}/v1`,
           api: 'google-generative-ai',
           models: [{ id: 'gemini-3.5-flash', name: 'gemini-3.5-flash', input: ['text', 'image'] }],
         },
@@ -672,7 +672,7 @@ export function ensureDefaultConfig(): void {
           enabled: true,
           config: {
             webSearch: {
-              baseUrl: SUDOCLAW_TAVILY_WEB_SEARCH_BASE_URL,
+              baseUrl: `${getSudorouterBaseUrl()}/search/tavily`,
             },
           },
         },

--- a/src/process/services/sudoclaw/sudoclawRuntimeSync.ts
+++ b/src/process/services/sudoclaw/sudoclawRuntimeSync.ts
@@ -1,8 +1,9 @@
-import type { SudoclawConfig, SudoclawProvider } from '@/common/ipcBridge';
-import { cachePut } from '@/common/nexus/secret-cache';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import type { SudoclawConfig, SudoclawProvider } from '@/common/ipcBridge';
+import { cachePut } from '@/common/nexus/secret-cache';
+import { getSudorouterBaseUrl } from '@/common/systemConfig';
 
 type RuntimeAgentModelsFile = {
   providers?: Record<string, Record<string, unknown> & { models?: Array<Record<string, unknown>> }>;
@@ -195,7 +196,7 @@ export function buildClaudeSettings(config: SudoclawConfig): Record<string, unkn
 
   return {
     env: {
-      ANTHROPIC_BASE_URL: 'https://hk.sudorouter.ai',
+      ANTHROPIC_BASE_URL: getSudorouterBaseUrl(),
       ANTHROPIC_AUTH_TOKEN: apiKey,
       ANTHROPIC_MODEL: modelId || 'gemini-3.5-flash',
     },

--- a/src/process/services/systemConfigBootstrap.ts
+++ b/src/process/services/systemConfigBootstrap.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Main-process systemConfig cache bootstrap.
+ *
+ * Why this exists:
+ *   The `src/common/systemConfig` module has ONE instance per process. The renderer
+ *   fills its own copy via `main.tsx` / `useSystemLoginMethod`, but the MAIN process
+ *   has no equivalent startup-time fill — historically the only main-side `fetchSystemConfig`
+ *   call lived inside the autoUpdater branch (`src/index.ts`), which is gated behind
+ *   `NEXUS_DISABLE_AUTO_UPDATE / NEXUS_E2E_TEST / CI`. When that branch is disabled (or
+ *   when its promise does not resolve), `getSkillHubBaseUrl()` / `getSudorouterBaseUrl()`
+ *   in the main process fall back to the hardcoded production URL — which then rejects
+ *   server-dispatched dev tokens with 401.
+ *
+ * Contract:
+ *   - Call once during app startup, after `initializeProcess()` (so ConfigStorage and IPC
+ *     bridges are ready), and BEFORE any main-side reader of the systemConfig cache runs.
+ *   - Awaits `fetchSystemConfig()` to completion so the cache is filled before returning.
+ *   - Never throws — startup must not be blocked by a network failure. Errors are logged
+ *     via mainError and swallowed.
+ *   - Idempotent: safe to call multiple times (each call replaces the module cache).
+ */
+
+import { mainLog, mainError } from '@process/utils/mainLogger';
+import { fetchSystemConfig } from '@/common/systemConfig';
+
+export async function ensureMainSystemConfig(): Promise<void> {
+  mainLog('systemConfigBootstrap', 'ensureMainSystemConfig start');
+  try {
+    const data = await fetchSystemConfig();
+    mainLog('systemConfigBootstrap', 'ensureMainSystemConfig done', {
+      hasData: data !== null,
+      loginMethod: data?.login_method ?? null,
+      skillhubBaseurl: data?.skillhub_baseurl ?? null,
+      sudorouterBaseurl: data?.sudorouter_baseurl ?? null,
+      logReportBaseurl: data?.log_report?.baseurl ?? null,
+      versionUpdateEnabled: data?.version_update?.enabled ?? null,
+      productImprovementEnabled: data?.product_improvement?.enabled ?? null,
+    });
+  } catch (err) {
+    // fetchSystemConfig is documented to internally try/catch and return null on failure;
+    // this catch is the safety net for any unexpected rejection path. Never re-throw.
+    mainError('systemConfigBootstrap', 'ensureMainSystemConfig failed (swallowed)', {
+      name: err instanceof Error ? err.name : typeof err,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/process/telemetry/CrashReporter.ts
+++ b/src/process/telemetry/CrashReporter.ts
@@ -18,7 +18,7 @@
 import { app } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { ProcessConfig } from '../initStorage';
+import { ProcessConfig, getSudoworkServerBaseUrlSync } from '../initStorage';
 import { buildVersion } from '../../common/buildInfo';
 import type { NativeCrashEvent, RendererCrashEvent, JsExceptionEvent, Breadcrumb, CrashContext, CrashEventBase, CrashBatchRequest, CrashBatchResponse, StoredCrashEvent, CrashReporterConfig, CrashProcessType, CrashReason } from '../../shared/types/crash';
 import { DEFAULT_CRASH_REPORTER_CONFIG } from '../../shared/types/crash';
@@ -672,7 +672,10 @@ export class CrashReporter {
 
   /** 发送批量请求 */
   private async sendBatch(request: CrashBatchRequest): Promise<CrashBatchResponse> {
-    const url = this.config.serverUrl!;
+    // 现读：用户自定义 telemetry.serverUrl 优先（转换 /telemetry/batch → /crash/events/batch）；
+    // 否则用现读的 sudowork-server baseUrl 派生 crash 上报地址
+    const customServerUrl = await ProcessConfig.get('telemetry.serverUrl').catch(() => undefined as unknown as string | undefined);
+    const url = customServerUrl ? customServerUrl.replace('/telemetry/batch', '/crash/events/batch') : `${getSudoworkServerBaseUrlSync()}/api/v1/crash/events/batch`;
     const encryptor = getTelemetryEncryptor();
 
     try {

--- a/src/process/telemetry/CrashReporter.ts
+++ b/src/process/telemetry/CrashReporter.ts
@@ -24,16 +24,15 @@ import type { NativeCrashEvent, RendererCrashEvent, JsExceptionEvent, Breadcrumb
 import { DEFAULT_CRASH_REPORTER_CONFIG } from '../../shared/types/crash';
 import { mapElectronArch } from '../../shared/types/telemetry';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
+import { getProductImprovementApiKey } from '../credentialsCache';
 import { getTelemetryEncryptor, initTelemetryEncryptor } from './TelemetryEncryptor';
 import { getUserContextSync } from './UserContext';
 import { ENCRYPTION_CONFIG } from './keys';
+import { isProductImprovementEnabled } from '@/common/systemConfig';
 
 // ============================================================
 // 常量定义
 // ============================================================
-
-/** sudowork-qms API Key - 用于认证上报请求 */
-const API_KEY = 'sk-8f3a2b1c9d5e7f6a4b3c2d1e8f9a0b7c';
 
 /** 本地存储文件名 */
 const STORAGE_FILE_NAME = 'crash-cache.json';
@@ -430,7 +429,7 @@ export class CrashReporter {
    * 用于应用退出前上报剩余事件
    */
   public async flushAll(): Promise<void> {
-    if (!isPersonalMode()) {
+    if (!isPersonalMode() || !isProductImprovementEnabled()) {
       this.eventQueue = [];
       this.cachedEvents = [];
       this.breadcrumbs = [];
@@ -515,7 +514,7 @@ export class CrashReporter {
    * 否则缓存事件，等待初始化后上报
    */
   private cacheOrAddEvent(event: StoredCrashEvent): void {
-    if (!isPersonalMode()) {
+    if (!isPersonalMode() || !isProductImprovementEnabled()) {
       this.cachedEvents = [];
       return;
     }
@@ -611,7 +610,7 @@ export class CrashReporter {
 
   /** 执行批量上报 */
   private async flush(): Promise<void> {
-    if (!isPersonalMode()) {
+    if (!isPersonalMode() || !isProductImprovementEnabled()) {
       this.eventQueue = [];
       this.cachedEvents = [];
       this.breadcrumbs = [];
@@ -679,11 +678,17 @@ export class CrashReporter {
     const encryptor = getTelemetryEncryptor();
 
     try {
+      const apiKey = getProductImprovementApiKey();
+      if (!apiKey) {
+        // D8: product_improvement api_key not provisioned — skip upload.
+        mainError('CrashReporter', 'product_improvement api_key not provisioned, skip sendBatch');
+        return { success: false, received: 0, error: 'product_improvement api_key missing' };
+      }
       // 构建请求体
       let body: string;
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
-        'X-API-Key': API_KEY,
+        'X-API-Key': apiKey,
       };
 
       // 如果加密器可用，使用加密请求

--- a/src/process/telemetry/TelemetryBatchReporter.ts
+++ b/src/process/telemetry/TelemetryBatchReporter.ts
@@ -17,7 +17,7 @@
 import { app } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { ProcessConfig } from '../initStorage';
+import { ProcessConfig, getSudoworkServerBaseUrlSync } from '../initStorage';
 import { buildVersion } from '../../common/buildInfo';
 import type { TelemetryEvent, TelemetryBatchRequest, TelemetryBatchResponse, TelemetryConfig, StoredTelemetryEvent, PerfTelemetryEvent, ConversationTelemetryEvent, InstallTelemetryEvent, TurnTelemetryEvent, StepTelemetryEvent, PerfData, ConversationData, InstallData, TurnData, StepData } from '../../shared/types/telemetry';
 import { mapElectronArch, DEFAULT_TELEMETRY_CONFIG } from '../../shared/types/telemetry';
@@ -447,7 +447,9 @@ export class TelemetryBatchReporter {
 
   /** 发送批量请求 */
   private async sendBatch(request: TelemetryBatchRequest): Promise<TelemetryBatchResponse> {
-    const url = this.config.serverUrl!;
+    // 现读：用户自定义 telemetry.serverUrl 优先；否则用现读的 sudowork-server baseUrl 派生
+    const customServerUrl = await ProcessConfig.get('telemetry.serverUrl').catch(() => undefined as unknown as string | undefined);
+    const url = customServerUrl || `${getSudoworkServerBaseUrlSync()}/api/v1/telemetry/batch`;
     const encryptor = getTelemetryEncryptor();
 
     try {

--- a/src/process/telemetry/TelemetryBatchReporter.ts
+++ b/src/process/telemetry/TelemetryBatchReporter.ts
@@ -22,9 +22,11 @@ import { buildVersion } from '../../common/buildInfo';
 import type { TelemetryEvent, TelemetryBatchRequest, TelemetryBatchResponse, TelemetryConfig, StoredTelemetryEvent, PerfTelemetryEvent, ConversationTelemetryEvent, InstallTelemetryEvent, TurnTelemetryEvent, StepTelemetryEvent, PerfData, ConversationData, InstallData, TurnData, StepData } from '../../shared/types/telemetry';
 import { mapElectronArch, DEFAULT_TELEMETRY_CONFIG } from '../../shared/types/telemetry';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
+import { getProductImprovementApiKey } from '../credentialsCache';
 import { getTelemetryEncryptor, initTelemetryEncryptor, isEncryptionAvailable } from './TelemetryEncryptor';
 import { ENCRYPTION_CONFIG } from './keys';
 import { getUserContextSync } from './UserContext';
+import { isProductImprovementEnabled } from '@/common/systemConfig';
 
 // ============================================================
 // 类型定义
@@ -43,9 +45,6 @@ interface TelemetryEventPayloadMap {
 // ============================================================
 // 常量定义
 // ============================================================
-
-/** sudowork-qms API Key - 用于认证上报请求 */
-const API_KEY = 'sk-8f3a2b1c9d5e7f6a4b3c2d1e8f9a0b7c';
 
 /** 本地存储文件名 */
 const STORAGE_FILE_NAME = 'telemetry-cache.json';
@@ -188,7 +187,7 @@ export class TelemetryBatchReporter {
    * @param agentType - Agent 类型 (sudocode, claude 等)
    */
   public record<K extends TelemetryEventType>(type: K, data: TelemetryEventPayloadMap[K], agentType?: string): void {
-    if (!isPersonalMode() || !this.enabled || !this.initialized) {
+    if (!isPersonalMode() || !isProductImprovementEnabled() || !this.enabled || !this.initialized) {
       return;
     }
 
@@ -226,7 +225,7 @@ export class TelemetryBatchReporter {
    * 用于应用退出前上报剩余事件
    */
   public async flushAll(): Promise<void> {
-    if (!isPersonalMode()) {
+    if (!isPersonalMode() || !isProductImprovementEnabled()) {
       this.eventQueue = [];
       await this.clearCacheFile();
       return;
@@ -339,7 +338,7 @@ export class TelemetryBatchReporter {
 
   /** 执行批量上报 */
   private async flush(): Promise<void> {
-    if (!isPersonalMode()) {
+    if (!isPersonalMode() || !isProductImprovementEnabled()) {
       this.eventQueue = [];
       await this.clearCacheFile();
       return;
@@ -453,10 +452,16 @@ export class TelemetryBatchReporter {
     const encryptor = getTelemetryEncryptor();
 
     try {
+      const apiKey = getProductImprovementApiKey();
+      if (!apiKey) {
+        // D8: product_improvement api_key not provisioned — skip upload.
+        mainError('Telemetry', 'product_improvement api_key not provisioned, skip sendBatch');
+        return { success: false, received: 0, error: 'product_improvement api_key missing' };
+      }
       let body: string;
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
-        'X-API-Key': API_KEY,
+        'X-API-Key': apiKey,
       };
 
       // 如果加密器可用，使用加密请求

--- a/src/process/telemetry/TelemetryEncryptor.ts
+++ b/src/process/telemetry/TelemetryEncryptor.ts
@@ -17,8 +17,8 @@
  */
 
 import * as crypto from 'crypto';
-import { TELEMETRY_PUBLIC_KEY_PEM, ENCRYPTION_CONFIG } from './keys';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
+import { ENCRYPTION_CONFIG, resolveTelemetryPublicKey } from './keys';
 
 // ============================================================
 // 类型定义
@@ -84,7 +84,7 @@ export class TelemetryEncryptor {
 
     try {
       // 解析 PEM 格式公钥
-      const pemKey = TELEMETRY_PUBLIC_KEY_PEM.trim();
+      const pemKey = resolveTelemetryPublicKey().trim();
 
       // 检查是否为占位符密钥
       if (pemKey.includes('PlaceholderPublicKeyContent') || pemKey.includes('ExampleKeyForDevelopment')) {
@@ -114,6 +114,18 @@ export class TelemetryEncryptor {
       this.enabled = false;
       this.initialized = true;
     }
+  }
+
+  /**
+   * Re-initialize with the current dispatch state (D6).
+   * Called after server-driven credentials are cached so an `encryption_required=true`
+   * dispatch swaps in the server's public key (resolveTelemetryPublicKey reads it live).
+   */
+  public async reinitialize(): Promise<void> {
+    this.initialized = false;
+    this.publicKey = null;
+    this.enabled = ENCRYPTION_CONFIG.enabled;
+    await this.initialize();
   }
 
   /**
@@ -153,7 +165,7 @@ export class TelemetryEncryptor {
           padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
           oaepHash: config.rsa.hash,
         },
-        aesKey,
+        aesKey
       );
 
       // Step 6: Base64 编码
@@ -222,6 +234,11 @@ export const getTelemetryEncryptor = (): TelemetryEncryptor => {
 /** 初始化加密器 */
 export const initTelemetryEncryptor = async (): Promise<void> => {
   await getTelemetryEncryptor().initialize();
+};
+
+/** 重新初始化加密器（凭据到达后用下发公钥，D6） */
+export const reinitTelemetryEncryptor = async (): Promise<void> => {
+  await getTelemetryEncryptor().reinitialize();
 };
 
 /** 加密数据 */

--- a/src/process/telemetry/keys.ts
+++ b/src/process/telemetry/keys.ts
@@ -10,6 +10,9 @@
  * 使用 RSA-2048 + AES-256-GCM 混合加密方案
  */
 
+import { getSystemConfigCache } from '@/common/systemConfig';
+import { getProductImprovementPublicKey } from '@/process/credentialsCache';
+
 // ============================================================
 // RSA 公钥配置
 // ============================================================
@@ -36,6 +39,25 @@ YBicgOr0E4jBhAtecVQOsbk2XADVSrEWGigJEZ1KJ6AP/2C2t9Om/8d/KP9w4F0H
 eQIDAQAB
 -----END PUBLIC KEY-----
 `;
+
+/**
+ * Resolve the qms encryption public key for the current dispatch state (D6).
+ *
+ * - `product_improvement.encryption_required=true` → use the dispatched
+ *   `credentials.product_improvement.public_key` (when provisioned).
+ * - Otherwise (or when the dispatched key is absent) → the hardcoded `TELEMETRY_PUBLIC_KEY_PEM`.
+ *
+ * Encryption-failure plaintext fallback behavior is unchanged (handled at the encrypt
+ * call sites in TelemetryBatchReporter / CrashReporter).
+ */
+export function resolveTelemetryPublicKey(): string {
+  const cache = getSystemConfigCache();
+  if (cache?.product_improvement?.encryption_required) {
+    const dispatched = getProductImprovementPublicKey();
+    if (dispatched) return dispatched;
+  }
+  return TELEMETRY_PUBLIC_KEY_PEM;
+}
 
 // ============================================================
 // 加密配置

--- a/src/process/utils/sudoworkLogUploader.ts
+++ b/src/process/utils/sudoworkLogUploader.ts
@@ -9,6 +9,8 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from '
 import { join } from 'node:path';
 import { app } from 'electron';
 import { buildVersion } from '@/common/buildInfo';
+import { getLogReportBaseUrl, isLogReportEnabled } from '@/common/systemConfig';
+import { getLogReportKey } from '@/process/credentialsCache';
 import { mapElectronArch } from '@/shared/types/telemetry';
 
 type LogUploadErrorEntry = {
@@ -82,8 +84,6 @@ type PersonalConfigSnapshot = {
 const SUDO_LOG_TENANT_ID = 'sudo';
 const LOG_PRODUCT = 'sudowork';
 const API_KEY_HEADER = 'X-API-Key';
-const API_KEY = 'sk-8f3a2b1c9d5e7f6a4b3c2d1e8f9a0b7c';
-const DEFAULT_BATCH_URL = 'https://sudolog.sudoprivacy.com/v1/logs/batch';
 const CACHE_FILE_NAME = 'sudowork-log-error-cache.json';
 const MAX_QUEUE_SIZE = 500;
 const MAX_BATCH_SIZE = 50;
@@ -170,7 +170,7 @@ function getBatchUrl(): string {
     return new URL('/v1/logs/batch', baseUrl).toString();
   }
 
-  return DEFAULT_BATCH_URL;
+  return `${getLogReportBaseUrl()}/v1/logs/batch`;
 }
 
 function hashIdentifier(value?: unknown): string | undefined {
@@ -354,7 +354,7 @@ class SudoworkLogUploader {
 
   public enqueue(entry: LogUploadErrorEntry): void {
     const config = getConfigSnapshot();
-    if (config.appMode !== 'c') {
+    if (config.appMode !== 'c' || !isLogReportEnabled()) {
       this.dropAndClear();
       return;
     }
@@ -481,7 +481,7 @@ class SudoworkLogUploader {
   }
 
   private async flush(): Promise<void> {
-    if (!isPersonalMode()) {
+    if (!isPersonalMode() || !isLogReportEnabled()) {
       this.dropAndClear();
       return;
     }
@@ -548,11 +548,18 @@ class SudoworkLogUploader {
     const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
 
     try {
+      const apiKey = getLogReportKey();
+      if (!apiKey) {
+        // D8: log_report key not provisioned — skip upload. Identity gating (§6.1) already
+        // prevents pre-login reports; this covers the post-login key-missing case.
+        console.error('[SudoworkLog] log_report key not provisioned, skip sendBatch');
+        return { success: false, received: 0, error: 'log_report key missing', retryable: false };
+      }
       const response = await fetch(getBatchUrl(), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          [API_KEY_HEADER]: API_KEY,
+          [API_KEY_HEADER]: apiKey,
         },
         body: JSON.stringify(request),
         signal: controller.signal,

--- a/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SystemModalContent.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import { ipcBridge } from '@/common';
 import { ConfigStorage } from '@/common/storage';
+import { isProductImprovementEnabled } from '@/common/systemConfig';
 import LanguageSwitcher from '@/renderer/components/LanguageSwitcher';
 import ProductImprovementDialog from '@/renderer/components/ProductImprovementDialog';
 import { formatTimestamp, joinFilePath } from '@/renderer/pages/conversation/grouped-history/utils/exportHelpers';
@@ -392,7 +393,7 @@ const SystemModalContent: React.FC = () => {
       hint: t('settings.avatarEnabledDesc'),
       component: <Switch checked={avatarEnabled} onChange={handleAvatarEnabledChange} className='settings-accent-switch' style={avatarEnabled ? { backgroundColor: 'var(--ui-accent-orange)' } : undefined} />,
     },
-    ...(isEnterprise
+    ...(isEnterprise || !isProductImprovementEnabled()
       ? []
       : [
           {

--- a/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
+++ b/src/renderer/components/SettingsModal/contents/secrets/TenantConfigItemGroup.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { ConfigStorage } from '@/common/storage';
 import configItemDefaultIcon from '@/renderer/assets/config-item-default.svg';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { BUILD_SUDOWORK_SERVER_BASE_URL, getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 import type { TenantConfigItem, TenantConfigValues } from './types';
 import PreferenceRow from './PreferenceRow';
 
@@ -20,10 +20,8 @@ function resolveIconUrl(iconUrl: string | null, baseUrl?: string): string {
   if (iconUrl.startsWith('data:') || iconUrl.startsWith('http://') || iconUrl.startsWith('https://')) {
     return iconUrl;
   }
-  if (baseUrl) {
-    return `${baseUrl.replace(/\/+$/, '')}${iconUrl.startsWith('/') ? iconUrl : `/${iconUrl}`}`;
-  }
-  return `${SUDOWORK_SERVER_BASE_URL}${iconUrl}`;
+  const resolvedBase = (baseUrl ?? BUILD_SUDOWORK_SERVER_BASE_URL).replace(/\/+$/, '');
+  return `${resolvedBase}${iconUrl.startsWith('/') ? iconUrl : `/${iconUrl}`}`;
 }
 
 const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string }> = ({ iconUrl, name }) => {
@@ -36,13 +34,19 @@ const ConfigItemIcon: React.FC<{ iconUrl?: string; name: string }> = ({ iconUrl,
   }, [iconUrl]);
 
   useEffect(() => {
-    if (!isEnterprise) return;
     let mounted = true;
     void (async () => {
       try {
-        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
-        if (mounted && typeof serverUrl === 'string') {
-          setBaseUrl(serverUrl);
+        if (isEnterprise) {
+          const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+          if (mounted && typeof serverUrl === 'string') {
+            setBaseUrl(serverUrl);
+          }
+        } else {
+          const resolved = await getSudoworkServerBaseUrl();
+          if (mounted) {
+            setBaseUrl(resolved);
+          }
         }
       } catch {
         // silent

--- a/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
+++ b/src/renderer/components/SettingsModal/contents/secrets/useTenantConfigItems.ts
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { secret, authProxy } from '@/common/ipcBridge';
 import { buildNamespace } from '@/common/nexus/namespace';
 import { MossSecretClient } from '@/common/nexus/moss-secret-client';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 import { ConfigStorage } from '@/common/storage';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useAuth } from '@/renderer/context/AuthContext';
@@ -51,101 +51,109 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
 
   const mountedRef = useRef(true);
 
-  const loadEnabledStates = useCallback(async (items: TenantConfigItem[], token: string) => {
-    if (isEnterprise && user?.id) {
-      // B端: use MossSecretClient.listSecrets() for enabled status
+  const loadEnabledStates = useCallback(
+    async (items: TenantConfigItem[], token: string) => {
+      if (isEnterprise && user?.id) {
+        // B端: use MossSecretClient.listSecrets() for enabled status
+        try {
+          const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+          const mossClient = new MossSecretClient(serverUrl, token, user.id);
+          const allSecrets = await mossClient.listSecrets();
+          const newMap: Record<number, boolean> = {};
+          for (const item of items) {
+            const namespace = buildNamespace(item.pinyin!, user.id);
+            const itemEntries = allSecrets.filter((s) => s.namespace === namespace);
+            newMap[item.id] = itemEntries.length > 0 && itemEntries.some((s) => s.enabled);
+          }
+          if (mountedRef.current) {
+            setEnabledMap(newMap);
+          }
+        } catch {
+          // Fall back to all disabled
+          if (mountedRef.current) {
+            const newMap: Record<number, boolean> = {};
+            for (const item of items) {
+              newMap[item.id] = false;
+            }
+            setEnabledMap(newMap);
+          }
+        }
+        return;
+      }
+
+      // C端: read from ConfigStorage
       try {
-        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
-        const mossClient = new MossSecretClient(serverUrl, token, user.id);
-        const allSecrets = await mossClient.listSecrets();
+        const stored = await ConfigStorage.get(TENANT_ENABLED_STORAGE_KEY);
+        const storedMap = (stored || {}) as Record<number, boolean>;
         const newMap: Record<number, boolean> = {};
         for (const item of items) {
-          const namespace = buildNamespace(item.pinyin!, user.id);
-          const itemEntries = allSecrets.filter(s => s.namespace === namespace);
-          newMap[item.id] = itemEntries.length > 0 && itemEntries.some(s => s.enabled);
+          newMap[item.id] = storedMap[item.id] ?? false;
         }
         if (mountedRef.current) {
           setEnabledMap(newMap);
         }
       } catch {
-        // Fall back to all disabled
-        if (mountedRef.current) {
-          const newMap: Record<number, boolean> = {};
-          for (const item of items) { newMap[item.id] = false; }
-          setEnabledMap(newMap);
-        }
+        // Ignore storage read errors
       }
-      return;
-    }
+    },
+    [isEnterprise, user?.id]
+  );
 
-    // C端: read from ConfigStorage
-    try {
-      const stored = await ConfigStorage.get(TENANT_ENABLED_STORAGE_KEY);
-      const storedMap = (stored || {}) as Record<number, boolean>;
-      const newMap: Record<number, boolean> = {};
-      for (const item of items) {
-        newMap[item.id] = storedMap[item.id] ?? false;
-      }
-      if (mountedRef.current) {
-        setEnabledMap(newMap);
-      }
-    } catch {
-      // Ignore storage read errors
-    }
-  }, [isEnterprise, user?.id]);
+  const loadValuesFromNexus = useCallback(
+    async (items: TenantConfigItem[], token: string) => {
+      const newValuesMap: Record<number, TenantConfigValues> = {};
+      const userId = user?.id;
 
-  const loadValuesFromNexus = useCallback(async (items: TenantConfigItem[], token: string) => {
-    const newValuesMap: Record<number, TenantConfigValues> = {};
-    const userId = user?.id;
+      if (isEnterprise && userId) {
+        // B端: use MossSecretClient to GET values from moss API
+        const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
+        const mossClient = new MossSecretClient(serverUrl, token, userId);
 
-    if (isEnterprise && userId) {
-      // B端: use MossSecretClient to GET values from moss API
-      const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
-      const mossClient = new MossSecretClient(serverUrl, token, userId);
-
-      for (const item of items) {
-        if (!item.pinyin) continue;
-        const namespace = buildNamespace(item.pinyin, userId);
-        const values: TenantConfigValues = {};
-        for (const entry of item.entries) {
-          try {
-            const value = await mossClient.getSecret(namespace, entry.config_key);
-            if (value) {
-              values[entry.config_key] = value;
-            }
-          } catch {
-            // Secret not found, skip
-          }
-        }
-        newValuesMap[item.id] = values;
-      }
-    } else {
-      // C端: use IPC to local nexusd
-      const promises: Promise<void>[] = [];
-      for (const item of items) {
-        if (!item.pinyin) continue;
-        const namespace = buildNamespace(item.pinyin);
-        const values: TenantConfigValues = {};
-        for (const entry of item.entries) {
-          const p = secret.get
-            .invoke({ namespace, key: entry.config_key })
-            .then((res) => {
-              if (res.success && res.data) {
-                values[entry.config_key] = res.data;
+        for (const item of items) {
+          if (!item.pinyin) continue;
+          const namespace = buildNamespace(item.pinyin, userId);
+          const values: TenantConfigValues = {};
+          for (const entry of item.entries) {
+            try {
+              const value = await mossClient.getSecret(namespace, entry.config_key);
+              if (value) {
+                values[entry.config_key] = value;
               }
-            })
-            .catch(() => {});
-          promises.push(p);
+            } catch {
+              // Secret not found, skip
+            }
+          }
+          newValuesMap[item.id] = values;
         }
-        newValuesMap[item.id] = values;
+      } else {
+        // C端: use IPC to local nexusd
+        const promises: Promise<void>[] = [];
+        for (const item of items) {
+          if (!item.pinyin) continue;
+          const namespace = buildNamespace(item.pinyin);
+          const values: TenantConfigValues = {};
+          for (const entry of item.entries) {
+            const p = secret.get
+              .invoke({ namespace, key: entry.config_key })
+              .then((res) => {
+                if (res.success && res.data) {
+                  values[entry.config_key] = res.data;
+                }
+              })
+              .catch(() => {});
+            promises.push(p);
+          }
+          newValuesMap[item.id] = values;
+        }
+        await Promise.all(promises);
       }
-      await Promise.all(promises);
-    }
 
-    if (mountedRef.current) {
-      setValuesMap(newValuesMap);
-    }
-  }, [isEnterprise, user?.id]);
+      if (mountedRef.current) {
+        setValuesMap(newValuesMap);
+      }
+    },
+    [isEnterprise, user?.id]
+  );
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -167,7 +175,7 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
         const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
         configItemsUrl = `${serverUrl}/api/v1/config/items`;
       } else {
-        configItemsUrl = `${SUDOWORK_SERVER_BASE_URL}/api/v1/config/items`;
+        configItemsUrl = `${await getSudoworkServerBaseUrl()}/api/v1/config/items`;
       }
 
       let response = await fetchWithAuth(configItemsUrl, token);
@@ -255,7 +263,7 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
           const token = await ensureValidToken();
           const serverUrl = await ConfigStorage.get('eeclaw.serverUrl');
           const mossClient = new MossSecretClient(serverUrl, token, user.id);
-          const item = configItems.find(i => i.id === configItemId);
+          const item = configItems.find((i) => i.id === configItemId);
           if (item?.pinyin) {
             const namespace = buildNamespace(item.pinyin, user.id);
             for (const entry of item.entries) {
@@ -277,7 +285,9 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
         await ConfigStorage.set(TENANT_ENABLED_STORAGE_KEY, newMap);
         const token = await ensureValidToken();
         if (token) {
-          const enabledIds = Object.entries(newMap).filter(([, v]) => v).map(([k]) => Number(k));
+          const enabledIds = Object.entries(newMap)
+            .filter(([, v]) => v)
+            .map(([k]) => Number(k));
           authProxy.refreshRules.invoke({ accessToken: token, enabledConfigItemIds: enabledIds }).catch((err) => {
             console.warn('[TenantConfig] Failed to refresh Auth Proxy rules:', err);
           });
@@ -286,7 +296,7 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
         console.error('[TenantConfig] Failed to save enabled state:', err);
       }
     },
-    [enabledMap, ensureValidToken, isEnterprise, user?.id, configItems],
+    [enabledMap, ensureValidToken, isEnterprise, user?.id, configItems]
   );
 
   const saveItem = useCallback(
@@ -316,9 +326,9 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
               } catch {
                 return { success: false as const };
               }
-            }),
+            })
           );
-          const allSuccess = results.every(r => r.success);
+          const allSuccess = results.every((r) => r.success);
           return allSuccess;
         }
 
@@ -358,9 +368,9 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
             } catch {
               return { success: false as const };
             }
-          }),
+          })
         );
-        const allSuccess = results.every(r => r.success);
+        const allSuccess = results.every((r) => r.success);
         return allSuccess;
       } catch (err) {
         console.error('[TenantConfig] Failed to save config item:', err);
@@ -371,7 +381,7 @@ export function useTenantConfigItems(refreshTrigger?: number): UseTenantConfigIt
         }
       }
     },
-    [isEnterprise, user?.id, ensureValidToken],
+    [isEnterprise, user?.id, ensureValidToken]
   );
 
   return {

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -339,6 +339,32 @@ async function applyLoginImageModel(): Promise<void> {
 }
 
 // 处理登录成功后的通用逻辑
+/**
+ * Fetch the server-driven credentials envelope (with the renderer-held JWT) and forward
+ * {nonce, ciphertext} to the main process for decryption + caching. Used by BOTH login
+ * paths — active login (handleLoginSuccess) and restart restore (refresh) — per §6.4, so
+ * reporters/skillhub keep working after a restart without a manual re-login.
+ * The JWT never leaves the renderer; only the encrypted envelope crosses IPC.
+ */
+async function fetchAndCacheCredentials(): Promise<void> {
+  if (!isDesktopRuntime) return;
+  try {
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (!stored) return;
+    const authStorage = JSON.parse(stored) as AuthStorage;
+    const jwt = authStorage.access_token;
+    if (!jwt) return;
+    const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/system-config/credentials`, {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    const json = (await res.json()) as { success?: boolean; nonce?: string; ciphertext?: string };
+    if (!json?.success || !json.nonce || !json.ciphertext) return;
+    await ipcBridge.systemConfig.cacheCredentials.invoke({ nonce: json.nonce, ciphertext: json.ciphertext });
+  } catch (err) {
+    console.warn('[Auth] fetch/cache server credentials failed:', err);
+  }
+}
+
 async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUser, setStatus: SetAuthStatus, setReady: SetAuthReady, setSyncMessage: SetSyncMessage, tenantIdFallback?: string) {
   const deviceId = getDeviceId();
   const mergedUser = mergeLoginUserData(data) as unknown as AuthUser;
@@ -478,6 +504,9 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
   setReady(true);
 
   if (isDesktopRuntime) {
+    // §6.4 active-login path: cache server-driven credentials BEFORE restarting the gateway
+    // subprocess so env injection (skillhub url/token) sees the dispatched values.
+    await fetchAndCacheCredentials();
     void restartSudoclawGatewayIfInstalled();
   }
 }
@@ -783,6 +812,9 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         setUser({ ...authStorage.user, token: authStorage.access_token });
         setStatus('authenticated');
         setReady(true);
+        // §6.4 restart-restore path: also cache credentials so reporters/skillhub work after
+        // a restart without requiring a manual re-login (fire-and-forget, don't block restore).
+        void fetchAndCacheCredentials();
         await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
 
         const restoredUserId = resolveConsumerUserId(authStorage.user);

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ipcBridge } from '@/common';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 import { ConfigStorage, type IConfigStorageRefer } from '@/common/storage';
 import { resolveLoginImageModelId } from '@/common/imageGenerationModelConfig';
 import { withCsrfToken } from '@/webserver/middleware/csrfClient';
@@ -566,7 +566,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           const authStorage: AuthStorage = JSON.parse(stored);
           const { refresh_token, device_id } = authStorage;
 
-          const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/refresh`, {
+          const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/refresh`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ refresh_token, device_id }),
@@ -967,7 +967,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     const deviceId = getDeviceId();
 
     try {
-      const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/login`, {
+      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1015,7 +1015,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     const deviceId = getDeviceId();
 
     try {
-      const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/register`, {
+      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1050,7 +1050,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const loginByPassword = useCallback(async ({ phone, password }: PasswordLoginParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/login-by-config`, {
+      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/login-by-config`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1074,7 +1074,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const registerByPassword = useCallback(async ({ phone, password, nickname, invitation_code }: PasswordRegisterParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/register-password`, {
+      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/register-password`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1102,7 +1102,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         return { success: false, message: '登录状态已过期，请重新登录' };
       }
       try {
-        const response = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/change-password`, {
+        const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/change-password`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -1366,7 +1366,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         const authStorage: AuthStorage = JSON.parse(stored);
         const { refresh_token, device_id } = authStorage;
 
-        await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/logout`, {
+        await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/logout`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ refresh_token, device_id }),

--- a/src/renderer/context/TenantConfigContext.tsx
+++ b/src/renderer/context/TenantConfigContext.tsx
@@ -5,8 +5,9 @@
  */
 
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useAuth } from './AuthContext';
 import { ipcBridge } from '@/common';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 import { ConfigStorage } from '@/common/storage';
 import type { TenantConfig, TenantConfigResponse } from '@/common/types/tenantConfig';
 import { DEFAULT_TENANT_CONFIG, TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
@@ -111,7 +112,7 @@ export const TenantConfigProvider: React.FC<React.PropsWithChildren> = ({ childr
       }
 
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const baseUrl = serverConfig.baseUrl || SUDOWORK_SERVER_BASE_URL;
+      const baseUrl = serverConfig.baseUrl || (await getSudoworkServerBaseUrl());
       const token = await ensureValidToken();
 
       if (!token) {

--- a/src/renderer/hooks/useConfigModelListWithImage.ts
+++ b/src/renderer/hooks/useConfigModelListWithImage.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import useSWR from 'swr';
 import { DEFAULT_IMAGE_GENERATION_MODEL } from '@/common/storage';
 import { ipcBridge } from '../../common';
+import { isSudorouterBaseUrl } from '@/common/systemConfig';
 
 const useConfigModelListWithImage = () => {
   const { data } = useSWR('configModelListWithImage', () => {
@@ -30,7 +31,7 @@ const useConfigModelListWithImage = () => {
         // AntigravityTools 平台：添加常用图像模型
         // AntigravityTools platform: add common image models
         platform.model = platform.model.concat(['gemini-3-pro-image-1x1']);
-      } else if (platform.baseUrl && platform.baseUrl.includes('sudorouter.ai')) {
+      } else if (isSudorouterBaseUrl(platform.baseUrl)) {
         // SudoRouter 平台：添加图像生成模型
         // SudoRouter platform: add image generation model
         const hasSudorouterImage = platform.model.some((m) => m.includes(DEFAULT_IMAGE_GENERATION_MODEL));

--- a/src/renderer/hooks/useSystemLoginMethod.ts
+++ b/src/renderer/hooks/useSystemLoginMethod.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { ipcBridge } from '@/common';
 import { fetchSystemConfig } from '@/common/systemConfig';
 
 /** 0 = 手机验证码（现状）；1 = 用户名密码（本次新增） */
@@ -29,6 +30,10 @@ async function fetchLoginMethod(): Promise<LoginMethod> {
       // system-config module cache (setSystemConfigCache) so synchronous base-url
       // helpers work for renderer consumers.
       const data = await fetchSystemConfig();
+      // Sync to main-process cache (see main.tsx for rationale).
+      if (data) {
+        void ipcBridge.systemConfig.syncFromRenderer.invoke({ data }).catch(() => {});
+      }
       const loginMethod: LoginMethod = data?.login_method === 1 ? 1 : 0;
       cachedLoginMethod = loginMethod;
       cachedAt = Date.now();

--- a/src/renderer/hooks/useSystemLoginMethod.ts
+++ b/src/renderer/hooks/useSystemLoginMethod.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
+import { fetchSystemConfig } from '@/common/systemConfig';
 
 /** 0 = 手机验证码（现状）；1 = 用户名密码（本次新增） */
 export type LoginMethod = 0 | 1;
@@ -25,9 +25,11 @@ async function fetchLoginMethod(): Promise<LoginMethod> {
   if (inflight) return inflight;
   inflight = (async (): Promise<LoginMethod> => {
     try {
-      const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/system-config`);
-      const data = (await res.json()) as { data?: { login_method?: unknown } };
-      const loginMethod: LoginMethod = data?.data?.login_method === 1 ? 1 : 0;
+      // Reuse the shared client; fetchSystemConfig() also fills the renderer's
+      // system-config module cache (setSystemConfigCache) so synchronous base-url
+      // helpers work for renderer consumers.
+      const data = await fetchSystemConfig();
+      const loginMethod: LoginMethod = data?.login_method === 1 ? 1 : 0;
       cachedLoginMethod = loginMethod;
       cachedAt = Date.now();
       return loginMethod;

--- a/src/renderer/hooks/useSystemLoginMethod.ts
+++ b/src/renderer/hooks/useSystemLoginMethod.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 
 /** 0 = 手机验证码（现状）；1 = 用户名密码（本次新增） */
 export type LoginMethod = 0 | 1;
@@ -25,7 +25,7 @@ async function fetchLoginMethod(): Promise<LoginMethod> {
   if (inflight) return inflight;
   inflight = (async (): Promise<LoginMethod> => {
     try {
-      const res = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/system-config`);
+      const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/system-config`);
       const data = (await res.json()) as { data?: { login_method?: unknown } };
       const loginMethod: LoginMethod = data?.data?.login_method === 1 ? 1 : 0;
       cachedLoginMethod = loginMethod;

--- a/src/renderer/i18n/i18n-keys.d.ts
+++ b/src/renderer/i18n/i18n-keys.d.ts
@@ -1913,6 +1913,10 @@ export type I18nKey =
   | 'settings.zentao.testAndConnect'
   | 'settings.zentao.username'
   | 'settings.zentao.usernameDesc'
+  | 'setup.serverUrl.hint'
+  | 'setup.serverUrl.invalidUrl'
+  | 'setup.serverUrl.placeholder'
+  | 'setup.serverUrl.toggle'
   | 'starOffice.monitor.assistPromptInstalled'
   | 'starOffice.monitor.checking'
   | 'starOffice.monitor.connectedInline'
@@ -2021,22 +2025,4 @@ export type I18nKey =
   | 'update.showInFolder'
   | 'update.upToDateTitle';
 
-export type I18nModule =
-  | 'common'
-  | 'agentMode'
-  | 'update'
-  | 'login'
-  | 'fileSelection'
-  | 'preview'
-  | 'conversation'
-  | 'settings'
-  | 'messages'
-  | 'mcp'
-  | 'acp'
-  | 'codex'
-  | 'tools'
-  | 'gemini'
-  | 'cron'
-  | 'starOffice'
-  | 'guid'
-  | 'agent';
+export type I18nModule = 'common' | 'agentMode' | 'update' | 'login' | 'fileSelection' | 'preview' | 'conversation' | 'settings' | 'messages' | 'mcp' | 'acp' | 'codex' | 'tools' | 'gemini' | 'cron' | 'starOffice' | 'guid' | 'agent' | 'setup';

--- a/src/renderer/i18n/locales/en-US/index.ts
+++ b/src/renderer/i18n/locales/en-US/index.ts
@@ -23,6 +23,7 @@ import guid from './guid.json';
 import agent from './agent.json';
 import agentStatus from './agentStatus.json';
 import telemetry from './telemetry.json';
+import setup from './setup.json';
 
 export default {
   common,
@@ -45,4 +46,5 @@ export default {
   agent,
   agentStatus,
   telemetry,
+  setup,
 };

--- a/src/renderer/i18n/locales/en-US/setup.json
+++ b/src/renderer/i18n/locales/en-US/setup.json
@@ -1,0 +1,8 @@
+{
+  "serverUrl": {
+    "toggle": "Use a custom server address",
+    "placeholder": "https://your-sudowork-server.com",
+    "hint": "Leave empty to use the default server",
+    "invalidUrl": "Please enter a valid HTTP/HTTPS address"
+  }
+}

--- a/src/renderer/i18n/locales/ja-JP/index.ts
+++ b/src/renderer/i18n/locales/ja-JP/index.ts
@@ -18,6 +18,7 @@ import starOffice from './starOffice.json';
 import guid from './guid.json';
 import agent from './agent.json';
 import agentStatus from './agentStatus.json';
+import setup from './setup.json';
 
 export default {
   common,
@@ -39,4 +40,5 @@ export default {
   guid,
   agent,
   agentStatus,
+  setup,
 };

--- a/src/renderer/i18n/locales/ja-JP/setup.json
+++ b/src/renderer/i18n/locales/ja-JP/setup.json
@@ -1,0 +1,8 @@
+{
+  "serverUrl": {
+    "toggle": "カスタムサーバーアドレスを使用",
+    "placeholder": "https://your-sudowork-server.com",
+    "hint": "空欄の場合はデフォルトのサーバーを使用します",
+    "invalidUrl": "有効な HTTP/HTTPS アドレスを入力してください"
+  }
+}

--- a/src/renderer/i18n/locales/ko-KR/index.ts
+++ b/src/renderer/i18n/locales/ko-KR/index.ts
@@ -18,6 +18,7 @@ import starOffice from './starOffice.json';
 import guid from './guid.json';
 import agent from './agent.json';
 import agentStatus from './agentStatus.json';
+import setup from './setup.json';
 
 export default {
   common,
@@ -39,4 +40,5 @@ export default {
   guid,
   agent,
   agentStatus,
+  setup,
 };

--- a/src/renderer/i18n/locales/ko-KR/setup.json
+++ b/src/renderer/i18n/locales/ko-KR/setup.json
@@ -1,0 +1,8 @@
+{
+  "serverUrl": {
+    "toggle": "사용자 지정 서버 주소 사용",
+    "placeholder": "https://your-sudowork-server.com",
+    "hint": "비워두면 기본 서버를 사용합니다",
+    "invalidUrl": "유효한 HTTP/HTTPS 주소를 입력하세요"
+  }
+}

--- a/src/renderer/i18n/locales/tr-TR/index.ts
+++ b/src/renderer/i18n/locales/tr-TR/index.ts
@@ -18,6 +18,7 @@ import starOffice from './starOffice.json';
 import guid from './guid.json';
 import agent from './agent.json';
 import agentStatus from './agentStatus.json';
+import setup from './setup.json';
 
 export default {
   common,
@@ -39,4 +40,5 @@ export default {
   guid,
   agent,
   agentStatus,
+  setup,
 };

--- a/src/renderer/i18n/locales/tr-TR/setup.json
+++ b/src/renderer/i18n/locales/tr-TR/setup.json
@@ -1,0 +1,8 @@
+{
+  "serverUrl": {
+    "toggle": "Özel sunucu adresi kullan",
+    "placeholder": "https://your-sudowork-server.com",
+    "hint": "Boş bırakırsanız varsayılan sunucu kullanılır",
+    "invalidUrl": "Lütfen geçerli bir HTTP/HTTPS adresi girin"
+  }
+}

--- a/src/renderer/i18n/locales/zh-CN/index.ts
+++ b/src/renderer/i18n/locales/zh-CN/index.ts
@@ -23,6 +23,7 @@ import guid from './guid.json';
 import agent from './agent.json';
 import agentStatus from './agentStatus.json';
 import telemetry from './telemetry.json';
+import setup from './setup.json';
 
 export default {
   common,
@@ -45,4 +46,5 @@ export default {
   agent,
   agentStatus,
   telemetry,
+  setup,
 };

--- a/src/renderer/i18n/locales/zh-CN/setup.json
+++ b/src/renderer/i18n/locales/zh-CN/setup.json
@@ -1,0 +1,8 @@
+{
+  "serverUrl": {
+    "toggle": "使用自定义服务器地址",
+    "placeholder": "https://your-sudowork-server.com",
+    "hint": "留空则使用默认服务器",
+    "invalidUrl": "请输入有效的 HTTP/HTTPS 地址"
+  }
+}

--- a/src/renderer/i18n/locales/zh-TW/index.ts
+++ b/src/renderer/i18n/locales/zh-TW/index.ts
@@ -18,6 +18,7 @@ import starOffice from './starOffice.json';
 import guid from './guid.json';
 import agent from './agent.json';
 import agentStatus from './agentStatus.json';
+import setup from './setup.json';
 
 export default {
   common,
@@ -39,4 +40,5 @@ export default {
   guid,
   agent,
   agentStatus,
+  setup,
 };

--- a/src/renderer/i18n/locales/zh-TW/setup.json
+++ b/src/renderer/i18n/locales/zh-TW/setup.json
@@ -1,0 +1,8 @@
+{
+  "serverUrl": {
+    "toggle": "使用自訂伺服器位址",
+    "placeholder": "https://your-sudowork-server.com",
+    "hint": "留空則使用預設伺服器",
+    "invalidUrl": "請輸入有效的 HTTP/HTTPS 位址"
+  }
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -16,6 +16,7 @@ import Layout from '@renderer/layouts/layout';
 import Router from '@renderer/router';
 import { ErrorBoundary } from '@renderer/components/ErrorBoundary';
 import { ipcBridge } from '@/common';
+import { fetchSystemConfig, isProductImprovementEnabled } from '@/common/systemConfig';
 
 const Main = () => {
   const { ready: authReady } = useAuth();
@@ -34,10 +35,12 @@ const Main = () => {
     }
 
     if (initReady && !optInChecked) {
-      ipcBridge.telemetry.getOptInShown
-        .invoke()
-        .then((result) => {
-          if (result.success && !result.data) {
+      // Fill the renderer system-config cache so the product_improvement switch
+      // (server-driven) is accurate before deciding whether to show the opt-in dialog.
+      Promise.all([ipcBridge.telemetry.getOptInShown.invoke(), fetchSystemConfig()])
+        .then(([result]) => {
+          // §4.5: hide the opt-in dialog when product_improvement is disabled server-side.
+          if (result.success && !result.data && isProductImprovementEnabled()) {
             // Opt-in dialog hasn't been shown yet - this is a new user (first install)
             setShowOptInDialog(true);
           }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -16,7 +16,23 @@ import Layout from '@renderer/layouts/layout';
 import Router from '@renderer/router';
 import { ErrorBoundary } from '@renderer/components/ErrorBoundary';
 import { ipcBridge } from '@/common';
-import { fetchSystemConfig, isProductImprovementEnabled } from '@/common/systemConfig';
+import { fetchSystemConfig, isProductImprovementEnabled, type SystemConfig } from '@/common/systemConfig';
+
+/**
+ * Fetch systemConfig in the renderer AND push the snapshot to the main process so the
+ * main-side cache stays aligned (the systemConfig module has one cache per process; a
+ * renderer-only fetch would leave main-side readers — skillHub / sudorouter /
+ * log-report — using a stale or empty cache).
+ * Null result = fetch failure; do NOT propagate (would wipe whatever main-process
+ * startup bootstrap previously cached).
+ */
+async function fetchSystemConfigAndSync(): Promise<SystemConfig | null> {
+  const data = await fetchSystemConfig();
+  if (data) {
+    void ipcBridge.systemConfig.syncFromRenderer.invoke({ data }).catch(() => {});
+  }
+  return data;
+}
 
 const Main = () => {
   const { ready: authReady } = useAuth();
@@ -37,7 +53,7 @@ const Main = () => {
     if (initReady && !optInChecked) {
       // Fill the renderer system-config cache so the product_improvement switch
       // (server-driven) is accurate before deciding whether to show the opt-in dialog.
-      Promise.all([ipcBridge.telemetry.getOptInShown.invoke(), fetchSystemConfig()])
+      Promise.all([ipcBridge.telemetry.getOptInShown.invoke(), fetchSystemConfigAndSync()])
         .then(([result]) => {
           // §4.5: hide the opt-in dialog when product_improvement is disabled server-side.
           if (result.success && !result.data && isProductImprovementEnabled()) {

--- a/src/renderer/pages/login/PasswordAuthPanel.tsx
+++ b/src/renderer/pages/login/PasswordAuthPanel.tsx
@@ -11,13 +11,14 @@ interface PasswordAuthPanelProps {
   appName: string;
   logo?: string;
   defaultLogo: string;
+  onBackToModeSelect?: () => void;
 }
 
 /**
  * 用户名密码 登录/注册面板（system login_method=1 时由 LoginPage 渲染）。
  * 自包含，不与手机验证码逻辑交织；登录/注册成功复用 AuthContext 的 handleLoginSuccess。
  */
-const PasswordAuthPanel: React.FC<PasswordAuthPanelProps> = ({ appName, logo, defaultLogo }) => {
+const PasswordAuthPanel: React.FC<PasswordAuthPanelProps> = ({ appName, logo, defaultLogo, onBackToModeSelect }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { loginByPassword, registerByPassword } = useAuth();
@@ -145,6 +146,14 @@ const PasswordAuthPanel: React.FC<PasswordAuthPanelProps> = ({ appName, logo, de
         </Button>
 
         {mode === 'login' && <div className='text-center text-12px text-tertiary mt-12px'>{t('login.pwdFootNote')}</div>}
+
+        {onBackToModeSelect && (
+          <div className='text-center mt-12px'>
+            <span className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors' onClick={onBackToModeSelect}>
+              ← 返回模式选择
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -536,7 +536,15 @@ const LoginPage: React.FC = () => {
                 <Input size='large' prefix={<Key className='text-tertiary' />} placeholder='moss_sk_xxx.yyy' value={apiKey} onChange={setApiKey} className='login-input !rd-12px h-48px' />
               </div>
             ) : (
-              <div className='flex flex-col gap-8px text-center'>{oauth2Loading ? <div className='text-13px text-tertiary py-12px'>正在检查 OAuth2 配置…</div> : oauth2Config?.enabled ? <div className='text-13px text-secondary py-4px'>点击下方按钮，将在浏览器中完成身份认证。</div> : <div className='text-13px text-tertiary py-12px'>管理员未启用 OAuth2 登录</div>}</div>
+              <div className='flex flex-col gap-8px text-center'>
+                {oauth2Loading ? (
+                  <div className='text-13px text-tertiary py-12px'>正在检查 OAuth2 配置…</div>
+                ) : oauth2Config?.enabled ? (
+                  <div className='text-13px text-secondary py-4px'>点击下方按钮，将在浏览器中完成身份认证。</div>
+                ) : (
+                  <div className='text-13px text-tertiary py-12px'>管理员未启用 OAuth2 登录</div>
+                )}
+              </div>
             )}
 
             {loginTab === 'oauth2' ? (
@@ -575,7 +583,7 @@ const LoginPage: React.FC = () => {
           <div className='login-page__background-circle login-page__background-circle--md' />
           <div className='login-page__background-circle login-page__background-circle--sm' />
         </div>
-        <PasswordAuthPanel appName={tenantConfig.app_name} logo={tenantConfig.logo} defaultLogo={SudoworkIcon} />
+        <PasswordAuthPanel appName={tenantConfig.app_name} logo={tenantConfig.logo} defaultLogo={SudoworkIcon} onBackToModeSelect={handleBackToModeSelect} />
       </div>
     );
   }

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, Input, Message, Space } from '@arco-design/web-react';
 import { Phone, Protect, Key, User, Lock } from '@icon-park/react';
-import { SUDOWORK_SERVER_BASE_URL } from '@/common/sudoworkServer';
+import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 import { DEFAULT_TENANT_CONFIG, TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
 import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import { isElectronDesktop, isMacOS } from '@/renderer/utils/platform';
@@ -236,7 +236,7 @@ const LoginPage: React.FC = () => {
 
     setLoading(true);
     try {
-      const res = await fetch(`${SUDOWORK_SERVER_BASE_URL}/api/v1/auth/send-code`, {
+      const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/send-code`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone: currentPhone }),

--- a/src/renderer/pages/setup/ModeSetup.tsx
+++ b/src/renderer/pages/setup/ModeSetup.tsx
@@ -5,10 +5,12 @@
  */
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button, Input, Message } from '@arco-design/web-react';
 import { ipcBridge } from '@/common';
 import { ConfigStorage } from '@/common/storage';
 import { setAppMode } from '@/common/eeclawMode';
+import { normalizeSudoworkServerUrl } from '@/common/sudoworkServer';
 import { TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
 import SudoworkIcon from '@/renderer/assets/sudowork-icon-dark.svg';
 import WindowControls from '@/renderer/components/WindowControls';
@@ -44,10 +46,13 @@ function isValidServerUrl(url: string): boolean {
 }
 
 const ModeSetup: React.FC = () => {
+  const { t } = useTranslation();
   const [selectedCard, setSelectedCard] = useState<CardType>(null);
   const [serverUrl, setServerUrl] = useState('');
   const [verifying, setVerifying] = useState(false);
   const [verifyResult, setVerifyResult] = useState<{ success: boolean; tenantName?: string; message?: string } | null>(null);
+  const [showConsumerServerForm, setShowConsumerServerForm] = useState(false);
+  const [consumerServerUrl, setConsumerServerUrl] = useState('');
 
   const handleCardSelect = (card: CardType) => {
     setSelectedCard(card);
@@ -56,10 +61,27 @@ const ModeSetup: React.FC = () => {
       setServerUrl('');
       setVerifyResult(null);
     }
+    // Switching away from consumer collapses the custom-server form (state preserved if user toggles back)
+    if (card !== 'consumer') {
+      setShowConsumerServerForm(false);
+    }
   };
 
   const handleConsumerNext = async () => {
     try {
+      // Persist user-supplied sudowork-server baseUrl (if any) BEFORE setAppMode/reload,
+      // so the very first API call after reload picks it up via current-read helpers.
+      const normalized = normalizeSudoworkServerUrl(consumerServerUrl);
+      if (normalized) {
+        if (!isValidServerUrl(normalized)) {
+          Message.error(t('setup.serverUrl.invalidUrl'));
+          return;
+        }
+        await ConfigStorage.set('system.sudoworkServerUrl', normalized);
+      } else {
+        // Empty input → clear any previously-saved override, fall back to build-define / literal.
+        await ConfigStorage.set('system.sudoworkServerUrl', undefined);
+      }
       await setAppMode('c');
       // Notify main process to start consumer services, then reload renderer
       // (avoids full app relaunch — same approach as enterprise mode)
@@ -195,9 +217,22 @@ const ModeSetup: React.FC = () => {
           </div>
         </div>
 
+        {/* Consumer: custom sudowork-server URL (collapsed toggle below the cards) */}
+        {selectedCard === 'consumer' && (
+          <button type='button' className='mt-12px text-12px text-tertiary underline cursor-pointer bg-transparent border-none' style={{ WebkitAppRegion: 'no-drag' } as WebkitAppRegionStyle} onClick={() => setShowConsumerServerForm((v) => !v)}>
+            {t('setup.serverUrl.toggle')}
+          </button>
+        )}
+        <div className={`mode-setup__form ${selectedCard === 'consumer' && showConsumerServerForm ? 'mode-setup__form--visible' : ''}`}>
+          <div className='flex flex-col gap-8px w-full'>
+            <Input size='large' placeholder={t('setup.serverUrl.placeholder')} value={consumerServerUrl} onChange={setConsumerServerUrl} className='mode-setup__input' />
+            {consumerServerUrl && !isValidServerUrl(consumerServerUrl) ? <p className='text-12px text-danger ml-4px'>{t('setup.serverUrl.invalidUrl')}</p> : <p className='text-12px text-tertiary ml-4px'>{t('setup.serverUrl.hint')}</p>}
+          </div>
+        </div>
+
         {/* Consumer button */}
         <div style={getModeActionStyle(selectedCard === 'consumer')}>
-          <Button type='primary' size='large' onClick={handleConsumerNext} className='mode-setup__btn mode-setup__btn--consumer'>
+          <Button type='primary' size='large' onClick={handleConsumerNext} className='mode-setup__btn mode-setup__btn--consumer' disabled={consumerServerUrl.trim().length > 0 && !isValidServerUrl(consumerServerUrl)}>
             开始使用
           </Button>
         </div>

--- a/src/shared/i18n-config.json
+++ b/src/shared/i18n-config.json
@@ -2,5 +2,5 @@
   "referenceLanguage": "zh-CN",
   "fallbackLanguage": "zh-CN",
   "supportedLanguages": ["zh-CN", "en-US", "ja-JP", "zh-TW", "ko-KR", "tr-TR"],
-  "modules": ["common", "agentMode", "update", "login", "fileSelection", "preview", "conversation", "settings", "messages", "mcp", "acp", "codex", "tools", "gemini", "cron", "starOffice", "guid", "agent"]
+  "modules": ["common", "agentMode", "update", "login", "fileSelection", "preview", "conversation", "settings", "messages", "mcp", "acp", "codex", "tools", "gemini", "cron", "starOffice", "guid", "agent", "setup"]
 }

--- a/src/webserver/routes/apiRoutes.ts
+++ b/src/webserver/routes/apiRoutes.ts
@@ -4,19 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Express, type NextFunction, type Request, type RequestHandler, type Response } from 'express';
 import fs from 'fs';
 import path from 'path';
 import http from 'http';
 import https from 'https';
 import { URL } from 'url';
-import { TokenMiddleware } from '@/webserver/auth/middleware/TokenMiddleware';
-import { ExtensionRegistry } from '@/extensions';
+import { type Express, type NextFunction, type Request, type RequestHandler, type Response } from 'express';
 import directoryApi from '../directoryApi';
 import { apiRateLimiter } from '../middleware/security';
-
-const SKILL_HUB_BASE_URL = 'https://sudoworkhub.sudoprivacy.com/api/skills';
-const SKILL_HUB_AUTHORIZATION = 'sud0@sudo';
+import { TokenMiddleware } from '@/webserver/auth/middleware/TokenMiddleware';
+import { ExtensionRegistry } from '@/extensions';
+import { getSkillHubBaseUrl } from '@/common/systemConfig';
+import { getSkillhubToken } from '@/process/credentialsCache';
 
 function normalizeMountPath(input: string): string {
   if (!input || input.trim() === '') return '/';
@@ -251,9 +250,14 @@ export function registerApiRoutes(app: Express): void {
       const query = typeof req.query.query === 'string' ? req.query.query : '';
       const category = typeof req.query.category === 'string' ? req.query.category : typeof req.query.categories === 'string' ? req.query.categories : '';
 
+      const token = getSkillhubToken();
+      if (!token) {
+        console.error('[SkillHub API] skillhub token not provisioned, skip');
+        return res.json({ success: false, msg: 'skillhub token missing' });
+      }
       const params = new URLSearchParams({ page, size, query, category });
-      const response = await fetch(`${SKILL_HUB_BASE_URL}?${params}`, {
-        headers: { Authorization: SKILL_HUB_AUTHORIZATION },
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/skills?${params}`, {
+        headers: { Authorization: token },
       });
       const data = await response.json();
       res.json({ success: true, data });
@@ -278,8 +282,13 @@ export function registerApiRoutes(app: Express): void {
       if (category) params.set('category', category);
       if (tenantId) params.set('tenant_id', tenantId);
 
-      const response = await fetch(`https://sudoworkhub.sudoprivacy.com/api/skills/cursor?${params}`, {
-        headers: { Authorization: SKILL_HUB_AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        console.error('[SkillHub API] skillhub token not provisioned, skip');
+        return res.json({ success: false, msg: 'skillhub token missing' });
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/skills/cursor?${params}`, {
+        headers: { Authorization: token },
       });
       const result = await response.json();
       // Return only the data part to match IBridgeResponse<ISkillHubListResponse>
@@ -292,8 +301,13 @@ export function registerApiRoutes(app: Express): void {
 
   app.get('/api/categories', apiRateLimiter, validateApiAccess, async (_req: Request, res: Response) => {
     try {
-      const response = await fetch('https://sudoworkhub.sudoprivacy.com/api/categories', {
-        headers: { Authorization: SKILL_HUB_AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        console.error('[SkillHub API] skillhub token not provisioned, skip');
+        return res.json({ success: false, msg: 'skillhub token missing' });
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/categories`, {
+        headers: { Authorization: token },
       });
       const data = await response.json();
       res.json({ success: true, data: data.data || [] });
@@ -306,8 +320,13 @@ export function registerApiRoutes(app: Express): void {
   app.get('/api/skill-hub/skills/:skillId', apiRateLimiter, validateApiAccess, async (req: Request, res: Response) => {
     try {
       const { skillId } = req.params;
-      const response = await fetch(`${SKILL_HUB_BASE_URL}/${skillId}`, {
-        headers: { Authorization: SKILL_HUB_AUTHORIZATION },
+      const token = getSkillhubToken();
+      if (!token) {
+        console.error('[SkillHub API] skillhub token not provisioned, skip');
+        return res.json({ success: false, msg: 'skillhub token missing' });
+      }
+      const response = await fetch(`${getSkillHubBaseUrl()}/api/skills/${skillId}`, {
+        headers: { Authorization: token },
       });
       const data = await response.json();
       res.json({ success: true, data: data.data });


### PR DESCRIPTION
# Pull Request

## Description

Bundles the server-driven endpoints work plus a small follow-up on the C-side login UI:

- **sudowork-server**: base URL is now user- and build-configurable
- **system-config**: base URLs, feature switches, and credentials are server-driven; main-process cache is backfilled via startup bootstrap and synced to renderer
- **login**: account/password auth panel now offers a "← 返回模式选择" entry, matching the existing entries on the enterprise and SMS login UIs

Commits:
- `feat(sudowork-server)`: make base URL user- and build-configurable
- `feat(system-config)`: make base URLs, switches, and credentials server-driven
- `fix(system-config)`: backfill main-process cache via startup bootstrap and renderer sync
- `feat(login)`: add back-to-mode-select entry on C-side password auth panel

## Related Issues

- Closes #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors

## Screenshots

<!-- N/A -->

## Additional Context

<!-- -->