### PR TITLE
fix(scode): resolve auto model from server modelIds with pricing-based fallback

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -12,10 +12,11 @@ import type { IAssistantInfo } from '@/process/AssistantManager';
 import type { IChannelPairingRequest, IChannelPluginStatus, IChannelSession, IChannelUser, IPluginCredentials } from '@/channels/types';
 import type { ISafetyStatus, IBlacklistConfig } from '@common/types/security';
 import type { AuthProxyRule } from '@/common/types/authProxy';
+import type { SystemConfig } from '@/common/systemConfig';
 import type { McpSource } from '../process/services/mcpServices/McpProtocol';
 import type { AcpBackend, AcpBackendAll, AcpModelInfo, PresetAgentType } from '../types/acpTypes';
 import type { SyncAllResult } from '../process/sync/remoteToLocalSync';
-import type { ScodeCustomModelProvider } from './scodeConfig';
+import type { ScodeCustomModelProvider, SpecificPricingItem } from './scodeConfig';
 import type { SlashCommandItem } from './slash/types';
 import type { IMcpServer, IProvider, TChatConversation, TProviderWithModel, ICssTheme } from './storage';
 import type { SecretMetadata } from './nexus/nexus-secret-client';
@@ -23,7 +24,6 @@ import type { FusePluginStatus } from './nexus/fuse-plugin-status';
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from './types/preview';
 import type { UpdateCheckRequest, UpdateCheckResult, UpdateDownloadProgressEvent, UpdateDownloadRequest, UpdateDownloadResult, AutoUpdateStatus } from './updateTypes';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from './utils/protocolDetector';
-import type { SystemConfig } from '@/common/systemConfig';
 
 export const shell = {
   openFile: bridge.buildProvider<void, string>('open-file'), // 使用系统默认程序打开文件
@@ -905,6 +905,8 @@ export const scode = {
   setDefaultModel: bridge.buildProvider<IBridgeResponse<void>, { modelId: string }>('scode.set-default-model'),
   /** Fetch live model list from sudorouter specific_pricing, rewrite sudocode.json models, return resolved model info */
   refreshModels: bridge.buildProvider<IBridgeResponse<AcpModelInfo>, void>('scode.refresh-models'),
+  /** Read-only fetch of sudorouter specific_pricing items (no write to sudocode.json) */
+  fetchSpecificPricing: bridge.buildProvider<IBridgeResponse<SpecificPricingItem[]>, void>('scode.fetch-specific-pricing'),
   /** Sync image generation model to sudocode.json tools.imageGenerationModel */
   setImageModel: bridge.buildProvider<IBridgeResponse<void>, { modelId: string | null }>('scode.set-image-model'),
   /** Get scode installation status */

--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -30,6 +30,29 @@ const OPENAI_RESPONSES_API = 'openai-responses';
 export const SCODE_AUTO_MODEL_ALIAS = 'auto';
 export const SCODE_AUTO_ROUTER_MODEL_ID = 'claude-opus-4-8';
 
+export type SpecificPricingItem = {
+  model_id: string;
+  model_ratio?: number;
+};
+
+export function resolveAutoRouterModelId(modelIds: string[], pricingItems?: SpecificPricingItem[]): string | null {
+  if (modelIds.length === 0) return null;
+  if (modelIds.length === 1) return modelIds[0];
+  if (modelIds.includes(SCODE_AUTO_ROUTER_MODEL_ID)) return SCODE_AUTO_ROUTER_MODEL_ID;
+  const idSet = new Set(modelIds);
+  let best: string | null = null;
+  let bestRatio = -Infinity;
+  for (const it of pricingItems || []) {
+    if (typeof it.model_ratio !== 'number') continue;
+    if (!idSet.has(it.model_id)) continue;
+    if (it.model_ratio > bestRatio) {
+      bestRatio = it.model_ratio;
+      best = it.model_id;
+    }
+  }
+  return best ?? modelIds[0];
+}
+
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
 }
@@ -83,9 +106,10 @@ function buildSudorouterModelEntry(modelId: string, alias = modelId): ScodeModel
   };
 }
 
-export function addScodeAutoModel(models: Record<string, ScodeModelEntry>): Record<string, ScodeModelEntry> {
-  models[SCODE_AUTO_MODEL_ALIAS] = buildSudorouterModelEntry(SCODE_AUTO_ROUTER_MODEL_ID, SCODE_AUTO_MODEL_ALIAS);
-  return models;
+export function addScodeAutoModel(models: Record<string, ScodeModelEntry>, modelIds: string[], pricingItems?: SpecificPricingItem[]): string | null {
+  const id = resolveAutoRouterModelId(modelIds, pricingItems);
+  if (id) models[SCODE_AUTO_MODEL_ALIAS] = buildSudorouterModelEntry(id, SCODE_AUTO_MODEL_ALIAS);
+  return id;
 }
 
 function buildCustomApiKeyModelEntry(providerId: string, model: ScodeCustomModelProvider['models'][number], alias: string): ScodeModelEntry {
@@ -201,11 +225,11 @@ export function normalizeCustomApiKeyModelsInScodeConfig(config: ScodeConfig | n
   return nextConfig;
 }
 
-export function buildScodeConfigFromLoginPayload(payload: LoginSudoclawPayload, existing?: ScodeConfig | null): ScodeConfig {
-  return mergeSudorouterIntoScodeConfig(existing || {}, payload);
+export function buildScodeConfigFromLoginPayload(payload: LoginSudoclawPayload, existing?: ScodeConfig | null, pricingItems?: SpecificPricingItem[]): ScodeConfig {
+  return mergeSudorouterIntoScodeConfig(existing || {}, payload, pricingItems);
 }
 
-export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | undefined, payload: LoginSudoclawPayload): ScodeConfig {
+export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | undefined, payload: LoginSudoclawPayload, pricingItems?: SpecificPricingItem[]): ScodeConfig {
   const modelIds = uniqueStrings(payload.models);
   const existingModels = existing?.models || {};
   const nextModels: Record<string, ScodeModelEntry> = {};
@@ -216,12 +240,11 @@ export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | un
     }
   }
 
-  addScodeAutoModel(nextModels);
+  const autoModelId = addScodeAutoModel(nextModels, modelIds, pricingItems);
   for (const modelId of modelIds) {
     nextModels[normalizeModelAlias(modelId)] = buildSudorouterModelEntry(modelId);
   }
 
-  const defaultModel = SCODE_AUTO_MODEL_ALIAS;
   const nextConfig: ScodeConfig = {
     ...existing,
     auth_modes: {
@@ -243,8 +266,8 @@ export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | un
     },
   };
 
-  if (defaultModel) {
-    nextConfig.default_model = defaultModel;
+  if (autoModelId) {
+    nextConfig.default_model = SCODE_AUTO_MODEL_ALIAS;
   } else {
     delete nextConfig.default_model;
   }

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -23,7 +23,7 @@ import { writeSudoclawImageGenerationModel } from '@process/bridge/imageGenerati
 import { ipcBridge } from '@/common';
 import { modelInputForModelId } from '@/common/imageUtils';
 import type { ScodeModelEntry } from '@/common/ipcBridge';
-import { addScodeAutoModel, extractCustomProvidersFromScodeConfig, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, type ScodeCustomModelProvider } from '@/common/scodeConfig';
+import { addScodeAutoModel, extractCustomProvidersFromScodeConfig, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, type ScodeCustomModelProvider, type SpecificPricingItem } from '@/common/scodeConfig';
 import { getSudorouterBaseUrl } from '@/common/systemConfig';
 
 const TAG = 'ScodeBridge';
@@ -100,8 +100,31 @@ export function writeScodeImageModel(modelId: string): void {
 
 type SpecificPricingResponse = {
   success?: boolean;
-  data?: Array<{ model_id?: string }>;
+  data?: SpecificPricingItem[];
 };
+
+/**
+ * Fetch sudorouter's specific_pricing items (including model_ratio).
+ * Returns [] on any fetch/parse failure or success!==true; each failure mode logs its own warn,
+ * so callers see the same diagnostic granularity as before the extraction.
+ */
+export async function fetchSpecificPricingItems(): Promise<SpecificPricingItem[]> {
+  let json: SpecificPricingResponse;
+  try {
+    const response = await fetch(`${getSudorouterBaseUrl()}/api/specific_pricing`, { signal: AbortSignal.timeout(15000) });
+    json = (await response.json()) as SpecificPricingResponse;
+  } catch (err) {
+    mainWarn(TAG, `specific_pricing fetch failed: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+
+  if (json.success !== true || !Array.isArray(json.data)) {
+    mainWarn(TAG, 'specific_pricing returned success!=true or no data');
+    return [];
+  }
+
+  return json.data.filter((it): it is SpecificPricingItem => typeof it?.model_id === 'string' && it.model_id.trim().length > 0);
+}
 
 /**
  * Fetch the live model list from sudorouter's specific_pricing endpoint and
@@ -113,21 +136,9 @@ type SpecificPricingResponse = {
  * degrades to the last-known list instead of going empty.
  */
 export async function syncScodeModelsFromPricing(): Promise<void> {
-  let json: SpecificPricingResponse;
-  try {
-    const response = await fetch(`${getSudorouterBaseUrl()}/api/specific_pricing`, { signal: AbortSignal.timeout(15000) });
-    json = (await response.json()) as SpecificPricingResponse;
-  } catch (err) {
-    mainWarn(TAG, `specific_pricing fetch failed, keeping existing models: ${err instanceof Error ? err.message : String(err)}`);
-    return;
-  }
+  const pricingItems = await fetchSpecificPricingItems();
 
-  if (json.success !== true || !Array.isArray(json.data)) {
-    mainWarn(TAG, 'specific_pricing returned success!=true or no data, keeping existing models');
-    return;
-  }
-
-  const modelIds = json.data.map((m) => (typeof m.model_id === 'string' ? m.model_id.trim() : '')).filter(Boolean);
+  const modelIds = pricingItems.map((m) => m.model_id.trim()).filter(Boolean);
   if (modelIds.length === 0) {
     mainWarn(TAG, 'specific_pricing returned empty model list, keeping existing models');
     return;
@@ -144,7 +155,7 @@ export async function syncScodeModelsFromPricing(): Promise<void> {
     }
   }
 
-  addScodeAutoModel(models);
+  addScodeAutoModel(models, modelIds, pricingItems);
   for (const modelId of modelIds) {
     models[modelId] = {
       alias: modelId,
@@ -341,6 +352,8 @@ export function registerScodeBridge(): void {
       return { success: false, msg };
     }
   });
+
+  ipcBridge.scode.fetchSpecificPricing.provider(async () => ({ success: true, data: await fetchSpecificPricingItems() }));
 
   ipcBridge.scode.setImageModel.provider(async ({ modelId }) => {
     try {

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -439,7 +439,9 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
 
     try {
       const currentScodeConfig = await ipcBridge.scode.getConfig.invoke().catch((): null => null);
-      const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data);
+      const pricingRes = await ipcBridge.scode.fetchSpecificPricing.invoke().catch((): null => null);
+      const pricingItems = pricingRes?.data ?? [];
+      const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data, pricingItems);
       const scodeSaveRes = await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig });
       if (!scodeSaveRes?.success) {
         throw new Error(scodeSaveRes?.msg || 'Sudocode saveConfig failed');
@@ -1192,7 +1194,9 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         const loginSudoclawPayload = extractLoginSudoclawPayload(result);
         if (loginSudoclawPayload) {
           const currentScodeConfig = await ipcBridge.scode.getConfig.invoke().catch((): null => null);
-          const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data);
+          const pricingRes = await ipcBridge.scode.fetchSpecificPricing.invoke().catch((): null => null);
+          const pricingItems = pricingRes?.data ?? [];
+          const scodeConfig = buildScodeConfigFromLoginPayload(loginSudoclawPayload, currentScodeConfig?.data, pricingItems);
           await ipcBridge.scode.saveConfig.invoke({ config: scodeConfig }).catch((err) => {
             console.warn('[Auth] Failed to save scode config on enterprise login:', err);
           });


### PR DESCRIPTION
Replace the hardcoded auto=claude-opus-4-8 with a 4-rule resolver:
- single model → use it as auto
- multi-model containing claude-opus-4-8 → use claude-opus-4-8
- multi-model without 4.8 → highest model_ratio from /api/specific_pricing
- fallback to modelIds[0] when pricing is unavailable or has no match

Add fetchSpecificPricing IPC channel so the renderer-side login paths
can fetch sudorouter pricing before writing sudocode.json. Make
default_model conditional on auto being generated to avoid pointing
to a non-existent alias.
