### PR TITLE
fix(ci): disable keychain auto-lock to fix macOS x64 codesign hang

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -266,6 +266,12 @@ jobs:
             security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
             security default-keychain -s build.keychain
             security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+            # Disable keychain auto-lock: unlock-keychain only stays unlocked ~5min,
+            # after which codesign (called late in afterPack on slow runners) hits a
+            # relocked keychain, triggers a GUI auth prompt, and hangs headless CI
+            # until the 6h job timeout. set-keychain-settings with no flags disables
+            # both idle-timeout and lock-on-sleep.
+            security set-keychain-settings build.keychain
 
             # Import certificate
             security import certificate.p12 -k build.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign


### PR DESCRIPTION
## 问题

macOS x64 nightly build 连续 5+ 天卡满 6h job timeout 被取消（arm64 / windows 正常）。

## 根因

`security unlock-keychain` 只让 keychain 保持解锁约 5 分钟，之后 macOS 自动 relock。step22 只在 build 开头 unlock 一次，未禁用自动锁。x64 在 Intel runner 上 packaging 慢，afterPack 的 codesign 落在 unlock 后约 7 分钟才执行（keychain 已 relock）→ codesign 访问锁定 keychain 触发 GUI 授权框 → headless CI 无法响应 → 永久 hang 到 timeout。

arm64 不受影响：Apple Silicon 快，afterPack 在 unlock 后约 4 分钟执行（未 relock）。

## 修复

step22 的 `unlock-keychain` 之后加 `security set-keychain-settings build.keychain`，禁用 idle-timeout 和 lock-on-sleep，让 keychain 全程保持解锁。一行改动，直击根因。

## 验证

用本分支触发 nightly macos-x64 build：codesign bdpan 从「卡 5h50m」变为「0.7 秒」，build 在 35 分钟内成功完成（与 arm64 同量级），不再卡 6h。所有 afterPack codesign（bdpan / rolldown / node / scode）均秒过。