### PR TITLE
fix(acp): client-side image size guard prevents sticky processing indicator

### DIFF
--- a/src/common/image-attachment-guard.ts
+++ b/src/common/image-attachment-guard.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Hard cap on the base64 size of any single image content block sudowork will
+ * hand to the ACP transport. Above this, the gRPC frame / Node IPC channel
+ * for `session/prompt` can stall and the renderer's processing indicator
+ * gets stuck forever (no error response → no `finish` event → no spinner
+ * reset). The 300s `session/prompt` timeout in AcpConnection is NOT a
+ * reliable backstop here: it only fires once the RPC actually dispatched,
+ * but oversized writes can wedge inside the gRPC writer queue.
+ *
+ * Why 25MB:
+ *  - sudocode's own image preflight (`image_registry.rs MAX_IMAGE_BYTES`)
+ *    caps the LLM-side payload at 5MB; this client-side number is the
+ *    TRANSPORT-side cap and is intentionally looser (5× headroom) so that
+ *    large screenshots still flow through and get downsampled server-side.
+ *  - Empirically (2026-06-28 ai-dev-browser drive of conv 78d6e31c):
+ *    2 × 52MB base64 images → gRPC `session/prompt` hung indefinitely,
+ *    the 300s connection-timeout never fired, the spinner stuck at 9m+.
+ *  - 25MB is comfortably under typical gRPC default `max_send_message_size`
+ *    (256MB) and well above any single typical screenshot.
+ *
+ * Duplication-vs-SSOT note: this cap exists ALONGSIDE sudocode's
+ * `image_registry.rs MAX_IMAGE_BYTES` (5MB). They serve different concerns —
+ * sudocode's is the LLM-side preflight cap; this one is the transport-side
+ * pre-flight cap. Intentional defense in depth, not an SSOT violation.
+ */
+export const IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Shape of an image content block as it travels through AcpAgent / ACP.
+ * Just enough fields to size-validate without coupling to the full schema.
+ */
+export interface ImageBlockForValidation {
+  /** base64-encoded image bytes (NOT the raw image; what actually ships over the wire). */
+  data: string;
+  /** MIME type, kept for diagnostic messages. */
+  mimeType: string;
+}
+
+/**
+ * Human-readable size formatter. Returns `"25.1 MB"`, `"190 KB"`, etc.
+ * Local to this module (`formatBytesForMessage` in AcpAgent isn't exported
+ * and copying would lose the SSOT we just established).
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Validate that every image's base64 size fits the transport cap. Returns
+ * a user-facing message describing the first oversize image, or `null` when
+ * all images are within cap.
+ *
+ * Returns early on the FIRST oversize image. Per-image rather than total
+ * because clients usually paste images one at a time; the per-image message
+ * gives clearer guidance than a "total exceeds" aggregate.
+ *
+ * @example
+ * const error = validateImageAttachmentSize([{ data: bigB64, mimeType: 'image/png' }]);
+ * if (error) { ui.showError(error); return; }
+ */
+export function validateImageAttachmentSize(images: ImageBlockForValidation[] | undefined | null, cap: number = IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES): string | null {
+  if (!images || images.length === 0) return null;
+
+  for (let i = 0; i < images.length; i++) {
+    const img = images[i];
+    if (img.data.length > cap) {
+      // Stopgap message — the SOTA fix is server-side auto-downsample /
+      // auto-VLM-routing so users never see this. Tracked at:
+      // https://s.shareone.vip/s/sudo-code-roadmap (search "image too large")
+      // For now we surface a soft message so the user knows what happened
+      // and the renderer's processing indicator clears (this guard's
+      // primary job is preventing the gRPC transport from wedging when
+      // base64 > 25MB, which would leave the spinner stuck forever).
+      return `图片 #${i + 1} 太大了 (约 ${formatBytes(img.data.length)}，临时上限 ${formatBytes(cap)})。可以先用其他工具压一下；这个限制是临时的，之后版本会在后端自动处理。`;
+    }
+  }
+
+  return null;
+}

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -23,6 +23,7 @@ import type { AcpQuestionData, CronMessageMeta, TMessage, TurnTokenUsage } from 
 import type { SlashCommandItem } from '@/common/slash/types';
 import { transformMessage } from '@/common/chatLib';
 import { DRAFTS_DIR_NAME, NEXUS_FILES_MARKER } from '@/common/constants';
+import { validateImageAttachmentSize } from '@/common/image-attachment-guard';
 import { appendNexusFilesMarker } from '@/common/nexusFiles';
 import type { IResponseMessage } from '@/common/ipcBridge';
 import { NavigationInterceptor, type NavigationToolData } from '@/common/navigation';
@@ -995,6 +996,19 @@ This identity statement takes priority over the default identity in USER.md.
             this.emitErrorMessage(tip);
             return { success: false, message: tip };
           }
+        }
+
+        // Client-side image-size guard. Without this, a >50MB base64 image
+        // can wedge the ACP gRPC writer queue and the `session/prompt` request
+        // never reaches the dispatched state — the 300s connection-timeout
+        // doesn't fire, no error response, no `finish` event, renderer's
+        // processing indicator sticks forever (empirical 9m-stuck failure
+        // mode observed 2026-06-28 with 2× 52MB base64 images).
+        // See @common/image-attachment-guard for the cap rationale + SSOT.
+        const imageSizeIssue = validateImageAttachmentSize(finalImages);
+        if (imageSizeIssue) {
+          this.emitErrorMessage(imageSizeIssue);
+          return { success: false, message: imageSizeIssue };
         }
 
         if (this.isFirstMessage) {

--- a/tests/unit/image-attachment-guard.test.ts
+++ b/tests/unit/image-attachment-guard.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES, formatBytes, validateImageAttachmentSize } from '@/common/image-attachment-guard';
+
+describe('formatBytes', () => {
+  it('formats bytes < 1KB as raw bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('formats < 1MB as KB (rounded)', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(190 * 1024)).toBe('190 KB');
+  });
+
+  it('formats >= 1MB as MB (1 decimal)', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(25 * 1024 * 1024)).toBe('25.0 MB');
+    expect(formatBytes(Math.floor(52.5 * 1024 * 1024))).toBe('52.5 MB');
+  });
+});
+
+describe('validateImageAttachmentSize', () => {
+  it('returns null for undefined / null / empty input (no images = no problem)', () => {
+    expect(validateImageAttachmentSize(undefined)).toBeNull();
+    expect(validateImageAttachmentSize(null)).toBeNull();
+    expect(validateImageAttachmentSize([])).toBeNull();
+  });
+
+  it('returns null when all images are under the cap', () => {
+    const small = 'x'.repeat(100 * 1024); // 100KB base64
+    expect(
+      validateImageAttachmentSize([
+        { data: small, mimeType: 'image/png' },
+        { data: small, mimeType: 'image/jpeg' },
+      ])
+    ).toBeNull();
+  });
+
+  it('returns null at exactly the cap (boundary — only STRICTLY above cap triggers)', () => {
+    const atCap = 'x'.repeat(IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES);
+    expect(validateImageAttachmentSize([{ data: atCap, mimeType: 'image/png' }])).toBeNull();
+  });
+
+  it('returns a user-facing message when the first image exceeds the cap', () => {
+    const oversize = 'x'.repeat(IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES + 1);
+    const got = validateImageAttachmentSize([{ data: oversize, mimeType: 'image/png' }]);
+    expect(got).not.toBeNull();
+    expect(got).toMatch(/图片 #1 太大了/);
+    expect(got).toMatch(/上限 25\.0 MB/);
+    // User-facing message must NOT leak internal architecture jargon
+    expect(got).not.toMatch(/sudocode|gRPC|transport|MAX_IMAGE_BYTES/);
+  });
+
+  it('reports the FIRST oversize image (early return, not aggregate)', () => {
+    const small = 'x'.repeat(100);
+    const oversize = 'x'.repeat(IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES + 1);
+    const got = validateImageAttachmentSize([
+      { data: small, mimeType: 'image/png' }, // #1 ok
+      { data: small, mimeType: 'image/png' }, // #2 ok
+      { data: oversize, mimeType: 'image/jpeg' }, // #3 too big
+      { data: oversize, mimeType: 'image/jpeg' }, // #4 also too big but never reported
+    ]);
+    expect(got).toMatch(/图片 #3 太大了/);
+    expect(got).not.toMatch(/图片 #4/);
+  });
+
+  it('respects a custom cap parameter (so tests + future callers can tune without env)', () => {
+    const small = 'x'.repeat(1024);
+    expect(validateImageAttachmentSize([{ data: small, mimeType: 'image/png' }], 100)).toMatch(/图片 #1 太大了/);
+    expect(validateImageAttachmentSize([{ data: small, mimeType: 'image/png' }], 10_000)).toBeNull();
+  });
+
+  it('regression: cap is 25 MB (matches AcpAgent transport limit, documented in module header)', () => {
+    // If this is bumped, also revisit the comment header explaining WHY 25MB
+    // (covers typical screenshots while leaving 5× headroom over sudocode's
+    // 5MB LLM-side preflight).
+    expect(IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES).toBe(25 * 1024 * 1024);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
         'src/common/chatLib.ts',
         'src/common/nexus/hubErrors.ts',
         'src/common/runtime-errors.ts',
+        'src/common/image-attachment-guard.ts',
         'src/common/nexusFiles.ts',
         'src/common/scodeConfig.ts',
         'src/common/slash/sudoworkCommands.ts',


### PR DESCRIPTION
## Summary

Per Ethan's real-e2e session 2026-06-28 driving sudowork via ai-dev-browser: pasting 2× 52 MB base64 images into a chat input wedged the gRPC \`session/prompt\` writer queue. The 300s \`AcpConnection\` timeout never fired (the RPC never reached the dispatched state), no error response arrived, no \`finish\` event was emitted, and the renderer's processing indicator stuck at 9m+ counting up forever.

## Root cause

sudocode's existing image preflight (#249) runs AFTER the bytes have been transported over gRPC. The transport layer itself has no client-side validation, so oversized payloads silently wedge. The renderer's \`processing\` state is only reset by the \`finish\` event from the backend — which never arrives in this case.

## Systemic fix

Parallel to the existing \`validateAttachmentContextRisk\` for text files: add \`validateImageAttachmentSize\` that rejects any single image whose base64 size exceeds 25 MB BEFORE the gRPC call. On reject:
- emit a soft user-facing tip via \`emitErrorMessage\` (which also emits the \`finish\` event → spinner clears correctly)
- return \`{success: false}\` so the caller doesn't proceed to send

## Why 25 MB

- sudocode's preflight cap is 5 MB (LLM-side); this is the **TRANSPORT-side** cap and is deliberately 5× looser so typical screenshots flow through and get downsampled server-side.
- Comfortably under typical gRPC \`max_send_message_size\` (256 MB).
- Empirically: 2× 52 MB observed to wedge the queue; 1× 20–25 MB sails through and gets preflighted normally.

## User-facing message is intentionally soft

\"图片 #N 太大了 (约 X MB，临时上限 25 MB)。可以先用其他工具压一下；这个限制是临时的，之后版本会在后端自动处理。\"

Asking users to manually compress images is sub-SOTA UX. The proper fix (server-side auto-downsample / auto-VLM-route) is filed in the sudocode roadmap as a **NEW row** in **sudocode PR #253**. This client-side cap is the explicit placeholder until that lands. The message text reflects this — \"临时上限\" + \"之后版本会在后端自动处理\".

## Implementation

| File | What |
|---|---|
| \`src/common/image-attachment-guard.ts\` (NEW) | \`IMAGE_ATTACHMENT_TRANSPORT_CAP_BYTES\` + \`formatBytes\` + \`validateImageAttachmentSize\`. Extracted as free functions (not a private method on AcpAgent) so unit tests don't require instantiating AcpAgent + heavy deps. Same SSOT-via-extraction pattern PR-B's \`runtime-errors.ts\` used. |
| \`src/process/task/AcpAgent.ts\` | Import + call after existing vision-capability guard, before \`sendToConnection\`. Same early-return shape as \`validateAttachmentContextRisk\`. |
| \`tests/unit/image-attachment-guard.test.ts\` (NEW) | 10 cases: format-bytes branches, boundary at-cap (only STRICTLY above triggers), first-oversize early-return, custom-cap override, **regression: user message must NOT leak internal jargon** ("sudocode", "gRPC", "transport"). |
| \`vitest.config.ts\` | Register new source in coverage.include. |

## Audit (8 principles)

1. **Simplify contract** ✅ — one cap, one validator function
2. **No boundary leak** ✅ — module in \`@/common\`, consumed by main process; nothing renderer-internal touched
3. **SSOT** ✅ — extracted shared module, both the constant and the validator live in one file. Note: this is sudowork-side TRANSPORT cap; sudocode's preflight cap is separate (LLM-side, 5 MB). Intentional defense in depth, not SSOT violation
4. **DRY** ✅ — no duplicated cap checking; the function is the single check
5. **Rust-first** ✅ N/A (TS-side validation at the IPC boundary)
6. **Perf-first** ✅ — fail fast at input, avoid wedging the transport
7. **Raft** ✅ N/A
8. **Systemic** ✅ — addresses the root cause (oversize wedges transport) rather than patching the symptom (sticky spinner after hang). Roadmap row in #253 documents the true SOTA fix this is a placeholder for.

## Followups (NOT in this PR)

- sudocode #253 documents the proper SOTA fix (auto-downsample + auto-VLM-route, server-side, transparent to user). When that lands, this client-side cap becomes dead code and can be removed.
- Sticky-spinner can still happen on other transport hangs (network glitch, scode crash mid-stream). Add a renderer-side watchdog as a separate hardening pass.

## Series tally

- ✅ sudowork PR-A #941: classifier SSOT
- ✅ sudowork PR-B #942: differentiated RuntimeErrorBanner + i18n
- ✅ sudowork PR-YAML #943: [api, smoke] regression guard
- ✅ sudocode PR-C/D #249: image preflight in ACP + circuit breaker
- ✅ sudocode PR-E #251: text-placeholder fallback
- ✅ sudocode PR-Tests #252: integration tests
- 🟢 **sudowork PR-F (this)**: client-side image size guard (sticky spinner fix)
- 🟢 sudocode PR-Roadmap #253: file the proper SOTA fix as roadmap gap