### PR TITLE
fix(acp): restore conversation context on session resume

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -9,7 +9,7 @@ import { promisify } from 'util';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { ACP_METHODS, JSONRPC_VERSION } from '@/types/acpTypes';
+import { ACP_METHODS, getAcpResumeStrategy, JSONRPC_VERSION } from '@/types/acpTypes';
 import type { AcpBackend, AcpIncomingMessage, AcpMessage, AcpNotification, AcpPermissionRequest, AcpPromptResponseUsage, AcpQuestionRequest, AcpQuestionResponseAnswer, AcpRequest, AcpResponse, AcpSessionConfigOption, AcpSessionModels, AcpSessionUpdate } from '@/types/acpTypes';
 import { mainLog } from '@process/utils/mainLogger';
 import { resolveNpxPath } from '@process/utils/shellEnv';
@@ -750,9 +750,12 @@ export class AcpConnection {
     // Sending the absolute path again makes some CLIs treat it as a nested relative path.
     const normalizedCwd = this.normalizeCwdForAgent(cwd);
 
-    // Build _meta for Claude/CodeBuddy ACP resume support
-    // claude-agent-acp and codebuddy use _meta.claudeCode.options.resume for session resume
-    const useMetaResume = (this.backend === 'claude' || this.backend === 'codebuddy') && options?.resumeSessionId;
+    // Resume on session/new is only meaningful for 'meta-resume' backends (claude-agent-acp /
+    // codebuddy), which carry the prior session id in `_meta.claudeCode.options.resume`. Every
+    // other backend resumes through the ACP-standard `session/load` (see getAcpResumeStrategy),
+    // so we never attach a generic `resumeSessionId` here — that param had no consumer and made
+    // scode silently mint a fresh, empty session instead of resuming.
+    const useMetaResume = getAcpResumeStrategy(this.backend) === 'meta-resume' && options?.resumeSessionId;
     const meta = useMetaResume
       ? {
           claudeCode: {
@@ -766,10 +769,8 @@ export class AcpConnection {
     const response = await this.sendRequest<AcpResponse & { sessionId?: string }>('session/new', {
       cwd: normalizedCwd,
       mcpServers: [] as unknown[],
-      // Claude/CodeBuddy ACP uses _meta for resume
+      // meta-resume backends (claude/codebuddy) pass the resume id through _meta
       ...(meta && { _meta: meta }),
-      // Generic resume parameters for other ACP backends
-      ...(this.backend !== 'claude' && this.backend !== 'codebuddy' && options?.resumeSessionId && { resumeSessionId: options.resumeSessionId }),
       ...(options?.forkSession && { forkSession: options.forkSession }),
     });
 

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -43,7 +43,7 @@ import type {
   ToolCallUpdate,
   ToolCallUpdateStatus,
 } from '@/types/acpTypes';
-import { ACP_BACKENDS_ALL, AcpErrorType, createAcpError } from '@/types/acpTypes';
+import { ACP_BACKENDS_ALL, AcpErrorType, createAcpError, getAcpResumeStrategy } from '@/types/acpTypes';
 import { ExtensionRegistry } from '@/extensions';
 import { getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
 import { applyPresetRuntime } from '@process/task/presetRuntime';
@@ -602,17 +602,16 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
 
     if (resumeSessionId) {
       try {
-        let response: { sessionId?: string };
+        // Resume routing is driven by the per-backend strategy (SSOT in acpTypes), not ad-hoc
+        // backend checks. 'session-load' (default: scode, codex, any ACP-compliant bridge) restores
+        // history from disk by id via the ACP-standard `session/load`. 'meta-resume' (claude/codebuddy)
+        // resumes through `session/new` + `_meta.claudeCode.options.resume`.
+        const strategy = getAcpResumeStrategy(this.extra.backend);
+        const response: { sessionId?: string } = strategy === 'meta-resume' ? await this.connection.newSession(this.extra.workspace, { resumeSessionId, forkSession: false }) : await this.connection.loadSession(resumeSessionId, this.extra.workspace);
 
-        if (this.extra.backend === 'codex') {
-          response = await this.connection.loadSession(resumeSessionId, this.extra.workspace);
-        } else {
-          response = await this.connection.newSession(this.extra.workspace, {
-            resumeSessionId,
-            forkSession: false,
-          });
-        }
-
+        // Only adopt a server-minted id when the mechanism legitimately issues a new one (meta-resume
+        // bridges may). `session/load` keeps the id we sent, so it never orphans the stored handle —
+        // which is exactly the bug that made scode resume silently start a fresh, empty session.
         if (response.sessionId && response.sessionId !== resumeSessionId) {
           this.extra.acpSessionId = response.sessionId;
           saveAcpSessionId(this.conversation_id, response.sessionId);

--- a/src/types/acpTypes.ts
+++ b/src/types/acpTypes.ts
@@ -174,6 +174,18 @@ export const POTENTIAL_ACP_CLIS: PotentialAcpCli[] = new Proxy([] as PotentialAc
 });
 
 /**
+ * 后端 ACP bridge 实现的会话恢复机制 / Session-resume mechanism a backend's ACP bridge implements.
+ * - 'session-load': ACP 标准 `session/load`，按 session id 从磁盘恢复完整历史（默认；codex、scode，
+ *   以及任何符合 ACP 标准的 bridge）/ ACP-standard `session/load` by id (default).
+ * - 'meta-resume': `session/new` 携带 `_meta.claudeCode.options.resume`（claude-agent-acp / codebuddy 专用）
+ *   / `session/new` carrying `_meta.claudeCode.options.resume`.
+ *
+ * 恢复失败时统一回退到全新会话，因此默认值对未经验证的 bridge 也是安全的（最坏等同于一次全新会话）。
+ * Resume falls back to a fresh session on failure, so the default is safe for unverified bridges.
+ */
+export type AcpResumeStrategy = 'session-load' | 'meta-resume';
+
+/**
  * ACP 后端 Agent 配置
  * 用于内置后端（claude, gemini, qwen）和用户自定义 Agent
  *
@@ -231,6 +243,13 @@ export interface AcpBackendConfig {
 
   /** 是否支持流式响应 / Whether this backend supports streaming responses */
   supportsStreaming?: boolean;
+
+  /**
+   * 此后端 ACP bridge 实现的会话恢复机制；缺省为 'session-load'（ACP 标准）。
+   * The session-resume mechanism this backend's ACP bridge implements; defaults to 'session-load'.
+   * 仅 claude/codebuddy 需覆盖为 'meta-resume'。详见 {@link AcpResumeStrategy}。
+   */
+  resumeStrategy?: AcpResumeStrategy;
 
   /**
    * 传递给子进程的自定义环境变量
@@ -356,6 +375,7 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     authRequired: true,
     enabled: true,
     supportsStreaming: false,
+    resumeStrategy: 'meta-resume', // claude-agent-acp resumes via session/new _meta.claudeCode.options.resume
   },
   gemini: {
     id: 'gemini',
@@ -402,6 +422,7 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     enabled: false, // ✅ Tencent CodeBuddy Code CLI，使用 `codebuddy --acp` 启动
     supportsStreaming: false,
     acpArgs: ['--acp'], // codebuddy 使用 --acp flag
+    resumeStrategy: 'meta-resume', // CodeBuddy ACP 复用 claude-agent-acp 的 _meta resume 机制
   },
   goose: {
     id: 'goose',
@@ -556,6 +577,16 @@ export function getAllAcpBackends(): AcpBackendConfig[] {
 // 检查后端是否启用 / Check if a backend is enabled
 export function isAcpBackendEnabled(backend: AcpBackendAll): boolean {
   return ACP_BACKENDS_ALL[backend]?.enabled ?? false;
+}
+
+/**
+ * 获取后端的会话恢复策略（SSOT）。缺省 'session-load'（ACP 标准）。
+ * Resolve a backend's session-resume strategy (single source of truth).
+ * Defaults to 'session-load' (the ACP-standard `session/load` path).
+ */
+export function getAcpResumeStrategy(backend: AcpBackend | null | undefined): AcpResumeStrategy {
+  if (!backend) return 'session-load';
+  return ACP_BACKENDS_ALL[backend]?.resumeStrategy ?? 'session-load';
 }
 
 // ACP 错误类型系统 - 优雅的错误处理 / ACP Error Type System - Elegant error handling

--- a/tests/e2e/cases/scode-resume-after-model-switch.yaml
+++ b/tests/e2e/cases/scode-resume-after-model-switch.yaml
@@ -1,0 +1,84 @@
+name: "scode session retained across model switch (resume regression guard)"
+description: >
+  A design partner's headline trigger: switching the model mid-conversation made
+  Sudo Code forget everything. The happy path keeps the session in the engine's
+  memory; the failure path tears down + reconnects the engine, and pre-fix that
+  reconnect resumed via scode's no-op `session/new` resumeSessionId -> a fresh
+  empty session -> amnesia. With PR #957's session/load routing, the reconnect
+  restores history, so the new model answers with full prior context.
+
+  The switch is driven by a REAL mouse click on the model dropdown -- the way a
+  user switches -- NOT the `/model` slash command (regular users don't type it).
+
+  Verified manually 2026-06-30 via ai-dev-browser against sudowork dev: seeded
+  the passphrase under the `auto` model, switched to `deepseek-v4-pro` via the
+  dropdown, asked for it, and the new model answered correctly -- with no file
+  reads (passphrase lived only in the scode session).
+
+tags: [api]
+
+steps:
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # -- Sudo Code backend --
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # -- Phase 1: seed a passphrase (conversation context only, never a file) --
+  - op: type_text
+    text: "The passphrase is AMETHYST-HIPPO-7. Remember it for this conversation only. Do NOT write it to any file. Acknowledge in one short sentence."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/resume-switch-01-seed.png"
+  - op: judge
+    expect: "Assistant acknowledges and echoes the passphrase AMETHYST-HIPPO-7"
+
+  # -- Phase 2: switch model via the dropdown (mouse, like a real user) --
+  # Click the model selector ("auto"), then pick a different model. The target
+  # must exist in the SudoRouter model list; deepseek-v4-pro is a common one --
+  # adjust to any available second model if the relay's catalog differs.
+  - op: mouse_click
+    text: "auto"
+  - op: pause
+    duration: 1500
+  - op: screenshot
+    path: "screenshots/resume-switch-02-dropdown.png"
+  - op: mouse_click
+    text: "deepseek-v4-pro"
+  - op: pause
+    duration: 2500
+  - op: screenshot
+    path: "screenshots/resume-switch-03-switched.png"
+
+  # -- Phase 3: the new model must recall from preserved context --
+  - op: type_text
+    text: "Answer ONLY from this conversation's context, do not read any file: what passphrase did I ask you to remember?"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/resume-switch-04-recall.png"
+  - op: judge
+    expect: >
+      Assistant reply contains "AMETHYST-HIPPO-7" -- conversation context survived
+      the model switch. A reply that lost context ("we just started", no
+      passphrase, or a different one) means the switch tore down the session.
+
+  # No-cheat guard: recall must come from preserved context, not a file read.
+  - op: db_audit
+    assert_metrics:
+      read_calls: "== 0"

--- a/tests/e2e/cases/scode-resume-after-restart.yaml
+++ b/tests/e2e/cases/scode-resume-after-restart.yaml
@@ -1,0 +1,93 @@
+name: "scode session restored after app restart (resume regression guard)"
+description: >
+  A design partner reported 2026-06-30: closing/restarting the app (or
+  continuing yesterday's work) made Sudo Code "forget" the whole conversation.
+  Root cause: sudowork resumed scode by passing a generic `resumeSessionId` to
+  `session/new`, which scode ignores -- it always minted a fresh, EMPTY session,
+  so resume silently lost all history. The UI still rendered the old conversation
+  (from sudowork's SQLite), masking the fact that the engine had no context.
+
+  Fix (PR #957): resume routes scode through the ACP-standard `session/load`,
+  which restores the prior session by id from disk.
+
+  This case proves it end-to-end: seed a passphrase, FULLY restart the Electron
+  process (destroying the in-memory scode session), reopen the same conversation
+  (triggers createOrResumeSession -> session/load), and assert the engine still
+  recalls the passphrase -- from restored conversation context, NOT a file. The
+  `read_calls == 0` audit guards against the model cheating by reading AGENTS.md
+  or a memory file (the passphrase is deliberately never written to disk).
+
+  Verified manually 2026-06-30 via ai-dev-browser against sudowork dev: seeded
+  the passphrase, killed all electron + scode processes, relaunched, reopened the
+  conversation, and the freshly-resumed engine answered with it. Passphrase
+  confirmed present ONLY in the scode session JSONL, never in AGENTS.md / config.
+
+tags: [api]
+
+steps:
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # -- Sudo Code backend --
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # -- Phase 1: seed a passphrase (conversation context only, never a file) --
+  - op: type_text
+    text: "The passphrase is AMETHYST-HIPPO-7. Remember it for this conversation only. Do NOT write it to any file, AGENTS.md, or memory. Acknowledge in one short sentence."
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/resume-restart-01-seed.png"
+  - op: judge
+    expect: "Assistant acknowledges and echoes the passphrase AMETHYST-HIPPO-7"
+
+  # -- Phase 2: FULL app restart -- destroys the in-memory scode session --
+  - op: restart_app
+    timeout: 180
+  - op: wait_for_app_ready
+    timeout: 300
+  - op: screenshot
+    path: "screenshots/resume-restart-02-after-restart.png"
+
+  # Reopen the same conversation from the sidebar -> createOrResumeSession ->
+  # session/load. The conversation title carries the passphrase, so click by text.
+  - op: mouse_click
+    text: "AMETHYST-HIPPO-7"
+  - op: pause
+    duration: 4000
+
+  # -- Phase 3: CRITICAL -- engine must recall from restored context --
+  # Pre-fix this FAILS: scode's session/new ignores resumeSessionId, so reopening
+  # starts a brand-new empty session and the model has no memory of Phase 1.
+  - op: type_text
+    text: "The app just restarted. Answer ONLY from this conversation's context, do not read any file: what passphrase did I ask you to remember?"
+  - op: press_key
+    key: "Enter"
+    wait: 3
+  - op: wait_for_response
+    timeout: 60
+  - op: screenshot
+    path: "screenshots/resume-restart-03-recall.png"
+  - op: judge
+    expect: >
+      Assistant reply contains "AMETHYST-HIPPO-7". This proves scode restored the
+      prior session via session/load across a full process restart. If the reply
+      says it has no prior context, starts fresh ("we just started"), or cannot
+      produce the passphrase, the resume fix is BROKEN.
+
+  # No-cheat guard: recall must come from restored context, not a file read.
+  # Zero "read" tool calls in this case proves it.
+  - op: db_audit
+    assert_metrics:
+      read_calls: "== 0"

--- a/tests/e2e/ops/restart_app.py
+++ b/tests/e2e/ops/restart_app.py
@@ -1,0 +1,50 @@
+"""restart_app -- restart the Electron app in place, preserving user state.
+
+Resume / session-continuity e2e cases need to prove the engine restores
+conversation context across a REAL process restart (the in-memory scode
+session is destroyed), not merely an in-process reconnect. This op:
+
+  1. kills the running Electron (and its scode engine child),
+  2. relaunches dev mode against the SAME user data dir -- no config reset,
+     so the conversation DB, acpSessionId, and on-disk scode session files
+     all survive,
+  3. waits for the CDP endpoint, then reconnects and hands the runner a
+     fresh tab (returned under ``_new_tab``; the runner swaps it in for the
+     remaining steps).
+
+State preservation is the whole point: unlike ``restart_electron.py``'s CLI
+``main()`` (which clears enterprise/consumer config for clean-state tests),
+this is a plain kill+relaunch that leaves every byte of user state in place.
+"""
+
+import os
+import sys
+
+# tests/e2e (this file's grandparent) must be importable so the sibling
+# `restart_electron` module resolves the same way the runner imports `ops.*`.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from restart_electron import kill_electron, launch_electron, wait_for_cdp  # noqa: E402
+
+from ops.connect import connect  # noqa: E402
+
+
+async def restart_app(tab, port: int = 9232, timeout: int = 120) -> dict:
+    """Kill + relaunch Electron preserving state, then reconnect.
+
+    Args:
+        tab: current (about-to-be-dead) tab -- unused; kept for op-signature parity.
+        port: CDP port the relaunched app exposes (launch_electron uses 9232).
+        timeout: seconds to wait for the CDP endpoint to come back.
+
+    Returns:
+        {"restarted": True, "_new_tab": <Tab>} on success -- the runner
+        reassigns its tab to ``_new_tab`` for subsequent steps.
+        {"error": str} if the app didn't come back up.
+    """
+    kill_electron()
+    launch_electron()
+    if not wait_for_cdp(port, timeout=timeout):
+        return {"error": f"restart_app: CDP not ready on port {port} within {timeout}s"}
+    _browser, new_tab = await connect(port=port)
+    return {"restarted": True, "_new_tab": new_tab}

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -72,6 +72,14 @@ async def run_case(tab, case_path: Path) -> dict:
         # Use shared invoke_op (same code path as run_op.py)
         result = await invoke_op(tab, op_name, OPS, **kwargs)
 
+        # An op can hand back a fresh connection (e.g. restart_app relaunches
+        # Electron, which kills the old tab). Swap it in for the remaining
+        # steps and keep the non-serializable Tab object out of the results log.
+        if isinstance(result, dict):
+            new_tab = result.pop("_new_tab", None)
+            if new_tab is not None:
+                tab = new_tab
+
         # Check result — ops with a "pass" key are assertions (judge, db_audit,
         # check_port_isolation, etc.); everything else is a plain action.
         if "pass" in result:

--- a/tests/unit/acpResumeStrategy.test.ts
+++ b/tests/unit/acpResumeStrategy.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getAcpResumeStrategy } from '@/types/acpTypes';
+
+/**
+ * Resume-strategy SSOT + AcpConnection.newSession wiring.
+ *
+ * Regression guard for the "amnesia on resume" bug: sudowork used to resume every
+ * non-codex backend by passing a generic `resumeSessionId` to `session/new`. scode's
+ * ACP `session/new` ignores that param and mints a fresh, EMPTY session — so resume
+ * silently lost all history. The fix routes resume by a declarative per-backend strategy:
+ * 'session-load' (default, ACP-standard) for scode/codex, 'meta-resume' for claude/codebuddy.
+ */
+describe('getAcpResumeStrategy (resume routing SSOT)', () => {
+  it('defaults to session-load for scode (the ACP-standard session/load path)', () => {
+    expect(getAcpResumeStrategy('scode')).toBe('session-load');
+  });
+
+  it('uses session-load for codex', () => {
+    expect(getAcpResumeStrategy('codex')).toBe('session-load');
+  });
+
+  it('uses meta-resume for claude and codebuddy', () => {
+    expect(getAcpResumeStrategy('claude')).toBe('meta-resume');
+    expect(getAcpResumeStrategy('codebuddy')).toBe('meta-resume');
+  });
+
+  it('defaults unverified/other backends to session-load (safe: falls back to fresh on failure)', () => {
+    expect(getAcpResumeStrategy('gemini')).toBe('session-load');
+    expect(getAcpResumeStrategy('qwen')).toBe('session-load');
+  });
+
+  it('tolerates null/undefined backend with the session-load default', () => {
+    expect(getAcpResumeStrategy(null)).toBe('session-load');
+    expect(getAcpResumeStrategy(undefined)).toBe('session-load');
+  });
+});
+
+type AcpConnectionCtor = typeof import('@/agent/acp/AcpConnection');
+
+async function loadAcpConnection(): Promise<AcpConnectionCtor> {
+  vi.resetModules();
+  vi.doMock('@process/telemetry', () => ({
+    recordFirstToken: vi.fn(),
+  }));
+  vi.doMock('@process/utils/mainLogger', () => ({
+    mainLog: vi.fn(),
+  }));
+  vi.doMock('@process/utils/shellEnv', () => ({
+    resolveNpxPath: vi.fn(() => 'npx'),
+  }));
+  vi.doMock('@process/services/authProxy', () => ({
+    getAuthProxyPort: vi.fn(() => null),
+    registerToken: vi.fn(),
+    revokeToken: vi.fn(),
+  }));
+  vi.doMock('@/agent/acp/modelInfo', () => ({
+    buildAcpModelInfo: vi.fn(() => null),
+    summarizeAcpModelInfo: vi.fn(() => null),
+  }));
+  vi.doMock('@/agent/acp/acpConnectors', () => ({
+    ACP_PERF_LOG: false,
+    connectClaude: vi.fn(),
+    connectCodebuddy: vi.fn(),
+    connectCodex: vi.fn(),
+    prepareCleanEnv: vi.fn(() => process.env),
+    spawnGenericBackend: vi.fn(),
+  }));
+
+  return await import('@/agent/acp/AcpConnection');
+}
+
+type NewSessionParams = {
+  resumeSessionId?: string;
+  _meta?: { claudeCode?: { options?: { resume?: string } } };
+};
+
+async function captureNewSessionParams(backend: string): Promise<NewSessionParams> {
+  const { AcpConnection } = await loadAcpConnection();
+  const connection = new AcpConnection();
+  const sendRequest = vi.fn().mockResolvedValue({ sessionId: 'srv-session-id' });
+  // sendRequest + backend are private; reach in to capture the wire params.
+  (connection as unknown as { sendRequest: typeof sendRequest }).sendRequest = sendRequest;
+  (connection as unknown as { backend: string }).backend = backend;
+
+  await connection.newSession('/workspace', { resumeSessionId: 'prior-session', forkSession: false });
+
+  const call = sendRequest.mock.calls[0];
+  expect(call?.[0]).toBe('session/new');
+  return call?.[1] as NewSessionParams;
+}
+
+describe('AcpConnection.newSession resume wiring', () => {
+  it('does NOT attach a generic resumeSessionId or _meta for scode (resumes via session/load instead)', async () => {
+    const params = await captureNewSessionParams('scode');
+    expect(params).not.toHaveProperty('resumeSessionId');
+    expect(params).not.toHaveProperty('_meta');
+  });
+
+  it('attaches _meta.claudeCode.options.resume for claude (meta-resume backend)', async () => {
+    const params = await captureNewSessionParams('claude');
+    expect(params).not.toHaveProperty('resumeSessionId');
+    expect(params._meta?.claudeCode?.options?.resume).toBe('prior-session');
+  });
+});


### PR DESCRIPTION
## Problem

Users reported the assistant "loses memory" (失忆) after an app restart, after resuming work the next day, or after switching models. A "continue previous work" turn came back with the model claiming the conversation had just started, and the token counter showed only the system-prompt baseline (~5.5K in) — the prior history never reached the model.

## Root cause

sudowork resumes a session by handing the engine a stored `acpSessionId`. For scode (and every non-codex backend) it did this by passing a generic `resumeSessionId` to `session/new`. scode's ACP server ignores that parameter and always builds a **fresh, empty** session — so resume silently lost all history. Worse, the returned empty-session id (`!== resumeSessionId`) overwrote the stored `acpSessionId`, orphaning the real session on disk.

Only codex used the ACP-standard `session/load`, which actually restores history by id. scode implements `session/load` too — sudowork just never used it for scode.

## Fix

Route resume by a declarative **per-backend strategy (single source of truth in `acpTypes`)**:

- `session-load` (default — scode, codex, any ACP-compliant bridge): restore history by id via the ACP-standard `session/load`.
- `meta-resume` (claude, codebuddy): keep the `_meta.claudeCode.options.resume` path on `session/new`.

The dead generic `resumeSessionId` param on `session/new` is removed (no backend consumed it), along with the ad-hoc codex special-case. `session/load` keeps the id we sent, so the orphan-overwrite can no longer happen.

Defaulting unverified backends (gemini/qwen/…) to `session-load` is **strictly ≥ the old behavior**: a backend whose bridge does not implement `session/load` errors and falls back to a fresh session — exactly what happened before — while any ACP-compliant bridge now actually resumes. No backend can regress; none silently rides a broken path unnoticed.

## Tests

`tests/unit/acpResumeStrategy.test.ts` (7 tests, pass locally): the resume-strategy SSOT table, and that `AcpConnection.newSession` no longer attaches a generic `resumeSessionId`/`_meta` for scode while still emitting `_meta` resume for claude.

## Engine-side companion

The sudocode engine side (durable compaction + `session.model` sync on model switch, plus an ACP resume round-trip integration test) is in a paired PR on `sudoprivacy/sudocode`, branch `fix/acp-session-resume-and-compaction`.