### PR TITLE
chore: bump version to 0.2.8

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -56,7 +56,12 @@ jobs:
         run: bun install --no-frozen-lockfile
 
       - name: Run secrets unit tests
-        run: bunx vitest run tests/unit/secrets/nexus-secret-client.test.ts tests/unit/secrets/secret-cache.test.ts
+        # secretsGrpcOnly is a static source-code guard (refuses HTTP
+        # secrets paths reintroducing the pre-PR-#733 bug that hit
+        # external user 进二 on v0.2.7). Pure file reads, no native deps
+        # — fits in this cheap unit-test job, not the heavy
+        # pr-integration-smoke that spins up a real cluster.
+        run: bunx vitest run tests/unit/secrets/nexus-secret-client.test.ts tests/unit/secrets/secret-cache.test.ts tests/integration/secretsGrpcOnly.integration.test.ts
 
   # Job 3: Build test across all platforms (parallel with code-quality and unit-tests)
   build-test:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -61,7 +61,11 @@ jobs:
         # external user 进二 on v0.2.7). Pure file reads, no native deps
         # — fits in this cheap unit-test job, not the heavy
         # pr-integration-smoke that spins up a real cluster.
-        run: bunx vitest run tests/unit/secrets/nexus-secret-client.test.ts tests/unit/secrets/secret-cache.test.ts tests/integration/secretsGrpcOnly.integration.test.ts
+        #
+        # nexus-secret-resilient covers the single→batch fallback wrapper
+        # that secretsApi.handlePut + pwdLoginService both call. Mocked,
+        # no native deps either.
+        run: bunx vitest run tests/unit/secrets/nexus-secret-client.test.ts tests/unit/secrets/secret-cache.test.ts tests/unit/secrets/nexus-secret-resilient.test.ts tests/integration/secretsGrpcOnly.integration.test.ts
 
   # Job 3: Build test across all platforms (parallel with code-quality and unit-tests)
   build-test:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -65,7 +65,7 @@ jobs:
         # nexus-secret-resilient covers the single→batch fallback wrapper
         # that secretsApi.handlePut + pwdLoginService both call. Mocked,
         # no native deps either.
-        run: bunx vitest run tests/unit/secrets/nexus-secret-client.test.ts tests/unit/secrets/secret-cache.test.ts tests/unit/secrets/nexus-secret-resilient.test.ts tests/integration/secretsGrpcOnly.integration.test.ts
+        run: bunx vitest run tests/unit/secrets/nexus-secret-client.test.ts tests/unit/secrets/secret-cache.test.ts tests/unit/secrets/nexus-secret-resilient.test.ts tests/unit/secrets/secretsApi.test.ts tests/integration/secretsGrpcOnly.integration.test.ts
 
   # Job 3: Build test across all platforms (parallel with code-quality and unit-tests)
   build-test:
@@ -198,7 +198,7 @@ jobs:
           just build-win-x64
           Write-Host "✓Build test passed for ${{ matrix.platform }}"
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: '--max-old-space-size=8192'
           MSVS_VERSION: 2022
           GYP_MSVS_VERSION: 2022
           WindowsTargetPlatformVersion: 10.0.19041.0
@@ -214,7 +214,7 @@ jobs:
           just build-win-arm64
           Write-Host "✓Build test passed for ${{ matrix.platform }}"
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: '--max-old-space-size=8192'
           MSVS_VERSION: 2022
           GYP_MSVS_VERSION: 2022
           WindowsTargetPlatformVersion: 10.0.19041.0
@@ -230,7 +230,7 @@ jobs:
           node scripts/build-with-builder.js auto ${{ matrix.build_args }}
           echo "✓Build test passed for ${{ matrix.platform }}"
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: '--max-old-space-size=8192'
           npm_config_arch: ${{ matrix.arch }}
           npm_config_target_arch: ${{ matrix.arch }}
           npm_config_runtime: electron

--- a/.github/workflows/pr-integration-smoke.yml
+++ b/.github/workflows/pr-integration-smoke.yml
@@ -66,6 +66,37 @@ jobs:
       - name: Run MCP server protocol test
         run: python3 tests/integration/browser_panel_mcp_server.py
 
+  authproxy-secrets-http-e2e:
+    # End-to-end of the SKILL → AuthProxyServer HTTP → handler path
+    # (the bug surface user 进二 hit on v0.2.7). Boots a real
+    # AuthProxyServer in-process and drives real fetch() calls against
+    # it with real token auth. Cluster + vault dylib are mocked here
+    # (covered by Vault Secrets gRPC E2E above); this job specifically
+    # locks in the HTTP transport + token auth + handler routing layers
+    # those gRPC tests don't reach.
+    name: AuthProxy /secrets HTTP E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Run authProxy /secrets HTTP e2e
+        run: bunx vitest run tests/integration/authProxySecretsHttp.integration.test.ts
+
   vault-signed-download:
     name: Vault Signed Download
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sudowork",
   "productName": "sudowork",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "新一代企业AI应用平台--AgentOPS|办公专家",
   "main": "./out/main/index.js",
   "engines": {

--- a/scripts/cdp-dev-shim-smoke.js
+++ b/scripts/cdp-dev-shim-smoke.js
@@ -161,10 +161,28 @@ async function evaluateInRendererResilient(cdpPort, expression, attempts = 5) {
 // Wrap the renderer-side call in a try/catch that JSON-stringifies the
 // result. Avoids depending on returnByValue's handling of nested
 // promises and gives us a uniform parse path on the node side.
+//
+// EACH probe self-waits for the shim. A previous version did one
+// up-front "is shim ready?" check then called the probe — but Vite/HMR
+// can reload the renderer in the window between the two evaluates,
+// wiping `window.__sudoworkDebug` and surfacing as
+// `TypeError: Cannot read properties of undefined (reading 'fuseT')`
+// (observed PR #937 round 1 on dev tip). Self-waiting in every probe
+// means a mid-eval reload either gets caught by the resilient retry
+// loop (Execution context destroyed) OR by the inner wait (shim missing
+// post-reload).
 function wrap(jsExpr) {
   return `(async () => {
-    try { return JSON.stringify({ ok: true, data: await ${jsExpr} }); }
-    catch (e) { return JSON.stringify({ ok: false, error: String(e && e.stack || e) }); }
+    try {
+      const start = Date.now();
+      while (!window.__sudoworkDebug?.fuseT && Date.now() - start < 30000) {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      if (!window.__sudoworkDebug?.fuseT) {
+        return JSON.stringify({ ok: false, error: 'window.__sudoworkDebug.fuseT missing after 30s wait — devTriggers.ts may not be loaded, or this is a production build' });
+      }
+      return JSON.stringify({ ok: true, data: await ${jsExpr} });
+    } catch (e) { return JSON.stringify({ ok: false, error: String(e && e.stack || e) }); }
   })()`;
 }
 
@@ -174,25 +192,10 @@ async function main() {
   const initialPage = await findPageTarget(cdpPort, waitSeconds);
   console.log(`[cdp-dev-shim-smoke] initial CDP target: ${initialPage.url}`);
 
-  // The renderer may still be hydrating when CDP first answers — the
-  // shim is attached during `import './bootstrap/devTriggers'` which
-  // can lag the initial page navigation. Vite also reloads the page
-  // shortly after open when it discovers new optimizable deps, which
-  // destroys the execution context. Both are handled by the resilient
-  // evaluate wrapper — it retries on context-destroyed and refetches
-  // the page target each attempt.
-  const waitExpr = `(async () => {
-    const start = Date.now();
-    while (!window.__sudoworkDebug?.fuseT && Date.now() - start < 30000) {
-      await new Promise((r) => setTimeout(r, 500));
-    }
-    return !!window.__sudoworkDebug?.fuseT;
-  })()`;
-  const waitRes = await evaluateInRendererResilient(cdpPort, waitExpr);
-  if (!waitRes?.result?.value) {
-    throw new Error('window.__sudoworkDebug.fuseT never appeared on the renderer (30s timeout). devTriggers.ts may not be imported, or this is a production build.');
-  }
-  console.log('[cdp-dev-shim-smoke] shim ready on window.__sudoworkDebug.fuseT');
+  // Each probe expression self-waits for `window.__sudoworkDebug.fuseT`
+  // (see wrap()). No need for a separate up-front check — that's the
+  // race condition that PR #937 round 1 hit (Vite reloaded between the
+  // up-front check and the probe call, wiping the shim).
 
   // Probe 1: runLazyInstallProbe.
   const probeRes = await evaluateInRendererResilient(cdpPort, wrap('window.__sudoworkDebug.fuseT.runLazyInstallProbe()'));

--- a/src/common/nexus/nexus-secret-resilient.ts
+++ b/src/common/nexus/nexus-secret-resilient.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Single-secret call wrappers that transparently fall back to the
+ * batch variants when the deployed vault plugin lacks the per-secret
+ * dispatch entries. This is the recurring "plugin ↔ client ABI skew"
+ * pattern documented in two prior incidents:
+ *
+ *  - `vault_plugin_secret_get_missing` (memory) — deployed nexus_vault.dll
+ *    builds shipped without the `secret_get` dispatch but kept the batch
+ *    + list variants. F1 + ShareOne both regressed silently because the
+ *    consumer code only tried the single-secret path.
+ *  - 进二 v0.2.7 bug (2026-06-27) — pre-PR #733 HTTP `SecretStoreClient`
+ *    couldn't talk to the gRPC-only cluster. PR #733 migrated the path
+ *    but `secretsApi.handlePut` was the one remaining caller without
+ *    fallback resilience; a future vault dylib regression on
+ *    `secret_put` would have surfaced the same symptom to her in
+ *    v0.2.8+ (different error message, same outcome: API key won't
+ *    persist). This module closes that gap.
+ *
+ * Why this module (vs duplicating helpers per consumer): every consumer
+ * that calls `putSecret`/`getSecret` should follow the SAME fallback
+ * policy, or the system splits into "resilient callers" and "fragile
+ * callers" — a fragile caller will be the one that breaks next.
+ * Keeping the policy in one file makes "add a new caller" mean
+ * `putSecretResilient(...)` instead of "decide whether to add a
+ * fallback this time".
+ *
+ * Out of scope (no batch variant exists upstream): `deleteSecret`,
+ * `restoreSecret`. If those single-method dispatches go missing on a
+ * deployed dylib, the only remediation is bumping the dylib version.
+ * Not adding speculative fallbacks for non-existent batch methods.
+ */
+
+import { getNexusSecretClient, type SecretMetadata } from './nexus-secret-client.js';
+
+/**
+ * Recognise the gRPC "method not found" / UNIMPLEMENTED error class.
+ * Both wordings have been observed in nexus-napi error messages
+ * depending on plugin-loader state: `UNIMPLEMENTED` when the cluster
+ * accepted the plugin but the method handler is absent; `method not
+ * found` when it's a routing-table miss. Match both case-insensitively.
+ *
+ * Non-matching errors propagate — we never silently swallow a real
+ * gRPC failure as if it were a missing method.
+ */
+export function isVaultMethodMissing(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /method not found|unimplemented/i.test(err.message);
+}
+
+/**
+ * `putSecret` with a `batch_put` fallback. Use this from every code
+ * path that writes a single secret to the vault. The batch dispatch
+ * accepts a 1-item array and returns the same metadata shape, so the
+ * fallback is semantically equivalent. Returns the metadata of the
+ * stored secret (either path).
+ */
+export function putSecretResilient(namespace: string, key: string, value: string, description?: string): SecretMetadata {
+  const client = getNexusSecretClient();
+  try {
+    return client.putSecret(namespace, key, value, description);
+  } catch (err) {
+    if (!isVaultMethodMissing(err)) throw err;
+    const results = client.batchPut([{ namespace, key, value, description }]);
+    if (!results.length) {
+      // batch_put returning empty for a 1-item input is a vault impl
+      // bug — surface it loudly rather than papering over it.
+      throw new Error(`batch_put fallback returned empty result for ${namespace}/${key}`);
+    }
+    return results[0];
+  }
+}
+
+/**
+ * `getSecret` with a `batch_get` fallback. Returns the stored value
+ * or `''` if absent. `''` is the same sentinel `batchGet` uses for
+ * missing keys (single-key call would throw `NotFound` instead — we
+ * normalise to the batch shape for consistency in fallback path).
+ */
+export function getSecretResilient(namespace: string, key: string): string {
+  const client = getNexusSecretClient();
+  try {
+    return client.getSecret(namespace, key);
+  } catch (err) {
+    if (!isVaultMethodMissing(err)) throw err;
+    const result = client.batchGet([{ namespace, key }]);
+    const values = Object.values(result);
+    return values.length ? values[0] : '';
+  }
+}

--- a/src/process/services/authProxy/secretsApi.ts
+++ b/src/process/services/authProxy/secretsApi.ts
@@ -11,16 +11,12 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { URL } from 'url';
 import { getNexusSecretClient } from '@common/nexus/nexus-secret-client';
+import { putSecretResilient } from '@common/nexus/nexus-secret-resilient';
 import { cachePut, cacheDelete } from '@common/nexus/secret-cache';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { ProcessConfig } from '@/process/initStorage';
-import {
-  findConfigItemByNamespace,
-  buildRuleFromRawItem,
-  addRuleToCache,
-  removeRuleFromCache,
-} from './configItemsLoader';
 import { ipcBridge } from '@/common';
+import { findConfigItemByNamespace, buildRuleFromRawItem, addRuleToCache, removeRuleFromCache } from './configItemsLoader';
 
 // ============================================================================
 // Mutex for serializing enabled-state writes
@@ -83,9 +79,7 @@ async function applyEnableSideEffect(namespace: string, intentEnable: boolean): 
       try {
         const client = getNexusSecretClient();
         const activeSecrets = client.listSecrets(namespace, false);
-        const hasActiveEntry = configItem.entries.some((entry) =>
-          activeSecrets.some((s) => s.key === entry.config_key),
-        );
+        const hasActiveEntry = configItem.entries.some((entry) => activeSecrets.some((s) => s.key === entry.config_key));
         if (!hasActiveEntry) {
           map[configItem.id] = false;
           removeRuleFromCache(configItem.id);
@@ -131,12 +125,7 @@ async function handleList(req: IncomingMessage, res: ServerResponse, parsedUrl: 
   }
 }
 
-async function handlePut(
-  req: IncomingMessage,
-  res: ServerResponse,
-  namespace: string,
-  key: string,
-): Promise<void> {
+async function handlePut(req: IncomingMessage, res: ServerResponse, namespace: string, key: string): Promise<void> {
   try {
     let body: string;
     try {
@@ -164,15 +153,25 @@ async function handlePut(
       return;
     }
 
-    const client = getNexusSecretClient();
-    const result = client.putSecret(namespace, key, value, description as string | undefined);
+    // putSecretResilient transparently falls back to batch_put if the
+    // deployed vault dylib is missing the single-secret dispatch — the
+    // recurring "plugin ABI skew" pattern documented in memory
+    // [[vault_plugin_secret_get_missing]]. Without this, 进二 (v0.2.7)'s
+    // bug class (API key won't persist → 500 → skill falls back to local
+    // file → user keeps falling back to credits) could recur in any
+    // future release that pins a vault dylib build missing secret_put.
+    const result = putSecretResilient(namespace, key, value, description as string | undefined);
 
     // PUT on a previously soft-deleted secret creates a new version but keeps deleted state.
     // restoreSecret clears deleted state, making the secret active again.
     // For non-deleted or first-create secrets, restoreSecret returns error which we ignore.
+    // (No resilient wrapper here — restore has no batch variant upstream.)
     try {
-      client.restoreSecret(namespace, key);
-    } catch {}
+      getNexusSecretClient().restoreSecret(namespace, key);
+    } catch {
+      // Intentional: restoreSecret throws on non-deleted secrets (the
+      // common path for first-time PUT). The throw isn't a failure.
+    }
 
     cachePut(namespace, key, value);
 
@@ -185,12 +184,7 @@ async function handlePut(
   }
 }
 
-async function handleDelete(
-  req: IncomingMessage,
-  res: ServerResponse,
-  namespace: string,
-  key: string,
-): Promise<void> {
+async function handleDelete(req: IncomingMessage, res: ServerResponse, namespace: string, key: string): Promise<void> {
   try {
     const client = getNexusSecretClient();
     const result = client.deleteSecret(namespace, key);
@@ -209,12 +203,7 @@ async function handleDelete(
 // Main entry point
 // ============================================================================
 
-export async function handleSecretsRequest(
-  req: IncomingMessage,
-  res: ServerResponse,
-  pathname: string,
-  parsedUrl: URL,
-): Promise<void> {
+export async function handleSecretsRequest(req: IncomingMessage, res: ServerResponse, pathname: string, parsedUrl: URL): Promise<void> {
   try {
     const segments = pathname.split('/').filter(Boolean);
     const method = req.method ?? 'GET';

--- a/src/process/services/pwdLogin/pwdLoginService.ts
+++ b/src/process/services/pwdLogin/pwdLoginService.ts
@@ -13,6 +13,7 @@ import type { IPwdLoginParams, IPwdLoginResult } from '@/common/ipcBridge';
 import { BaseApprovalStore, type IApprovalKey } from '@/common/approval/ApprovalStore';
 import { PermissionType } from '@/common/codex/types/permissionTypes';
 import { getNexusSecretClient } from '@/common/nexus/nexus-secret-client';
+import { putSecretResilient, getSecretResilient } from '@/common/nexus/nexus-secret-resilient';
 import { buildNamespace } from '@/common/nexus/namespace';
 import { mainError, mainLog } from '@process/utils/mainLogger';
 import { ProcessConfig } from '@/process/initStorage';
@@ -55,36 +56,9 @@ export interface PwdLoginEntryStatus {
   hasCredential: boolean;
 }
 
-/** True when a gRPC error is "method not found" — some deployed vault plugin
- *  builds are missing the single-secret `secret_get`/`secret_put` dispatch but
- *  DO have the batch + list variants. We transparently fall back to those. */
-function isMethodNotFound(err: unknown): boolean {
-  return err instanceof Error && /method not found/i.test(err.message);
-}
-
-/** getSecret with a batchGet fallback (resilient to plugins missing secret_get). */
-function getSecretResilient(namespace: string, key: string): string {
-  const client = getNexusSecretClient();
-  try {
-    return client.getSecret(namespace, key);
-  } catch (err) {
-    if (!isMethodNotFound(err)) throw err;
-    const result = client.batchGet([{ namespace, key }]);
-    const values = Object.values(result);
-    return values.length ? values[0] : '';
-  }
-}
-
-/** putSecret with a batchPut fallback (resilient to plugins missing secret_put). */
-function putSecretResilient(namespace: string, key: string, value: string, description?: string): void {
-  const client = getNexusSecretClient();
-  try {
-    client.putSecret(namespace, key, value, description);
-  } catch (err) {
-    if (!isMethodNotFound(err)) throw err;
-    client.batchPut([{ namespace, key, value, description }]);
-  }
-}
+// Resilient wrappers (single → batch fallback for vault dylib builds missing
+// the per-secret dispatch entries) moved to @common/nexus/nexus-secret-resilient
+// so every secret-writing caller follows the same policy. Import above.
 
 async function getRegistry(): Promise<PwdLoginEntry[]> {
   try {

--- a/tests/integration/authProxySecretsHttp.integration.test.ts
+++ b/tests/integration/authProxySecretsHttp.integration.test.ts
@@ -1,0 +1,296 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * End-to-end test of the SKILL path that user 进二 hit on v0.2.7:
+ *
+ *   skill subprocess
+ *     → fetch SUDOWORK_AUTH_PROXY_BASE_URL/secrets/...
+ *     → AuthProxyServer HTTP listen on 127.0.0.1
+ *     → token validation
+ *     → handleSecretsRequest dispatch
+ *     → NexusSecretClient (mocked in-memory)
+ *
+ * Boots a real AuthProxyServer in-process, registers a test token via
+ * the real `registerToken` API, then drives real HTTP `fetch` calls
+ * against it. Cluster + vault dylib are mocked (covered separately by
+ * `tests/integration/secrets-grpc.integration.test.ts`); this test
+ * focuses on what those don't cover: HTTP transport + token auth +
+ * server routing + the full skill-style request shape.
+ *
+ * Together with Gap 1 (resilient unit) + Gap 2 (handler integration)
+ * + secrets-grpc (real cluster), this triangulates: skill HTTP →
+ * authProxy → handler → resilient wrapper → real cluster. Every layer
+ * has at least one test that exercises it.
+ *
+ * Runs in pr-integration-smoke (needs spawn + http). NOT in the cheap
+ * pr-checks unit test job.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── In-memory persisting secret store (mirrors Gap 2 mock pattern) ─
+
+interface StoredSecret {
+  namespace: string;
+  key: string;
+  value: string;
+  description?: string;
+  version: number;
+  deleted: boolean;
+}
+
+let store: Map<string, StoredSecret>;
+
+function storeKey(namespace: string, key: string): string {
+  return `${namespace}/${key}`;
+}
+
+function toMetadata(s: StoredSecret) {
+  return { namespace: s.namespace, key: s.key, description: s.description, currentVersion: s.version, deleted: s.deleted, createdAt: Date.now(), updatedAt: Date.now() };
+}
+
+const mockClient = {
+  putSecret: vi.fn((namespace: string, key: string, value: string, description?: string) => {
+    const k = storeKey(namespace, key);
+    const existing = store.get(k);
+    const stored: StoredSecret = { namespace, key, value, description: description ?? existing?.description, version: (existing?.version ?? 0) + 1, deleted: false };
+    store.set(k, stored);
+    return toMetadata(stored);
+  }),
+  batchPut: vi.fn((items: Array<{ namespace: string; key: string; value: string; description?: string }>) => {
+    return items.map((i) => mockClient.putSecret(i.namespace, i.key, i.value, i.description));
+  }),
+  getSecret: vi.fn((namespace: string, key: string) => {
+    const s = store.get(storeKey(namespace, key));
+    if (!s || s.deleted) throw new Error(`Not found: ${namespace}/${key}`);
+    return s.value;
+  }),
+  batchGet: vi.fn(),
+  deleteSecret: vi.fn((namespace: string, key: string) => {
+    const k = storeKey(namespace, key);
+    const existing = store.get(k);
+    if (!existing) return false;
+    store.set(k, { ...existing, deleted: true });
+    return true;
+  }),
+  restoreSecret: vi.fn((namespace: string, key: string) => {
+    const k = storeKey(namespace, key);
+    const existing = store.get(k);
+    if (!existing) throw new Error('Secret not found or not deleted');
+    store.set(k, { ...existing, deleted: false });
+    return true;
+  }),
+  listSecrets: vi.fn((namespace?: string, includeDeleted = false) => {
+    return [...store.values()].filter((s) => (!namespace || s.namespace === namespace) && (includeDeleted || !s.deleted)).map(toMetadata);
+  }),
+};
+
+// ─── Mock the heavy infra the handler imports ───────────────────────
+
+vi.mock('@common/nexus/nexus-secret-client', () => ({
+  getNexusSecretClient: () => mockClient,
+}));
+vi.mock('@common/nexus/nexus-secret-resilient', async () => {
+  const { putSecretResilient } = await import('../../src/common/nexus/nexus-secret-resilient');
+  return { putSecretResilient };
+});
+vi.mock('@common/nexus/secret-cache', () => ({
+  cachePut: vi.fn(),
+  cacheDelete: vi.fn(),
+  resolveSecret: vi.fn(async () => null),
+}));
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+vi.mock('@/process/initStorage', () => ({
+  ProcessConfig: {
+    getSync: vi.fn(() => ({})),
+    get: vi.fn(async () => undefined),
+    set: vi.fn(async () => {}),
+  },
+}));
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    authProxy: {
+      enabledStateChanged: { emit: vi.fn() },
+    },
+  },
+}));
+vi.mock('../../src/process/services/authProxy/configItemsLoader', () => ({
+  findConfigItemByNamespace: vi.fn(() => null),
+  buildRuleFromRawItem: vi.fn(),
+  addRuleToCache: vi.fn(),
+  removeRuleFromCache: vi.fn(),
+  findRuleForUrl: vi.fn(() => null),
+  getRules: vi.fn(() => []),
+}));
+// auto-login pwd_login route — not exercised here, but imported by AuthProxyServer.
+vi.mock('../../src/process/services/authProxy/pwdLoginApi', () => ({
+  handlePwdLoginRequest: vi.fn(async (_req, res) => {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end('{"error":"not in test"}');
+  }),
+}));
+vi.mock('../../src/process/services/authProxy/ssrfGuard', () => ({
+  validateRemoteUrl: vi.fn(async () => ({ valid: true })),
+}));
+
+// ─── Test fixtures ──────────────────────────────────────────────────
+
+let serverInstance: import('../../src/process/services/authProxy/AuthProxyServer').AuthProxyServer;
+let port: number;
+const TEST_TOKEN = 'test-token-abc123';
+
+beforeAll(async () => {
+  // Use real AuthProxyServer to drive REAL HTTP + token auth + routing.
+  // Pass a no-op minimatch — not exercised by /secrets routes.
+  const { AuthProxyServer } = await import('../../src/process/services/authProxy/AuthProxyServer');
+  serverInstance = new AuthProxyServer(() => false);
+  port = await serverInstance.start();
+  serverInstance.registerToken(TEST_TOKEN, process.pid);
+});
+
+afterAll(async () => {
+  await serverInstance.stop();
+});
+
+beforeEach(() => {
+  store = new Map();
+  vi.clearAllMocks();
+});
+
+// ─── Skill-style fetch helper ──────────────────────────────────────
+
+interface SkillResponse {
+  status: number;
+  body: { success: boolean; data?: unknown; msg?: string; error?: string };
+}
+
+async function skillFetch(method: string, path: string, body?: unknown, opts?: { token?: string }): Promise<SkillResponse> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${opts?.token ?? TEST_TOKEN}`,
+  };
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  const res = await fetch(`http://127.0.0.1:${port}${path}`, init);
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : {} };
+}
+
+// ─── Real user journeys (HTTP-level, the actual skill path) ─────────
+
+describe('AuthProxy /secrets HTTP — full skill round-trip', () => {
+  it('Journey: skill saves API key → GETs list → sees it', async () => {
+    // Real fetch, real HTTP, real AuthProxyServer routing, real token auth
+    const put = await skillFetch('PUT', '/secrets/service:shareone/api_key', { value: 'sk-prod-xyz', description: 'ShareOne live' });
+    expect(put.status).toBe(200);
+    expect(put.body.success).toBe(true);
+    expect((put.body.data as { key: string }).key).toBe('api_key');
+
+    const list = await skillFetch('GET', '/secrets?namespace=service:shareone');
+    expect(list.status).toBe(200);
+    const entries = list.body.data as Array<{ namespace: string; key: string }>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ namespace: 'service:shareone', key: 'api_key' });
+  });
+
+  it('Journey: skill rotates API key (second PUT bumps version, single entry)', async () => {
+    await skillFetch('PUT', '/secrets/ns/k', { value: 'v1' });
+    const rotate = await skillFetch('PUT', '/secrets/ns/k', { value: 'v2' });
+    expect(rotate.status).toBe(200);
+    expect((rotate.body.data as { currentVersion: number }).currentVersion).toBe(2);
+
+    const list = await skillFetch('GET', '/secrets?namespace=ns');
+    expect((list.body.data as unknown[]).length).toBe(1);
+  });
+
+  it('Journey: skill DELETEs key → list no longer shows it', async () => {
+    await skillFetch('PUT', '/secrets/ns/k', { value: 'v' });
+    const del = await skillFetch('DELETE', '/secrets/ns/k');
+    expect(del.status).toBe(200);
+
+    const list = await skillFetch('GET', '/secrets?namespace=ns');
+    expect((list.body.data as unknown[]).length).toBe(0);
+  });
+});
+
+// ─── Token auth (the HTTP-layer protection unit tests can't reach) ──
+
+describe('AuthProxy /secrets HTTP — token authentication', () => {
+  it('rejects request with no Authorization header → 401', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/secrets/ns/k`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: '{"value":"v"}' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects request with unregistered token → 401', async () => {
+    const res = await skillFetch('PUT', '/secrets/ns/k', { value: 'v' }, { token: 'fake-token' });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts request with a registered token → 200', async () => {
+    const fresh = 'fresh-token-xyz';
+    serverInstance.registerToken(fresh, process.pid);
+    const res = await skillFetch('PUT', '/secrets/ns/k', { value: 'v' }, { token: fresh });
+    expect(res.status).toBe(200);
+    serverInstance.revokeToken(fresh);
+  });
+
+  it('rejects after revokeToken even if previously valid → 401', async () => {
+    const revoked = 'revoked-token';
+    serverInstance.registerToken(revoked, process.pid);
+    serverInstance.revokeToken(revoked);
+    const res = await skillFetch('PUT', '/secrets/ns/k', { value: 'v' }, { token: revoked });
+    expect(res.status).toBe(401);
+  });
+
+  it('health check is unauthenticated → 200 with no token', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('ok');
+  });
+});
+
+// ─── HTTP-layer body / contract correctness ─────────────────────────
+
+describe('AuthProxy /secrets HTTP — request body + response shape', () => {
+  it('PUT with empty body → 400 (skill should never send this)', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/secrets/ns/k`, { method: 'PUT', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TEST_TOKEN}` } });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /secrets returns JSON array under data', async () => {
+    await skillFetch('PUT', '/secrets/ns/k1', { value: 'v1' });
+    await skillFetch('PUT', '/secrets/ns/k2', { value: 'v2' });
+    const list = await skillFetch('GET', '/secrets?namespace=ns');
+    expect(Array.isArray(list.body.data)).toBe(true);
+    expect((list.body.data as unknown[]).length).toBe(2);
+  });
+});
+
+// ─── The 进二 bug class — full HTTP round-trip with vault method-missing ─
+
+describe('AuthProxy /secrets HTTP — vault method-missing resilience', () => {
+  it('skill PUT returns 200 even when single-secret dispatch is missing (batch fallback)', async () => {
+    // Simulate the v0.2.7 / future-regression scenario: vault dylib
+    // missing secret_put. Without resilience, skill sees 500 →
+    // discards the API key → falls back to credits → 进二's exact
+    // bug.
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('method not found');
+    });
+    mockClient.batchPut.mockReturnValueOnce([{ namespace: 'ns', key: 'k', currentVersion: 1, deleted: false, description: undefined, createdAt: Date.now(), updatedAt: Date.now() }]);
+
+    const res = await skillFetch('PUT', '/secrets/ns/k', { value: 'v' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockClient.batchPut).toHaveBeenCalled();
+  });
+});

--- a/tests/integration/secretsGrpcOnly.integration.test.ts
+++ b/tests/integration/secretsGrpcOnly.integration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Static guard: secrets MUST go through gRPC, not HTTP.
+ *
+ * Context: v0.2.7 (cut 2026-06-06) shipped the old HTTP `SecretStoreClient`
+ * → `fetch('http://localhost:12022/api/v2/secrets')`. nexusd-cluster on
+ * :12022 is gRPC-only (intentional architecture — see DynamicNexusVfsService
+ * docstring + nexus-vfs design); HTTP/1.1 requests get ECONNRESET, surfacing
+ * to skill callers as `fetch failed` 500. PR #733 (commits a0c23096 +
+ * 77e10f27 + dad79af1 + 97a1eea4 + 013a2c24 + 1187181e + f6c02d91 +
+ * 63c4fb56) migrated to `NexusSecretClient` (gRPC via napi NexusGrpcClient).
+ *
+ * The functional test `tests/integration/secrets-grpc.integration.test.ts`
+ * + unit tests under `tests/unit/secrets/` verify gRPC works end-to-end —
+ * but they would still pass if someone added a SECOND code path that uses
+ * HTTP (e.g., a "fallback" or "the gRPC path doesn't expose X so let me
+ * just fetch directly"). This file is the architectural guard that pins
+ * the invariant statically, so the regression class is caught at PR review
+ * time rather than after a release ships and an external user hits it.
+ *
+ * Real incident: user 进二 hit this on v0.2.7 (could not save API key →
+ * fell back to credits → ran out of credits → reported bug). Fix shipped
+ * in v0.2.8.
+ *
+ * If you need to add a new secrets call path, route it through
+ * `getNexusSecretClient()` (see `src/common/nexus/nexus-secret-client.ts`).
+ * Do NOT introduce a parallel HTTP path. If gRPC is missing a method,
+ * extend `password-vault.<method>` dispatch upstream in nexi-lab/nexus
+ * + regenerate the protobuf, don't shortcut through HTTP.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// Files allowed to mention the dead HTTP secrets surface — this test file
+// itself (we explain the regression class in the doc above) + the dead
+// `fetch-client.ts` and its doc neighbors (scheduled for cleanup in a
+// follow-up PR; still in tree but verified zero callers via grep).
+const HTTP_SECRETS_MENTION_ALLOWLIST = new Set([
+  // The grep walks src/ which excludes tests by default; explicit allowlist
+  // covers source files that legitimately reference the legacy URL (e.g. in
+  // docstrings explaining the migration).
+]);
+
+/** Recursively yield every .ts/.tsx file under `dir`, skipping node_modules
+ *  + generated/ + the tests tree (only source code is gated). */
+function* walkSourceFiles(dir: string): Generator<string> {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'generated') continue;
+      yield* walkSourceFiles(full);
+    } else if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
+      yield full;
+    }
+  }
+}
+
+function readSrc(rel: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf-8');
+}
+
+describe('Secrets must go through gRPC — static architectural guard', () => {
+  it('authProxy secretsApi.ts uses getNexusSecretClient (gRPC) for all CRUD handlers', () => {
+    // Positive assertion: the production secrets API handler MUST import
+    // and use the gRPC client. A refactor that drops this import would
+    // mean someone routed secrets elsewhere — surface that immediately.
+    const secretsApi = readSrc('src/process/services/authProxy/secretsApi.ts');
+    expect(secretsApi).toMatch(/from ['"]@common\/nexus\/nexus-secret-client['"]/);
+    expect(secretsApi).toMatch(/getNexusSecretClient/);
+    // Each CRUD handler (list / put / delete) must obtain the client.
+    // Count is informational — if it drops to 0 the imports check above
+    // already fails; >=3 means each handler holds its own ref (no shared
+    // mutable singleton at module scope).
+    const usages = secretsApi.match(/getNexusSecretClient\(\)/g) ?? [];
+    expect(usages.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('authProxy secretsApi.ts does NOT call any HTTP /api/v2/secrets endpoint', () => {
+    // The exact failure mode v0.2.7 shipped: a `fetch` to the HTTP secrets
+    // path. Reject any reintroduction.
+    const secretsApi = readSrc('src/process/services/authProxy/secretsApi.ts');
+    expect(secretsApi).not.toMatch(/\/api\/v2\/secrets/);
+    expect(secretsApi).not.toMatch(/\bfetch\s*\(/);
+    expect(secretsApi).not.toMatch(/\bFetchClient\b/);
+    expect(secretsApi).not.toMatch(/\bSecretStoreClient\b/);
+  });
+
+  it('no source file under src/ defines, imports, or instantiates `SecretStoreClient`', () => {
+    // PR #733 deleted the class. Any reappearance as actual code — class
+    // definition, import binding, `new` instantiation, or inheritance —
+    // is the regression we're guarding against. Walk every .ts/.tsx under
+    // src/ rather than grepping a fixed file list, so a sneaky
+    // re-introduction in a new location still trips this.
+    //
+    // Mentions in comments / docstrings are deliberately OK (e.g.
+    // `nexus-secret-client.ts` documents what it replaced). The checks
+    // below match code constructs only — `class/new/extends Name` or
+    // `import {... Name ...}` — not bare name occurrences.
+    const offenders: string[] = [];
+    for (const file of walkSourceFiles(path.join(REPO_ROOT, 'src'))) {
+      const rel = path.relative(REPO_ROOT, file).replace(/\\/g, '/');
+      if (HTTP_SECRETS_MENTION_ALLOWLIST.has(rel)) continue;
+      const content = fs.readFileSync(file, 'utf-8');
+      const codeRef = /\b(?:class|new|extends)\s+SecretStoreClient\b/.test(content);
+      const importRef = /^\s*import\s+[^;]*\bSecretStoreClient\b/m.test(content);
+      if (codeRef || importRef) {
+        offenders.push(rel);
+      }
+    }
+    expect(offenders, `SecretStoreClient must stay deleted (PR #733). Offending files:\n  ${offenders.join('\n  ')}\nUse NexusSecretClient (gRPC) instead — see src/common/nexus/nexus-secret-client.ts`).toEqual([]);
+  });
+
+  it('no source file under src/ calls fetch() against /api/v2/secrets', () => {
+    // Catches the case where someone bypasses authProxy entirely by
+    // calling the (non-existent) HTTP endpoint directly — perhaps to
+    // "test something" or as a "fallback". The gRPC path via
+    // NexusSecretClient is the only sanctioned one.
+    const offenders: { file: string; match: string }[] = [];
+    for (const file of walkSourceFiles(path.join(REPO_ROOT, 'src'))) {
+      const rel = path.relative(REPO_ROOT, file).replace(/\\/g, '/');
+      if (HTTP_SECRETS_MENTION_ALLOWLIST.has(rel)) continue;
+      const content = fs.readFileSync(file, 'utf-8');
+      // Match `fetch(<anything>/api/v2/secrets)` across reasonable
+      // whitespace + same-line URL composition. Multiline string-built
+      // URLs would slip through — that's an accepted blindspot; the
+      // common-case regression is single-line.
+      const match = content.match(/fetch\s*\([^)]*\/api\/v2\/secrets/);
+      if (match) {
+        offenders.push({ file: rel, match: match[0] });
+      }
+    }
+    expect(offenders, `Secrets must go through gRPC NexusSecretClient.callBinary('password-vault.*'), not HTTP /api/v2/secrets. Offending files:\n  ${offenders.map((o) => `${o.file}: ${o.match}`).join('\n  ')}`).toEqual([]);
+  });
+});

--- a/tests/unit/pwdLogin.test.ts
+++ b/tests/unit/pwdLogin.test.ts
@@ -158,9 +158,12 @@ vi.mock('@/common/nexus/nexus-secret-client', () => ({
       }
       return out;
     },
-    batchPut: (secrets: Array<{ namespace: string; key: string; value: string }>) => {
+    batchPut: (secrets: Array<{ namespace: string; key: string; value: string; description?: string }>) => {
       batchPutCalls.push(secrets);
       for (const s of secrets) secretStore.set(`${s.namespace}/${s.key}`, s.value);
+      // Mirror the real NexusSecretClient.batchPut return shape — putSecretResilient
+      // reads the first element to surface metadata to its caller.
+      return secrets.map((s) => ({ namespace: s.namespace, key: s.key, currentVersion: 1, deleted: false, description: s.description }));
     },
     listSecrets: (namespace: string) => {
       listSecretsCalls.push(namespace);

--- a/tests/unit/secrets/nexus-secret-resilient.test.ts
+++ b/tests/unit/secrets/nexus-secret-resilient.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the singleton client; we'll swap its behavior per test.
+const mockClient = {
+  putSecret: vi.fn(),
+  getSecret: vi.fn(),
+  batchPut: vi.fn(),
+  batchGet: vi.fn(),
+};
+
+vi.mock('@common/nexus/nexus-secret-client.js', () => ({
+  getNexusSecretClient: () => mockClient,
+}));
+
+// Resolve via the path the resilient module uses; the .js extension is the
+// emit suffix preserved through bundler resolution.
+import { putSecretResilient, getSecretResilient, isVaultMethodMissing } from '../../../src/common/nexus/nexus-secret-resilient';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isVaultMethodMissing', () => {
+  it('matches "method not found" case-insensitively', () => {
+    expect(isVaultMethodMissing(new Error('Method Not Found'))).toBe(true);
+    expect(isVaultMethodMissing(new Error('rpc error: method not found'))).toBe(true);
+  });
+
+  it('matches "UNIMPLEMENTED"', () => {
+    expect(isVaultMethodMissing(new Error('StatusCode.UNIMPLEMENTED'))).toBe(true);
+    expect(isVaultMethodMissing(new Error('14 UNIMPLEMENTED: ...'))).toBe(true);
+  });
+
+  it('does NOT match other error classes', () => {
+    expect(isVaultMethodMissing(new Error('Network error'))).toBe(false);
+    expect(isVaultMethodMissing(new Error('SHA mismatch'))).toBe(false);
+    expect(isVaultMethodMissing(new Error('plugin API version mismatch: plugin=3, kernel=5'))).toBe(false);
+  });
+
+  it('does NOT match non-Error inputs', () => {
+    expect(isVaultMethodMissing('method not found')).toBe(false);
+    expect(isVaultMethodMissing(null)).toBe(false);
+    expect(isVaultMethodMissing(undefined)).toBe(false);
+  });
+});
+
+describe('putSecretResilient', () => {
+  const meta = { namespace: 'svc:pwdlogin', key: 'demo', currentVersion: 1, deleted: false };
+
+  it('returns putSecret metadata on the happy path (single-secret dispatch present)', () => {
+    mockClient.putSecret.mockReturnValueOnce(meta);
+    const result = putSecretResilient('svc:pwdlogin', 'demo', 'value', 'desc');
+    expect(result).toEqual(meta);
+    expect(mockClient.putSecret).toHaveBeenCalledWith('svc:pwdlogin', 'demo', 'value', 'desc');
+    expect(mockClient.batchPut).not.toHaveBeenCalled();
+  });
+
+  it('falls back to batchPut when single-secret dispatch is missing', () => {
+    // This is the 进二-bug-class: deployed vault dylib lacks secret_put.
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('rpc method not found: secret_put');
+    });
+    mockClient.batchPut.mockReturnValueOnce([meta]);
+    const result = putSecretResilient('svc:pwdlogin', 'demo', 'value', 'desc');
+    expect(result).toEqual(meta);
+    expect(mockClient.batchPut).toHaveBeenCalledWith([{ namespace: 'svc:pwdlogin', key: 'demo', value: 'value', description: 'desc' }]);
+  });
+
+  it('falls back on UNIMPLEMENTED too (alternate error wording)', () => {
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('StatusCode.UNIMPLEMENTED');
+    });
+    mockClient.batchPut.mockReturnValueOnce([meta]);
+    expect(putSecretResilient('ns', 'k', 'v')).toEqual(meta);
+    expect(mockClient.batchPut).toHaveBeenCalled();
+  });
+
+  it('does NOT swallow non-method-missing errors', () => {
+    // ABI mismatch / network / signature failures must propagate, not be
+    // masked as "fall back to batch".
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('plugin API version mismatch: plugin=3, kernel=5');
+    });
+    expect(() => putSecretResilient('ns', 'k', 'v')).toThrow(/version mismatch/);
+    expect(mockClient.batchPut).not.toHaveBeenCalled();
+  });
+
+  it('surfaces empty-batch-result loudly (vault impl bug, not silent success)', () => {
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('method not found');
+    });
+    mockClient.batchPut.mockReturnValueOnce([]);
+    expect(() => putSecretResilient('ns', 'k', 'v')).toThrow(/batch_put fallback returned empty/);
+  });
+});
+
+describe('getSecretResilient', () => {
+  it('returns the value on the happy path', () => {
+    mockClient.getSecret.mockReturnValueOnce('the-value');
+    expect(getSecretResilient('ns', 'k')).toBe('the-value');
+    expect(mockClient.batchGet).not.toHaveBeenCalled();
+  });
+
+  it('falls back to batchGet when single dispatch is missing', () => {
+    mockClient.getSecret.mockImplementationOnce(() => {
+      throw new Error('method not found');
+    });
+    mockClient.batchGet.mockReturnValueOnce({ k: 'the-value' });
+    expect(getSecretResilient('ns', 'k')).toBe('the-value');
+    expect(mockClient.batchGet).toHaveBeenCalledWith([{ namespace: 'ns', key: 'k' }]);
+  });
+
+  it("returns '' when fallback batchGet has no matching key (vault sentinel)", () => {
+    mockClient.getSecret.mockImplementationOnce(() => {
+      throw new Error('UNIMPLEMENTED');
+    });
+    mockClient.batchGet.mockReturnValueOnce({});
+    expect(getSecretResilient('ns', 'k')).toBe('');
+  });
+
+  it('does NOT swallow non-method-missing errors', () => {
+    mockClient.getSecret.mockImplementationOnce(() => {
+      throw new Error('Not found: ns/k');
+    });
+    expect(() => getSecretResilient('ns', 'k')).toThrow(/Not found/);
+    expect(mockClient.batchGet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/secrets/secretsApi.test.ts
+++ b/tests/unit/secrets/secretsApi.test.ts
@@ -1,0 +1,342 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration test for `handleSecretsRequest` — the authProxy /secrets
+ * route handler that external skill subprocesses hit. Covers the
+ * regression surface that pure-unit tests of `NexusSecretClient` miss:
+ * URL parsing, method dispatch, body validation, JSON shape, error
+ * mapping, and the cross-handler data flow (PUT → LIST sees the key
+ * → DELETE → LIST no longer sees the key) — the actual user journey
+ * a skill walks through when saving / retrieving API keys.
+ *
+ * Real client integration (napi → cluster → vault) is covered by
+ * `tests/integration/secrets-grpc.integration.test.ts`; this test
+ * uses a persisting in-memory client so PUT followed by LIST actually
+ * shows the secret, but doesn't require a running cluster (so it runs
+ * in the cheap Secrets Unit Tests CI job).
+ *
+ * Real user journey driving each test:
+ *   PUT → LIST: "Save my API key, then verify it's in the list"
+ *   PUT same key with new value: "Rotate my API key in place"
+ *   PUT → DELETE → LIST: "Remove my old API key, verify it's gone"
+ *   GET missing key → 405: route correctness for unhappy URL shapes
+ *   PUT with invalid body → 400: skill body-validation contract
+ *
+ * What this guards against (the 进二 v0.2.7 bug class):
+ *   - A handler returning 200 when the underlying secret_put failed
+ *     (the failure path that surfaces as "key disappeared next time")
+ *   - PUT response not reflecting the actual stored metadata
+ *   - LIST silently missing newly-PUT entries (cache race / forgot to
+ *     emit enabledStateChanged etc.)
+ *   - URL parsing accepting paths that bypass the namespace/key check
+ */
+
+import { EventEmitter } from 'events';
+import type { IncomingMessage, ServerResponse } from 'http';
+import { URL } from 'url';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── In-memory client that persists across calls within one test ────
+// (the alternative — re-mocking per call — defeats the data-flow tests
+// where PUT must be visible to subsequent LIST).
+interface StoredSecret {
+  namespace: string;
+  key: string;
+  value: string;
+  description?: string;
+  version: number;
+  createdAt: number;
+  updatedAt: number;
+  deleted: boolean;
+}
+
+let store: Map<string, StoredSecret>;
+
+function storeKey(namespace: string, key: string): string {
+  return `${namespace}/${key}`;
+}
+
+function toMetadata(s: StoredSecret) {
+  return { namespace: s.namespace, key: s.key, description: s.description, currentVersion: s.version, deleted: s.deleted, createdAt: s.createdAt, updatedAt: s.updatedAt };
+}
+
+const mockClient = {
+  putSecret: vi.fn((namespace: string, key: string, value: string, description?: string) => {
+    const k = storeKey(namespace, key);
+    const existing = store.get(k);
+    const now = Date.now();
+    const stored: StoredSecret = {
+      namespace,
+      key,
+      value,
+      description: description ?? existing?.description,
+      version: (existing?.version ?? 0) + 1,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      deleted: false,
+    };
+    store.set(k, stored);
+    return toMetadata(stored);
+  }),
+  batchPut: vi.fn(),
+  getSecret: vi.fn(),
+  batchGet: vi.fn(),
+  deleteSecret: vi.fn((namespace: string, key: string) => {
+    const k = storeKey(namespace, key);
+    const existing = store.get(k);
+    if (!existing) return false;
+    store.set(k, { ...existing, deleted: true });
+    return true;
+  }),
+  restoreSecret: vi.fn((namespace: string, key: string) => {
+    const k = storeKey(namespace, key);
+    const existing = store.get(k);
+    if (!existing) {
+      // Match the real client: restore of a non-existent / never-deleted
+      // secret throws. The handler catches and ignores — that's the
+      // common-case for first-time PUT.
+      throw new Error('Secret not found or not deleted');
+    }
+    store.set(k, { ...existing, deleted: false });
+    return true;
+  }),
+  listSecrets: vi.fn((namespace?: string, includeDeleted = false) => {
+    return [...store.values()].filter((s) => (!namespace || s.namespace === namespace) && (includeDeleted || !s.deleted)).map(toMetadata);
+  }),
+};
+
+// ─── Mock everything the handler imports that isn't load-bearing for
+//     handler logic. The handler's job is route → client; the cache,
+//     config, and bridge layers have their own tests. ─────────────────
+
+vi.mock('@common/nexus/nexus-secret-client', () => ({
+  getNexusSecretClient: () => mockClient,
+}));
+vi.mock('@common/nexus/nexus-secret-resilient', async () => {
+  const { putSecretResilient: realPut } = await import('../../../src/common/nexus/nexus-secret-resilient');
+  return { putSecretResilient: realPut };
+});
+vi.mock('@common/nexus/secret-cache', () => ({
+  cachePut: vi.fn(),
+  cacheDelete: vi.fn(),
+}));
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+vi.mock('@/process/initStorage', () => ({
+  ProcessConfig: {
+    getSync: vi.fn(() => ({})),
+    get: vi.fn(async () => undefined),
+    set: vi.fn(async () => {}),
+  },
+}));
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    authProxy: {
+      enabledStateChanged: { emit: vi.fn() },
+    },
+  },
+}));
+vi.mock('../../../src/process/services/authProxy/configItemsLoader', () => ({
+  findConfigItemByNamespace: vi.fn(() => null),
+  buildRuleFromRawItem: vi.fn(),
+  addRuleToCache: vi.fn(),
+  removeRuleFromCache: vi.fn(),
+}));
+
+// Lazy import so the mocks above land before the handler resolves them.
+let handleSecretsRequest: (req: IncomingMessage, res: ServerResponse, pathname: string, parsedUrl: URL) => Promise<void>;
+
+// ─── Mock req / res helpers ─────────────────────────────────────────
+
+class MockRequest extends EventEmitter {
+  method: string;
+  constructor(method: string, body?: string) {
+    super();
+    this.method = method;
+    // Defer body emit so the handler can attach listeners first.
+    if (body !== undefined) {
+      setImmediate(() => {
+        this.emit('data', Buffer.from(body, 'utf-8'));
+        this.emit('end');
+      });
+    } else {
+      setImmediate(() => this.emit('end'));
+    }
+  }
+  destroy() {}
+}
+
+class MockResponse {
+  statusCode = 0;
+  headers: Record<string, string> = {};
+  body = '';
+  headersSent = false;
+  writeHead(status: number, headers: Record<string, string>): void {
+    this.statusCode = status;
+    this.headers = headers;
+    this.headersSent = true;
+  }
+  end(payload: string): void {
+    this.body = payload;
+  }
+}
+
+async function invoke(method: string, pathname: string, body?: unknown): Promise<MockResponse> {
+  const req = new MockRequest(method, body !== undefined ? JSON.stringify(body) : undefined) as unknown as IncomingMessage;
+  const res = new MockResponse();
+  const parsedUrl = new URL(`http://localhost${pathname}`);
+  await handleSecretsRequest(req, res as unknown as ServerResponse, parsedUrl.pathname, parsedUrl);
+  return res;
+}
+
+function parseBody(res: MockResponse): { success: boolean; data?: unknown; msg?: string } {
+  return JSON.parse(res.body);
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────
+
+beforeEach(async () => {
+  store = new Map();
+  vi.clearAllMocks();
+  // Re-import per test so the singleton state inside the handler module
+  // doesn't bleed between tests (vi.resetModules would also work but is
+  // heavier).
+  const mod = await import('../../../src/process/services/authProxy/secretsApi');
+  handleSecretsRequest = mod.handleSecretsRequest;
+});
+
+// ─── Real user journeys ────────────────────────────────────────────
+
+describe('handleSecretsRequest — full user journeys', () => {
+  it('Journey: skill saves an API key → lists secrets → sees the key', async () => {
+    // Step 1: PUT — skill saves API key for ShareOne
+    const putRes = await invoke('PUT', '/secrets/service:shareone/api_key', { value: 'sk-test-abc', description: 'ShareOne prod key' });
+    expect(putRes.statusCode).toBe(200);
+    const putBody = parseBody(putRes);
+    expect(putBody.success).toBe(true);
+    expect((putBody.data as { key: string }).key).toBe('api_key');
+
+    // Step 2: LIST — skill verifies the key shows up
+    const listRes = await invoke('GET', '/secrets?namespace=service:shareone');
+    expect(listRes.statusCode).toBe(200);
+    const listBody = parseBody(listRes);
+    expect(listBody.success).toBe(true);
+    const entries = listBody.data as Array<{ namespace: string; key: string }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toMatchObject({ namespace: 'service:shareone', key: 'api_key' });
+  });
+
+  it('Journey: rotate an API key in place (second PUT bumps version)', async () => {
+    await invoke('PUT', '/secrets/service:shareone/api_key', { value: 'sk-old' });
+    const rotateRes = await invoke('PUT', '/secrets/service:shareone/api_key', { value: 'sk-new' });
+
+    expect(rotateRes.statusCode).toBe(200);
+    const data = parseBody(rotateRes).data as { currentVersion: number };
+    expect(data.currentVersion).toBe(2);
+
+    // Verify only ONE entry in list (rotation, not duplicate)
+    const listBody = parseBody(await invoke('GET', '/secrets?namespace=service:shareone'));
+    expect((listBody.data as unknown[]).length).toBe(1);
+  });
+
+  it('Journey: delete a key and verify it disappears from list', async () => {
+    await invoke('PUT', '/secrets/service:shareone/api_key', { value: 'sk-test' });
+
+    const deleteRes = await invoke('DELETE', '/secrets/service:shareone/api_key');
+    expect(deleteRes.statusCode).toBe(200);
+    expect(parseBody(deleteRes).success).toBe(true);
+
+    const listBody = parseBody(await invoke('GET', '/secrets?namespace=service:shareone'));
+    expect((listBody.data as unknown[]).length).toBe(0);
+  });
+
+  it('Journey: LIST scoped to namespace ignores other namespaces', async () => {
+    await invoke('PUT', '/secrets/service:shareone/api_key', { value: 'a' });
+    await invoke('PUT', '/secrets/service:other/api_key', { value: 'b' });
+
+    const listBody = parseBody(await invoke('GET', '/secrets?namespace=service:shareone'));
+    expect((listBody.data as Array<{ namespace: string }>).every((s) => s.namespace === 'service:shareone')).toBe(true);
+    expect((listBody.data as unknown[]).length).toBe(1);
+  });
+});
+
+// ─── Handler contract / negative paths ──────────────────────────────
+
+describe('handleSecretsRequest — input validation & error mapping', () => {
+  it('PUT with missing "value" field → 400', async () => {
+    const res = await invoke('PUT', '/secrets/ns/k', { description: 'no value here' });
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).msg).toMatch(/value/);
+  });
+
+  it('PUT with invalid JSON body → 400', async () => {
+    const req = new MockRequest('PUT', '{not json}') as unknown as IncomingMessage;
+    const res = new MockResponse();
+    const url = new URL('http://localhost/secrets/ns/k');
+    await handleSecretsRequest(req, res as unknown as ServerResponse, url.pathname, url);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).msg).toMatch(/JSON/);
+  });
+
+  it('PUT with body over 64KB → 413', async () => {
+    // 65KB string just past the 64KB limit
+    const oversized = 'x'.repeat(64 * 1024 + 1);
+    const res = await invoke('PUT', '/secrets/ns/k', { value: oversized });
+    expect(res.statusCode).toBe(413);
+  });
+
+  it('unsupported method on /secrets/ns/k → 405', async () => {
+    const res = await invoke('PATCH', '/secrets/ns/k');
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('unknown path shape → 404', async () => {
+    const res = await invoke('GET', '/secrets/ns/k/extra/segment');
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('client throwing non-method-missing error → 500 with msg', async () => {
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('plugin API version mismatch: plugin=3, kernel=5');
+    });
+    const res = await invoke('PUT', '/secrets/ns/k', { value: 'v' });
+    expect(res.statusCode).toBe(500);
+    expect(parseBody(res).msg).toMatch(/version mismatch/);
+  });
+});
+
+// ─── The 进二 bug class — fallback resilience at the handler level ─
+
+describe('handleSecretsRequest — vault method-missing resilience', () => {
+  it('PUT succeeds via batch_put fallback when secret_put is method-not-found', async () => {
+    // Vault dylib missing secret_put — the recurring 进二 bug class
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('method not found');
+    });
+    mockClient.batchPut.mockReturnValueOnce([{ namespace: 'service:shareone', key: 'api_key', currentVersion: 1, deleted: false, description: undefined }]);
+
+    const res = await invoke('PUT', '/secrets/service:shareone/api_key', { value: 'sk-test' });
+
+    expect(res.statusCode).toBe(200);
+    expect(parseBody(res).success).toBe(true);
+    expect(mockClient.batchPut).toHaveBeenCalledWith([{ namespace: 'service:shareone', key: 'api_key', value: 'sk-test', description: undefined }]);
+  });
+
+  it('PUT succeeds via batch_put fallback for UNIMPLEMENTED gRPC status too', async () => {
+    mockClient.putSecret.mockImplementationOnce(() => {
+      throw new Error('14 UNIMPLEMENTED: no method password-vault.secret_put');
+    });
+    mockClient.batchPut.mockReturnValueOnce([{ namespace: 'ns', key: 'k', currentVersion: 1, deleted: false, description: undefined }]);
+
+    const res = await invoke('PUT', '/secrets/ns/k', { value: 'v' });
+    expect(res.statusCode).toBe(200);
+    expect(mockClient.batchPut).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Cut v0.2.8 stable release. Carries 603 commits since v0.2.7 (2026-06-06), including:

- **PR #733** (gRPC migration) — `SecretStoreClient` HTTP → `NexusSecretClient` gRPC. Fixes the vault-service bug user 进二 hit on v0.2.7 (密钥写入 → `fetch failed` 500 because nexusd-cluster is gRPC-only and the old HTTP client got `ECONNRESET`).
- **PR #924** (CDP dev-shim CI smoke + launch-dev fail-fast + getInstallState fix)
- **PR #927** (ABI v5 alignment: nexus-vfs 0.4.0 + vault 0.4.0 + lc 0.3.0 + fuse 0.5.0)
- Plus 60+ other PRs (Dify, scode, dify, web_search, browser-panel, server URL handling, etc.)

## After merge
Push `v0.2.8` tag at the merge commit to trigger `build-and-release.yml` → 4-platform builds → GH releases publish (`latest.yml`/`latest-mac.yml`) → COS upload to `sudowork-release-1309794936/sudowork/release/latest/`. Existing v0.2.7 installs will see the update on next auto-check (electron-updater, `releaseType: release`).

## Test plan

- [x] Dev tip `248a019e` confirmed clean — `secretsApi.ts` uses `getNexusSecretClient()` (gRPC) at 4 call sites, 0 HTTP usages of `/api/v2/secrets`
- [x] CI protection: `Vault Secrets gRPC E2E` (full CRUD E2E in pr-integration-smoke.yml) + `Secrets Unit Tests` (9 unit tests in pr-checks.yml) + `Vault Signed Download`
- [x] Recent merges (PR #934-936) all green on these jobs