### PR TITLE
fix(build): don't bundle nexus-vault plugin in macOS app to pass notarization

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -211,11 +211,10 @@ extraResources:
     to: .
     filter:
       - v*-scode-macos-*
-  # Vault plugin - versioned, optional
-  - from: resources
-    to: .
-    filter:
-      - v*-nexus-vault-macos-*
+  # Vault plugin is intentionally NOT bundled on macOS: its dylib carries a
+  # detached Nexus signature and must not be Apple-codesigned (afterPack.js
+  # excludes it), but Apple notarization rejects unsigned Mach-O inside the
+  # .app. VaultPluginInstaller downloads it at runtime into ~/.nexus-vfs/plugins.
 
 win:
   legalTrademarks: Copyright © 2026 北京数牍科技有限公司


### PR DESCRIPTION
## Problem

The v0.2.9 release build failed Apple notarization:

> `Sudowork.app/Contents/Resources/v0.4.0-nexus-vault-macos-arm64.tar.gz/.../libnexus_vault.dylib` — The binary is not signed with a valid Developer ID certificate / signature does not include a secure timestamp.

## Root cause

PR #950 bundled the vault plugin archive into the notarized macOS `.app` via `extraResources`. The `libnexus_vault.dylib` inside it is **intentionally excluded** from Apple codesigning (`scripts/afterPack.js` `NEXUS_SIGNED_PLUGIN_ARCHIVE_RE`) because codesigning would alter its bytes and invalidate Nexus's own detached plugin signature. But Apple's notary recursively unpacks the tarball and requires every Mach-O to be Developer-ID signed — mutually exclusive with the detached-signature model.

## Fix

Remove the `v*-nexus-vault-macos-*` `extraResources` filter. `VaultPluginInstaller.install()` already falls back to runtime download into `~/.nexus-vfs/plugins/` when no bundled archive is present, so functionality is preserved (macOS first-run fetches the plugin over the network).

Windows bundling is left intact — Windows builds are not notarized.