### PR TITLE
fix(dify): unblock main-process enhancement calls and clean Dify query

### DIFF
--- a/src/process/bridge/difyBridge.ts
+++ b/src/process/bridge/difyBridge.ts
@@ -67,11 +67,201 @@ interface ServerEnvelope<T> {
  * renderer-facing IBridgeResponse. The shape contract: the server already
  * wraps everything in `{ success, data, msg }`; we just relay.
  */
-async function sudoworkServerCall<T>(url: string, init: RequestInit): Promise<IBridgeResponse<T>> {
+/**
+ * Hard cap for non-streaming calls into sudowork-server. Anything beyond this
+ * is treated as "Dify enhancement timed out" — the AcpAgent caller will then
+ * fall through to the graceful-degrade path and send the user's message
+ * verbatim instead of hanging the chat indefinitely.
+ *
+ * Sized to cover agent-chat: Dify Agent ReAct chains can run for minutes
+ * when the workflow includes several retrieval + tool-use steps. blocking
+ * `/enhancement/invoke` aggregates the entire upstream stream before
+ * returning a single JSON envelope, so this deadline covers TCP connect +
+ * TLS + the full server-side Dify round-trip. Workflow and rag-only finish
+ * well under this; they share the same constant for consistency.
+ */
+const SUDOWORK_SERVER_CALL_TIMEOUT_MS = 300000;
+
+/**
+ * Direct-call entry point for in-process consumers (the enhancement
+ * orchestrator runs in the main process alongside this bridge — going through
+ * the IPC `bridge.adapter` would broadcast the event only to renderer
+ * windows, and the local provider would never see its own invocation, so the
+ * Promise hangs forever. Calling this helper directly side-steps that.)
+ */
+export async function callGetEnhancement(
+  accessToken: string,
+  assistantId: string,
+): Promise<IBridgeResponse<{ enabled: boolean; mode?: 'agent-chat' | 'workflow' | 'rag-only' }>> {
+  if (!accessToken || !assistantId) {
+    return { success: false, msg: 'accessToken and assistantId required' };
+  }
+  return sudoworkServerCall<{ enabled: boolean; mode?: 'agent-chat' | 'workflow' | 'rag-only' }>(
+    agentUrl(assistantId, '/enhancement'),
+    { headers: jsonHeaders(accessToken) },
+  );
+}
+
+/** See `callGetEnhancement` for why direct calls exist alongside the IPC provider. */
+export async function callInvokeEnhancement(args: {
+  accessToken: string;
+  assistantId: string;
+  query: string;
+  conversationId?: string;
+}): Promise<IBridgeResponse<{ text: string; mode: 'agent-chat' | 'workflow' | 'rag-only'; elapsedMs: number; citations?: unknown[] }>> {
+  if (!args.accessToken || !args.assistantId || !args.query) {
+    return { success: false, msg: 'accessToken, assistantId and query required' };
+  }
+  return sudoworkServerCall(agentUrl(args.assistantId, '/enhancement/invoke'), {
+    method: 'POST',
+    headers: jsonHeaders(args.accessToken),
+    body: JSON.stringify({ query: args.query, conversation_id: args.conversationId ?? '' }),
+  });
+}
+
+/**
+ * Direct-call version of the streaming enhancement path (workflow mode). The
+ * IPC `dify.startEnhancement.invoke()` returns a streamId and then dispatches
+ * `dify.enhancementProgress / Result / End` events to the renderer. That's
+ * unusable from the orchestrator (which already lives in the main process —
+ * see callGetEnhancement docstring for the bridge-broadcast-only quirk that
+ * dropped main → main IPC calls). This helper pumps the SSE stream inline
+ * and resolves a single Promise with the final result; per-node progress is
+ * forwarded via the optional `onProgress` callback so the orchestrator can
+ * still surface "🟢 step name" rows without going through IPC.
+ */
+export async function callStartEnhancementStream(args: {
+  accessToken: string;
+  assistantId: string;
+  query: string;
+  conversationId?: string;
+  onProgress?: (step: string, nodeId?: string, nodeType?: string) => void;
+}): Promise<IBridgeResponse<{ text: string; mode: 'agent-chat' | 'workflow' | 'rag-only'; elapsedMs: number; citations?: unknown[] }>> {
+  if (!args.accessToken || !args.assistantId || !args.query) {
+    return { success: false, msg: 'accessToken, assistantId and query required' };
+  }
+
+  const url = agentUrl(args.assistantId, '/enhancement/invoke-stream');
+  mainLog('DifyBridge', `callStartEnhancementStream enter url=${url}`);
+
   let resp: Response;
   try {
-    resp = await fetch(url, init);
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: jsonHeaders(args.accessToken),
+      body: JSON.stringify({ query: args.query, conversation_id: args.conversationId ?? '' }),
+    });
   } catch (err) {
+    mainWarn('DifyBridge', `callStartEnhancementStream connect failed: ${(err as Error).message}`);
+    return { success: false, msg: `connect failed: ${(err as Error).message}` };
+  }
+  if (!resp.ok || !resp.body) {
+    const detail = await resp.text().catch(() => '');
+    return { success: false, msg: `upstream ${resp.status}: ${detail.slice(0, 200)}` };
+  }
+
+  // Inline SSE pump — mirrors `pumpEnhancementSse` but resolves a single
+  // Promise instead of emitting IPC events. Resolves on `result`/`error`/
+  // stream-end. Bails on dangling streams via an inactivity timer so the
+  // chat doesn't sit at "正在处理中" forever if the server stops sending.
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+  let result: { text: string; mode: 'agent-chat' | 'workflow' | 'rag-only'; elapsedMs: number; citations?: unknown[] } | null = null;
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let sep = buffer.indexOf('\n\n');
+      while (sep !== -1) {
+        const rawFrame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        sep = buffer.indexOf('\n\n');
+
+        let event = '';
+        const dataLines: string[] = [];
+        for (const line of rawFrame.split('\n')) {
+          if (line.startsWith('event:')) event = line.slice(6).trim();
+          else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+        }
+        if (dataLines.length === 0) continue;
+        let payload: Record<string, unknown> = {};
+        try {
+          payload = JSON.parse(dataLines.join('\n'));
+        } catch {
+          continue;
+        }
+        if (event === 'progress' || payload.kind === 'progress') {
+          try {
+            args.onProgress?.(
+              String(payload.step ?? ''),
+              payload.nodeId as string | undefined,
+              payload.nodeType as string | undefined,
+            );
+          } catch (err) {
+            mainWarn('DifyBridge', 'callStartEnhancementStream onProgress threw:', err);
+          }
+        } else if (event === 'result' || payload.kind === 'result') {
+          result = {
+            text: String(payload.text ?? ''),
+            mode: (payload.mode as 'agent-chat' | 'workflow' | 'rag-only') ?? 'workflow',
+            elapsedMs: Number(payload.elapsedMs ?? 0),
+            citations: payload.citations as unknown[] | undefined,
+          };
+        } else if (event === 'error' || payload.kind === 'error') {
+          const msg = String(payload.message ?? 'enhancement error');
+          mainWarn('DifyBridge', `callStartEnhancementStream upstream error: ${msg}`);
+          return { success: false, msg };
+        }
+      }
+    }
+  } catch (err) {
+    mainWarn('DifyBridge', `callStartEnhancementStream read failed: ${(err as Error).message}`);
+    return { success: false, msg: `stream read failed: ${(err as Error).message}` };
+  }
+
+  if (!result) {
+    return { success: false, msg: 'stream ended without result' };
+  }
+  return { success: true, data: result };
+}
+
+async function sudoworkServerCall<T>(url: string, init: RequestInit): Promise<IBridgeResponse<T>> {
+  const t0 = Date.now();
+  mainLog('DifyBridge', `sudoworkServerCall enter url=${url} method=${init.method ?? 'GET'}`);
+  // Merge any caller-supplied AbortSignal with our timeout. If the caller did
+  // not provide one, the timeout signal alone gates the fetch.
+  const timeoutSignal = AbortSignal.timeout(SUDOWORK_SERVER_CALL_TIMEOUT_MS);
+  const signal = init.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal;
+  // Belt-and-suspenders: some Electron Node builds have surprised us with
+  // AbortSignal.timeout being silently ignored on `fetch`. Add an explicit
+  // setTimeout that calls AbortController.abort() — at worst we get two
+  // abort sources racing, at best this is the one that actually fires.
+  const controller = new AbortController();
+  const hardTimer = setTimeout(() => {
+    mainWarn('DifyBridge', `sudoworkServerCall hard-timeout after ${SUDOWORK_SERVER_CALL_TIMEOUT_MS}ms; aborting url=${url}`);
+    controller.abort(new Error('sudoworkServerCall hard timeout'));
+  }, SUDOWORK_SERVER_CALL_TIMEOUT_MS);
+  const finalSignal = AbortSignal.any([signal, controller.signal]);
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, { ...init, signal: finalSignal });
+    clearTimeout(hardTimer);
+  } catch (err) {
+    clearTimeout(hardTimer);
+    const elapsed = Date.now() - t0;
+    const isTimeout = (err as Error).name === 'TimeoutError' || (err as Error).name === 'AbortError';
+    if (isTimeout) {
+      mainWarn('DifyBridge', `sudoworkServerCall timed out after ${elapsed}ms url=${url}`);
+      return { success: false, msg: `sudowork-server timeout after ${elapsed}ms` };
+    }
+    mainWarn('DifyBridge', `sudoworkServerCall network error after ${elapsed}ms url=${url}: ${(err as Error).message}`);
     return { success: false, msg: `network: ${(err as Error).message}` };
   }
   let body: unknown = null;
@@ -494,6 +684,7 @@ export function initDifyBridge(): void {
   // ============================================================================
 
   dify.getEnhancement.provider(async ({ accessToken, assistantId }) => {
+    mainLog('DifyBridge', `getEnhancement provider invoked assistantId=${assistantId} tokenLen=${accessToken?.length ?? 0}`);
     if (!accessToken || !assistantId) {
       return { success: false, msg: 'accessToken and assistantId required' };
     }
@@ -501,6 +692,7 @@ export function initDifyBridge(): void {
   });
 
   dify.invokeEnhancement.provider(async ({ accessToken, assistantId, query, conversationId }) => {
+    mainLog('DifyBridge', `invokeEnhancement provider invoked assistantId=${assistantId} queryLen=${query?.length ?? 0} tokenLen=${accessToken?.length ?? 0}`);
     if (!accessToken || !assistantId || !query) {
       return { success: false, msg: 'accessToken, assistantId and query required' };
     }

--- a/src/process/services/dify/enhancement.ts
+++ b/src/process/services/dify/enhancement.ts
@@ -16,7 +16,11 @@
  */
 
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
-import { dify } from '@/common/ipcBridge';
+// Direct main-process helpers — we MUST NOT route these calls through the
+// `dify.*` IPC bridge from here because the bridge's adapter only broadcasts
+// to renderer windows (not back to main). The main-side provider would never
+// fire and the Promise would hang. See difyBridge.ts:callGetEnhancement.
+import { callGetEnhancement, callInvokeEnhancement, callStartEnhancementStream } from '@process/bridge/difyBridge';
 
 export type EnhancementMode = 'agent-chat' | 'workflow' | 'rag-only';
 
@@ -65,12 +69,19 @@ export interface AugmentResult {
  * enhancement, never a requirement.
  */
 export async function probeEnhancement(accessToken: string, assistantId: string): Promise<EnhancementMeta> {
+  const t0 = Date.now();
+  mainLog('DifyEnhancement', `probe start assistantId=${assistantId}`);
   try {
-    const resp = await dify.getEnhancement.invoke({ accessToken, assistantId });
-    if (!resp.success || !resp.data) return { enabled: false };
-    return resp.data as EnhancementMeta;
+    const resp = await callGetEnhancement(accessToken, assistantId);
+    if (!resp.success || !resp.data) {
+      mainLog('DifyEnhancement', `probe done in ${Date.now() - t0}ms → disabled (success=${resp.success}, msg=${resp.msg ?? '∅'})`);
+      return { enabled: false };
+    }
+    const meta = resp.data as EnhancementMeta;
+    mainLog('DifyEnhancement', `probe done in ${Date.now() - t0}ms → enabled=${meta.enabled} mode=${meta.mode ?? '∅'}`);
+    return meta;
   } catch (err) {
-    mainWarn('DifyEnhancement', 'probe failed; treating as disabled:', err);
+    mainWarn('DifyEnhancement', `probe failed in ${Date.now() - t0}ms; treating as disabled:`, err);
     return { enabled: false };
   }
 }
@@ -91,10 +102,19 @@ export function getEnhancementPromptSuffix(meta: EnhancementMeta): string {
  * endpoint so we can surface per-node progress to the renderer; otherwise we
  * use the blocking endpoint.
  *
+ * `query` is what we send to Dify as the user's question — keep it small and
+ * semantically clean (the raw user text, not the scode system prompt). If
+ * `finalMessage` is supplied, the returned `augmentedMessage` will be
+ * `<knowledge_context>${dify_text}</knowledge_context>\n\n${finalMessage}` —
+ * this is how AcpAgent layers the Dify result on top of the fully-wrapped
+ * scode message (preset rules + identity override + file intent marking
+ * etc.). Without `finalMessage` we fall back to wrapping `query` itself,
+ * which matches the original single-argument behavior.
+ *
  * The `onProgress` callback fires for workflow steps so the renderer can
  * render a `🟢 step name` row in the chat transcript while we wait.
  */
-export async function augmentMessage(args: { accessToken: string; assistantId: string; meta: EnhancementMeta; query: string; conversationId?: string; onProgress?: (step: string) => void }): Promise<AugmentResult | null> {
+export async function augmentMessage(args: { accessToken: string; assistantId: string; meta: EnhancementMeta; query: string; finalMessage?: string; conversationId?: string; onProgress?: (step: string) => void }): Promise<AugmentResult | null> {
   if (!args.meta.enabled || !args.meta.mode) return null;
 
   const mode = args.meta.mode;
@@ -107,20 +127,25 @@ export async function augmentMessage(args: { accessToken: string; assistantId: s
 
 async function runBlockingAugment(args: Parameters<typeof augmentMessage>[0], mode: EnhancementMode): Promise<AugmentResult | null> {
   const start = Date.now();
-  const resp = await dify.invokeEnhancement.invoke({
+  mainLog('DifyEnhancement', `blocking invoke start mode=${mode} assistantId=${args.assistantId} queryLen=${args.query.length} finalMessageLen=${args.finalMessage?.length ?? 0}`);
+  const resp = await callInvokeEnhancement({
     accessToken: args.accessToken,
     assistantId: args.assistantId,
     query: args.query,
     conversationId: args.conversationId,
   });
   if (!resp.success || !resp.data) {
-    mainWarn('DifyEnhancement', `blocking invoke failed: ${resp.msg ?? 'unknown'}`);
+    mainWarn('DifyEnhancement', `blocking invoke failed in ${Date.now() - start}ms: ${resp.msg ?? 'unknown'}`);
     return null;
   }
   const text = resp.data.text ?? '';
-  if (text.length === 0) return null;
+  if (text.length === 0) {
+    mainLog('DifyEnhancement', `blocking invoke returned empty text in ${Date.now() - start}ms — skipping augment`);
+    return null;
+  }
+  mainLog('DifyEnhancement', `blocking invoke done in ${Date.now() - start}ms textLen=${text.length}`);
   return {
-    augmentedMessage: composeMessage(text, mode, args.query),
+    augmentedMessage: composeMessage(text, mode, args.finalMessage ?? args.query),
     injectedText: text,
     promptSuffix: ENHANCEMENT_PRELUDE[mode],
     mode,
@@ -129,72 +154,59 @@ async function runBlockingAugment(args: Parameters<typeof augmentMessage>[0], mo
 }
 
 async function runWorkflowAugment(args: Parameters<typeof augmentMessage>[0], mode: EnhancementMode): Promise<AugmentResult | null> {
-  const start = await dify.startEnhancement.invoke({
+  const begin = Date.now();
+  mainLog('DifyEnhancement', `workflow stream start mode=${mode} assistantId=${args.assistantId} queryLen=${args.query.length} finalMessageLen=${args.finalMessage?.length ?? 0}`);
+
+  // Direct call — see `callStartEnhancementStream` for why the original
+  // event-based path via `dify.startEnhancement.invoke` + `dify.enhancement*`
+  // listeners cannot work from the main process (the IPC bridge's adapter
+  // only broadcasts events to renderer windows, never back to main, so the
+  // Promise + listeners would hang forever exactly the way blocking mode
+  // used to hang before we added `callGetEnhancement`).
+  const resp = await callStartEnhancementStream({
     accessToken: args.accessToken,
     assistantId: args.assistantId,
     query: args.query,
     conversationId: args.conversationId,
+    onProgress: (step) => {
+      try {
+        args.onProgress?.(step);
+      } catch (err) {
+        mainWarn('DifyEnhancement', 'workflow onProgress callback threw:', err);
+      }
+    },
   });
-  if (!start.success || !start.data) {
-    mainWarn('DifyEnhancement', `start workflow failed: ${start.msg ?? 'unknown'}`);
+  if (!resp.success || !resp.data) {
+    mainWarn('DifyEnhancement', `workflow stream failed in ${Date.now() - begin}ms: ${resp.msg ?? 'unknown'}`);
     return null;
   }
-  const { streamId } = start.data;
-  const begin = Date.now();
-
-  return new Promise<AugmentResult | null>((resolve) => {
-    let injected: { text: string; elapsedMs: number } | null = null;
-
-    const onProgress = (evt: { streamId: string; step: string }) => {
-      if (evt.streamId !== streamId) return;
-      try {
-        args.onProgress?.(evt.step);
-      } catch (err) {
-        mainWarn('DifyEnhancement', 'onProgress callback threw:', err);
-      }
-    };
-    const onResult = (evt: { streamId: string; text: string; elapsedMs: number }) => {
-      if (evt.streamId !== streamId) return;
-      injected = { text: evt.text, elapsedMs: evt.elapsedMs };
-    };
-    const onEnd = (evt: { streamId: string; ok: boolean; error?: string }) => {
-      if (evt.streamId !== streamId) return;
-      // Detach listeners — IPC emitters expose `.off` symmetric to `.on` in
-      // sudowork's bridge runtime; if the project uses a different teardown
-      // primitive this will need adjustment when integrated.
-      try {
-        (dify.enhancementProgress as any).off?.(onProgress);
-        (dify.enhancementResult as any).off?.(onResult);
-        (dify.enhancementEnd as any).off?.(onEnd);
-      } catch {
-        /* best-effort cleanup */
-      }
-      if (!evt.ok || !injected) {
-        mainWarn('DifyEnhancement', `workflow stream ended without result: ${evt.error ?? 'unknown'}`);
-        resolve(null);
-        return;
-      }
-      mainLog('DifyEnhancement', `workflow ${streamId} finished in ${injected.elapsedMs}ms`);
-      resolve({
-        augmentedMessage: composeMessage(injected.text, mode, args.query),
-        injectedText: injected.text,
-        promptSuffix: ENHANCEMENT_PRELUDE[mode],
-        mode,
-        elapsedMs: injected.elapsedMs || Date.now() - begin,
-      });
-    };
-
-    dify.enhancementProgress.on(onProgress);
-    dify.enhancementResult.on(onResult);
-    dify.enhancementEnd.on(onEnd);
-  });
+  const text = resp.data.text;
+  if (text.length === 0) {
+    mainLog('DifyEnhancement', `workflow stream returned empty text in ${Date.now() - begin}ms — skipping augment`);
+    return null;
+  }
+  const elapsedMs = resp.data.elapsedMs || Date.now() - begin;
+  mainLog('DifyEnhancement', `workflow stream done in ${elapsedMs}ms textLen=${text.length}`);
+  return {
+    augmentedMessage: composeMessage(text, mode, args.finalMessage ?? args.query),
+    injectedText: text,
+    promptSuffix: ENHANCEMENT_PRELUDE[mode],
+    mode,
+    elapsedMs,
+  };
 }
 
-function composeMessage(injected: string, mode: EnhancementMode, originalQuery: string): string {
+function composeMessage(injected: string, mode: EnhancementMode, userContentForAssistant: string): string {
+  // `userContentForAssistant` is whatever AcpAgent built for the local agent
+  // (identity override + preset rules + file intent marking + user typed
+  // text). The Dify-side `injected` text is the RAG / Agent / Workflow
+  // result keyed off the *raw* user query — see `augmentMessage` docstring
+  // for why we don't want the scode system prompt pollution to also leak
+  // into the Dify query.
   const block = `<knowledge_context source="enterprise_knowledge_agent" mode="${mode}">
 ${injected.trim()}
 </knowledge_context>
 
-${originalQuery}`;
+${userContentForAssistant}`;
   return block;
 }

--- a/src/process/services/dify/enhancementOrchestrator.ts
+++ b/src/process/services/dify/enhancementOrchestrator.ts
@@ -74,31 +74,47 @@ export async function enhancePresetContext(conversationId: string, presetContext
 
 /**
  * Optionally wrap the user message with a `<knowledge_context>` block.
- * Returns the original message verbatim if:
+ *
+ * `rawUserQuery` is what we send to Dify — the cleanest semantic
+ * representation of the user's intent (typically `data.content` after
+ * stripping internal markers). Keep this small and focused.
+ *
+ * `fullAssistantMessage` is what the local agent ultimately receives — the
+ * fully-wrapped scode prompt (identity override + assistant rules + preset
+ * runtime appendix + file intent marking + the actual user query). The
+ * returned string is `<knowledge_context>${dify_text}</knowledge_context>
+ * \n\n${fullAssistantMessage}`. If omitted, falls back to wrapping
+ * `rawUserQuery` itself (original single-argument behavior, kept for
+ * non-AcpAgent callers).
+ *
+ * Returns the original `fullAssistantMessage` (or `rawUserQuery` if not
+ * provided) verbatim if:
  *   - the session was never bound
  *   - the bound assistant has no enhancement
  *   - the Dify call fails for any reason (graceful degrade)
  */
-export async function augmentUserContent(conversationId: string, userContent: string, onProgress?: (step: string) => void): Promise<string> {
+export async function augmentUserContent(conversationId: string, rawUserQuery: string, fullAssistantMessage?: string, onProgress?: (step: string) => void): Promise<string> {
+  const fallback = fullAssistantMessage ?? rawUserQuery;
   const binding = SESSIONS.get(conversationId);
-  if (!binding) return userContent;
+  if (!binding) return fallback;
   const meta = await ensureMeta(binding);
-  if (!meta.enabled) return userContent;
+  if (!meta.enabled) return fallback;
 
   try {
     const result = await augmentMessage({
       accessToken: binding.accessToken,
       assistantId: binding.assistantId,
       meta,
-      query: userContent,
+      query: rawUserQuery,
+      finalMessage: fullAssistantMessage,
       conversationId: binding.difyConversationId,
       onProgress,
     });
-    if (!result) return userContent;
+    if (!result) return fallback;
     return result.augmentedMessage;
   } catch (err) {
     mainWarn('DifyEnhancementOrchestrator', 'augment failed; passing through:', err);
-    return userContent;
+    return fallback;
   }
 }
 

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -937,6 +937,15 @@ This identity statement takes priority over the default identity in USER.md.
         if (contentToSend.includes(NEXUS_FILES_MARKER)) {
           contentToSend = contentToSend.split(NEXUS_FILES_MARKER)[0].trimEnd();
         }
+        // Snapshot the user's RAW typed text right after marker-stripping.
+        // Everything below this point appends scode-specific scaffolding —
+        // file refs, skill tags, the full preset system prompt for first
+        // messages, identity-override blocks for subsequent messages. That
+        // scaffolding is *local-agent context* and must not pollute the
+        // query we send to Dify (which should answer the user's actual
+        // intent, not the scode bootstrap prose). We pass this snapshot to
+        // `augmentUserContent` as the Dify-side query at the very end.
+        const rawUserQuery = contentToSend;
 
         if (data.files && data.files.length > 0) {
           const fileRefs = data.files
@@ -1036,9 +1045,18 @@ This identity statement takes priority over the default identity in USER.md.
         // Dify enhancement: wrap user message with <knowledge_context> block
         // when this conversation has a bound Dify-enhanced assistant. Falls
         // through unchanged for non-enhanced sessions or on any error.
+        //
+        // We pass two args: `rawUserQuery` is what Dify sees as the user's
+        // question; `contentToSend` (already fully wrapped with scode
+        // scaffolding above) is what the local agent ultimately receives,
+        // with the Dify-returned text prepended as a <knowledge_context>
+        // block. This separation is critical — without it, Dify's RAG /
+        // Agent receives the entire 10K scode bootstrap prompt instead of
+        // the actual question, and just parrots whatever fallback line is
+        // closest at hand.
         try {
           const { augmentUserContent } = await import('@process/services/dify/enhancementOrchestrator');
-          contentToSend = await augmentUserContent(this.conversation_id, contentToSend);
+          contentToSend = await augmentUserContent(this.conversation_id, rawUserQuery, contentToSend);
         } catch (augErr) {
           mainWarn('[AcpAgent]', 'Dify augment failed; sending original message:', augErr);
         }


### PR DESCRIPTION
## Summary

- Switch Dify enhancement invocations in the main process from the `dify.*` IPC bridge to direct main-process helpers. The bridge adapter only broadcasts to renderer windows, so main → main calls never resolved and chats hung indefinitely.
- Add a hard timeout (`AbortSignal.timeout` + belt-and-suspenders `setTimeout`) on `sudoworkServerCall` so any future stall surfaces as a graceful-degrade fallback instead of a frozen turn.
- Stop polluting the Dify-side query with the full scode bootstrap (identity override, preset rules, file intent markers). Snapshot the raw user text in `AcpAgent` before scaffolding and pass it to `augmentUserContent` as the Dify query, while wrapping the returned `<knowledge_context>` block around the fully-scaffolded message that the local agent receives.

## Test plan

- [ ] Open a chat with a Dify-enhanced assistant bound to **rag-only** mode and verify the turn completes (no indefinite "正在处理中").
- [ ] Repeat for **agent-chat** and **workflow** modes; confirm workflow per-node progress (`🟢 step name`) still renders.
- [ ] Send a message and inspect logs — Dify query should contain just the user's typed text, not the scode preset prose.
- [ ] Simulate sudowork-server hang (e.g. block port) and confirm the turn falls through to the unenhanced path after ~5 min with a clear warn log instead of hanging.
- [ ] Verify non-enhanced sessions still behave identically (no Dify call attempted).