### PR TITLE
fix(settings): skip debounced-search first run to avoid double fetch in hub lists

### DIFF
--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -746,6 +746,8 @@ const AgentModalContent: React.FC = () => {
 
   // Track if sync has been triggered for current tab session (avoid loop)
   const syncTriggeredRef = useRef(false);
+  // Skip the debounced-search effect's first mount run — initial load is handled by the category-change effect
+  const searchInitializedRef = useRef(false);
 
   // Sync status state
   const [syncStatus, setSyncStatus] = useState<{
@@ -873,6 +875,12 @@ const AgentModalContent: React.FC = () => {
   );
 
   const currentAssistantTenantId = resolveAssistantTenantId(activeTab);
+
+  // Keep fetchHubAssistants stable: read current activeTab/currentAssistantTenantId from refs
+  const activeTabRef = useRef(activeTab);
+  activeTabRef.current = activeTab;
+  const currentAssistantTenantIdRef = useRef(currentAssistantTenantId);
+  currentAssistantTenantIdRef.current = currentAssistantTenantId;
 
   // Fetch installed assistants for comparison with Hub
   const fetchInstalledAssistantNames = useCallback(async () => {
@@ -1019,8 +1027,8 @@ const AgentModalContent: React.FC = () => {
         const query = hubSearchQueryRef.current.trim();
         // Enterprise mode: use sourceType to specify directory (hub or tenant)
         // Personal mode: use tenantId for tenant assistants
-        const sourceType = isEnterprise && activeTab === 'exclusive' ? 'tenant' : undefined;
-        const tenantId = isEnterprise ? undefined : currentAssistantTenantId;
+        const sourceType = isEnterprise && activeTabRef.current === 'exclusive' ? 'tenant' : undefined;
+        const tenantId = isEnterprise ? undefined : currentAssistantTenantIdRef.current;
 
         if (isElectronDesktop()) {
           const res = await assistantHub.fetchAssistants.invoke({ cursor, limit: 40, query, category, tenantId, sourceType });
@@ -1060,7 +1068,7 @@ const AgentModalContent: React.FC = () => {
         setHubLoadingMore(false);
       }
     },
-    [activeTab, currentAssistantTenantId, fetchLatestAssistantVersions, isEnterprise, t]
+    [fetchLatestAssistantVersions, isEnterprise, t]
   );
 
   // Load more Hub assistants (infinite scroll)
@@ -1103,7 +1111,11 @@ const AgentModalContent: React.FC = () => {
 
   // Debounced search reload for Hub
   useEffect(() => {
-    if (activeTab === 'installed') return;
+    if (!searchInitializedRef.current) {
+      searchInitializedRef.current = true;
+      return;
+    }
+    if (activeTabRef.current === 'installed') return;
     const timer = setTimeout(() => {
       setHubAssistantList([]);
       setHubNextCursor(null);
@@ -1111,7 +1123,7 @@ const AgentModalContent: React.FC = () => {
       void fetchHubAssistants();
     }, 300);
     return () => clearTimeout(timer);
-  }, [activeTab, hubSearchQuery, fetchHubAssistants]);
+  }, [hubSearchQuery, fetchHubAssistants]);
 
   // Listen for sync completed event (enterprise mode)
   useEffect(() => {

--- a/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/SkillModalContent.tsx
@@ -655,6 +655,12 @@ const SkillModalContent: React.FC = () => {
   const enterpriseCode = user?.enterprise_code?.trim();
   const currentTenantId = resolveSkillTenantId(activeTab, enterpriseCode);
 
+  // Keep fetchSkills stable: read current activeTab/currentTenantId from refs instead of the closure
+  const activeTabRef = useRef(activeTab);
+  activeTabRef.current = activeTab;
+  const currentTenantIdRef = useRef(currentTenantId);
+  currentTenantIdRef.current = currentTenantId;
+
   // Enterprise mode detection - use useAppMode hook for renderer process
   const { isEnterprise } = useAppMode();
 
@@ -663,6 +669,8 @@ const SkillModalContent: React.FC = () => {
 
   // Track if sync has been triggered for current tab session (avoid loop)
   const syncTriggeredRef = useRef(false);
+  // Skip the debounced-search effect's first mount run — initial load is handled by the category-change effect
+  const searchInitializedRef = useRef(false);
 
   // Sync status state
   const [syncStatus, setSyncStatus] = useState<{
@@ -957,9 +965,9 @@ const SkillModalContent: React.FC = () => {
         // Always read the CURRENT values from refs — no stale-closure risk
         const category = selectedCategoryRef.current === 'all' ? '' : selectedCategoryRef.current;
         const query = searchQueryRef.current.trim();
-        const tenantId = currentTenantId;
+        const tenantId = currentTenantIdRef.current;
 
-        if (activeTab === 'exclusive' && !tenantId) {
+        if (activeTabRef.current === 'exclusive' && !tenantId) {
           setSkills([]);
           setNextCursor(null);
           setHasMore(false);
@@ -1007,7 +1015,7 @@ const SkillModalContent: React.FC = () => {
       }
     },
     // Minimal stable deps — selectedCategory/searchQuery/latestVersions read from refs
-    [activeTab, currentTenantId, fetchLatestVersions, t]
+    [fetchLatestVersions, t]
   );
 
   // ---- Load more ----
@@ -1078,7 +1086,11 @@ const SkillModalContent: React.FC = () => {
 
   // Debounced search reload
   useEffect(() => {
-    if (activeTab === 'installed') return;
+    if (!searchInitializedRef.current) {
+      searchInitializedRef.current = true;
+      return;
+    }
+    if (activeTabRef.current === 'installed') return;
     const timer = setTimeout(() => {
       setSkills([]);
       setLatestVersions(new Map());
@@ -1087,7 +1099,7 @@ const SkillModalContent: React.FC = () => {
       void fetchSkills();
     }, 300);
     return () => clearTimeout(timer);
-  }, [activeTab, searchQuery, fetchSkills]);
+  }, [searchQuery, fetchSkills]);
 
   // Fetch categories on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix double-refresh (double fetch) in Agent/Skill Hub lists on first mount and tab switch
- Add `searchInitializedRef` to skip the debounced-search effect's first mount run (initial load handled by category-change effect)
- Read `activeTab`/`currentTenantId` via refs in `fetchHubAssistants`/`fetchSkills` so the callbacks stay stable; remove `activeTab`/`currentTenantId` from their dependency arrays and from the search effect deps

## Test plan
- [ ] Open SettingsModal -> Agent/Skill Hub: only one network request fires on mount (no double fetch)
- [ ] Switch between store/exclusive/installed tabs: only one fetch per switch
- [ ] Type in search box: list reloads after 300ms debounce
- [ ] Clear search box: list reloads