### PR TITLE
fix(acp): don't poison session on single_request_too_large (PR-A of context-overflow series)

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -2710,6 +2710,13 @@ This identity statement takes priority over the default identity in USER.md.
     const classification = classifyLlmError(this.streamedContextErrorBuffer);
     if (!CONTEXT_OVERFLOW_REASONS.has(classification.type)) return;
 
+    // Defer the "should session be torn down?" decision to the classifier's SSOT.
+    // single_request_too_large and request_body_too_large both have
+    // recoverableByNewSession=false because they're per-request size errors —
+    // poisoning the session would silently drop chat history on every
+    // oversized-attach attempt. Only context_window_exceeded sets the flag true.
+    if (!classification.recoverableByNewSession) return;
+
     const reason = classification.type === 'request_body_too_large' ? 'request_body_too_large' : classification.type === 'single_request_too_large' ? 'single_request_too_large' : 'context_window_exceeded';
     void this.markRuntimeContextPoisoned(classification.userMessage, reason, { disconnectNow: false });
   }

--- a/src/process/utils/llmErrorClassification.ts
+++ b/src/process/utils/llmErrorClassification.ts
@@ -46,10 +46,16 @@ export function classifyLlmError(error: unknown): LlmErrorClassification {
   const message = extractErrorMessage(error);
 
   if (includesAny(message, SINGLE_REQUEST_PATTERNS)) {
+    // single_request errors mean THIS one message exceeded the model's per-request
+    // size cap (e.g. oversized image, big paste). The conversation history is fine
+    // — only the current input is too large. Setting recoverableByNewSession=false
+    // prevents callers (e.g. AcpAgent.markRuntimeContextPoisoned) from tearing
+    // down the ACP session, which would otherwise silently drop full chat history
+    // on every oversized-attach attempt.
     return {
       type: 'single_request_too_large',
-      recoverableByNewSession: true,
-      userMessage: '这次请求内容过大，超过当前模型处理限制。已为后续消息准备新的运行时上下文；如果要重试这份附件，请先压缩图片、拆分文件，或减少本次输入。',
+      recoverableByNewSession: false,
+      userMessage: '这次请求内容过大，超出当前模型单次请求限制。请压缩图片、拆分文件，或减少本次输入后重试；先前对话历史保留。',
     };
   }
 

--- a/tests/e2e/cases/acp-single-request-preserves-session.yaml
+++ b/tests/e2e/cases/acp-single-request-preserves-session.yaml
@@ -1,0 +1,89 @@
+name: "single_request_too_large preserves chat history (no session poison)"
+description: >
+  Regression test for the bug 进二 hit 2026-06-28: sending an oversized
+  image / very long message tripped single_request_too_large, which
+  PRE-FIX caused AcpAgent.markRuntimeContextPoisoned to delete the ACP
+  session — silently dropping full chat history on every attempt.
+
+  POST-FIX: the classifier returns recoverableByNewSession=false for
+  single_request_too_large (history is fine, only THIS message is too
+  big), both poisoning sites (response-error and streamed-error) gate
+  on that flag, so session is preserved.
+
+  Verifies the systemic SSOT fix lands at the user level: after the
+  error, the previous turns are still visible AND a follow-up message
+  uses the same ACP session.
+
+  NOTE 2026-06-28: this YAML is currently a TEST PLAN, not a runnable
+  case. The e2e framework does not yet have an attach_file / paste_image
+  op (no precedent in tests/e2e/ops/*.py). Promoting this to a
+  runnable case requires adding one of:
+    - attach_file op: programmatic file input population via CDP
+      DOM.setFileInputFiles
+    - inject_oversized_text op: bulk-fill the input field with N MB of
+      text (cheaper than wrangling binary clipboard via CDP)
+  Once the op exists, replace the placeholder steps with real ones.
+
+  For now, this case documents the manual reproduction. See PR diff
+  for the systemic fix landed in tests/unit/llmErrorClassification.test.ts.
+
+tags: [api, smoke, manual]
+
+steps:
+  # ── Phase 0: Wait for app startup ──
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # ── Phase 1: Open / create a conversation with the default agent ──
+  # MANUAL: click "新对话" in sidebar → select an ACP backend (scode /
+  # claude / qwen — any backend that classifies single_request errors).
+  - op: screenshot
+    path: "screenshots/acp-srtl-00-conversation-ready.png"
+
+  # ── Phase 2: Build short history (3 normal turns) so we can verify
+  #             it is preserved after the error fires ──
+  # MANUAL: send "hello, what's 2+2?", wait for response.
+  # MANUAL: send "now what's 5*7?", wait for response.
+  - op: screenshot
+    path: "screenshots/acp-srtl-01-history-built.png"
+  - op: judge
+    expect: "Chat shows 2 user messages and 2 assistant replies"
+
+  # ── Phase 3: Trigger single_request_too_large ──
+  # MANUAL: paste/attach an oversized payload. Two known triggers:
+  #   (a) Attach a 25MB+ PNG (drag-drop into chat input)
+  #   (b) Paste ~200KB of repeated text (most ACP backends classify
+  #       this as single_request_too_large via the over-cap LLM API).
+  # The error should surface as an inline error message in chat.
+  - op: screenshot
+    path: "screenshots/acp-srtl-02-error-fired.png"
+  - op: judge
+    expect: "Error message indicating single_request_too_large /
+      content too large / 请求内容过大. The error MUST mention that
+      previous history is preserved (no '新的运行时上下文' wording —
+      that wording was removed in the fix)."
+
+  # ── Phase 4: CRITICAL — verify history NOT lost ──
+  - op: judge
+    expect: "All 4 prior messages from Phase 2 (2 user + 2 assistant)
+      are still visible in the chat window. Session counter unchanged."
+
+  # ── Phase 5: Send a follow-up referencing prior context ──
+  # MANUAL: send "what was my first question?"
+  # Pre-fix: model would have no memory (new ACP session), would say
+  # something like "I don't have prior context" or fabricate.
+  # Post-fix: model recalls "what's 2+2".
+  - op: screenshot
+    path: "screenshots/acp-srtl-03-history-recalled.png"
+  - op: judge
+    expect: "Assistant reply references '2+2' or 'what's 2 plus 2'
+      from the user's Phase 2 first message. This proves the ACP
+      session is the SAME session — context preserved end-to-end."
+
+  # ── Phase 6 (optional): DB-level verification ──
+  # MANUAL: open sudowork DB at %APPDATA%\sudowork\sudowork.db,
+  # query the conversation row's extra.acpSessionId field. It MUST
+  # be the same value before and after Phase 3.
+  # Pre-fix: extra.acpSessionId would be cleared (set to undefined) by
+  # markRuntimeContextPoisoned. Also extra.acpContextHealth.poisoned
+  # would flip to true. Both must NOT happen post-fix.

--- a/tests/unit/llmErrorClassification.test.ts
+++ b/tests/unit/llmErrorClassification.test.ts
@@ -2,18 +2,31 @@ import { describe, expect, it } from 'vitest';
 import { classifyLlmError } from '@/process/utils/llmErrorClassification';
 
 describe('classifyLlmError', () => {
-  it.each(['[context_window_exceeded] compacted history still exceeds limit', 'context_window_blocked for model: estimated input exceeds context window', 'maximum context length exceeded', 'token limit exceeded', '对话内容过长，超出模型处理限制'])('classifies recoverable context overflow: %s', (message) => {
+  it.each(['[context_window_exceeded] compacted history still exceeds limit', 'context_window_blocked for model: estimated input exceeds context window', 'maximum context length exceeded', 'token limit exceeded', '对话内容过长，超出模型处理限制'])(
+    'classifies recoverable context overflow: %s',
+    (message) => {
+      expect(classifyLlmError(message)).toMatchObject({
+        type: 'context_window_exceeded',
+        recoverableByNewSession: true,
+      });
+    }
+  );
+
+  it.each(['当前请求内容过大，超出模型处理限制', '图片或文本内容过大，超出了模型的处理限制。', 'single_request_too_large'])('classifies oversized current requests as session-preserving (only this one message is too big, history is fine): %s', (message) => {
+    // Regression guard: prior to 2026-06-28 this returned recoverableByNewSession=true,
+    // which caused AcpAgent.markRuntimeContextPoisoned to delete the ACP session
+    // on every oversized-attach attempt — silently dropping full chat history.
+    // single_request errors must NOT trigger session reset: shrink THIS input, keep history.
     expect(classifyLlmError(message)).toMatchObject({
-      type: 'context_window_exceeded',
-      recoverableByNewSession: true,
+      type: 'single_request_too_large',
+      recoverableByNewSession: false,
     });
   });
 
-  it.each(['当前请求内容过大，超出模型处理限制', '图片或文本内容过大，超出了模型的处理限制。', 'single_request_too_large'])('classifies oversized current requests as fresh-context recoverable: %s', (message) => {
-    expect(classifyLlmError(message)).toMatchObject({
-      type: 'single_request_too_large',
-      recoverableByNewSession: true,
-    });
+  it('single_request_too_large userMessage indicates history is preserved (no "新的运行时上下文" wording)', () => {
+    const got = classifyLlmError('图片或文本内容过大');
+    expect(got.userMessage).toContain('先前对话历史保留');
+    expect(got.userMessage).not.toContain('新的运行时上下文');
   });
 
   it('classifies request body size failures separately', () => {


### PR DESCRIPTION
## Summary

进二 hit `[context_window_exceeded][single_request_too_large]` 2026-06-28 — and worse, full chat history kept being silently dropped between retries. Root cause: the LLM error classifier returned `recoverableByNewSession: true` for `single_request_too_large`, which caused `AcpAgent.markRuntimeContextPoisoned` to delete `acpSessionId` on every oversized-attach attempt → next message started a brand-new ACP session → conversation history gone.

**Wrong remediation**: single_request errors mean THIS one message exceeded the model's per-request size cap (oversized image, big paste). History is fine — only the current input is too large. User should reduce attachment size or split; previous turns remain valid.

Implementation now matches the documented design intent from May 2026: `docs/plans/2026-05-28-sudocode-context-limit-guard-design.md:491` already said _"如果是 single_request_too_large，不要自动清 session，因为新 session 也会失败。只提示用户压缩/拆分附件。"_ — implementation had diverged from plan.

## Two fix sites (both SSOT-routed through classifier)

1. **`src/process/utils/llmErrorClassification.ts`** — flip `recoverableByNewSession` to `false` for `single_request_too_large`. Update `userMessage` to reflect that history is preserved (removed misleading "已为后续消息准备新的运行时上下文" wording).
2. **`src/process/task/AcpAgent.ts` `handleStreamedContextLimitError`** (line 2702-2714) — defer the "tear session down?" decision to classifier's `recoverableByNewSession` flag. Pre-fix this site always poisoned for any `CONTEXT_OVERFLOW_REASONS` hit, bypassing the SSOT entirely (more severe than the response-error site).

The response-error branch at `AcpAgent.ts:1304-1309` already gates on `recoverableByNewSession`, so the classifier flip cascades there naturally — no code change needed.

## Audit (Ethan's 8 principles)

1. **Simplify contract** ✅ — `recoverableByNewSession` is now the single source of truth for "should reset session"
2. **No boundary leak** ✅ — SSOT in classifier, both call sites consume it uniformly
3. **SSOT** ✅ — eliminates duplicate "should I reset" logic
4. **DRY** ✅ — same gate at both call sites
5. **Rust-first** ✅ N/A (classification is at ACP/TS boundary)
6. **Perf-first** ✅ — fewer DB writes (no spurious context poison records on every oversized-attach)
7. **Raft** ✅ N/A
8. **Systemic** ✅ — fixes class "wrong error → wrong remediation" + implementation/design-doc drift

## Tests

- **Unit** (`tests/unit/llmErrorClassification.test.ts`): 11 cases pass. Includes regression guard on the userMessage wording change.
- **E2E manual reproduction** (`tests/e2e/cases/acp-single-request-preserves-session.yaml`): documents the manual steps to verify at the user level (tagged `[api, smoke, manual]`). Currently a TEST PLAN — promoting to runnable case is gated on adding an `attach_file` / `inject_oversized_text` op to `tests/e2e/ops/` (no precedent yet in the framework).

## E2E verification status (honest)

Attempted programmatic drive via ai-dev-browser (the canonical tool for sudowork UI testing per standing acceptance bar):
- ✅ Connect to sudowork CDP at :9230 — works
- ✅ `page_discover` returns 280-element accessibility tree — works
- ✅ `click_by_ref` (clicked `智能体` tab, navigated to agent library) — works
- ✅ Screenshot capture — works
- ❌ Full oversized-payload flow — gated on: agent install on test profile + API key configured + attach_file or massive-text-inject op (none of which exists in this profile / e2e framework)

Driver script saved at `<scratchpad>/pra_e2e_drive.py` as starting point for future ai-dev-browser drives once the framework gets `attach_file`/`inject_oversized_text` ops.

**Bottom line**: classifier unit tests prove the SSOT fix at the function level; manual reproduction recipe in PR body + YAML test plan documents the user-level behavior; ai-dev-browser drive infrastructure validated but full automated scenario needs additional ops.

## Manual e2e steps (for reviewer verification)

In a local sudowork dev build (`bun run start`):
1. Create / open any ACP conversation with a vision-capable model
2. Send 2 normal turns (`hello what's 2+2?`, `now what's 5*7?`) → wait for replies → 2 user + 2 assistant messages visible
3. Trigger `single_request_too_large` via one of:
   - Attach a 25MB+ PNG (drag-drop into chat input)
   - Paste ~200KB of text
4. **Assert**: error message shown inline. All 4 prior messages still visible. No session counter increment.
5. Send follow-up: `what was my first question?`
6. **Assert**: assistant replies with reference to `2+2` (proves SAME ACP session — context preserved end-to-end)
7. (Optional DB check) `%APPDATA%\sudowork\sudowork.db` — `extra.acpSessionId` UNCHANGED between steps 2 and 6; `extra.acpContextHealth.poisoned` MUST NOT be `true`

## Pre-fix vs post-fix

| | Pre-fix | Post-fix |
|---|---|---|
| Error classification | `recoverableByNewSession: true` | `recoverableByNewSession: false` |
| `markRuntimeContextPoisoned` called | YES (both sites) | NO |
| `acpSessionId` after error | cleared (silently) | preserved |
| Chat history after error | dropped on next message | preserved |
| User experience | "context kept being lost between retries" (进二's words) | history retained, user shrinks input + retries |

## Part of series

This is PR-A of a 4-PR systemic fix for the context overflow + image preflight issue:
- **PR-A (this)**: don't poison session on single_request_too_large
- **PR-B**: differentiated runtime error UX (RuntimeErrorBanner + i18n)
- **PR-C**: sudocode Rust image preflight + napi compress helper (cross-repo)
- **PR-D**: sudocode CC-parity auto-compact threshold + circuit breaker + `/compact` slash (cross-repo)

Design doc: `<scratchpad>/context-overflow-systemic-design.md` (not in repo).