### PR TITLE
fix(scode): refresh web_search credentials on login

### DIFF
--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -261,8 +261,8 @@ export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | un
     web_search: {
       ...(existing?.web_search || {}),
       provider: existing?.web_search?.provider || 'tavily',
-      apiUrl: existing?.web_search?.apiUrl || `${getSudorouterBaseUrl()}/search/tavily/search`,
-      apiKey: existing?.web_search?.apiKey || payload.sudorouterKey || '',
+      apiUrl: `${getSudorouterBaseUrl()}/search/tavily/search`,
+      apiKey: payload.sudorouterKey || '',
     },
   };
 


### PR DESCRIPTION
## 问题
换账号或更换 sudorouter 秘钥后重新登录，`sudocode.json` 的 `web_search`（`apiUrl`/`apiKey`）不更新，仍保留旧账号凭据，导致 web_search 指向错误地址/秘钥。

## 根因
`mergeSudorouterIntoScodeConfig`（`src/common/scodeConfig.ts`）中 `web_search.apiUrl`/`apiKey` 用了「保留旧值」语义（`existing?.web_search?.xxx || 默认值`），而同函数其它 sudorouter 字段（`auth_modes.proxy.sudorouter`、`models`、`default_model`）均为「每次登录刷新」。web_search 是唯一例外。

## 修复
`apiUrl`/`apiKey` 改为每次登录直接用新值（与 `auth_modes` 同款），`provider` 行维持原状。登出逻辑与 saveConfig 保护逻辑不动——登出残留旧值会在下次登录被新值覆盖。