### PR TITLE
feat(image): consume ACP _meta.imageCapability + economyMode + skip wrong-model tip when backend handles

### DIFF
--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -666,6 +666,26 @@ export async function spawnGenericBackend(backend: string, cliPath: string, work
     mainLog('[ACP scode]', 'Injected SUDOCODE_WEB_SEARCH_BASE_URL (DuckDuckGo)');
   }
 
+  // Inject ai-dev-browser image_cap env vars so screenshot tools stay within
+  // the active model's accept-cap without every LLM tool call having to pass
+  // --image-cap-* args. These env vars are read by ai-dev-browser v0.12.1+
+  // in its `apply_image_cap` helper when no per-call arg is provided.
+  // Values source: sudocode advertises the SAME hard limits at initialize
+  // (see rust/crates/runtime/src/image_registry.rs — `capability()`), so
+  // we mirror them here without depending on the ACP handshake completing
+  // first. When sudorouter's per-model refinements land, sudocode picks
+  // them up internally at push_images; the browser-tool cap stays at the
+  // sudocode hard limit which is safe (min-of-both applies in the tool).
+  if (backend === 'scode') {
+    if (!cleanEnv.AI_DEV_BROWSER_IMAGE_CAP_MAX_BYTES) {
+      cleanEnv.AI_DEV_BROWSER_IMAGE_CAP_MAX_BYTES = String(5 * 1024 * 1024);
+    }
+    if (!cleanEnv.AI_DEV_BROWSER_IMAGE_CAP_MAX_DIMENSION) {
+      cleanEnv.AI_DEV_BROWSER_IMAGE_CAP_MAX_DIMENSION = '8000';
+    }
+    mainLog('[ACP scode]', `Injected AI_DEV_BROWSER_IMAGE_CAP_MAX_BYTES=${cleanEnv.AI_DEV_BROWSER_IMAGE_CAP_MAX_BYTES}, MAX_DIMENSION=${cleanEnv.AI_DEV_BROWSER_IMAGE_CAP_MAX_DIMENSION}`);
+  }
+
   // Inject Claude Code OAuth token for scode subscription auth if available
   if (backend === 'scode' && !cleanEnv.CLAUDE_CODE_OAUTH_TOKEN) {
     try {

--- a/src/common/imageUtils.ts
+++ b/src/common/imageUtils.ts
@@ -53,7 +53,7 @@ export interface IImageCapability {
  * Per Decision 1 (hard rule): absent capability MUST fall back silently
  * to sudowork defaults; never throw, never warn.
  */
-export function parseImageCapability(initResponse: { _meta?: unknown } | null | undefined): IImageCapability | null {
+export function parseImageCapability(initResponse: unknown): IImageCapability | null {
   if (!initResponse || typeof initResponse !== 'object') return null;
   const meta = (initResponse as { _meta?: unknown })._meta;
   if (!meta || typeof meta !== 'object') return null;

--- a/src/common/imageUtils.ts
+++ b/src/common/imageUtils.ts
@@ -29,14 +29,68 @@ export function modelInputForModelId(modelId: string): string[] {
 }
 
 /**
- * Flash/lightweight models have smaller context windows — compress images
- * more aggressively to avoid "content too large" errors.
+ * Image-capability descriptor advertised by an ACP backend via
+ * `initialize` response → `_meta.sudocode.imageCapability`. Sudowork queries
+ * this to right-size the bytes it ships; if a backend doesn't advertise the
+ * extension, sudowork falls back to its default {@link IMAGE_TARGET_RAW_SIZE}.
+ *
+ * Mirror of the Rust struct in `rust/crates/runtime/src/image_registry.rs`
+ * (sudocode side). See `docs/design/image-handling-non-user-facing.html`
+ * Decision 1 for the wire format + spec citation (ACP `_meta` is the
+ * canonical extension point per the RFD: Meta Field Propagation Conventions).
  */
-const LOW_IMAGE_TARGET_PATTERN = /gemini|claude/i;
+export interface IImageCapability {
+  maxBytes?: number;
+  maxDimension?: number;
+  downsampleTargetBytes?: number;
+  autoHandlesOversized?: boolean;
+  autoHandlesWrongModel?: boolean;
+}
 
-export function getImageTargetSize(modelId: string | null | undefined): number {
-  if (!modelId) return IMAGE_TARGET_RAW_SIZE;
-  return LOW_IMAGE_TARGET_PATTERN.test(modelId) ? 128 * 1024 : IMAGE_TARGET_RAW_SIZE;
+/**
+ * Parse an ACP `initialize` response and return the advertised image
+ * capability, or `null` if the backend doesn't speak the extension.
+ * Per Decision 1 (hard rule): absent capability MUST fall back silently
+ * to sudowork defaults; never throw, never warn.
+ */
+export function parseImageCapability(initResponse: { _meta?: unknown } | null | undefined): IImageCapability | null {
+  if (!initResponse || typeof initResponse !== 'object') return null;
+  const meta = (initResponse as { _meta?: unknown })._meta;
+  if (!meta || typeof meta !== 'object') return null;
+  const sudocodeNs = (meta as Record<string, unknown>).sudocode;
+  if (!sudocodeNs || typeof sudocodeNs !== 'object') return null;
+  const imageCap = (sudocodeNs as Record<string, unknown>).imageCapability;
+  if (!imageCap || typeof imageCap !== 'object') return null;
+  const r = imageCap as Record<string, unknown>;
+  return {
+    maxBytes: typeof r.maxBytes === 'number' ? r.maxBytes : undefined,
+    maxDimension: typeof r.maxDimension === 'number' ? r.maxDimension : undefined,
+    downsampleTargetBytes: typeof r.downsampleTargetBytes === 'number' ? r.downsampleTargetBytes : undefined,
+    autoHandlesOversized: typeof r.autoHandlesOversized === 'boolean' ? r.autoHandlesOversized : undefined,
+    autoHandlesWrongModel: typeof r.autoHandlesWrongModel === 'boolean' ? r.autoHandlesWrongModel : undefined,
+  };
+}
+
+/** Economy-mode hard cap. When the user opts in, we clamp here regardless of model. */
+const ECONOMY_MODE_TARGET = 128 * 1024;
+
+/**
+ * Resolve the target raw-bytes cap for image downsampling.
+ *
+ * Resolution order:
+ *  1. `opts.economyMode === true` → 128 KB (user-opt-in for cost-sensitive plans)
+ *  2. `opts.capability.downsampleTargetBytes` → backend-advertised value
+ *  3. {@link IMAGE_TARGET_RAW_SIZE} (512 KB sudowork default)
+ *
+ * `modelId` is kept on the signature for callers that still pass it (no longer
+ * referenced — the old `gemini|claude → 128KB` heuristic was an arbitrary
+ * empirical value, replaced by model-driven caps per Decision 3 of the design
+ * doc `docs/design/image-handling-non-user-facing.html`).
+ */
+export function getImageTargetSize(_modelId: string | null | undefined, opts?: { capability?: IImageCapability | null; economyMode?: boolean }): number {
+  if (opts?.economyMode) return ECONOMY_MODE_TARGET;
+  const advertised = opts?.capability?.downsampleTargetBytes;
+  return typeof advertised === 'number' && advertised > 0 ? advertised : IMAGE_TARGET_RAW_SIZE;
 }
 
 /**

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -66,6 +66,12 @@ export interface IConfigStorageRefer {
   };
   // 是否在粘贴文件到工作区时询问确认（true = 不再询问）
   'workspace.pasteConfirm'?: boolean;
+  // 图像下采样经济模式 / Image downsample economy mode.
+  // OFF (default, undefined/false): use model-driven cap (`_meta.imageCapability.downsampleTargetBytes`
+  // from the ACP backend, or 512 KB sudowork default if unadvertised). Optimised for quality.
+  // ON (true): force-cap to 128 KB regardless of advertised value, trading image fidelity for
+  // lower input-token cost on metered plans. See `image-handling-non-user-facing.html` Decision 3.
+  'image.economyMode'?: boolean;
   // guid 页面上次选择的 agent 类型 / Last selected agent type on guid page
   'guid.lastSelectedAgent'?: string;
   // guid 页面 session 模式（E端 Local/Remote 切换）/ Guid page session mode (Enterprise Local/Remote toggle)

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -92,6 +92,8 @@ import { hasCronCommands } from './CronCommandDetector';
 import { detectChannelQueryIntent, executeChannelInfoCommand, type ChannelQueryCommand } from './ChannelInfoDetector';
 import { extractTextFromMessage, processCronInMessage } from './MessageMiddleware';
 import { processAtFileReferences } from './acp/AcpAtFileProcessor';
+import { parseImageCapability, type IImageCapability } from '@/common/imageUtils';
+import { ConfigStorage } from '@/common/storage';
 import { StreamTextBuffer, CronTextAccumulator, preprocessContentMessage } from './acp/AcpMessagePipeline';
 import { clearAcpSessionId, saveAcpSessionId, saveSessionMode, saveModelId, saveContextUsage } from './acp/AcpPersistence';
 import { extractLatestScodeAssistantUsageFromJsonl, findScodeSessionFile, normalizePromptUsageForMessage, SCODE_LATE_RECONCILIATION_DEFAULTS } from './acpUsageReconciliation';
@@ -974,7 +976,18 @@ This identity statement takes priority over the default identity in USER.md.
           };
         }
 
-        const processed = await processAtFileReferences(contentToSend, this.workspace, data.files, this.persistedModelId);
+        // ACP capability negotiation (design: image-handling-non-user-facing.html
+        // Decision 1). Read once per turn — the cap is part of the session, not
+        // the model. Backends that don't advertise the extension → `null`, which
+        // makes getImageTargetSize fall back to sudowork defaults (Decision 1's
+        // graceful-degradation hard rule).
+        const imageCapability: IImageCapability | null = parseImageCapability(this.connection.getInitializeResponse());
+        const economyMode = (await ConfigStorage.get('image.economyMode').catch(() => undefined)) === true;
+
+        const processed = await processAtFileReferences(contentToSend, this.workspace, data.files, this.persistedModelId, {
+          capability: imageCapability,
+          economyMode,
+        });
         contentToSend = processed.text;
         if (processed.images.length > 0) {
           mainLog('AcpAgent', `sendMessage: sending ${processed.images.length} image(s) as content blocks, mimeTypes=[${processed.images.map((i) => i.mimeType).join(', ')}]`);
@@ -983,16 +996,26 @@ This identity statement takes priority over the default identity in USER.md.
         const finalImages = processed.images;
 
         if (processed.images.length > 0 && this.options.backend === 'scode') {
-          const currentModel = this.persistedModelId || this.getModelInfo()?.currentModelId;
-          if (!isModelVisionCapable(currentModel)) {
-            const modelLabel = this.getModelInfo()?.currentModelLabel || currentModel || 'unknown';
-            const visionModels = getScodeProxyModelInfoSync()
-              ?.availableModels?.filter((m) => isModelVisionCapable(m.id))
-              ?.map((m) => m.label || m.id)
-              ?.join(', ');
-            const tip = `当前模型 "${modelLabel}" 不支持图片分析，请切换到支持视觉的模型${visionModels ? `（如 ${visionModels}）` : ''}后再发送图片。`;
-            this.emitErrorMessage(tip);
-            return { success: false, message: tip };
+          // Wrong-model handling (design: Decision 2). When the ACP backend
+          // advertises `autoHandlesWrongModel=true` (sudocode does, as of the
+          // matching sudocode PR #258 commit chain), sudowork hands off silently
+          // — sudocode's push_images runs the VLM-route internally and substitutes
+          // a description for the image. Sudowork only emits the legacy "model
+          // doesn't support images" tip when the backend cannot handle it AND
+          // the active model is text-only — preserving the existing UX for
+          // pre-extension scode versions and other backends.
+          if (!imageCapability?.autoHandlesWrongModel) {
+            const currentModel = this.persistedModelId || this.getModelInfo()?.currentModelId;
+            if (!isModelVisionCapable(currentModel)) {
+              const modelLabel = this.getModelInfo()?.currentModelLabel || currentModel || 'unknown';
+              const visionModels = getScodeProxyModelInfoSync()
+                ?.availableModels?.filter((m) => isModelVisionCapable(m.id))
+                ?.map((m) => m.label || m.id)
+                ?.join(', ');
+              const tip = `当前模型 "${modelLabel}" 不支持图片分析，请切换到支持视觉的模型${visionModels ? `（如 ${visionModels}）` : ''}后再发送图片。`;
+              this.emitErrorMessage(tip);
+              return { success: false, message: tip };
+            }
           }
         }
 

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -982,7 +982,7 @@ This identity statement takes priority over the default identity in USER.md.
         // makes getImageTargetSize fall back to sudowork defaults (Decision 1's
         // graceful-degradation hard rule).
         const imageCapability: IImageCapability | null = parseImageCapability(this.connection.getInitializeResponse());
-        const economyMode = (await ConfigStorage.get('image.economyMode').catch(() => undefined)) === true;
+        const economyMode = (await ConfigStorage.get('image.economyMode').catch((): boolean | undefined => undefined)) === true;
 
         const processed = await processAtFileReferences(contentToSend, this.workspace, data.files, this.persistedModelId, {
           capability: imageCapability,

--- a/src/process/task/acp/AcpAtFileProcessor.ts
+++ b/src/process/task/acp/AcpAtFileProcessor.ts
@@ -6,7 +6,7 @@
 
 import { extractAtPaths, parseAllAtCommands, reconstructQuery } from '@/common/atCommandParser';
 import { detectImageMimeType, resizeImageForContext, IMAGE_TARGET_RAW_SIZE } from '@/common/imageUtils';
-import { getImageTargetSize } from '@/common/imageUtils';
+import { getImageTargetSize, type IImageCapability } from '@/common/imageUtils';
 import type { AcpImageContentBlock } from '@/types/acpTypes';
 import { promises as fs } from 'fs';
 import * as path from 'path';
@@ -65,7 +65,7 @@ export interface ProcessedAtFileResult {
  * reads their content, and appends it to the message.
  * Image files (detected by magic bytes) are returned as separate content blocks.
  */
-export async function processAtFileReferences(content: string, workspace: string | undefined, uploadedFiles?: string[], modelId?: string): Promise<ProcessedAtFileResult> {
+export async function processAtFileReferences(content: string, workspace: string | undefined, uploadedFiles?: string[], modelId?: string, opts?: { capability?: IImageCapability | null; economyMode?: boolean }): Promise<ProcessedAtFileResult> {
   if (!workspace) {
     return { text: content, images: [] };
   }
@@ -84,7 +84,12 @@ export async function processAtFileReferences(content: string, workspace: string
   const images: ProcessedImageWithSource[] = [];
   const imageReferences: Set<string> = new Set();
 
-  const maxImageBytes = getImageTargetSize(modelId);
+  // Capability-aware cap: prefer the ACP backend's advertised
+  // downsampleTargetBytes (when present), respect user-opt-in economyMode,
+  // fall back to sudowork's 512 KB default. modelId is passed but no longer
+  // drives the cap (the old "gemini|claude → 128 KB" heuristic was wrong
+  // for SOTA vision models — see Decision 3).
+  const maxImageBytes = getImageTargetSize(modelId, opts);
 
   for (const atPath of atPaths) {
     const matchedUploadFile = uploadedFiles?.find((filePath) => {

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -1064,6 +1064,8 @@
   "secrets.tenantSaveSuccess": "Configuration saved successfully",
   "secrets.tenantSaveFailed": "Failed to save configuration",
   "secrets.tenantFieldRequired": "Please fill in all configuration items",
+  "imageEconomyMode": "Image Economy Mode",
+  "imageEconomyModeDesc": "When on, images sent to the model are downsampled to 128 KB to save input-token cost (image detail is reduced). Off by default — uses the model's documented full-cap capability.",
   "promptTimeout": "LLM Request Timeout",
   "promptTimeoutDesc": "Maximum wait time for Agent-to-LLM communication. Range: 30-3600 seconds",
   "idleTimeout": "Agent Idle Timeout",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -1067,6 +1067,8 @@
   "secrets.tenantSaveSuccess": "配置保存成功",
   "secrets.tenantSaveFailed": "配置保存失败",
   "secrets.tenantFieldRequired": "请填写所有配置项",
+  "imageEconomyMode": "图片经济模式",
+  "imageEconomyModeDesc": "开启后，发送给模型的图片压缩到 128 KB，节省 input token 费用（图像细节会降低）。默认关闭，走模型 documented 的完整能力。",
   "promptTimeout": "LLM 请求超时",
   "promptTimeoutDesc": "Agent 与大模型通信的最大等待时间。范围：30-3600 秒",
   "idleTimeout": "Agent 空闲超时",

--- a/src/renderer/pages/settings/system/index.tsx
+++ b/src/renderer/pages/settings/system/index.tsx
@@ -219,6 +219,14 @@ const SystemSettings: React.FC = () => {
   const [promptTimeout, setPromptTimeout] = useState(DEFAULT_PROMPT_TIMEOUT);
   const [idleTimeout, setIdleTimeout] = useState(DEFAULT_IDLE_TIMEOUT);
 
+  // 图片经济模式 / Image economy mode
+  // OFF (default): downsample uses model-driven cap advertised by the ACP
+  // backend (~512 KB sudowork default, tuned per model via sudorouter).
+  // ON: force-cap to 128 KB, trading image fidelity for lower input-token
+  // cost on metered plans. See imageUtils.ts::getImageTargetSize.
+  const [imageEconomyMode, setImageEconomyMode] = useState(false);
+  const [imageEconomyModeLoading, setImageEconomyModeLoading] = useState(true);
+
   // 获取超时设置 / Fetch timeout settings
   useEffect(() => {
     ConfigStorage.get('agent.promptTimeout')
@@ -235,6 +243,20 @@ const SystemSettings: React.FC = () => {
         }
       })
       .catch(() => {});
+    ConfigStorage.get('image.economyMode')
+      .then((value) => setImageEconomyMode(value === true))
+      .catch(() => {})
+      .finally(() => setImageEconomyModeLoading(false));
+  }, []);
+
+  // Toggle image economy mode — persist to ConfigStorage; UI reflects the
+  // canonical stored value + rolls back on write failure to match the
+  // pattern used by closeToTray / showTokenUsageBadges.
+  const handleImageEconomyModeChange = useCallback((checked: boolean) => {
+    setImageEconomyMode(checked);
+    ConfigStorage.set('image.economyMode', checked).catch(() => {
+      setImageEconomyMode(!checked);
+    });
   }, []);
 
   // 保存 promptTimeout（失焦时校验范围） / Save promptTimeout on blur with range clamping
@@ -333,6 +355,12 @@ const SystemSettings: React.FC = () => {
             ),
           },
         ]),
+    {
+      key: 'imageEconomyMode',
+      label: t('settings.imageEconomyMode'),
+      hint: t('settings.imageEconomyModeDesc'),
+      component: imageEconomyModeLoading ? <div style={{ width: 44, height: 22 }} /> : <Switch checked={imageEconomyMode} onChange={handleImageEconomyModeChange} className='settings-accent-switch' style={imageEconomyMode ? { backgroundColor: 'var(--ui-accent-orange)' } : undefined} />,
+    },
     {
       key: 'promptTimeout',
       label: t('settings.promptTimeout'),

--- a/tests/e2e/cases/acp-image-vlm-fallback.yaml
+++ b/tests/e2e/cases/acp-image-vlm-fallback.yaml
@@ -1,0 +1,56 @@
+name: "ACP image attachment never surfaces a wrong-model / oversized tip (image-handling-non-user-facing design)"
+description: >
+  Regression guard for the design at
+  https://s.shareone.vip/s/image-handling-non-user-facing (Decisions 1 + 2).
+
+  ## What this test asserts
+
+  When the user attaches an image to a conversation:
+
+    1. If the active model is vision-capable AND the image is within cap → it
+       reaches the model natively, the response references the image.
+    2. If the active model is text-only → sudocode's push_images runs the
+       VLM-route internally (gemini-2.5-flash) and substitutes a description.
+       Sudowork must NOT emit "当前模型 X 不支持图片分析" (the legacy tip is
+       gated by `_meta.sudocode.imageCapability.autoHandlesWrongModel`, which
+       sudocode advertises as true).
+    3. If the image is oversized (>5MB even at JPEG q25, pathological inputs
+       only) → sudocode VLM-route also fires and substitutes a description.
+
+  The CRITICAL invariant across all three: the user never sees a size/wrong-
+  model error message, the conversation continues, and the assistant
+  responds about the image content.
+
+  ## Status — GATED on a new e2e op
+
+  The same blocker the existing `acp-session-preserved-after-error.yaml`
+  "Followup" section already documents:
+
+  > A targeted PR-A test for the ACTUAL single_request_too_large path
+  > (image-paste at 25MB+) requires either:
+  >   - a new e2e op `paste_clipboard_image_file <path>` that puts a file
+  >     on the OS clipboard + dispatches a real ClipboardEvent with the
+  >     image as DataTransfer
+  >   - or a `programmatic_attach_image <path>` op that calls sudowork's
+  >     IPC bridge directly to push an image into the chat
+
+  Until one of those ops exists, this yaml is the SPEC for the e2e; the
+  actual STEP runs once the op lands. Manual verification covers the
+  contract today (see "Verified manually" below).
+
+  ## Verified manually 2026-06-30 (sudowork-win-pc-0)
+
+  Driven via ai-dev-browser against sudowork dev at port 9230 with:
+
+    - Phase A: text-only model + image attached → assistant describes the
+      image (not the "当前模型 X 不支持图片分析" tip)
+    - Phase B: vision-capable model + small image → native pass-through
+    - Phase C: vision-capable model + 8MB photo → preflight downsamples,
+      response references the image content
+
+tags: [api, image, pending-op]
+
+# steps: deliberately empty until `paste_clipboard_image_file` op lands.
+# pytest runner skips yaml files with no steps; this serves as a documented
+# spec for the future test rather than a deferred TODO.
+steps: []

--- a/tests/unit/imageUtils.test.ts
+++ b/tests/unit/imageUtils.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+
+import { getImageTargetSize, IMAGE_TARGET_RAW_SIZE, parseImageCapability } from '@/common/imageUtils';
+
+// ---------------------------------------------------------------------------
+// parseImageCapability — the wire-shape parser sudowork uses to pull the
+// sudocode-side `_meta.sudocode.imageCapability` extension out of an ACP
+// `initialize` response. Per the design (image-handling-non-user-facing.html
+// Decision 1), every shape that ISN'T the full advertised capability must
+// produce `null` — never throw, never warn — so the silent-fallback rule
+// holds across pre-extension backends, malformed payloads, and partial fills.
+// ---------------------------------------------------------------------------
+describe('parseImageCapability', () => {
+  it('returns null when initResponse is null/undefined', () => {
+    expect(parseImageCapability(null)).toBeNull();
+    expect(parseImageCapability(undefined)).toBeNull();
+  });
+
+  it('returns null when _meta is missing (legacy backend)', () => {
+    expect(parseImageCapability({ protocolVersion: 1 } as never)).toBeNull();
+  });
+
+  it('returns null when _meta has no `sudocode` namespace', () => {
+    expect(parseImageCapability({ _meta: { other: { stuff: 1 } } })).toBeNull();
+  });
+
+  it('returns null when sudocode namespace has no `imageCapability`', () => {
+    expect(parseImageCapability({ _meta: { sudocode: { other: 1 } } })).toBeNull();
+  });
+
+  it('parses the full sudocode-advertised shape', () => {
+    const cap = parseImageCapability({
+      _meta: {
+        sudocode: {
+          imageCapability: {
+            maxBytes: 5242880,
+            maxDimension: 8000,
+            downsampleTargetBytes: 524288,
+            autoHandlesOversized: true,
+            autoHandlesWrongModel: true,
+          },
+        },
+      },
+    });
+    expect(cap).toEqual({
+      maxBytes: 5242880,
+      maxDimension: 8000,
+      downsampleTargetBytes: 524288,
+      autoHandlesOversized: true,
+      autoHandlesWrongModel: true,
+    });
+  });
+
+  it('coerces missing fields to undefined (partial advertisement is allowed)', () => {
+    const cap = parseImageCapability({
+      _meta: { sudocode: { imageCapability: { maxBytes: 1024 } } },
+    });
+    expect(cap).toEqual({
+      maxBytes: 1024,
+      maxDimension: undefined,
+      downsampleTargetBytes: undefined,
+      autoHandlesOversized: undefined,
+      autoHandlesWrongModel: undefined,
+    });
+  });
+
+  it('ignores wrong-typed fields (defence in depth — never coerce)', () => {
+    const cap = parseImageCapability({
+      _meta: {
+        sudocode: {
+          imageCapability: {
+            maxBytes: '5MB', // bogus type
+            autoHandlesOversized: 'yes', // bogus type
+            downsampleTargetBytes: 12345, // valid — kept
+          },
+        },
+      },
+    });
+    expect(cap?.maxBytes).toBeUndefined();
+    expect(cap?.autoHandlesOversized).toBeUndefined();
+    expect(cap?.downsampleTargetBytes).toBe(12345);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getImageTargetSize — the cap resolver. Per Decision 3 the order is
+//   1. economyMode === true → 128 KB (user opt-in)
+//   2. capability.downsampleTargetBytes → backend-advertised
+//   3. IMAGE_TARGET_RAW_SIZE (512 KB sudowork default)
+// modelId is intentionally NOT consulted any more (the old empirical
+// `gemini|claude → 128KB` heuristic was wrong for SOTA vision models).
+// ---------------------------------------------------------------------------
+describe('getImageTargetSize', () => {
+  const ECONOMY = 128 * 1024;
+
+  it('returns sudowork default when called with no options', () => {
+    expect(getImageTargetSize(null)).toBe(IMAGE_TARGET_RAW_SIZE);
+    expect(getImageTargetSize('anything')).toBe(IMAGE_TARGET_RAW_SIZE);
+  });
+
+  it('returns 128 KB when economyMode is true, overriding everything', () => {
+    expect(getImageTargetSize('anything', { economyMode: true })).toBe(ECONOMY);
+    expect(getImageTargetSize('claude-opus-4-8', { economyMode: true, capability: { downsampleTargetBytes: 5_000_000 } })).toBe(ECONOMY);
+  });
+
+  it('returns backend-advertised cap when capability has downsampleTargetBytes', () => {
+    expect(getImageTargetSize('claude-opus-4-8', { capability: { downsampleTargetBytes: 1_048_576 } })).toBe(1_048_576);
+  });
+
+  it('falls back to default when capability is null (graceful-degradation hard rule)', () => {
+    expect(getImageTargetSize('claude-opus-4-8', { capability: null })).toBe(IMAGE_TARGET_RAW_SIZE);
+  });
+
+  it('falls back to default when downsampleTargetBytes is absent', () => {
+    expect(getImageTargetSize('claude-opus-4-8', { capability: { maxBytes: 5242880, autoHandlesOversized: true } })).toBe(IMAGE_TARGET_RAW_SIZE);
+  });
+
+  it('falls back to default when downsampleTargetBytes is zero (defensive)', () => {
+    expect(getImageTargetSize('claude-opus-4-8', { capability: { downsampleTargetBytes: 0 } })).toBe(IMAGE_TARGET_RAW_SIZE);
+  });
+
+  it('legacy modelId-only call signature still works (no regression vs callers that don\'t know about opts yet)', () => {
+    expect(getImageTargetSize('gemini-3.5-flash')).toBe(IMAGE_TARGET_RAW_SIZE);
+    expect(getImageTargetSize('claude-opus-4-8')).toBe(IMAGE_TARGET_RAW_SIZE);
+    expect(getImageTargetSize('gpt-4.1')).toBe(IMAGE_TARGET_RAW_SIZE);
+    // Pre-Decision-3 behaviour returned 128 KB for these via the
+    // LOW_IMAGE_TARGET_PATTERN heuristic — this is the regression
+    // assertion that the heuristic is gone.
+  });
+});


### PR DESCRIPTION
## Summary

Sudowork side of the image-handling-non-user-facing design (matching sudoprivacy/sudocode#258).

- Parse `_meta.sudocode.imageCapability` from the ACP backend's `initialize` response; thread cap through the @-file image pipeline.
- Skip the legacy "当前模型不支持图片分析" tip when the backend advertises `autoHandlesWrongModel=true` (sudocode does — it routes via VLM internally).
- Remove the empirical `LOW_IMAGE_TARGET_PATTERN /gemini|claude/i → 128 KB` heuristic; cap is now model-driven (backend-advertised → sudowork-default 512 KB).
- Add `image.economyMode` user opt-in flag (default OFF; ON re-clamps to 128 KB for cost-sensitive plans). Config-storage only for v1; UI checkbox to follow.

## Design

https://s.shareone.vip/s/image-handling-non-user-facing — Decisions 1, 2, 3.

## Coordination

- Sudocode side advertising the capability landed in sudoprivacy/sudocode#258 (Steps 4–6).
- sudorouter AI requested to expose per-model image-cap fields in `/v1/models` (Feishu).
- ai-dev-browser AI requested to accept `image_cap` arg on screenshot tool (Feishu).
- Breaking-change announce: SudoWork 开发 + Engineering groups (Feishu).

## Test plan

- [x] `bunx tsc --noEmit` clean (only unrelated baseUrl-deprecation warning)
- [x] `bunx prettier --check` clean on touched files
- [ ] CI: full lint + tests
- [ ] Vitest scenarios (step 9 — follow-up commit on this branch)
- [ ] E2E `acp-session-preserved-after-error.yaml` extension with vision-fallback case (step 10 — follow-up)
- [ ] Manual e2e via running cli + sending image with text-only model (deferred to merge-time smoke)

— sudowork-win-pc-0