### PR TITLE
feat(image-models): source from pricing API and auto-repair stale model

### DIFF
--- a/src/common/imageGenerationModelConfig.ts
+++ b/src/common/imageGenerationModelConfig.ts
@@ -76,3 +76,34 @@ export function pickDefaultImageModelFromPricing(items: SpecificImagePricingItem
   }
   return best ? best.model_id : items[0].model_id;
 }
+
+/**
+ * Resolve the runtime JSON model id and the persisted useModel against the live
+ * pricing list. Switch-off always yields jsonModelId null — resolveImageConfig uses
+ * any non-empty model without checking the switch, so the runtime JSON must be empty
+ * when off; a stale useModel is still repaired in the persistence layer so the
+ * feature works the moment the switch is turned back on.
+ *
+ * Caller invariants: `saved` exists; `items` is non-empty (so defaultModel is valid).
+ */
+export function resolveImageModelWithAvailability(saved: ImageGenerationModelConfig, items: SpecificImagePricingItem[]): { jsonModelId: string | null; persistedUseModel: string; changed: boolean } {
+  const switchOn = saved.switch !== false;
+  const useModel = saved.useModel;
+  const inList = !!(useModel && items.some((it) => it.model_id === useModel));
+  const defaultModel = pickDefaultImageModelFromPricing(items);
+
+  if (!switchOn) {
+    if (useModel && !inList) {
+      return { jsonModelId: null, persistedUseModel: defaultModel, changed: true };
+    }
+    return { jsonModelId: null, persistedUseModel: useModel ?? '', changed: false };
+  }
+
+  if (useModel && inList) {
+    return { jsonModelId: useModel, persistedUseModel: useModel, changed: false };
+  }
+  if (useModel && !inList) {
+    return { jsonModelId: defaultModel || null, persistedUseModel: defaultModel, changed: true };
+  }
+  return { jsonModelId: defaultModel || null, persistedUseModel: '', changed: false };
+}

--- a/src/common/imageGenerationModelConfig.ts
+++ b/src/common/imageGenerationModelConfig.ts
@@ -5,6 +5,7 @@
  */
 
 import { DEFAULT_IMAGE_GENERATION_MODEL, type IConfigStorageRefer } from './storage';
+import type { SpecificImagePricingItem } from './scodeConfig';
 
 /**
  * Old builds hardcoded this as the default image generation model. It is still a
@@ -31,15 +32,15 @@ export function pickImageGenerationModelId(config: Partial<ImageGenerationModelC
  * current default. After the migration flag has been set, an explicit selection
  * of gpt-image-1.5 is preserved.
  */
-export function migrateImageGenerationModelConfig(saved: ImageGenerationModelConfig | undefined | null, alreadyMigrated: boolean): { config: ImageGenerationModelConfig; changed: boolean } {
+export function migrateImageGenerationModelConfig(saved: ImageGenerationModelConfig | undefined | null, alreadyMigrated: boolean, defaultModelId: string): { config: ImageGenerationModelConfig; changed: boolean } {
   if (!saved) {
-    return { config: { useModel: DEFAULT_IMAGE_GENERATION_MODEL, switch: true } as ImageGenerationModelConfig, changed: true };
+    return { config: { useModel: defaultModelId, switch: true } as ImageGenerationModelConfig, changed: true };
   }
   if (!saved.useModel) {
-    return { config: { ...saved, useModel: DEFAULT_IMAGE_GENERATION_MODEL }, changed: true };
+    return { config: { ...saved, useModel: defaultModelId }, changed: true };
   }
   if (!alreadyMigrated && saved.useModel === LEGACY_DEFAULT_IMAGE_GENERATION_MODEL) {
-    return { config: { ...saved, useModel: DEFAULT_IMAGE_GENERATION_MODEL }, changed: true };
+    return { config: { ...saved, useModel: defaultModelId }, changed: true };
   }
   return { config: saved, changed: false };
 }
@@ -49,8 +50,29 @@ export function migrateImageGenerationModelConfig(saved: ImageGenerationModelCon
  * feature is enabled, otherwise the current default. Never unconditionally
  * overrides a user selection.
  */
-export function resolveLoginImageModelId(saved: ImageGenerationModelConfig | undefined | null): string | null {
-  if (!saved) return DEFAULT_IMAGE_GENERATION_MODEL;
+export function resolveLoginImageModelId(saved: ImageGenerationModelConfig | undefined | null, defaultModelId: string): string | null {
+  if (!saved) return defaultModelId;
   if (saved.switch === false) return null;
-  return saved.useModel || DEFAULT_IMAGE_GENERATION_MODEL;
+  return saved.useModel || defaultModelId;
+}
+
+/**
+ * Pick the default image generation model from sudorouter specific_image_pricing items.
+ * Rules: empty → ''; single → that one; contains DEFAULT_IMAGE_GENERATION_MODEL → it;
+ * otherwise the highest model_ratio (first on ties); ratio all-missing → first item.
+ */
+export function pickDefaultImageModelFromPricing(items: SpecificImagePricingItem[]): string {
+  if (!items || items.length === 0) return '';
+  if (items.length === 1) return items[0].model_id;
+  if (items.some((it) => it.model_id === DEFAULT_IMAGE_GENERATION_MODEL)) {
+    return DEFAULT_IMAGE_GENERATION_MODEL;
+  }
+  let best: SpecificImagePricingItem | null = null;
+  for (const it of items) {
+    if (typeof it.model_ratio !== 'number') continue;
+    if (!best || it.model_ratio > best.model_ratio!) {
+      best = it;
+    }
+  }
+  return best ? best.model_id : items[0].model_id;
 }

--- a/src/common/imagePricingSource.ts
+++ b/src/common/imagePricingSource.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getSudorouterBaseUrl } from './systemConfig';
+import { pickDefaultImageModelFromPricing } from './imageGenerationModelConfig';
+import type { SpecificImagePricingItem } from './scodeConfig';
+
+/**
+ * Fetch sudorouter specific_image_pricing items (the live image-model list + ratios).
+ *
+ * Deliberately dependency-free (only `fetch` / `getSudorouterBaseUrl` / `console.warn`):
+ * no @process/* heavy deps, so it is usable from BOTH the main and renderer processes
+ * and can be exercised against a local mock HTTP server in unit tests.
+ *
+ * Returns `null` on ANY failure (network/timeout/parse/success!==true) so callers can
+ * distinguish "failed → keep old value" from "succeeded but empty". On success returns
+ * the data array (possibly `[]`), with empty/whitespace `model_id` entries filtered out.
+ */
+export async function fetchSpecificImagePricingItems(): Promise<SpecificImagePricingItem[] | null> {
+  let json: { success?: boolean; data?: SpecificImagePricingItem[] };
+  try {
+    const response = await fetch(`${getSudorouterBaseUrl()}/api/specific_image_pricing`, {
+      signal: AbortSignal.timeout(15000),
+    });
+    json = (await response.json()) as typeof json;
+  } catch (err) {
+    console.warn('[imagePricingSource] specific_image_pricing fetch failed:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+
+  if (json.success !== true || !Array.isArray(json.data)) {
+    console.warn('[imagePricingSource] specific_image_pricing returned success!=true or no data');
+    return null;
+  }
+
+  return json.data.filter((it) => typeof it?.model_id === 'string' && it.model_id.trim().length > 0);
+}
+
+/**
+ * Resolve the rule-based default image model id from the pricing endpoint.
+ *
+ * Semantics of the return value (lets callers handle failure vs. empty distinctly):
+ * - `null` → fetch failed (caller should keep the existing value, do NOT overwrite);
+ * - `''`   → endpoint succeeded but returned an empty list (feature effectively off);
+ * - other → the rule-selected model id (see pickDefaultImageModelFromPricing).
+ */
+export async function resolveDefaultImageModel(): Promise<string | null> {
+  const items = await fetchSpecificImagePricingItems();
+  if (items === null) return null;
+  return pickDefaultImageModelFromPricing(items);
+}

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -16,7 +16,7 @@ import type { SystemConfig } from '@/common/systemConfig';
 import type { McpSource } from '../process/services/mcpServices/McpProtocol';
 import type { AcpBackend, AcpBackendAll, AcpModelInfo, PresetAgentType } from '../types/acpTypes';
 import type { SyncAllResult } from '../process/sync/remoteToLocalSync';
-import type { ScodeCustomModelProvider, SpecificPricingItem } from './scodeConfig';
+import type { ScodeCustomModelProvider, SpecificImagePricingItem, SpecificPricingItem } from './scodeConfig';
 import type { SlashCommandItem } from './slash/types';
 import type { IMcpServer, IProvider, TChatConversation, TProviderWithModel, ICssTheme } from './storage';
 import type { SecretMetadata } from './nexus/nexus-secret-client';
@@ -907,6 +907,8 @@ export const scode = {
   refreshModels: bridge.buildProvider<IBridgeResponse<AcpModelInfo>, void>('scode.refresh-models'),
   /** Read-only fetch of sudorouter specific_pricing items (no write to sudocode.json) */
   fetchSpecificPricing: bridge.buildProvider<IBridgeResponse<SpecificPricingItem[]>, void>('scode.fetch-specific-pricing'),
+  /** Read-only fetch of sudorouter specific_image_pricing items (image models) */
+  fetchSpecificImagePricing: bridge.buildProvider<IBridgeResponse<SpecificImagePricingItem[]>, void>('scode.fetch-specific-image-pricing'),
   /** Sync image generation model to sudocode.json tools.imageGenerationModel */
   setImageModel: bridge.buildProvider<IBridgeResponse<void>, { modelId: string | null }>('scode.set-image-model'),
   /** Get scode installation status */

--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -35,6 +35,12 @@ export type SpecificPricingItem = {
   model_ratio?: number;
 };
 
+export type SpecificImagePricingItem = {
+  model_id: string;
+  model_ratio?: number;
+  extra?: Record<string, unknown>;
+};
+
 export function resolveAutoRouterModelId(modelIds: string[], pricingItems?: SpecificPricingItem[]): string | null {
   if (modelIds.length === 0) return null;
   if (modelIds.length === 1) return modelIds[0];

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -187,12 +187,17 @@ export async function syncScodeModelsFromPricing(): Promise<void> {
 async function syncImageModelOnStartup(): Promise<void> {
   try {
     const { ProcessConfig } = await import('@process/initStorage');
-    const { DEFAULT_IMAGE_GENERATION_MODEL } = await import('@/common/storage');
+    const { resolveDefaultImageModel } = await import('@/common/imagePricingSource');
     const imageConfig = await ProcessConfig.get('tools.imageGenerationModel');
     const switchOn = imageConfig ? imageConfig.switch : true;
-    const modelId = switchOn && imageConfig?.useModel ? imageConfig.useModel : DEFAULT_IMAGE_GENERATION_MODEL;
-    if (modelId) {
-      writeScodeImageModel(modelId);
+    if (switchOn && imageConfig?.useModel) {
+      writeScodeImageModel(imageConfig.useModel);
+    } else if (!switchOn) {
+      writeScodeImageModel('');
+    } else {
+      const def = await resolveDefaultImageModel();
+      if (def === null) return;
+      writeScodeImageModel(def);
     }
   } catch (err) {
     mainWarn(TAG, `Failed to sync image model on startup: ${err instanceof Error ? err.message : String(err)}`);
@@ -354,6 +359,12 @@ export function registerScodeBridge(): void {
   });
 
   ipcBridge.scode.fetchSpecificPricing.provider(async () => ({ success: true, data: await fetchSpecificPricingItems() }));
+
+  ipcBridge.scode.fetchSpecificImagePricing.provider(async () => {
+    const { fetchSpecificImagePricingItems } = await import('@/common/imagePricingSource');
+    const data = await fetchSpecificImagePricingItems();
+    return data === null ? { success: false, msg: 'image pricing fetch failed' } : { success: true, data };
+  });
 
   ipcBridge.scode.setImageModel.provider(async ({ modelId }) => {
     try {

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -181,24 +181,43 @@ export async function syncScodeModelsFromPricing(): Promise<void> {
 }
 
 /**
+ * Resolve the image generation model id for a main-process sync point (startup /
+ * sudoclaw gateway start). Always returns a definitive modelId (null → runtime
+ * writes ''). A stale useModel is repaired in the persistence layer; a pricing
+ * fetch failure / empty list keeps the existing useModel untouched.
+ */
+export async function resolveImageModelForMainSync(): Promise<{ modelId: string | null }> {
+  const { ProcessConfig } = await import('@process/initStorage');
+  const { fetchSpecificImagePricingItems } = await import('@/common/imagePricingSource');
+  const { pickDefaultImageModelFromPricing, pickImageGenerationModelId, resolveImageModelWithAvailability } = await import('@/common/imageGenerationModelConfig');
+
+  const saved = await ProcessConfig.get('tools.imageGenerationModel');
+  const items = await fetchSpecificImagePricingItems();
+
+  if (!saved) {
+    const def = items ? pickDefaultImageModelFromPricing(items) : '';
+    return { modelId: def || null };
+  }
+
+  if (items === null || items.length === 0) {
+    return { modelId: pickImageGenerationModelId(saved) };
+  }
+
+  const { jsonModelId, persistedUseModel, changed } = resolveImageModelWithAvailability(saved, items);
+  if (changed) {
+    await ProcessConfig.set('tools.imageGenerationModel', { ...saved, useModel: persistedUseModel });
+  }
+  return { modelId: jsonModelId };
+}
+
+/**
  * Sync image generation model from ProcessConfig to sudocode.json on startup.
  * This runs independently of sudoclaw.
  */
 async function syncImageModelOnStartup(): Promise<void> {
   try {
-    const { ProcessConfig } = await import('@process/initStorage');
-    const { resolveDefaultImageModel } = await import('@/common/imagePricingSource');
-    const imageConfig = await ProcessConfig.get('tools.imageGenerationModel');
-    const switchOn = imageConfig ? imageConfig.switch : true;
-    if (switchOn && imageConfig?.useModel) {
-      writeScodeImageModel(imageConfig.useModel);
-    } else if (!switchOn) {
-      writeScodeImageModel('');
-    } else {
-      const def = await resolveDefaultImageModel();
-      if (def === null) return;
-      writeScodeImageModel(def);
-    }
+    const { modelId } = await resolveImageModelForMainSync();
+    writeScodeImageModel(modelId ?? '');
   } catch (err) {
     mainWarn(TAG, `Failed to sync image model on startup: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -189,7 +189,18 @@ export async function syncScodeModelsFromPricing(): Promise<void> {
 export async function resolveImageModelForMainSync(): Promise<{ modelId: string | null }> {
   const { ProcessConfig } = await import('@process/initStorage');
   const { fetchSpecificImagePricingItems } = await import('@/common/imagePricingSource');
-  const { pickDefaultImageModelFromPricing, pickImageGenerationModelId, resolveImageModelWithAvailability } = await import('@/common/imageGenerationModelConfig');
+  const { pickDefaultImageModelFromPricing, pickImageGenerationModelId, resolveImageModelWithAvailability } = await import(
+    '@/common/imageGenerationModelConfig'
+  );
+  const { getSystemConfigCache } = await import('@/common/systemConfig');
+
+  // 冷启动竞态修复：syncImageModelOnStartup 可能在 ensureMainSystemConfig（填充 systemConfigCache）
+  // 之前触发，此时 getSudorouterBaseUrl() 会 fallback 到 build 硬编码而非服务器 dispatch 的真实
+  // sudorouter，导致用错误的 pricing 列表校验（或 fetch 失败而不修正）。等待 cache 填充后再继续。
+  const cacheDeadline = Date.now() + 35_000;
+  while (!getSystemConfigCache() && Date.now() < cacheDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
 
   const saved = await ProcessConfig.get('tools.imageGenerationModel');
   const items = await fetchSpecificImagePricingItems();
@@ -217,7 +228,13 @@ export async function resolveImageModelForMainSync(): Promise<{ modelId: string 
 async function syncImageModelOnStartup(): Promise<void> {
   try {
     const { modelId } = await resolveImageModelForMainSync();
-    writeScodeImageModel(modelId ?? '');
+    const resolved = modelId ?? '';
+    writeScodeImageModel(resolved);
+    // sudoclaw.json 的 imageGenerationModel 是运行期生图主路径读取的字段(resolveImageConfig 先读它)。
+    // 桌面模式启动时不会自动拉起 sudoclaw 网关,故 syncImageModelToSudoclaw(入口B,网关健康后才触发)
+    // 不会执行——若不同步,失效模型会残留在 sudoclaw.json 导致生图失败。此处复用写 sudoclaw 的 helper
+    // (自带 existsSync 守卫,文件不存在则 no-op,等网关首次写入)。
+    writeSudoclawImageGenerationModel(resolved, SUDOCLAW_CONFIG_PATH);
   } catch (err) {
     mainWarn(TAG, `Failed to sync image model on startup: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -8,12 +8,12 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as path from 'node:path';
 import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
+import { getSkillHubBaseUrl } from '@/common/systemConfig';
+import { getSkillhubToken } from '@/process/credentialsCache';
 import { initStatusManager } from '../initStatus';
 import { isSudoclawHealthPayload, SUDOCLAW_HEALTH_TIMEOUT_MS, type SudoclawHealthPayload } from '../sudoclaw/sudoclawHealth';
 import { AdbResultSidechannel } from '../sudoclaw/AdbResultSidechannel';
 import { runtimeInstaller } from './RuntimeInstaller';
-import { getSkillHubBaseUrl } from '@/common/systemConfig';
-import { getSkillhubToken } from '@/process/credentialsCache';
 
 type SudoclawGateway = import('@/agent/sudoclaw/SudoclawGatewayManager').OpenClawGatewayManager;
 
@@ -383,7 +383,21 @@ export class ServiceManager {
     try {
       mainLog('ServiceManager', 'Starting Sudoclaw gateway...');
       const { OpenClawGatewayManager } = await import('@/agent/sudoclaw');
-      const { SUDOCLAW_DIR, SUDOCLAW_DEFAULT_PORT, SUDOCLAW_CONFIG_PATH, ensureDefaultConfig, repairSudoclawConfig, getSudoclawVersionState, ensureSudoclawInstalled, ensureUserMdSafetyRules, ensureUserMdIdentityStatement, ensureUserMdNoGeneratedByStatement, ensureUserMdNoExposeUserMdStatement, ensureUserMdFileSendInstruction, ensureUserMdVersionInfoStatement } = await import('../sudoclaw/SudoclawInstallService');
+      const {
+        SUDOCLAW_DIR,
+        SUDOCLAW_DEFAULT_PORT,
+        SUDOCLAW_CONFIG_PATH,
+        ensureDefaultConfig,
+        repairSudoclawConfig,
+        getSudoclawVersionState,
+        ensureSudoclawInstalled,
+        ensureUserMdSafetyRules,
+        ensureUserMdIdentityStatement,
+        ensureUserMdNoGeneratedByStatement,
+        ensureUserMdNoExposeUserMdStatement,
+        ensureUserMdFileSendInstruction,
+        ensureUserMdVersionInfoStatement,
+      } = await import('../sudoclaw/SudoclawInstallService');
       await this.ensureNodeReadyForSudoclawStart();
 
       const versionState = getSudoclawVersionState();
@@ -585,10 +599,7 @@ export class ServiceManager {
 
   private async syncImageModelToSudoclaw(sudoclawConfigPath: string): Promise<void> {
     try {
-      const { ProcessConfig } = await import('@/process/initStorage');
       const { DEFAULT_IMAGE_PARSING_MODEL } = await import('@/common/storage');
-      const imageConfig = await ProcessConfig.get('tools.imageGenerationModel');
-      const switchOn = imageConfig ? imageConfig.switch : true;
 
       const fs = await import('fs');
       if (!fs.existsSync(sudoclawConfigPath)) return;
@@ -617,20 +628,12 @@ export class ServiceManager {
       config.agents.defaults.imageModel = findProvider(DEFAULT_IMAGE_PARSING_MODEL);
 
       // Sync generation model (生图) → agents.defaults.imageGenerationModel (read by Electron).
-      // Three-branch logic placed AFTER the parsing-model sync above: on a pricing fetch
-      // failure (def===null) the existing value is preserved instead of early-returning,
-      // so the parsing-model sync + write below still run (an early return would skip them).
-      let generationModel: string;
-      if (switchOn && imageConfig?.useModel) {
-        generationModel = imageConfig.useModel;
-      } else if (!switchOn) {
-        generationModel = '';
-      } else {
-        const { resolveDefaultImageModel } = await import('@/common/imagePricingSource');
-        const def = await resolveDefaultImageModel();
-        const existing = config.agents.defaults.imageGenerationModel;
-        generationModel = def === null ? (typeof existing === 'string' ? existing : '') : def;
-      }
+      // Delegate to the shared main-process resolver: it repairs a stale useModel against the
+      // live pricing list and guarantees switch-off → '' (resolveImageConfig uses any non-empty
+      // model without checking the switch, so the runtime JSON must be empty when off).
+      const { resolveImageModelForMainSync } = await import('@process/bridge/scodeBridge');
+      const { modelId } = await resolveImageModelForMainSync();
+      const generationModel = modelId ?? '';
       config.agents.defaults.imageGenerationModel = generationModel;
 
       fs.writeFileSync(sudoclawConfigPath, JSON.stringify(config, null, 2), 'utf-8');

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -586,11 +586,9 @@ export class ServiceManager {
   private async syncImageModelToSudoclaw(sudoclawConfigPath: string): Promise<void> {
     try {
       const { ProcessConfig } = await import('@/process/initStorage');
-      const { DEFAULT_IMAGE_PARSING_MODEL, DEFAULT_IMAGE_GENERATION_MODEL } = await import('@/common/storage');
+      const { DEFAULT_IMAGE_PARSING_MODEL } = await import('@/common/storage');
       const imageConfig = await ProcessConfig.get('tools.imageGenerationModel');
-      // Generation model: from user config or default
       const switchOn = imageConfig ? imageConfig.switch : true;
-      const generationModel = switchOn && imageConfig?.useModel ? imageConfig.useModel : DEFAULT_IMAGE_GENERATION_MODEL;
 
       const fs = await import('fs');
       if (!fs.existsSync(sudoclawConfigPath)) return;
@@ -618,18 +616,31 @@ export class ServiceManager {
       // Sync parsing model (看图) → agents.defaults.imageModel (read by gateway)
       config.agents.defaults.imageModel = findProvider(DEFAULT_IMAGE_PARSING_MODEL);
 
-      // Sync generation model (生图) → agents.defaults.imageGenerationModel (read by Electron)
-      config.agents.defaults.imageGenerationModel = switchOn ? generationModel : '';
+      // Sync generation model (生图) → agents.defaults.imageGenerationModel (read by Electron).
+      // Three-branch logic placed AFTER the parsing-model sync above: on a pricing fetch
+      // failure (def===null) the existing value is preserved instead of early-returning,
+      // so the parsing-model sync + write below still run (an early return would skip them).
+      let generationModel: string;
+      if (switchOn && imageConfig?.useModel) {
+        generationModel = imageConfig.useModel;
+      } else if (!switchOn) {
+        generationModel = '';
+      } else {
+        const { resolveDefaultImageModel } = await import('@/common/imagePricingSource');
+        const def = await resolveDefaultImageModel();
+        const existing = config.agents.defaults.imageGenerationModel;
+        generationModel = def === null ? (typeof existing === 'string' ? existing : '') : def;
+      }
+      config.agents.defaults.imageGenerationModel = generationModel;
 
       fs.writeFileSync(sudoclawConfigPath, JSON.stringify(config, null, 2), 'utf-8');
       mainLog('ServiceManager', `Synced image models to sudoclaw.json — parsing: ${DEFAULT_IMAGE_PARSING_MODEL}, generation: ${generationModel}`);
 
       // Also sync generation model to sudocode.json so the image-generation skill
-      // bash script can read it without depending on sudoclaw.json.
-      if (generationModel) {
-        const { writeScodeImageModel } = await import('@process/bridge/scodeBridge');
-        writeScodeImageModel(generationModel);
-      }
+      // bash script can read it without depending on sudoclaw.json. Written unconditionally
+      // (switchOff→'' and fetch-failure→preserved value included) so both JSONs stay consistent.
+      const { writeScodeImageModel } = await import('@process/bridge/scodeBridge');
+      writeScodeImageModel(generationModel);
     } catch (err) {
       mainError('ServiceManager', 'Failed to sync image model to sudoclaw.json', err);
     }

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import { ipcBridge } from '@/common';
 import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 import { ConfigStorage, type IConfigStorageRefer } from '@/common/storage';
-import { pickDefaultImageModelFromPricing, resolveLoginImageModelId } from '@/common/imageGenerationModelConfig';
+import { pickDefaultImageModelFromPricing, pickImageGenerationModelId, resolveImageModelWithAvailability } from '@/common/imageGenerationModelConfig';
 import { withCsrfToken } from '@/webserver/middleware/csrfClient';
 import { getSudorouterPrimaryModelPath, mergeSudorouterProvidersIntoConfig } from '@/common/sudoclawModelConfig';
 import { buildScodeConfigFromLoginPayload, SCODE_AUTO_MODEL_ALIAS } from '@/common/scodeConfig';
@@ -335,16 +335,22 @@ function resolveConsumerTenantId(user: Partial<AuthUser> & { tenant_id?: string 
 // Apply the image model on login: respect the user's saved selection instead of unconditionally forcing the default.
 async function applyLoginImageModel(): Promise<void> {
   const saved = await ConfigStorage.get('tools.imageGenerationModel').catch((): undefined => undefined);
-  // Only hit the pricing endpoint when there is no effective user selection;
-  // when saved is valid (switch off, or a chosen useModel) no request is made.
-  const needsDefault = !saved || (saved.switch !== false && !saved.useModel);
-  let defaultModelId = '';
-  if (needsDefault) {
-    const res = await ipcBridge.scode.fetchSpecificImagePricing.invoke().catch((): null => null);
-    if (!res?.success) return;
-    defaultModelId = pickDefaultImageModelFromPricing(res.data ?? []);
+  const res = await ipcBridge.scode.fetchSpecificImagePricing.invoke().catch((): null => null);
+  const items = res?.success && Array.isArray(res.data) ? res.data : null; // null = 失败
+  if (!saved) {
+    const def = items ? pickDefaultImageModelFromPricing(items) : '';
+    await ipcBridge.scode.setImageModel.invoke({ modelId: def || null }).catch(() => {});
+    return;
   }
-  await ipcBridge.scode.setImageModel.invoke({ modelId: resolveLoginImageModelId(saved, defaultModelId) }).catch(() => {});
+  if (items === null || items.length === 0) {
+    await ipcBridge.scode.setImageModel.invoke({ modelId: pickImageGenerationModelId(saved) }).catch(() => {});
+    return;
+  }
+  const { jsonModelId, persistedUseModel, changed } = resolveImageModelWithAvailability(saved, items);
+  if (changed) {
+    await ConfigStorage.set('tools.imageGenerationModel', { ...saved, useModel: persistedUseModel }).catch(() => {});
+  }
+  await ipcBridge.scode.setImageModel.invoke({ modelId: jsonModelId }).catch(() => {});
 }
 
 // 处理登录成功后的通用逻辑

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import { ipcBridge } from '@/common';
 import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
 import { ConfigStorage, type IConfigStorageRefer } from '@/common/storage';
-import { resolveLoginImageModelId } from '@/common/imageGenerationModelConfig';
+import { pickDefaultImageModelFromPricing, resolveLoginImageModelId } from '@/common/imageGenerationModelConfig';
 import { withCsrfToken } from '@/webserver/middleware/csrfClient';
 import { getSudorouterPrimaryModelPath, mergeSudorouterProvidersIntoConfig } from '@/common/sudoclawModelConfig';
 import { buildScodeConfigFromLoginPayload, SCODE_AUTO_MODEL_ALIAS } from '@/common/scodeConfig';
@@ -335,7 +335,16 @@ function resolveConsumerTenantId(user: Partial<AuthUser> & { tenant_id?: string 
 // Apply the image model on login: respect the user's saved selection instead of unconditionally forcing the default.
 async function applyLoginImageModel(): Promise<void> {
   const saved = await ConfigStorage.get('tools.imageGenerationModel').catch((): undefined => undefined);
-  await ipcBridge.scode.setImageModel.invoke({ modelId: resolveLoginImageModelId(saved) }).catch(() => {});
+  // Only hit the pricing endpoint when there is no effective user selection;
+  // when saved is valid (switch off, or a chosen useModel) no request is made.
+  const needsDefault = !saved || (saved.switch !== false && !saved.useModel);
+  let defaultModelId = '';
+  if (needsDefault) {
+    const res = await ipcBridge.scode.fetchSpecificImagePricing.invoke().catch((): null => null);
+    if (!res?.success) return;
+    defaultModelId = pickDefaultImageModelFromPricing(res.data ?? []);
+  }
+  await ipcBridge.scode.setImageModel.invoke({ modelId: resolveLoginImageModelId(saved, defaultModelId) }).catch(() => {});
 }
 
 // 处理登录成功后的通用逻辑

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -451,6 +451,8 @@
   "imageGenerationDescription": "Choose which configured image-capable model the tool should use by default.",
   "mcp": "MCP Integration",
   "imageGenerationModel": "Image Model",
+  "imageModelLoading": "Loading image models...",
+  "imageModelListLoadFailed": "Failed to load image model list.",
   "imageGenerationGuide": "Image Model Setup Guide",
   "noAvailable": "No available image models, please configure first.",
   "mcpSettings": "MCP Tools Configuration",

--- a/src/renderer/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/i18n/locales/ja-JP/settings.json
@@ -420,6 +420,8 @@
   "imageGenerationDescription": "画像ツールで使用する既存の画像対応モデルを選択します。",
   "mcp": "MCP統合",
   "imageGenerationModel": "画像モデル",
+  "imageModelLoading": "画像モデルを読み込み中...",
+  "imageModelListLoadFailed": "画像モデルリストの読み込みに失敗しました。",
   "imageGenerationGuide": "画像モデル設定ガイド",
   "noAvailable": "利用可能な画像モデルがありません。先に設定してください。",
   "mcpSettings": "MCPツール設定",

--- a/src/renderer/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/i18n/locales/ko-KR/settings.json
@@ -420,6 +420,8 @@
   "imageGenerationDescription": "도구가 기본적으로 사용할 구성된 이미지 가능 모델을 선택하세요.",
   "mcp": "MCP 통합",
   "imageGenerationModel": "이미지 모델",
+  "imageModelLoading": "이미지 모델을 불러오는 중...",
+  "imageModelListLoadFailed": "이미지 모델 목록을 불러오지 못했습니다.",
   "imageGenerationGuide": "이미지 모델 설정 가이드",
   "noAvailable": "사용 가능한 이미지 모델이 없습니다. 먼저 구성하세요.",
   "mcpSettings": "MCP 도구 구성",

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -417,6 +417,8 @@
   "imageGenerationDescription": "Aracın varsayılan olarak hangi yapılandırılmış görüntü yetenekli modeli kullanacağını seçin.",
   "mcp": "MCP Entegrasyonu",
   "imageGenerationModel": "Görüntü Modeli",
+  "imageModelLoading": "Görüntü modelleri yükleniyor...",
+  "imageModelListLoadFailed": "Görüntü modeli listesi yüklenemedi.",
   "imageGenerationGuide": "Görüntü Modeli Kurulum Rehberi",
   "noAvailable": "Mevcut görüntü modeli yok, lütfen önce yapılandırın.",
   "mcpSettings": "MCP Araçları Yapılandırması",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -451,6 +451,8 @@
   "imageGenerationDescription": "选择默认用于图像工具的已配置模型。",
   "mcp": "MCP 集成",
   "imageGenerationModel": "图像模型",
+  "imageModelLoading": "正在加载图片模型...",
+  "imageModelListLoadFailed": "图片模型列表加载失败。",
   "imageGenerationGuide": "图像模型配置指南",
   "noAvailable": "暂无可用图像模型，请先配置。",
   "mcpSettings": "MCP 工具配置",

--- a/src/renderer/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/i18n/locales/zh-TW/settings.json
@@ -420,6 +420,8 @@
   "imageGenerationDescription": "選擇預設用於圖像工具的已配置模型。",
   "mcp": "MCP 集成",
   "imageGenerationModel": "圖像模型",
+  "imageModelLoading": "正在載入圖片模型...",
+  "imageModelListLoadFailed": "圖片模型列表載入失敗。",
   "imageGenerationGuide": "圖像模型配置指南",
   "noAvailable": "暫無可用圖像模型，請先配置。",
   "mcpSettings": "MCP 工具配置",

--- a/src/renderer/pages/settings/tools/index.tsx
+++ b/src/renderer/pages/settings/tools/index.tsx
@@ -1,26 +1,19 @@
 import { Form, Select, Switch } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { migrateImageGenerationModelConfig, pickImageGenerationModelId } from '@/common/imageGenerationModelConfig';
+import { migrateImageGenerationModelConfig, pickDefaultImageModelFromPricing, pickImageGenerationModelId } from '@/common/imageGenerationModelConfig';
 import { scode } from '@/common/ipcBridge';
-import { ConfigStorage, DEFAULT_IMAGE_GENERATION_MODEL, type IConfigStorageRefer } from '@/common/storage';
+import { ConfigStorage, type IConfigStorageRefer } from '@/common/storage';
 import AionScrollArea from '@renderer/components/base/AionScrollArea';
 import PageWrapper from '@renderer/components/base/PageWrapper';
 import McpManagementSection from './components/McpManagementSection';
-import type { IImageGenerationModelOption } from './types';
-
-const IMAGE_GENERATION_MODEL_OPTIONS: IImageGenerationModelOption[] = [
-  { label: 'gemini-3.1-flash-image', value: 'gemini-3.1-flash-image' },
-  { label: 'gemini-3-pro-image', value: 'gemini-3-pro-image' },
-  { label: 'gemini-2.5-flash-image', value: 'gemini-2.5-flash-image' },
-  { label: 'gpt-image-1.5', value: 'gpt-image-1.5' },
-  { label: 'gpt-image-1', value: 'gpt-image-1' },
-  { label: 'doubao-seedream-4-0-250828', value: 'doubao-seedream-4-0-250828' },
-];
 
 export default function ToolsSettings() {
   const { t } = useTranslation();
   const [imageGenerationModel, setImageGenerationModel] = useState<IConfigStorageRefer['tools.imageGenerationModel'] | undefined>();
+  const [imageOptions, setImageOptions] = useState<{ label: string; value: string }[]>([]);
+  const [isImageListLoading, setIsImageListLoading] = useState(false);
+  const [isImageListError, setIsImageListError] = useState(false);
 
   const syncImageGenerationModel = useCallback((modelConfig: IConfigStorageRefer['tools.imageGenerationModel']) => {
     const modelId = pickImageGenerationModelId(modelConfig);
@@ -30,17 +23,32 @@ export default function ToolsSettings() {
   useEffect(() => {
     const loadConfigs = async () => {
       try {
-        const saved = await ConfigStorage.get('tools.imageGenerationModel');
-        const alreadyMigrated = (await ConfigStorage.get('migration.imageGenerationModelDefaultMigrated').catch((): boolean => false)) === true;
-        const { config, changed } = migrateImageGenerationModelConfig(saved, alreadyMigrated);
+        setIsImageListLoading(true);
+        const result = await scode.fetchSpecificImagePricing.invoke().catch((): null => null);
+        setIsImageListLoading(false);
 
-        setImageGenerationModel(config);
-        if (changed) {
-          await ConfigStorage.set('tools.imageGenerationModel', config).catch(() => {});
-          await syncImageGenerationModel(config);
-        }
-        if (!alreadyMigrated) {
-          await ConfigStorage.set('migration.imageGenerationModelDefaultMigrated', true).catch(() => {});
+        if (result?.success && Array.isArray(result.data)) {
+          setImageOptions(result.data.map((item) => ({ label: item.model_id, value: item.model_id })));
+          setIsImageListError(false);
+
+          const defaultModelId = pickDefaultImageModelFromPricing(result.data);
+          const saved = await ConfigStorage.get('tools.imageGenerationModel');
+          const alreadyMigrated = (await ConfigStorage.get('migration.imageGenerationModelDefaultMigrated').catch((): boolean => false)) === true;
+          const { config, changed } = migrateImageGenerationModelConfig(saved, alreadyMigrated, defaultModelId);
+
+          setImageGenerationModel(config);
+          if (changed) {
+            await ConfigStorage.set('tools.imageGenerationModel', config).catch(() => {});
+            await syncImageGenerationModel(config);
+          }
+          if (!alreadyMigrated) {
+            await ConfigStorage.set('migration.imageGenerationModelDefaultMigrated', true).catch(() => {});
+          }
+        } else {
+          // Fetch failed: empty dropdown + error hint; leave ConfigStorage untouched (keep old value).
+          setImageOptions([]);
+          setIsImageListError(true);
+          setImageGenerationModel(await ConfigStorage.get('tools.imageGenerationModel').catch((): undefined => undefined));
         }
       } catch (error) {
         console.error('Failed to load image generation model config:', error);
@@ -85,14 +93,16 @@ export default function ToolsSettings() {
               <Form layout='horizontal' labelAlign='left' className='space-y-3'>
                 <Form.Item label={t('settings.imageGenerationModel', '图像模型')}>
                   <Select
-                    value={imageGenerationModel?.useModel || DEFAULT_IMAGE_GENERATION_MODEL}
-                    disabled={!imageGenerationModel?.switch}
+                    value={imageGenerationModel?.useModel ?? ''}
+                    disabled={!imageGenerationModel?.switch || isImageListLoading || isImageListError}
                     onChange={(val) => {
                       onImageGenerationModelChange({ useModel: val as string });
                     }}
-                    options={IMAGE_GENERATION_MODEL_OPTIONS}
+                    options={imageOptions}
                     style={{ minWidth: 260 }}
                   />
+                  {isImageListLoading && <div className='text-12px text-secondary mt-8px'>{t('settings.imageModelLoading')}</div>}
+                  {isImageListError && <div className='text-12px text-secondary mt-8px'>{t('settings.imageModelListLoadFailed')}</div>}
                 </Form.Item>
               </Form>
             </div>


### PR DESCRIPTION
本 PR 把图片生成模型改为从 sudorouter pricing API 动态获取，并自动修正已下架的模型。

## 改动
- **pricing 数据源**：图片模型下拉/默认从 GET /api/specific_image_pricing 动态获取（设置页下拉、启动/登录/网关同步）。rebase 到 dev 后已迁移到新设置页 pages/settings/tools（dev 重构 4ac1fce3）。
- **失效模型自动修正**：持久层 useModel 不在 pricing 列表时回退默认模型并写回持久层；覆盖登录/启动/网关三处入口；只改 useModel 不改 switch；pricing 失败/空时不动持久层（失败安全）。
- **冷启动竞态修复**：resolveImageModelForMainSync 等待 systemConfigCache 填充后再 fetch pricing（修复冷启动时用 build fallback 导致失效模型不修正）；syncImageModelOnStartup 同时写 sudoclaw.json（桌面模式不启动网关时也能同步）。

## 测试
- vitest 单元/集成：resolveImageModelWithAvailability 真值表 + resolveImageModelForMainSync 全分支（失败安全/switch 语义/持久层写入）。
- 经多轮独立 peer-review（计划/代码/测试）审核。