### PR TITLE
chore: bump version to 0.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sudowork",
   "productName": "sudowork",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "新一代企业AI应用平台--AgentOPS|办公专家",
   "main": "./out/main/index.js",
   "engines": {


### PR DESCRIPTION
Bump version 0.2.8 → 0.2.9 ahead of tagging v0.2.9 to trigger the release/packaging build.