### PR TITLE
fix(telemetry): repair product-improvement reporting (init hang + encryption mismatch)

### DIFF
--- a/src/common/systemConfig.ts
+++ b/src/common/systemConfig.ts
@@ -80,9 +80,10 @@ export function getSystemConfigCache(): SystemConfig | null {
 }
 
 // ---- fetch (public, no auth; fetch + res.json() work in both processes) ----
-export async function fetchSystemConfig(): Promise<SystemConfig | null> {
+export async function fetchSystemConfig(baseUrl?: string): Promise<SystemConfig | null> {
   try {
-    const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/system-config`);
+    const base = baseUrl ?? await getSudoworkServerBaseUrl();
+    const res = await fetch(`${base}/api/v1/system-config`);
     const json = (await res.json()) as { success?: boolean; data?: SystemConfig };
     if (json?.success && json.data) {
       setSystemConfigCache(json.data);

--- a/src/process/services/systemConfigBootstrap.ts
+++ b/src/process/services/systemConfigBootstrap.ts
@@ -28,11 +28,17 @@
 
 import { mainLog, mainError } from '@process/utils/mainLogger';
 import { fetchSystemConfig } from '@/common/systemConfig';
+import { getSudoworkServerBaseUrlSync } from '@process/initStorage';
 
 export async function ensureMainSystemConfig(): Promise<void> {
   mainLog('systemConfigBootstrap', 'ensureMainSystemConfig start');
   try {
-    const data = await fetchSystemConfig();
+    // main 进程必须用 getSudoworkServerBaseUrlSync（ProcessConfig.getSync）解析 base URL：
+    // common 的 getSudoworkServerBaseUrl 内部走 ConfigStorage.get（@office-ai/platform BroadcastChannel IPC），
+    // 在 main 进程 renderer 未就绪时会永久挂起，阻塞后续 initializeTelemetry()。
+    // 与 src/process/index.ts:79 对 system.appMode 的处理同理。
+    const base = getSudoworkServerBaseUrlSync();
+    const data = await fetchSystemConfig(base);
     mainLog('systemConfigBootstrap', 'ensureMainSystemConfig done', {
       hasData: data !== null,
       loginMethod: data?.login_method ?? null,

--- a/src/process/telemetry/CrashReporter.ts
+++ b/src/process/telemetry/CrashReporter.ts
@@ -18,6 +18,7 @@
 import { app } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { isProductImprovementEnabled } from '@/common/systemConfig';
 import { ProcessConfig, getSudoworkServerBaseUrlSync } from '../initStorage';
 import { buildVersion } from '../../common/buildInfo';
 import type { NativeCrashEvent, RendererCrashEvent, JsExceptionEvent, Breadcrumb, CrashContext, CrashEventBase, CrashBatchRequest, CrashBatchResponse, StoredCrashEvent, CrashReporterConfig, CrashProcessType, CrashReason } from '../../shared/types/crash';
@@ -28,7 +29,6 @@ import { getProductImprovementApiKey } from '../credentialsCache';
 import { getTelemetryEncryptor, initTelemetryEncryptor } from './TelemetryEncryptor';
 import { getUserContextSync } from './UserContext';
 import { ENCRYPTION_CONFIG } from './keys';
-import { isProductImprovementEnabled } from '@/common/systemConfig';
 
 // ============================================================
 // 常量定义
@@ -157,7 +157,10 @@ export class CrashReporter {
         serverUrl: customServerUrl.replace('/telemetry/batch', '/crash/events/batch'),
       };
     } else {
-      this.config = DEFAULT_CRASH_REPORTER_CONFIG;
+      this.config = {
+        ...DEFAULT_CRASH_REPORTER_CONFIG,
+        serverUrl: `${getSudoworkServerBaseUrlSync()}/api/v1/crash/events/batch`,
+      };
     }
 
     // 加载离线缓存

--- a/src/process/telemetry/TelemetryBatchReporter.ts
+++ b/src/process/telemetry/TelemetryBatchReporter.ts
@@ -17,16 +17,32 @@
 import { app } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { isProductImprovementEnabled } from '@/common/systemConfig';
 import { ProcessConfig, getSudoworkServerBaseUrlSync } from '../initStorage';
 import { buildVersion } from '../../common/buildInfo';
-import type { TelemetryEvent, TelemetryBatchRequest, TelemetryBatchResponse, TelemetryConfig, StoredTelemetryEvent, PerfTelemetryEvent, ConversationTelemetryEvent, InstallTelemetryEvent, TurnTelemetryEvent, StepTelemetryEvent, PerfData, ConversationData, InstallData, TurnData, StepData } from '../../shared/types/telemetry';
+import type {
+  TelemetryEvent,
+  TelemetryBatchRequest,
+  TelemetryBatchResponse,
+  TelemetryConfig,
+  StoredTelemetryEvent,
+  PerfTelemetryEvent,
+  ConversationTelemetryEvent,
+  InstallTelemetryEvent,
+  TurnTelemetryEvent,
+  StepTelemetryEvent,
+  PerfData,
+  ConversationData,
+  InstallData,
+  TurnData,
+  StepData,
+} from '../../shared/types/telemetry';
 import { mapElectronArch, DEFAULT_TELEMETRY_CONFIG } from '../../shared/types/telemetry';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
 import { getProductImprovementApiKey } from '../credentialsCache';
 import { getTelemetryEncryptor, initTelemetryEncryptor, isEncryptionAvailable } from './TelemetryEncryptor';
 import { ENCRYPTION_CONFIG } from './keys';
 import { getUserContextSync } from './UserContext';
-import { isProductImprovementEnabled } from '@/common/systemConfig';
 
 // ============================================================
 // 类型定义
@@ -146,9 +162,9 @@ export class TelemetryBatchReporter {
       return;
     }
 
-    // 获取自定义服务器地址 (可选)，否则使用默认地址
+    // 获取自定义服务器地址 (可选)，否则用现读的 sudowork-server baseUrl 派生（与 sendBatch 一致）
     const customServerUrl = await ProcessConfig.get('telemetry.serverUrl').catch(() => undefined as unknown as string | undefined);
-    const serverUrl = customServerUrl || DEFAULT_TELEMETRY_CONFIG.serverUrl!;
+    const serverUrl = customServerUrl || `${getSudoworkServerBaseUrlSync()}/api/v1/telemetry/batch`;
 
     this.config = {
       ...DEFAULT_TELEMETRY_CONFIG,

--- a/src/process/telemetry/TelemetryEncryptor.ts
+++ b/src/process/telemetry/TelemetryEncryptor.ts
@@ -18,7 +18,7 @@
 
 import * as crypto from 'crypto';
 import { mainLog, mainWarn, mainError } from '../utils/mainLogger';
-import { ENCRYPTION_CONFIG, resolveTelemetryPublicKey } from './keys';
+import { ENCRYPTION_CONFIG, resolveTelemetryPublicKey, isEncryptionRequired } from './keys';
 
 // ============================================================
 // 类型定义
@@ -79,6 +79,14 @@ export class TelemetryEncryptor {
    */
   public async initialize(): Promise<void> {
     if (this.initialized) {
+      return;
+    }
+
+    // server encryption_required=false 时不加密（server 无私钥，仅支持明文）
+    if (!isEncryptionRequired()) {
+      this.enabled = false;
+      this.initialized = true;
+      mainLog('TelemetryEncryptor', 'Encryption disabled: server encryption_required=false, reporting plaintext');
       return;
     }
 

--- a/src/process/telemetry/keys.ts
+++ b/src/process/telemetry/keys.ts
@@ -59,6 +59,17 @@ export function resolveTelemetryPublicKey(): string {
   return TELEMETRY_PUBLIC_KEY_PEM;
 }
 
+/**
+ * 是否需要加密上报。跟随 server 下发的 `product_improvement.encryption_required`：
+ * - 显式 `false` → 明文上报（server 不配私钥，仅支持明文）
+ * - `true` 或 cache 缺失 → 加密（fail-open，保守，避免误关生产 server）
+ */
+export function isEncryptionRequired(): boolean {
+  const cache = getSystemConfigCache();
+  if (!cache) return true;
+  return cache.product_improvement?.encryption_required !== false;
+}
+
 // ============================================================
 // 加密配置
 // ============================================================


### PR DESCRIPTION
Two independent root causes prevented telemetry/crash from reaching the
server; both fixed.

1. Telemetry never initialized. ensureMainSystemConfig awaited
   getSudoworkServerBaseUrl() -> ConfigStorage.get (@office-ai/platform),
   whose BroadcastChannel IPC never resolves in the main process before the
   renderer is ready. This permanently blocked initializeTelemetry(), so
   this.initialized stayed false and record() silently dropped every event.
   Fix: resolve the base URL via getSudoworkServerBaseUrlSync (ProcessConfig)
   in the main bootstrap; fetchSystemConfig takes an optional baseUrl so the
   renderer keeps its default async resolution.

2. Server dropped encrypted batches. Client hard-coded encryption on and
   ignored the server's encryption_required. With encryption_required=false
   the server ships no private key; decryptMiddleware skips decryption, the
   encrypted payload has no events, and received=0 (silent data loss).
   Fix: gate encryption on server product_improvement.encryption_required via
   new keys.isEncryptionRequired(); fail-open to encrypted when undecided.
   CrashReporter benefits automatically (shares the encryptor singleton).

Also align Telemetry/Crash Initialized server URL with the actual sendBatch
target (getSudoworkServerBaseUrlSync) instead of the hardcoded public default.
