### PR TITLE
feat(workspace): file upload for remote/enterprise (moss) sessions

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -88,6 +88,7 @@ export const conversation = {
   getWorkspace: bridge.buildProvider<IDirOrFile[], { conversation_id: string; workspace: string; path: string; search?: string }>('conversation.get-workspace'),
   getRemoteWorkspace: bridge.buildProvider<IRemoteWorkspaceResponse, { conversation_id: string; path?: string; search?: string }>('conversation.get-remote-workspace'),
   previewRemoteWorkspaceFile: bridge.buildProvider<IBridgeResponse<MossWorkspaceFilePreview>, { conversation_id: string; path: string }>('conversation.preview-remote-workspace-file'),
+  copyFilesToRemoteWorkspace: bridge.buildProvider<IBridgeResponse<{ copiedFiles: string[]; failedFiles: Array<{ path: string; error: string }> }>, { conversation_id: string; filePaths: string[]; targetDir?: string; sourceRoot?: string }>('conversation.copy-files-to-remote-workspace'),
   getRemoteAvailableSkills: bridge.buildProvider<IRemoteAvailableSkillsResponse, { conversation_id: string }>('conversation.get-remote-available-skills'),
   responseSearchWorkSpace: bridge.buildProvider<void, { file: number; dir: number; match?: IDirOrFile }>('conversation.response.search.workspace'),
   reloadContext: bridge.buildProvider<IBridgeResponse, { conversation_id: string }>('conversation.reload-context'),

--- a/src/common/types/tenantConfig.ts
+++ b/src/common/types/tenantConfig.ts
@@ -40,6 +40,15 @@ export interface TenantConfig {
    * override locally. null/undefined → shown (default true).
    */
   client_show_tool_calls?: boolean | null;
+  /**
+   * 企业版客户端上传到会话工作区的单个文件大小上限（字节）。由 Moss 管理端控制，
+   * 仅企业模式生效；null/undefined 视为默认 20MB。客户端在上传前用它做大小校验，
+   * 服务端同样强制此上限。
+   * Max size (bytes) for a single file uploaded into a session workspace.
+   * Controlled by the Moss admin; enterprise mode only. null/undefined → 20MB
+   * default. The client pre-checks size against it; the server also enforces it.
+   */
+  workspace_upload_limit_bytes?: number | null;
 }
 
 /**
@@ -51,7 +60,7 @@ export interface TenantConfigResponse {
   msg?: string;
 }
 
-export type TenantConfigInput = Partial<Record<keyof TenantConfig, string | boolean | null | undefined>>;
+export type TenantConfigInput = Partial<TenantConfig>;
 
 export const TENANT_CONFIG_STORAGE_KEY = 'sudowork_tenant_config';
 
@@ -59,6 +68,10 @@ export const TENANT_CONFIG_STORAGE_KEY = 'sudowork_tenant_config';
  * 默认租户配置
  * 当接口未返回或字段为空时使用此默认值
  */
+/** Default single-file workspace upload limit (20MB) when the tenant config
+ *  does not specify one. Mirrors the moss server default. */
+export const DEFAULT_WORKSPACE_UPLOAD_LIMIT_BYTES = 20 * 1024 * 1024;
+
 export const DEFAULT_TENANT_CONFIG: Required<TenantConfig> = {
   logo: undefined,
   app_name: 'SudoWork',
@@ -68,6 +81,7 @@ export const DEFAULT_TENANT_CONFIG: Required<TenantConfig> = {
   app_company_name: '北京数牍科技有限公司',
   client_cron_enabled: true,
   client_show_tool_calls: true,
+  workspace_upload_limit_bytes: DEFAULT_WORKSPACE_UPLOAD_LIMIT_BYTES,
 };
 
 export function resolveTenantConfig(config?: TenantConfigInput | null): Required<TenantConfig> {
@@ -82,5 +96,12 @@ export function resolveTenantConfig(config?: TenantConfigInput | null): Required
     client_cron_enabled: config?.client_cron_enabled === false ? false : true,
     // Only an explicit `false` hides tool calls; null/undefined → default shown.
     client_show_tool_calls: config?.client_show_tool_calls === false ? false : true,
+    // Use the configured limit only when it is a positive number; otherwise default.
+    workspace_upload_limit_bytes:
+      typeof config?.workspace_upload_limit_bytes === 'number' &&
+      Number.isFinite(config.workspace_upload_limit_bytes) &&
+      config.workspace_upload_limit_bytes > 0
+        ? config.workspace_upload_limit_bytes
+        : DEFAULT_WORKSPACE_UPLOAD_LIMIT_BYTES,
   };
 }

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -740,11 +740,32 @@ export function initConversationBridge(): void {
       const copiedFiles: string[] = [];
       const failedFiles: Array<{ path: string; error: string }> = [];
 
+      // Fetch the current upload limit fresh (per upload batch) so an admin
+      // change on the Moss server is picked up immediately; fall back to 20MB
+      // if it can't be read. The server enforces the same limit regardless.
+      let uploadLimitBytes = 20 * 1024 * 1024;
+      try {
+        const fetched = await api.getWorkspaceUploadLimitBytes();
+        if (typeof fetched === 'number' && fetched > 0) {
+          uploadLimitBytes = fetched;
+        }
+      } catch (error) {
+        mainWarn('conversationBridge', 'Failed to fetch upload limit, using default:', error);
+      }
+      const limitMb = Math.round(uploadLimitBytes / (1024 * 1024));
+
       const normalizeRelative = (p: string) => p.split(path.sep).join('/').replace(/^\/+/, '');
       const prefix = targetDir ? normalizeRelative(targetDir).replace(/\/+$/, '') : '';
 
       for (const filePath of filePaths) {
         try {
+          // Pre-check size against the fresh limit so the user gets a specific
+          // message without a wasted upload.
+          const stat = await fs.stat(filePath);
+          if (stat.size > uploadLimitBytes) {
+            failedFiles.push({ path: filePath, error: `Uploaded file exceeds size limit (${limitMb}MB)` });
+            continue;
+          }
           const relInsideRoot = sourceRoot ? path.relative(sourceRoot, filePath) : path.basename(filePath);
           const rel = normalizeRelative(prefix ? path.posix.join(prefix, normalizeRelative(relInsideRoot)) : relInsideRoot);
           const buffer = await fs.readFile(filePath);

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -725,6 +725,50 @@ export function initConversationBridge(): void {
     }
   });
 
+  // Remote counterpart of fs.copyFilesToWorkspace: reads local source files and
+  // uploads their bytes into the Moss session's server-side workspace. Returns
+  // the same { copiedFiles, failedFiles } shape so the renderer paste/drag/add
+  // flows can branch on dataSource without other changes.
+  ipcBridge.conversation.copyFilesToRemoteWorkspace.provider(async ({ conversation_id, filePaths, targetDir, sourceRoot }) => {
+    try {
+      const { extra, mossSessionId, pending } = getRemoteConversationSession(conversation_id);
+      if (pending || !mossSessionId) {
+        return { success: false, msg: 'Moss session is pending' };
+      }
+      const api = getRemoteConversationMossApi(extra);
+
+      const copiedFiles: string[] = [];
+      const failedFiles: Array<{ path: string; error: string }> = [];
+
+      const normalizeRelative = (p: string) => p.split(path.sep).join('/').replace(/^\/+/, '');
+      const prefix = targetDir ? normalizeRelative(targetDir).replace(/\/+$/, '') : '';
+
+      for (const filePath of filePaths) {
+        try {
+          const relInsideRoot = sourceRoot ? path.relative(sourceRoot, filePath) : path.basename(filePath);
+          const rel = normalizeRelative(prefix ? path.posix.join(prefix, normalizeRelative(relInsideRoot)) : relInsideRoot);
+          const buffer = await fs.readFile(filePath);
+          const result = await api.uploadSessionWorkspaceFile(mossSessionId, {
+            path: rel,
+            contentBase64: buffer.toString('base64'),
+          });
+          copiedFiles.push(result.relativePath || rel);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          mainError('conversationBridge', `Failed to upload file ${filePath} to remote workspace:`, message);
+          failedFiles.push({ path: filePath, error: message });
+        }
+      }
+
+      const success = failedFiles.length === 0;
+      return { success, data: { copiedFiles, failedFiles }, msg: success ? undefined : 'Some files failed to upload' };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      mainError('conversationBridge', 'copyFilesToRemoteWorkspace failed:', msg);
+      return { success: false, msg };
+    }
+  });
+
   ipcBridge.conversation.getRemoteAvailableSkills.provider(async ({ conversation_id }) => {
     try {
       const { extra, mossSessionId, pending } = getRemoteConversationSession(conversation_id);

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -255,6 +255,26 @@ export class MossSessionApi {
   }
 
   /**
+   * Fetch the current workspace upload size limit (bytes) from tenant config.
+   * GET /api/v1/tenant/config -> data.workspace_upload_limit_bytes
+   *
+   * Returns null if unavailable, so callers can fall back to a default. Read
+   * fresh right before an upload so admin changes are picked up immediately
+   * (the server enforces the same limit regardless).
+   */
+  async getWorkspaceUploadLimitBytes(): Promise<number | null> {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/tenant/config`, {
+      method: 'GET',
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const body = await response.json();
+    const limit = body?.data?.workspace_upload_limit_bytes;
+    return typeof limit === 'number' && Number.isFinite(limit) && limit > 0 ? limit : null;
+  }
+
+  /**
    * Get session-scoped skills that are actually available to the Moss backend.
    * GET /api/v1/sessions/{sessionId}/skills/available
    */

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -221,6 +221,40 @@ export class MossSessionApi {
   }
 
   /**
+   * Upload a file into a Moss session workspace.
+   * POST /api/v1/sessions/{sessionId}/workspace/file
+   *
+   * The server writes the bytes into the session's server-side workspace
+   * (session.cwd) under the given workspace-relative path and returns the
+   * stored relativePath + size.
+   */
+  async uploadSessionWorkspaceFile(
+    sessionId: string,
+    params: { path: string; contentBase64: string },
+  ): Promise<{ relativePath: string; size: number }> {
+    const response = await this.fetchWithRetry(
+      `${this.serverUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/workspace/file`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          path: params.path,
+          content_base64: params.contentBase64,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to upload session workspace file: ${response.status} ${text}`);
+    }
+
+    return (await response.json()) as { relativePath: string; size: number };
+  }
+
+  /**
    * Get session-scoped skills that are actually available to the Moss backend.
    * GET /api/v1/sessions/{sessionId}/skills/available
    */

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
@@ -17,6 +17,11 @@ interface UseWorkspacePasteOptions {
   messageApi: MessageApi;
   t: (key: string) => string;
 
+  // Conversation identity + data source. When dataSource === 'moss-session',
+  // uploads target the remote Moss workspace instead of the local filesystem.
+  conversation_id: string;
+  dataSource?: string;
+
   // Dependencies from useWorkspaceTree
   files: IDirOrFile[];
   selected: string[];
@@ -34,11 +39,36 @@ interface UseWorkspacePasteOptions {
  * Handle file paste and add logic
  */
 export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
-  const { workspace, messageApi, t, files, selected, selectedNodeRef, refreshWorkspace, pasteConfirm, setPasteConfirm, closePasteConfirm } = options;
+  const { workspace, messageApi, t, conversation_id, dataSource, files, selected, selectedNodeRef, refreshWorkspace, pasteConfirm, setPasteConfirm, closePasteConfirm } = options;
+
+  const isRemote = dataSource === 'moss-session';
 
   // 跟踪粘贴目标文件夹（用于视觉反馈）
   // Track paste target folder (for visual feedback)
   const [pasteTargetFolder, setPasteTargetFolder] = useState<string | null>(null);
+
+  /**
+   * Copy/upload files into the workspace, transparently choosing between the
+   * local filesystem (fs.copyFilesToWorkspace) and the remote Moss workspace
+   * (conversation.copyFilesToRemoteWorkspace) based on dataSource. Returns the
+   * same { copiedFiles, failedFiles } shape in both cases.
+   *
+   * @param targetFolderPath absolute path of the destination folder (local mode)
+   * @param targetFolderKey  workspace-relative destination folder (remote mode)
+   */
+  const copyFilesIntoWorkspace = useCallback(
+    async (filePaths: string[], targetFolderPath: string, targetFolderKey?: string) => {
+      if (isRemote) {
+        return ipcBridge.conversation.copyFilesToRemoteWorkspace.invoke({
+          conversation_id,
+          filePaths,
+          targetDir: targetFolderKey || undefined,
+        });
+      }
+      return ipcBridge.fs.copyFilesToWorkspace.invoke({ filePaths, workspace: targetFolderPath });
+    },
+    [isRemote, conversation_id]
+  );
 
   /**
    * 添加文件（从文件系统选择器）
@@ -52,7 +82,7 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
       })
       .then((res) => {
         if (res?.success && res.data && !res.data.canceled && res.data.filePaths.length > 0) {
-          return ipcBridge.fs.copyFilesToWorkspace.invoke({ filePaths: res.data.filePaths, workspace }).then((result) => {
+          return copyFilesIntoWorkspace(res.data.filePaths, workspace, '').then((result) => {
             const copiedFiles = result.data?.copiedFiles ?? [];
             const failedFiles = result.data?.failedFiles ?? [];
 
@@ -73,7 +103,7 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
       .catch(() => {
         // Silently ignore errors
       });
-  }, [workspace, refreshWorkspace, messageApi, t]);
+  }, [workspace, refreshWorkspace, messageApi, t, copyFilesIntoWorkspace]);
 
   /**
    * 处理文件粘贴（从粘贴服务）
@@ -98,7 +128,7 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
       if (skipConfirm) {
         try {
           const filePaths = filesMeta.map((f) => f.path);
-          const res = await ipcBridge.fs.copyFilesToWorkspace.invoke({ filePaths, workspace: targetFolderPath });
+          const res = await copyFilesIntoWorkspace(filePaths, targetFolderPath, targetFolderKey);
           const copiedFiles = res.data?.copiedFiles ?? [];
           const failedFiles = res.data?.failedFiles ?? [];
 
@@ -131,7 +161,7 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
         targetFolder: targetFolderKey,
       });
     },
-    [workspace, refreshWorkspace, t, messageApi, files, selected, selectedNodeRef, setPasteConfirm]
+    [workspace, refreshWorkspace, t, messageApi, files, selected, selectedNodeRef, setPasteConfirm, copyFilesIntoWorkspace]
   );
 
   /**
@@ -150,9 +180,10 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
       // 获取目标文件夹路径 / Get target folder path
       const targetFolder = getTargetFolderPath(selectedNodeRef.current, selected, files, workspace);
       const targetFolderPath = targetFolder.fullPath;
+      const targetFolderKey = targetFolder.relativePath;
 
       const filePaths = pasteConfirm.filesToPaste.map((f) => f.path);
-      const res = await ipcBridge.fs.copyFilesToWorkspace.invoke({ filePaths, workspace: targetFolderPath });
+      const res = await copyFilesIntoWorkspace(filePaths, targetFolderPath, targetFolderKey);
       const copiedFiles = res.data?.copiedFiles ?? [];
       const failedFiles = res.data?.failedFiles ?? [];
 
@@ -172,7 +203,7 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
     } finally {
       setPasteTargetFolder(null);
     }
-  }, [pasteConfirm, closePasteConfirm, messageApi, t, files, selected, selectedNodeRef, workspace, refreshWorkspace]);
+  }, [pasteConfirm, closePasteConfirm, messageApi, t, files, selected, selectedNodeRef, workspace, refreshWorkspace, copyFilesIntoWorkspace]);
 
   // 注册粘贴服务以在工作空间组件获得焦点时捕获全局粘贴事件
   // Register paste service to catch global paste events when workspace component is focused

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
@@ -9,8 +9,6 @@ import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
 import { usePasteService } from '@/renderer/hooks/usePasteService';
-import { useTenantConfig } from '@/renderer/context/TenantConfigContext';
-import { DEFAULT_WORKSPACE_UPLOAD_LIMIT_BYTES } from '@/common/types/tenantConfig';
 import type { MessageApi, PasteConfirmState, SelectedNodeRef } from '../types';
 import { getTargetFolderPath } from '../utils/treeHelpers';
 
@@ -44,8 +42,6 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
   const { workspace, messageApi, t, conversation_id, dataSource, files, selected, selectedNodeRef, refreshWorkspace, pasteConfirm, setPasteConfirm, closePasteConfirm } = options;
 
   const isRemote = dataSource === 'moss-session';
-  const { config: tenantConfig } = useTenantConfig();
-  const uploadLimitBytes = tenantConfig.workspace_upload_limit_bytes || DEFAULT_WORKSPACE_UPLOAD_LIMIT_BYTES;
 
   // 跟踪粘贴目标文件夹（用于视觉反馈）
   // Track paste target folder (for visual feedback)
@@ -57,9 +53,10 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
    * (conversation.copyFilesToRemoteWorkspace) based on dataSource. Returns the
    * same { copiedFiles, failedFiles } shape in both cases.
    *
-   * For remote uploads the file size is pre-checked against the Moss-managed
-   * limit so the user gets an immediate "exceeds size limit (NMB)" message
-   * without a wasted upload; the server enforces the same limit as a backstop.
+   * For remote uploads, the main-process handler fetches the current upload
+   * limit fresh and pre-checks each file's size, returning oversized files as
+   * failures with a specific "exceeds size limit (NMB)" message; the Moss
+   * server enforces the same limit as a backstop.
    *
    * @param targetFolderPath absolute path of the destination folder (local mode)
    * @param targetFolderKey  workspace-relative destination folder (remote mode)
@@ -67,49 +64,15 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
   const copyFilesIntoWorkspace = useCallback(
     async (filePaths: string[], targetFolderPath: string, targetFolderKey?: string) => {
       if (isRemote) {
-        // Pre-check sizes; collect oversized files as failures and only upload
-        // the ones within the limit. Keeps the { copiedFiles, failedFiles } shape.
-        const limitMb = Math.round(uploadLimitBytes / (1024 * 1024));
-        const withinLimit: string[] = [];
-        const failedFiles: Array<{ path: string; error: string }> = [];
-        for (const filePath of filePaths) {
-          let size = 0;
-          try {
-            const meta = await ipcBridge.fs.getFileMetadata.invoke({ path: filePath });
-            size = typeof meta?.size === 'number' ? meta.size : 0;
-          } catch {
-            // If size can't be determined, let the server be the gate.
-          }
-          if (size > uploadLimitBytes) {
-            failedFiles.push({
-              path: filePath,
-              error: `Uploaded file exceeds size limit (${limitMb}MB)`,
-            });
-          } else {
-            withinLimit.push(filePath);
-          }
-        }
-
-        if (withinLimit.length === 0) {
-          return { success: false, data: { copiedFiles: [], failedFiles }, msg: failedFiles[0]?.error };
-        }
-
-        const res = await ipcBridge.conversation.copyFilesToRemoteWorkspace.invoke({
+        return ipcBridge.conversation.copyFilesToRemoteWorkspace.invoke({
           conversation_id,
-          filePaths: withinLimit,
+          filePaths,
           targetDir: targetFolderKey || undefined,
         });
-        // Merge pre-check failures into the bridge result.
-        const mergedFailed = [...failedFiles, ...(res.data?.failedFiles ?? [])];
-        return {
-          success: res.success && mergedFailed.length === 0,
-          data: { copiedFiles: res.data?.copiedFiles ?? [], failedFiles: mergedFailed },
-          msg: mergedFailed.length > 0 ? (res.msg || failedFiles[0]?.error) : res.msg,
-        };
       }
       return ipcBridge.fs.copyFilesToWorkspace.invoke({ filePaths, workspace: targetFolderPath });
     },
-    [isRemote, conversation_id, uploadLimitBytes, t]
+    [isRemote, conversation_id]
   );
 
   /**

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
@@ -9,6 +9,8 @@ import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
 import { usePasteService } from '@/renderer/hooks/usePasteService';
+import { useTenantConfig } from '@/renderer/context/TenantConfigContext';
+import { DEFAULT_WORKSPACE_UPLOAD_LIMIT_BYTES } from '@/common/types/tenantConfig';
 import type { MessageApi, PasteConfirmState, SelectedNodeRef } from '../types';
 import { getTargetFolderPath } from '../utils/treeHelpers';
 
@@ -42,6 +44,8 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
   const { workspace, messageApi, t, conversation_id, dataSource, files, selected, selectedNodeRef, refreshWorkspace, pasteConfirm, setPasteConfirm, closePasteConfirm } = options;
 
   const isRemote = dataSource === 'moss-session';
+  const { config: tenantConfig } = useTenantConfig();
+  const uploadLimitBytes = tenantConfig.workspace_upload_limit_bytes || DEFAULT_WORKSPACE_UPLOAD_LIMIT_BYTES;
 
   // 跟踪粘贴目标文件夹（用于视觉反馈）
   // Track paste target folder (for visual feedback)
@@ -53,21 +57,59 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
    * (conversation.copyFilesToRemoteWorkspace) based on dataSource. Returns the
    * same { copiedFiles, failedFiles } shape in both cases.
    *
+   * For remote uploads the file size is pre-checked against the Moss-managed
+   * limit so the user gets an immediate "exceeds size limit (NMB)" message
+   * without a wasted upload; the server enforces the same limit as a backstop.
+   *
    * @param targetFolderPath absolute path of the destination folder (local mode)
    * @param targetFolderKey  workspace-relative destination folder (remote mode)
    */
   const copyFilesIntoWorkspace = useCallback(
     async (filePaths: string[], targetFolderPath: string, targetFolderKey?: string) => {
       if (isRemote) {
-        return ipcBridge.conversation.copyFilesToRemoteWorkspace.invoke({
+        // Pre-check sizes; collect oversized files as failures and only upload
+        // the ones within the limit. Keeps the { copiedFiles, failedFiles } shape.
+        const limitMb = Math.round(uploadLimitBytes / (1024 * 1024));
+        const withinLimit: string[] = [];
+        const failedFiles: Array<{ path: string; error: string }> = [];
+        for (const filePath of filePaths) {
+          let size = 0;
+          try {
+            const meta = await ipcBridge.fs.getFileMetadata.invoke({ path: filePath });
+            size = typeof meta?.size === 'number' ? meta.size : 0;
+          } catch {
+            // If size can't be determined, let the server be the gate.
+          }
+          if (size > uploadLimitBytes) {
+            failedFiles.push({
+              path: filePath,
+              error: `Uploaded file exceeds size limit (${limitMb}MB)`,
+            });
+          } else {
+            withinLimit.push(filePath);
+          }
+        }
+
+        if (withinLimit.length === 0) {
+          return { success: false, data: { copiedFiles: [], failedFiles }, msg: failedFiles[0]?.error };
+        }
+
+        const res = await ipcBridge.conversation.copyFilesToRemoteWorkspace.invoke({
           conversation_id,
-          filePaths,
+          filePaths: withinLimit,
           targetDir: targetFolderKey || undefined,
         });
+        // Merge pre-check failures into the bridge result.
+        const mergedFailed = [...failedFiles, ...(res.data?.failedFiles ?? [])];
+        return {
+          success: res.success && mergedFailed.length === 0,
+          data: { copiedFiles: res.data?.copiedFiles ?? [], failedFiles: mergedFailed },
+          msg: mergedFailed.length > 0 ? (res.msg || failedFiles[0]?.error) : res.msg,
+        };
       }
       return ipcBridge.fs.copyFilesToWorkspace.invoke({ filePaths, workspace: targetFolderPath });
     },
-    [isRemote, conversation_id]
+    [isRemote, conversation_id, uploadLimitBytes, t]
   );
 
   /**
@@ -94,7 +136,8 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
 
             if (!result.success || failedFiles.length > 0) {
               // 部分或全部失败时给出显式提示 / Surface warning when any copy operation fails
-              const fallback = failedFiles.length > 0 ? 'Some files failed to copy' : result.msg;
+              const specific = failedFiles[0]?.error;
+              const fallback = specific || (failedFiles.length > 0 ? 'Some files failed to copy' : result.msg);
               messageApi.warning(fallback || t('common.unknownError') || 'Copy failed');
             }
           });
@@ -138,8 +181,10 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
           }
 
           if (!res.success || failedFiles.length > 0) {
-            // 如果有文件粘贴失败则通知用户 / Notify user when any paste fails
-            const fallback = failedFiles.length > 0 ? 'Some files failed to copy' : res.msg;
+            // Prefer the specific per-file error (e.g. size-limit message) so the
+            // user sees a meaningful reason rather than a generic notice.
+            const specific = failedFiles[0]?.error;
+            const fallback = specific || (failedFiles.length > 0 ? 'Some files failed to copy' : res.msg);
             messageApi.warning(fallback || t('common.unknownError') || 'Paste failed');
           }
         } catch {
@@ -193,7 +238,8 @@ export function useWorkspacePaste(options: UseWorkspacePasteOptions) {
       }
 
       if (!res.success || failedFiles.length > 0) {
-        const fallback = failedFiles.length > 0 ? 'Some files failed to copy' : res.msg;
+        const specific = failedFiles[0]?.error;
+        const fallback = specific || (failedFiles.length > 0 ? 'Some files failed to copy' : res.msg);
         messageApi.warning(fallback || t('common.unknownError') || 'Paste failed');
       }
 

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -59,6 +59,12 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
   const { openPreview } = usePreviewContext();
   const navigate = useNavigate();
 
+  // Remote Moss-session workspaces are rendered readonly (no local FS to
+  // edit/rename/delete), but file UPLOAD is supported via the remote upload
+  // endpoint. allowUpload re-enables the upload affordances (drag-drop, paste)
+  // for that mode while leaving the other readonly restrictions intact.
+  const allowUpload = !readonly || dataSource === 'moss-session';
+
   // Message API setup
   const [internalMessageApi, messageContext] = Message.useMessage();
   const messageApi = externalMessageApi ?? internalMessageApi;
@@ -277,6 +283,8 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
     workspace,
     messageApi,
     t,
+    conversation_id,
+    dataSource,
     files: treeHook.files,
     selected: treeHook.selected,
     selectedNodeRef: treeHook.selectedNodeRef,
@@ -848,11 +856,11 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
       <div
         className='chat-workspace workspace-card size-full flex flex-col relative'
         tabIndex={0}
-        onFocus={readonly ? undefined : pasteHook.onFocusPaste}
-        onClick={readonly ? undefined : pasteHook.onFocusPaste}
-        {...(readonly ? {} : dragImportHook.dragHandlers)}
+        onFocus={!allowUpload ? undefined : pasteHook.onFocusPaste}
+        onClick={!allowUpload ? undefined : pasteHook.onFocusPaste}
+        {...(!allowUpload ? {} : dragImportHook.dragHandlers)}
         style={
-          !readonly && dragImportHook.isDragging
+          allowUpload && dragImportHook.isDragging
             ? {
                 border: '1px dashed rgb(var(--primary-6))',
                 borderRadius: '18px',
@@ -862,8 +870,8 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
             : undefined
         }
       >
-        {!readonly && dragImportHook.isDragging && (
-          <div className='absolute inset-0 pointer-events-none z-30 f-center px-32px'>
+        {allowUpload && dragImportHook.isDragging && (
+          <div className='absolute inset-0 pointer-events-none z-30 flex items-center justify-center px-32px'>
             <div
               className='w-full max-w-480px text-center text-white rounded-16px px-32px py-28px'
               style={{
@@ -891,7 +899,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
           </div>
         )}
         {/* Paste Confirm Modal */}
-        {!readonly && (
+        {allowUpload && (
           <Modal
             visible={modalsHook.pasteConfirm.visible}
             title={null}
@@ -1298,7 +1306,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
                 renderTitle={(node) => {
                   const relativePath = node.dataRef.relativePath;
                   const isFile = node.dataRef.isFile;
-                  const isPasteTarget = !readonly && !isFile && pasteHook.pasteTargetFolder === relativePath;
+                  const isPasteTarget = allowUpload && !isFile && pasteHook.pasteTargetFolder === relativePath;
                   const nodeData = node.dataRef as IDirOrFile;
                   const directFileCount = !isFile ? (nodeData.children ?? []).filter((child) => child.isFile && !isHiddenWorkspaceEntry(child.name)).length : 0;
                   // Display .drafts with i18n name / 草稿箱目录显示本地化名称


### PR DESCRIPTION
## Summary
Brings remote/enterprise (`moss-session`) conversations to **parity with local mode for workspace file upload**. Previously the remote workspace was read-only (drag/paste/add disabled behind `readonly`); **reading** was already supported via `getRemoteWorkspace` / `previewRemoteWorkspaceFile`.

## Changes
- **`MossSessionApi.uploadSessionWorkspaceFile`** — POSTs to the moss server's new `/api/v1/sessions/:id/workspace/file` endpoint (base64 payload).
- **`conversationBridge.copyFilesToRemoteWorkspace`** — main-process handler that reads local source files and uploads them into the session's server-side workspace, returning the same `{ copiedFiles, failedFiles }` shape as local `fs.copyFilesToWorkspace` so the renderer flows are unchanged.
- **`useWorkspacePaste`** — routes drag/paste/add through the remote upload path when `dataSource === 'moss-session'`. Existing error surfacing (warning on `failedFiles`, error on throw) now covers remote failures too.
- **`workspace/index.tsx`** — introduces `allowUpload = !readonly || dataSource === 'moss-session'` to re-enable only the upload affordances (drag, paste, paste-confirm) while leaving rename/delete/new-folder readonly-gated.

## Error handling
Upload/attach failures surface the same way as local mode (Arco `messageApi.warning` on partial failure, `messageApi.error` on throw).

## Dependency
Requires the moss server upload endpoint: **sudoprivacy/moss#102**.

## Testing
- `tsc --noEmit`: no new errors (the lone `electron.vite.config.ts` error pre-exists on `dev`).
- Full `electron-vite build` (main + preload + renderer) ✓.
- The server endpoint this calls was e2e-verified end-to-end (20/20) against a real moss server + Docker session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)