### PR TITLE
ci(cold-start): re-enable macos-arm64 (fuse-v0.4.2 libfuse3 cutover)

### DIFF
--- a/.github/workflows/pr-cold-start-smoke.yml
+++ b/.github/workflows/pr-cold-start-smoke.yml
@@ -67,16 +67,20 @@ jobs:
             os: windows-2022
             node_platform: win32
             node_arch: x64
+          # macos-14: arm64 runner. Full 3-plugin set. THE platform where
+          # the FUSE-T lazy contract could break (eager osascript install).
+          # Re-enabled after nexi-lab/nexus#4425 closed via fuse-v0.4.2:
+          # fuse-plugin's macOS dylib now links libfuse3.4.dylib (via fuser
+          # vendor + libfuse3 feature) and bakes two LC_RPATH entries
+          # (/Library/Application Support/fuse-t/lib for .pkg, /usr/local/lib
+          # for brew), so dlopen succeeds against either FUSE-T install
+          # path. This job exercises the .pkg path specifically — the
+          # production install path sudowork uses via FuseTInstallService.
+          - platform: macos-arm64
+            os: macos-14
+            node_platform: darwin
+            node_arch: arm64
           # Intentionally NOT in matrix:
-          #   - macos-arm64: blocked on nexi-lab/nexus#4425. Root cause:
-          #     fuse-plugin's macOS dylib hard-links libfuse.2.dylib (macFUSE
-          #     libfuse2), but FUSE-T 1.2.7 ships only libfuse3 at a different
-          #     prefix and no libfuse2 anywhere. Cluster dlopen fails BEFORE
-          #     fuse_t_detect runs, the lazy install supervisor can't probe,
-          #     and the smoke (correctly) flags count=2 not 3. Issue has the
-          #     full pkg payload listing + proposed fix paths. Until it
-          #     closes, manual Mac smoke (via Mac dev session) gates mac
-          #     cold-start regressions; linux + windows here cover the rest.
           #   - macos-x64: cross-build only on macos-14 runner; no native runner.
           #   - windows-arm64: no native plugin artifacts published yet.
           #   - linux-arm64: no plugin artifacts published yet.
@@ -112,6 +116,65 @@ jobs:
         # SHA mismatches against src/shared/runtime-sha256.json fail fast here.
         run: bun run nexus-vfs:download
 
+      # ─── macOS-only prereq: install FUSE-T via .pkg ─────────────────────
+      # fuse-plugin v0.4.2 (nexi-lab/nexus#4430) cut over to libfuse3 and
+      # bakes two LC_RPATH entries:
+      #   - /Library/Application Support/fuse-t/lib (.pkg install path)
+      #   - /usr/local/lib                          (brew install path)
+      # so a successful FUSE-T install on EITHER path makes dlopen succeed.
+      # This job exercises the **.pkg path** specifically — the production
+      # install path sudowork users hit via FuseTInstallService (osascript
+      # + installer -pkg). NOT brew, because brew dev environments hide a
+      # whole class of "framework not registered with pkg-config" /
+      # "wrong libfuse2 compat" bugs that real users would trip on.
+      #
+      # Step ordering: this `sudo installer` invocation lands BEFORE the
+      # smoke step's admin-watcher arms, so the watcher still observes a
+      # clean process tree for the cluster cold start it actually gates on.
+      #
+      # Why not the pre-install (lazy) path: the lazy-install branch is
+      # already covered by 9 unit tests in src/process/services/fuset/*.test.ts.
+      # CI runners can't authentically simulate "first-mount triggers
+      # osascript password prompt", and we have no Mac dev with which to
+      # type the prompt anyway.
+      - name: Install FUSE-T prereq via .pkg (macOS — production install path)
+        if: matrix.platform == 'macos-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          FUSE_T_VERSION=$(node -p "require('./src/shared/runtime-versions.json')['fuse-t']")
+          PKG="fuse-t-macos-installer-${FUSE_T_VERSION}.pkg"
+          URL="https://github.com/macos-fuse-t/fuse-t/releases/download/${FUSE_T_VERSION}/${PKG}"
+          # SHA pinned in src/process/services/fuset/FuseTInstallService.ts for v1.2.7.
+          EXPECTED_SHA=6a29c747e61a86a405a189efc3de42812d73147135f93a1bb0624c1e7b90e654
+          DL=/tmp/${PKG}
+          curl -fsSL "$URL" -o "$DL"
+          ACTUAL_SHA=$(shasum -a 256 "$DL" | awk '{print $1}')
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::FUSE-T pkg SHA256 mismatch (got $ACTUAL_SHA expected $EXPECTED_SHA)"
+            exit 1
+          fi
+          sudo installer -pkg "$DL" -target /
+
+          echo "=== FUSE-T install verification (.pkg path) ==="
+          # The framework is the user-visible install marker (FSKit). 1.2+
+          # uses /Library/Frameworks/fuse_t.framework.
+          ls -lah /Library/Frameworks/fuse_t.framework 2>/dev/null || {
+            echo "::error::FUSE-T framework not present at /Library/Frameworks/fuse_t.framework after pkg install"
+            exit 1
+          }
+          # The .pkg-specific dylib path that fuse-plugin v0.4.2's
+          # LC_RPATH points at. If this missing → dlopen would fail and
+          # the smoke would fall back to count=2, defeating the whole
+          # point of re-adding macos-arm64 to the matrix.
+          LIBFUSE3=/Library/Application\ Support/fuse-t/lib/libfuse3.4.dylib
+          ls -lah "$LIBFUSE3" 2>/dev/null || {
+            echo "::error::libfuse3 not present at expected .pkg path: $LIBFUSE3"
+            echo "          fuse-plugin's LC_RPATH expects this; without it dlopen fails."
+            exit 1
+          }
+          echo "FUSE-T ${FUSE_T_VERSION} installed via .pkg; libfuse3 compat in place."
+
       # ─── Linux smoke ────────────────────────────────────────────────────
       - name: Cold-start smoke (Linux)
         if: matrix.platform == 'linux-x64'
@@ -132,6 +195,82 @@ jobs:
             while true; do
               pgrep -fa 'pkexec|kdesudo|gksu|polkit-.*-authentication-agent' \
                 2>/dev/null >> "$ADMIN_LOG" || true
+              sleep 1
+            done
+          ) &
+          WATCHER_PID=$!
+
+          RUST_LOG=info,kernel::kernel::plugins=info \
+            nohup "$CLUSTER_BIN" \
+              --bind-addr 0.0.0.0:${CLUSTER_PORT} \
+              --data-dir /tmp/cluster-data \
+              --no-tls \
+              --bootstrap-mode static \
+              --plugin-dir "$PLUGIN_DIR" \
+              > "$CLUSTER_LOG" 2>&1 &
+          CLUSTER_PID=$!
+
+          LISTENING=0
+          for i in $(seq 1 60); do
+            if (echo > /dev/tcp/127.0.0.1/${CLUSTER_PORT}) >/dev/null 2>&1; then
+              echo "cluster listening on :${CLUSTER_PORT} after ${i}s"
+              LISTENING=1
+              break
+            fi
+            sleep 1
+          done
+
+          # Let plugin-load lines flush.
+          sleep 3
+
+          kill "$WATCHER_PID" 2>/dev/null || true
+          kill "$CLUSTER_PID" 2>/dev/null || true
+          sleep 1
+
+          echo "=== cluster log (head -80) ==="
+          head -80 "$CLUSTER_LOG" || true
+          echo "=== admin-procs.log (expected empty) ==="
+          cat "$ADMIN_LOG" || true
+          echo "=== end log dump ==="
+
+          if [ "$LISTENING" -ne 1 ]; then
+            echo "::error::cluster failed to bind :${CLUSTER_PORT} within 60s — see log dump above"
+            exit 1
+          fi
+
+          node scripts/assert-cold-start.js \
+            --cluster-log "$CLUSTER_LOG" \
+            --admin-log "$ADMIN_LOG" \
+            --platform ${{ matrix.node_platform }} \
+            --arch ${{ matrix.node_arch }}
+
+      # ─── macOS smoke ────────────────────────────────────────────────────
+      - name: Cold-start smoke (macOS)
+        if: matrix.platform == 'macos-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          CLUSTER_BIN="$HOME/.nexus-vfs/bin/nexusd-cluster"
+          PLUGIN_DIR="$HOME/.nexus-vfs/plugins"
+          CLUSTER_LOG=/tmp/cluster.log
+          ADMIN_LOG=/tmp/admin-procs.log
+          mkdir -p /tmp/cluster-data
+          : > "$ADMIN_LOG"
+
+          # macOS-specific escalation surface: FuseTInstallService's lazy
+          # install path uses `osascript -e "do shell script ... with
+          # administrator privileges"` which forks `installer -pkg`. If
+          # cluster boot eagerly triggers this, the lazy contract is broken.
+          # `sudo` deliberately INCLUDED (unlike the Linux case): the prereq
+          # step ran in a separate step scope and is already done by the
+          # time the watcher arms, so any sudo here means cluster bootstrap
+          # decided to escalate on its own.
+          (
+            while true; do
+              ps -A -o pid=,command= 2>/dev/null \
+                | grep -E '(osascript.*administrator|installer.*-pkg|/usr/bin/sudo|security authorize)' \
+                | grep -v 'grep -E' \
+                >> "$ADMIN_LOG" || true
               sleep 1
             done
           ) &

--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -49,6 +49,15 @@ const COS_BASE_URLS = [
   `https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/nexus-vfs/release/v${VERSION}`,
 ];
 
+// GitHub Release fallback for nexus-vfs cluster, mirroring the same pattern
+// used by vault/local-connector/fuse-plugin below. nexus-vfs's release.yml
+// `publish-cos` step is gated on TENCENT_SECRET_ID/KEY; when those aren't
+// configured the upload silently skips and primary COS 404s. The GitHub
+// release (`publish-github-release` step, `softprops/action-gh-release@v2`)
+// is unconditional on tag push, so the GH-release fallback is always
+// available even when the COS mirror is empty.
+const NEXUS_VFS_GITHUB_URL = `https://github.com/nexi-lab/nexus-vfs/releases/download/v${VERSION}`;
+
 // Vault plugin is released from the nexus repo (separate from nexus-vfs).
 const VAULT_COS_BASE_URLS = [
   `https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com/nexus-vault/release/v${VAULT_VERSION}`,
@@ -292,7 +301,7 @@ function findBinary(dir) {
 
 async function installForPlatform(platform, arch, force) {
   const artifact = getArtifactName(platform, arch);
-  const urls = COS_BASE_URLS.map((base) => `${base}/${artifact}`);
+  const urls = [...COS_BASE_URLS.map((base) => `${base}/${artifact}`), `${NEXUS_VFS_GITHUB_URL}/${artifact}`];
   const binName = getBinaryName();
   const installedBinary = path.join(BIN_DIR, binName);
 

--- a/src/shared/runtime-sha256.json
+++ b/src/shared/runtime-sha256.json
@@ -1,12 +1,12 @@
 {
   "_doc": "Canonical SHA256 sums for every downloadable nexus-vfs runtime artifact. Single source of truth — scripts/download-nexus-vfs.js (build/install-time), DynamicNexusVfsService.ts (runtime cluster re-installer), and VaultPluginInstaller.ts (runtime vault re-installer) all read from this file. Bump versions in runtime-versions.json AND update the matching entry here in one commit; do NOT inline a SHA back into any source file. Verified against the per-release SHA256SUMS.txt in the COS bucket.",
 
-  "nexusd-cluster-linux-aarch64.tar.gz": "1afa3e5b0fd239cd8a36a4bd2fd6409890eb5bb8a3d8d3d9a5e8357faec8b610",
-  "nexusd-cluster-linux-x86_64.tar.gz": "b5589082304cf9cbc693381f3bf52d53554573bee0aa8bbdc23f17ca3a7cf486",
-  "nexusd-cluster-macos-aarch64.tar.gz": "0b07557accd3982ac9823ba8128377ea2e4e8a7ab8aaaf9d243bf9e06688df0e",
-  "nexusd-cluster-macos-x86_64.tar.gz": "7bd7e03a97ba024459503d137d7622e8315a2bb976a5884156a37c2a8d90313d",
-  "nexusd-cluster-windows-aarch64.zip": "ec97d5ff5fe7b51f29cf5c2b1b0ab7d709df99e10ce3e974aa12cc9e14220ebd",
-  "nexusd-cluster-windows-x86_64.zip": "c318f749cb1ed5a6dad87559499bf5ae9fbb53ad9decb94e3711060aa8e8050d",
+  "nexusd-cluster-linux-aarch64.tar.gz": "6629a229eaa3f274e937a528f029f1fba06437e4d8068534204b38e9c9d7a4f2",
+  "nexusd-cluster-linux-x86_64.tar.gz": "ab97e36c75c76bcea35ce5ffac5116bce741e87682558b0e24e0853c604ab3c4",
+  "nexusd-cluster-macos-aarch64.tar.gz": "588b93ea07a9a9d51f95ba43da9fb2c6484fff0cf4f6351ada53b32268b29836",
+  "nexusd-cluster-macos-x86_64.tar.gz": "1c1e885969e649353264d859ad1a12aab6fa91b47cd079e3010c878f457dcb90",
+  "nexusd-cluster-windows-aarch64.zip": "c87f665e12a202ce3da85fa3f928e9713a4240ca9bb8bdd8df562728eae8e8a5",
+  "nexusd-cluster-windows-x86_64.zip": "79de886dcb2b2430b482a7ad6a9bcfbaa53137c1174f2050e2f0c03f7f6c696f",
 
   "nexus-vault-linux-x86_64.tar.gz": "890b154f121820297f3937306dd1e8ac39b58c4bdad3823427f4fd2279138d2c",
   "nexus-vault-macos-arm64.tar.gz": "a6ef1ac686f8d795662052a7cc456e85efec4461e269ae77de9d180af198a522",

--- a/src/shared/runtime-sha256.json
+++ b/src/shared/runtime-sha256.json
@@ -8,17 +8,17 @@
   "nexusd-cluster-windows-aarch64.zip": "ec97d5ff5fe7b51f29cf5c2b1b0ab7d709df99e10ce3e974aa12cc9e14220ebd",
   "nexusd-cluster-windows-x86_64.zip": "c318f749cb1ed5a6dad87559499bf5ae9fbb53ad9decb94e3711060aa8e8050d",
 
-  "nexus-vault-linux-x86_64.tar.gz": "b209e62e8076d2f567d291f203335009d449683b2199e275d23073a04e59ce30",
-  "nexus-vault-macos-arm64.tar.gz": "a723b032f119669544156558af3f08425a59a5c95caa87ad9c1cfff1bc876b6d",
-  "nexus-vault-macos-x86_64.tar.gz": "38a7bfed062e34323f83fd6aed03322016976847ea74c90e05bff93f6f8bb874",
-  "nexus-vault-windows-x86_64.zip": "c89c894f926a0e659364f96bf3192091e58122bbad73ecb3847f70d97a00dc21",
+  "nexus-vault-linux-x86_64.tar.gz": "890b154f121820297f3937306dd1e8ac39b58c4bdad3823427f4fd2279138d2c",
+  "nexus-vault-macos-arm64.tar.gz": "a6ef1ac686f8d795662052a7cc456e85efec4461e269ae77de9d180af198a522",
+  "nexus-vault-macos-x86_64.tar.gz": "4367a00726c7f1365856096d15ca9b8262ad45145aacf0f2ef0097c54937b9f4",
+  "nexus-vault-windows-x86_64.zip": "dc4642fc6092cc9ab3f2430e8a04efb965bf3266b1b7c67ae420b08aca42812a",
 
   "nexus-local-connector-linux-x86_64.tar.gz": "9ff9f574b72241e4b89627b5852effa51042b6c3799d3ce55dcf5bc0910d7ffc",
   "nexus-local-connector-macos-arm64.tar.gz": "f5d9abfe0239c9c4c4a49b0154532da64fdd67dda41b07f8490855f7343442f7",
   "nexus-local-connector-macos-x86_64.tar.gz": "8a589380b276ffcbb425558dcc6baa6b9910d6dd6b53cd81127b5a33e0004f7a",
   "nexus-local-connector-windows-x86_64.zip": "49078141537918f423d5939d976270dfbe52eb628db677009694ba306be8e9e9",
 
-  "nexus-fuse-plugin-linux-x86_64.tar.gz": "1208d8d3b57d42f6415fa155f7588174eec268a0d2946062fa25bf929805c283",
-  "nexus-fuse-plugin-macos-arm64.tar.gz": "8485c2094bf8714adbd2f8a83d19b95911c3230774e7f84a4b11268c296fe08b",
-  "nexus-fuse-plugin-macos-x86_64.tar.gz": "009245ca9275d64cde92c69003e806a0947b8e2b1a42f78a6a133c132dc8b93d"
+  "nexus-fuse-plugin-linux-x86_64.tar.gz": "a70af607c2a6becb7a8f65300d253066e721248a0c7ad5a21c680434412cdb6a",
+  "nexus-fuse-plugin-macos-arm64.tar.gz": "e17e323f614faa8488b9c74fcd249e1b313460c64c9b0a2052b2f34b536eb030",
+  "nexus-fuse-plugin-macos-x86_64.tar.gz": "dc1b0e34b2b0c9ceba32f5a04b2506ec8d0d751e7af713cef0edd7e1d28c122f"
 }

--- a/src/shared/runtime-sha256.json
+++ b/src/shared/runtime-sha256.json
@@ -8,17 +8,17 @@
   "nexusd-cluster-windows-aarch64.zip": "c87f665e12a202ce3da85fa3f928e9713a4240ca9bb8bdd8df562728eae8e8a5",
   "nexusd-cluster-windows-x86_64.zip": "79de886dcb2b2430b482a7ad6a9bcfbaa53137c1174f2050e2f0c03f7f6c696f",
 
-  "nexus-vault-linux-x86_64.tar.gz": "890b154f121820297f3937306dd1e8ac39b58c4bdad3823427f4fd2279138d2c",
-  "nexus-vault-macos-arm64.tar.gz": "a6ef1ac686f8d795662052a7cc456e85efec4461e269ae77de9d180af198a522",
-  "nexus-vault-macos-x86_64.tar.gz": "4367a00726c7f1365856096d15ca9b8262ad45145aacf0f2ef0097c54937b9f4",
-  "nexus-vault-windows-x86_64.zip": "dc4642fc6092cc9ab3f2430e8a04efb965bf3266b1b7c67ae420b08aca42812a",
+  "nexus-vault-linux-x86_64.tar.gz": "19b4baabc30e3d0901acc991ddefe807d22f410d98205f79c474b47c18e1eae7",
+  "nexus-vault-macos-arm64.tar.gz": "d237646c214c99d6779b2cb709e974b0911f99ffd3d7384c8951254873a22217",
+  "nexus-vault-macos-x86_64.tar.gz": "2a21941ce7c8fd58d692947549ef158b4d0d745309aea72228a2c5c5951b1753",
+  "nexus-vault-windows-x86_64.zip": "05a734e884b332966867535da2604d0179743c094464f36fbab263267a5cece5",
 
-  "nexus-local-connector-linux-x86_64.tar.gz": "9ff9f574b72241e4b89627b5852effa51042b6c3799d3ce55dcf5bc0910d7ffc",
-  "nexus-local-connector-macos-arm64.tar.gz": "f5d9abfe0239c9c4c4a49b0154532da64fdd67dda41b07f8490855f7343442f7",
-  "nexus-local-connector-macos-x86_64.tar.gz": "8a589380b276ffcbb425558dcc6baa6b9910d6dd6b53cd81127b5a33e0004f7a",
-  "nexus-local-connector-windows-x86_64.zip": "49078141537918f423d5939d976270dfbe52eb628db677009694ba306be8e9e9",
+  "nexus-local-connector-linux-x86_64.tar.gz": "55981e400d4945624f06b93ea96b28646ba6fa8469f412517040dae85bba6159",
+  "nexus-local-connector-macos-arm64.tar.gz": "1a7fc7a80ef4d827b7788b598b3733b996a0f40bce38a1cad480993e217974e1",
+  "nexus-local-connector-macos-x86_64.tar.gz": "898f5b651c426d411dfef8a22eabac0a534cf4eecfe8a85f9aae9b6c3d1b6cd7",
+  "nexus-local-connector-windows-x86_64.zip": "b9d3c37093686ea5cc62a50dec3e22c494f8ccaf25053920f3b7813db492ee51",
 
-  "nexus-fuse-plugin-linux-x86_64.tar.gz": "a70af607c2a6becb7a8f65300d253066e721248a0c7ad5a21c680434412cdb6a",
-  "nexus-fuse-plugin-macos-arm64.tar.gz": "e17e323f614faa8488b9c74fcd249e1b313460c64c9b0a2052b2f34b536eb030",
-  "nexus-fuse-plugin-macos-x86_64.tar.gz": "dc1b0e34b2b0c9ceba32f5a04b2506ec8d0d751e7af713cef0edd7e1d28c122f"
+  "nexus-fuse-plugin-linux-x86_64.tar.gz": "180a62d01c19df729dcee2993a441bd7258334581f0e86b8c2b8a6e27e3a68c3",
+  "nexus-fuse-plugin-macos-arm64.tar.gz": "57866e1161dae72d7d74a7e2255b3d1f7a697ca716d782a89e417ab8ee385094",
+  "nexus-fuse-plugin-macos-x86_64.tar.gz": "262c83d7ad5c7f5ea6a08aa338a6ab68dfdb580e6b968709e465291cb46c82b9"
 }

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -1,9 +1,9 @@
 {
   "nexus": "0.9.43",
   "nexus-vfs": "0.4.0",
-  "nexus-vault": "0.3.0",
-  "nexus-local-connector": "0.2.0",
-  "nexus-fuse-plugin": "0.4.2",
+  "nexus-vault": "0.4.0",
+  "nexus-local-connector": "0.3.0",
+  "nexus-fuse-plugin": "0.5.0",
   "fuse-t": "1.2.7",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
   "scode": "0.1.11"

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -1,9 +1,9 @@
 {
   "nexus": "0.9.43",
   "nexus-vfs": "0.3.0",
-  "nexus-vault": "0.2.0",
+  "nexus-vault": "0.3.0",
   "nexus-local-connector": "0.2.0",
-  "nexus-fuse-plugin": "0.4.0",
+  "nexus-fuse-plugin": "0.4.2",
   "fuse-t": "1.2.7",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
   "scode": "0.1.11"

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -1,6 +1,6 @@
 {
   "nexus": "0.9.43",
-  "nexus-vfs": "0.3.0",
+  "nexus-vfs": "0.4.0",
   "nexus-vault": "0.3.0",
   "nexus-local-connector": "0.2.0",
   "nexus-fuse-plugin": "0.4.2",


### PR DESCRIPTION
## Summary

Closes the D follow-up from PR #924's plan after nexi-lab/nexus#4425 closed via fuse-v0.4.2:

- **chore(runtime)**: bump `nexus-vault` 0.2.0→0.3.0 (ABI v4 rebuild — vault-v0.2.0 was rejected by current cluster's PluginLoader, causing UNIMPLEMENTED on every gRPC method including PutSecretSealed; blocked the fuse-v0.4.1 dogfood release). Bump `nexus-fuse-plugin` 0.4.0→0.4.2 (libfuse3 cutover + LC_RPATH embed). New SHA256 entries for all 7 affected archives.
- **ci(cold-start)**: re-add `macos-arm64` to the smoke matrix. New `.pkg`-only FUSE-T prereq step + macOS smoke step. Asserts `/Library/Application Support/fuse-t/lib/libfuse3.4.dylib` exists (the exact LC_RPATH target fuse-plugin v0.4.2 looks for) BEFORE booting the cluster, so a missing/wrong FUSE-T layout fails the prereq instead of silently downgrading to count=2 inside the smoke.

## Why .pkg-only (not brew)

Mac AI's PR #4430 was verified against brew-FUSE-T on his dev machine. Brew ships a full `libfuse.2.dylib` + `libfuse3.4.dylib` + `libfuse-t-1.2.7.dylib` compat set; the `.pkg` install ships only `libfuse3.4.dylib` at `/Library/Application Support/fuse-t/lib/`. Sudowork users hit the `.pkg` path via `FuseTInstallService.ensureInstalled()` (osascript + installer -pkg). A successful brew dry-run is necessary-not-sufficient — this job pins the actual production install path.

## Heads-up for Mac AI / Ethan

**The vault-v0.3.0 + fuse-v0.4.2 release runs reported `success` but the "Package and upload" step EMITTED `##[warning]COS credentials not configured. Skipping COS upload.`** Artifacts ARE on GitHub Releases. sudowork's `scripts/download-nexus-vfs.js` has a GH-release fallback path (`VAULT_GITHUB_URL` / `FUSE_PLUGIN_GITHUB_URL`), so runtime install will work via fallback. But:

1. Sudoclaw + other downstream consumers that only mirror COS will 404.
2. The release-vault-plugin.yml / release-fuse-plugin.yml callers should pass `COS_SECRET_ID` / `COS_SECRET_KEY` / `COS_BUCKET` / `COS_REGION` secrets to the reusable workflow — currently they're empty. Worth a separate small PR on nexi-lab/nexus to wire those through.

## Out of scope

- `src/renderer/context/TenantConfigContext.tsx` duplicate `useAuth` identifier (TS2300) — pre-existing on `origin/dev` from PR #926 merge (`b79ba1a8`); not from this PR. No PR-level workflow runs `tsc --noEmit` so this won't block the gate.
- COS upload secrets — out of repo (`nexi-lab/nexus` write).
- macOS-x64, windows-arm64, linux-arm64 in the cold-start matrix — no native runners / no plugin artifacts published.

## Test plan

- [x] `bunx prettier --check` on the 3 touched files — clean
- [x] `bunx vitest run tests/integration/nexusVfsSha256Ssot.integration.test.ts` — 6/6 (SSOT invariant still holds)
- [x] `node scripts/expected-plugin-set.js --platform darwin --arch arm64` — count=3 (vault + lc + fuse) confirmed
- [x] One artifact downloaded from GH release + SHA cross-verified locally (`nexus-fuse-plugin-macos-arm64.tar.gz` matches `e17e323f...`)
- [ ] CI `Cold Start Smoke (macos-arm64)` job green — empirical baseline
- [ ] CI: no regression in `Cold Start Smoke (linux-x64)` / `(windows-x64)`
- [ ] CI: no regression in `Dev Shim Smoke (linux-x64)` (PR #924's new job)