### PR TITLE
feat(channels): multi-item ACP questions & free-text items in DingTalk dtmd flow

### DIFF
--- a/src/channels/agent/ChannelMessageService.ts
+++ b/src/channels/agent/ChannelMessageService.ts
@@ -68,8 +68,8 @@ interface IStreamState {
  */
 interface IPendingItem {
   id: string;
-  kind: 'single_select' | 'multi_select';
-  /** option label -> submission value */
+  kind: 'single_select' | 'multi_select' | 'text';
+  /** option label -> submission value (empty Map for text kind) */
   labelToValue: Map<string, string>;
   /** accumulated submission values (multi_select only) */
   selectedValues: string[];
@@ -501,18 +501,25 @@ export class ChannelMessageService {
     if (items.length === 0 || !content.toolCallId) return false;
     for (const item of items) {
       const k = item.kind;
-      if (k !== 'single_select' && k !== 'multi_select' && k !== 'boolean') return false;
+      if (k !== 'single_select' && k !== 'multi_select' && k !== 'boolean' && k !== 'text') return false;
     }
 
     const pendingItems: IPendingItem[] = items.map((item): IPendingItem => {
       const labelToValue = new Map<string, string>();
-      for (const option of item.options ?? []) {
-        labelToValue.set(option.label, option.value);
+      // text item has no dtmd options; its labelToValue stays empty.
+      if (item.kind !== 'text') {
+        for (const option of item.options ?? []) {
+          labelToValue.set(option.label, option.value);
+        }
       }
       // boolean 视作 single_select：行为完全一致（点哪个 label 即提交对应 value）
+      let kind: IPendingItem['kind'];
+      if (item.kind === 'multi_select') kind = 'multi_select';
+      else if (item.kind === 'text') kind = 'text';
+      else kind = 'single_select';
       return {
         id: item.id,
-        kind: item.kind === 'multi_select' ? 'multi_select' : 'single_select',
+        kind,
         labelToValue,
         selectedValues: [],
       };
@@ -603,6 +610,13 @@ export class ChannelMessageService {
         staleQuestionIndex: pending.staleLabels.get(text)!,
         currentIndex: pending.currentIndex,
       };
+    } else if (current.kind === 'text') {
+      // Free-text item: accept any user input as the answer.
+      // markItemLabelsStale is a no-op here (current.labelToValue is empty).
+      pending.completedAnswers.push({ id: current.id, value: text, label: text });
+      this.markItemLabelsStale(pending, current);
+      pending.currentIndex++;
+      displayLabel = text;
     } else {
       return { kind: 'no_match' };
     }

--- a/src/channels/agent/ChannelMessageService.ts
+++ b/src/channels/agent/ChannelMessageService.ts
@@ -55,6 +55,11 @@ interface IStreamState {
   draining: boolean;
   /** Pending messages buffered during draining phase */
   pendingMessages: IResponseMessage[];
+  /**
+   * Promises returned by async callbacks that haven't settled yet. Awaited on
+   * finish so resolve() doesn't fire while a callback is still mid-await.
+   */
+  inFlightCallbacks: Set<Promise<void>>;
 }
 
 /**
@@ -176,7 +181,7 @@ export class ChannelMessageService {
         stream.draining = true;
         // Use microtask to defer stream deletion and resolution
         // This ensures all synchronous message emissions are processed before stream is removed
-        queueMicrotask(() => {
+        queueMicrotask(async () => {
           const drainingStream = this.activeStreams.get(conversationId);
           if (drainingStream && drainingStream.msgId === stream.msgId) {
             // Flush all pending messages that arrived during draining phase
@@ -184,6 +189,12 @@ export class ChannelMessageService {
               this.processMessageEvent(pendingEvent, drainingStream);
             }
             drainingStream.pendingMessages = [];
+            // Drain in-flight async callbacks so the caller's finalize step sees
+            // up-to-date state (e.g. sentMessageIds containing the just-created card).
+            // Loop because a callback may fire more callbacks during await.
+            while (drainingStream.inFlightCallbacks.size > 0) {
+              await Promise.all(Array.from(drainingStream.inFlightCallbacks));
+            }
             // Delete stream and resolve
             this.activeStreams.delete(conversationId);
             drainingStream.resolve(drainingStream.msgId);
@@ -221,7 +232,12 @@ export class ChannelMessageService {
       // insert: true means new message, false means update existing message
 
       const isInsert = type === 'insert';
-      stream.callback(msg, isInsert);
+      // Callback's declared return is void, but async implementations actually return a Promise.
+      // Promise.resolve uniformly wraps both cases so the finish path can await any in-flight
+      // async work before resolving the outer sendMessage Promise.
+      const promise = Promise.resolve(stream.callback(msg, isInsert));
+      stream.inFlightCallbacks.add(promise);
+      promise.finally(() => stream.inFlightCallbacks.delete(promise));
     });
     this.messageListMap.set(event.conversation_id, messageList.slice(-20));
   }
@@ -355,6 +371,7 @@ export class ChannelMessageService {
         timedOut: false,
         draining: false,
         pendingMessages: [],
+        inFlightCallbacks: new Set(),
       });
 
       // Build payload — ACP agents use { content }.

--- a/src/channels/agent/ChannelMessageService.ts
+++ b/src/channels/agent/ChannelMessageService.ts
@@ -63,27 +63,54 @@ interface IStreamState {
 }
 
 /**
- * A pending ACP question awaiting the user's dtmd button-tap answer.
- * 待答 ACP 选项题状态：用户点击 dtmd 按钮的回答将路由到 answerQuestion。
+ * A pending ACP question item (one of possibly many in a multi-question prompt).
+ * 单道待答题。
  */
-interface IPendingQuestion {
-  toolCallId: string;
-  questionId: string;
+interface IPendingItem {
+  id: string;
   kind: 'single_select' | 'multi_select';
   /** option label -> submission value */
   labelToValue: Map<string, string>;
-  /** accumulated submission values (multi_select) */
+  /** accumulated submission values (multi_select only) */
   selectedValues: string[];
 }
 
 /**
- * submitAnswer 的路由结果。
- * - single_done: single_select 已作答（已调 answerQuestion）
- * - multi_submit: multi_select 已提交累积值（已调 answerQuestion）
- * - multi_select: multi_select 累积了一项（尚未调 answerQuestion）
- * - no_match: 文本不匹配任何选项 / 空选提交 → 调用方按普通用户消息处理
+ * A pending ACP question (1 or more items) awaiting the user's dtmd button-tap answer.
+ * 待答 ACP 选项题状态：用户点击 dtmd 按钮的回答将累积，直到所有题答完再一次性 answerQuestion。
  */
-export type PendingAnswerResult = { kind: 'single_done'; displayLabel: string } | { kind: 'multi_submit'; displayLabel: string } | { kind: 'multi_select'; displayLabel: string } | { kind: 'no_match' };
+interface IPendingQuestion {
+  toolCallId: string;
+  /** Original content kept for re-rendering subsequent items. */
+  originalContent: AcpQuestionData;
+  items: IPendingItem[];
+  /** Index of the item currently awaiting an answer (0-based). */
+  currentIndex: number;
+  /** Answers accumulated from already-answered items, submitted in bulk on the last item. */
+  completedAnswers: AcpQuestionResponseAnswer[];
+  /**
+   * All offered option labels of already-answered items → that item's index.
+   * Used to detect stale-button taps: once an item has advanced, tapping ANY of
+   * its old card's buttons (selected or not) should be reported as stale rather
+   * than fall through to a new agent turn.
+   */
+  staleLabels: Map<string, number>;
+}
+
+/**
+ * submitAnswer 的路由结果。
+ * - item_done: 当前题已作答（multi_select 已提交）但仍有未答的下一题，尚未调 answerQuestion
+ * - multi_select_accumulate: multi_select 当前题累积了一项（尚未提交）
+ * - all_done: 最后一道已作答 → 已一次性调 answerQuestion(completedAnswers)
+ * - stale: 用户回头点了已答题的旧 dtmd 按钮
+ * - no_match: 文本不匹配任何选项 → 调用方按普通用户消息处理
+ */
+export type PendingAnswerResult =
+  | { kind: 'item_done'; displayLabel: string; currentIndex: number; totalItems: number }
+  | { kind: 'multi_select_accumulate'; displayLabel: string }
+  | { kind: 'all_done'; displayLabel: string }
+  | { kind: 'stale'; staleQuestionIndex: number; currentIndex: number }
+  | { kind: 'no_match' };
 
 /** multi_select 提交哨兵（与 dtmd 提交按钮 content 一致）/ submit sentinel */
 const QA_SUBMIT_SENTINEL = '__qa_submit__';
@@ -237,7 +264,7 @@ export class ChannelMessageService {
       // async work before resolving the outer sendMessage Promise.
       const promise = Promise.resolve(stream.callback(msg, isInsert));
       stream.inFlightCallbacks.add(promise);
-      promise.finally(() => stream.inFlightCallbacks.delete(promise));
+      void promise.finally(() => stream.inFlightCallbacks.delete(promise));
     });
     this.messageListMap.set(event.conversation_id, messageList.slice(-20));
   }
@@ -464,26 +491,53 @@ export class ChannelMessageService {
    * button-taps route to answerQuestion instead of sendMessage (which would
    * treat the answer as a new turn — AcpAgent.sendMessage ignores pendingQuestions).
    *
-   * 为会话登记待答 ACP 选项题（出站首次提问时调用）。
+   * Returns true if registered (all items have supported kinds and toolCallId is set);
+   * false otherwise so the caller can render the downgrade text path.
+   *
+   * 为会话登记待答 ACP 选项题（出站首次提问时调用）；返回是否登记成功。
    */
-  registerPendingQuestion(conversationId: string, content: AcpQuestionData): void {
+  registerPendingQuestion(conversationId: string, content: AcpQuestionData): boolean {
     const items = content.items ?? [];
-    const item = items[0];
-    const kind = item?.kind;
-    if (items.length !== 1 || !item || !content.toolCallId) return;
-    if (kind !== 'single_select' && kind !== 'multi_select' && kind !== 'boolean') return;
-
-    const labelToValue = new Map<string, string>();
-    for (const option of item.options ?? []) {
-      labelToValue.set(option.label, option.value);
+    if (items.length === 0 || !content.toolCallId) return false;
+    for (const item of items) {
+      const k = item.kind;
+      if (k !== 'single_select' && k !== 'multi_select' && k !== 'boolean') return false;
     }
+
+    const pendingItems: IPendingItem[] = items.map((item): IPendingItem => {
+      const labelToValue = new Map<string, string>();
+      for (const option of item.options ?? []) {
+        labelToValue.set(option.label, option.value);
+      }
+      // boolean 视作 single_select：行为完全一致（点哪个 label 即提交对应 value）
+      return {
+        id: item.id,
+        kind: item.kind === 'multi_select' ? 'multi_select' : 'single_select',
+        labelToValue,
+        selectedValues: [],
+      };
+    });
+
     this.pendingQuestions.set(conversationId, {
       toolCallId: content.toolCallId,
-      questionId: item.id,
-      kind: kind === 'multi_select' ? 'multi_select' : 'single_select',
-      labelToValue,
-      selectedValues: [],
+      originalContent: content,
+      items: pendingItems,
+      currentIndex: 0,
+      completedAnswers: [],
+      staleLabels: new Map<string, number>(),
     });
+    return true;
+  }
+
+  /**
+   * Returns the data needed to render the NEXT pending item card
+   * (i.e. the item at currentIndex). Used after submitAnswer returns item_done
+   * so the ActionExecutor can dispatch the next question's card.
+   */
+  getPendingForNextRender(conversationId: string): { content: AcpQuestionData; itemIndex: number } | null {
+    const pending = this.pendingQuestions.get(conversationId);
+    if (!pending) return null;
+    return { content: pending.originalContent, itemIndex: pending.currentIndex };
   }
 
   /**
@@ -494,11 +548,19 @@ export class ChannelMessageService {
   }
 
   /**
-   * Submit a user's text answer toward a pending question.
-   * - single 命中 → answerQuestion + single_done
-   * - multi 命中选项 → 累积(去重) + multi_select（不调 answerQuestion）
-   * - multi 提交哨兵 → answerQuestion(累积值, ' / ' 连接) + multi_submit
-   * - 否则 → no_match（调用方按普通用户消息处理）
+   * Submit a user's text answer toward the currently-pending item of a pending question.
+   *
+   * Routing for `current = items[currentIndex]`:
+   * 1. `__qa_submit__` 哨兵 + current.kind === 'multi_select' → 合并累积值为单答案推入
+   *    completedAnswers，advance；进入终态判断（步骤 4）
+   * 2. text 命中 current.labelToValue：
+   *    - single_select：推入单答案，advance → 终态判断
+   *    - multi_select：去重累积到 current.selectedValues，返回 multi_select_accumulate
+   * 3. 陈旧检测：text 命中任何已答题的 label → 返回 stale
+   * 4. 终态判断：
+   *    - currentIndex < items.length → item_done（调用方应渲染下一题卡片）
+   *    - currentIndex === items.length → 一次性 answerQuestion(completedAnswers)，all_done
+   * 5. 都不命中 → no_match（调用方按普通用户消息处理）
    *
    * multi_select 的 ' / ' 连接口径与桌面端 MessageAcpQuestion 一致。
    */
@@ -506,31 +568,57 @@ export class ChannelMessageService {
     const pending = this.pendingQuestions.get(conversationId);
     if (!pending) return { kind: 'no_match' };
 
-    if (text === QA_SUBMIT_SENTINEL && pending.kind === 'multi_select') {
-      if (pending.selectedValues.length === 0) {
+    const current = pending.items[pending.currentIndex];
+    if (!current) return { kind: 'no_match' };
+
+    let displayLabel: string | null = null;
+
+    if (text === QA_SUBMIT_SENTINEL && current.kind === 'multi_select') {
+      if (current.selectedValues.length === 0) {
         return { kind: 'no_match' };
       }
-      const displayLabel = this.labelsForValues(pending, pending.selectedValues).join(' / ');
-      const submissionValue = pending.selectedValues.join(' / ');
-      this.answerQuestion(conversationId, pending.toolCallId, [{ id: pending.questionId, value: submissionValue, label: displayLabel }]);
+      const labels = this.labelsForValues(current, current.selectedValues);
+      const submissionValue = current.selectedValues.join(' / ');
+      const submissionLabel = labels.join(' / ');
+      pending.completedAnswers.push({ id: current.id, value: submissionValue, label: submissionLabel });
+      this.markItemLabelsStale(pending, current);
+      pending.currentIndex++;
+      displayLabel = submissionLabel;
+    } else if (current.labelToValue.has(text)) {
+      const value = current.labelToValue.get(text)!;
+      if (current.kind === 'single_select') {
+        pending.completedAnswers.push({ id: current.id, value, label: text });
+        this.markItemLabelsStale(pending, current);
+        pending.currentIndex++;
+        displayLabel = text;
+      } else {
+        if (!current.selectedValues.includes(value)) {
+          current.selectedValues.push(value);
+        }
+        return { kind: 'multi_select_accumulate', displayLabel: text };
+      }
+    } else if (pending.staleLabels.has(text)) {
+      return {
+        kind: 'stale',
+        staleQuestionIndex: pending.staleLabels.get(text)!,
+        currentIndex: pending.currentIndex,
+      };
+    } else {
+      return { kind: 'no_match' };
+    }
+
+    // 终态判断
+    if (pending.currentIndex >= pending.items.length) {
+      this.answerQuestion(conversationId, pending.toolCallId, pending.completedAnswers);
       this.pendingQuestions.delete(conversationId);
-      return { kind: 'multi_submit', displayLabel };
+      return { kind: 'all_done', displayLabel: displayLabel! };
     }
-
-    if (pending.labelToValue.has(text)) {
-      const value = pending.labelToValue.get(text)!;
-      if (pending.kind === 'single_select') {
-        this.answerQuestion(conversationId, pending.toolCallId, [{ id: pending.questionId, value, label: text }]);
-        this.pendingQuestions.delete(conversationId);
-        return { kind: 'single_done', displayLabel: text };
-      }
-      if (!pending.selectedValues.includes(value)) {
-        pending.selectedValues.push(value);
-      }
-      return { kind: 'multi_select', displayLabel: text };
-    }
-
-    return { kind: 'no_match' };
+    return {
+      kind: 'item_done',
+      displayLabel: displayLabel!,
+      currentIndex: pending.currentIndex,
+      totalItems: pending.items.length,
+    };
   }
 
   /**
@@ -542,11 +630,22 @@ export class ChannelMessageService {
   }
 
   /**
+   * Record every offered label of an item as "stale" before advancing past it.
+   * After advance, tapping any of these labels (selected or not) on the old card
+   * should be reported as a stale tap rather than fall through to a new agent turn.
+   */
+  private markItemLabelsStale(pending: IPendingQuestion, item: IPendingItem): void {
+    for (const lbl of item.labelToValue.keys()) {
+      pending.staleLabels.set(lbl, pending.currentIndex);
+    }
+  }
+
+  /**
    * Map already-selected submission values back to display labels (multi_select).
    */
-  private labelsForValues(pending: IPendingQuestion, values: string[]): string[] {
+  private labelsForValues(item: IPendingItem, values: string[]): string[] {
     const valueToLabel = new Map<string, string>();
-    for (const [label, value] of pending.labelToValue) {
+    for (const [label, value] of item.labelToValue) {
       valueToLabel.set(value, label);
     }
     return values.map((v) => valueToLabel.get(v) ?? v);

--- a/src/channels/agent/ChannelMessageService.ts
+++ b/src/channels/agent/ChannelMessageService.ts
@@ -9,7 +9,8 @@ import WorkerManage from '@/process/WorkerManage';
 import { getDatabase } from '@/process/database';
 import type BaseAgent from '@/process/task/BaseAgent';
 import { queueConversationWorkspaceSkillSync } from '@/process/bridge/conversationBridge';
-import { composeMessage, transformMessage, type TMessage } from '../../common/chatLib';
+import type { AcpQuestionResponseAnswer } from '@/types/acpTypes';
+import { composeMessage, transformMessage, type TMessage, type AcpQuestionData } from '../../common/chatLib';
 import { uuid } from '../../common/utils';
 import type { IResponseMessage } from '../../common/ipcBridge';
 import { channelEventBus, type IAgentMessageEvent } from './ChannelEventBus';
@@ -57,6 +58,32 @@ interface IStreamState {
 }
 
 /**
+ * A pending ACP question awaiting the user's dtmd button-tap answer.
+ * 待答 ACP 选项题状态：用户点击 dtmd 按钮的回答将路由到 answerQuestion。
+ */
+interface IPendingQuestion {
+  toolCallId: string;
+  questionId: string;
+  kind: 'single_select' | 'multi_select';
+  /** option label -> submission value */
+  labelToValue: Map<string, string>;
+  /** accumulated submission values (multi_select) */
+  selectedValues: string[];
+}
+
+/**
+ * submitAnswer 的路由结果。
+ * - single_done: single_select 已作答（已调 answerQuestion）
+ * - multi_submit: multi_select 已提交累积值（已调 answerQuestion）
+ * - multi_select: multi_select 累积了一项（尚未调 answerQuestion）
+ * - no_match: 文本不匹配任何选项 / 空选提交 → 调用方按普通用户消息处理
+ */
+export type PendingAnswerResult = { kind: 'single_done'; displayLabel: string } | { kind: 'multi_submit'; displayLabel: string } | { kind: 'multi_select'; displayLabel: string } | { kind: 'no_match' };
+
+/** multi_select 提交哨兵（与 dtmd 提交按钮 content 一致）/ submit sentinel */
+const QA_SUBMIT_SENTINEL = '__qa_submit__';
+
+/**
  * ChannelMessageService - Manages message sending for Channel
  *
  * Architecture (分离设计):
@@ -72,6 +99,12 @@ export class ChannelMessageService {
    * Active message stream cache: conversationId -> stream state
    */
   private activeStreams: Map<string, IStreamState> = new Map();
+
+  /**
+   * 待答 ACP 选项题缓存：conversationId -> 待答状态
+   * Pending ACP question cache: conversationId -> pending state
+   */
+  private pendingQuestions: Map<string, IPendingQuestion> = new Map();
 
   /**
    * 全局事件监听器清理函数
@@ -406,6 +439,119 @@ export class ChannelMessageService {
       console.error(`[ChannelMessageService] Failed to confirm tool call:`, error);
       throw error;
     }
+  }
+
+  /**
+   * Register a pending ACP question for a conversation.
+   * Called on the first (insert) outbound acp_question so subsequent inbound
+   * button-taps route to answerQuestion instead of sendMessage (which would
+   * treat the answer as a new turn — AcpAgent.sendMessage ignores pendingQuestions).
+   *
+   * 为会话登记待答 ACP 选项题（出站首次提问时调用）。
+   */
+  registerPendingQuestion(conversationId: string, content: AcpQuestionData): void {
+    const items = content.items ?? [];
+    const item = items[0];
+    const kind = item?.kind;
+    if (items.length !== 1 || !item || !content.toolCallId) return;
+    if (kind !== 'single_select' && kind !== 'multi_select' && kind !== 'boolean') return;
+
+    const labelToValue = new Map<string, string>();
+    for (const option of item.options ?? []) {
+      labelToValue.set(option.label, option.value);
+    }
+    this.pendingQuestions.set(conversationId, {
+      toolCallId: content.toolCallId,
+      questionId: item.id,
+      kind: kind === 'multi_select' ? 'multi_select' : 'single_select',
+      labelToValue,
+      selectedValues: [],
+    });
+  }
+
+  /**
+   * Whether the conversation has a pending ACP question awaiting an answer.
+   */
+  hasPendingQuestion(conversationId: string): boolean {
+    return this.pendingQuestions.has(conversationId);
+  }
+
+  /**
+   * Submit a user's text answer toward a pending question.
+   * - single 命中 → answerQuestion + single_done
+   * - multi 命中选项 → 累积(去重) + multi_select（不调 answerQuestion）
+   * - multi 提交哨兵 → answerQuestion(累积值, ' / ' 连接) + multi_submit
+   * - 否则 → no_match（调用方按普通用户消息处理）
+   *
+   * multi_select 的 ' / ' 连接口径与桌面端 MessageAcpQuestion 一致。
+   */
+  submitAnswer(conversationId: string, text: string): PendingAnswerResult {
+    const pending = this.pendingQuestions.get(conversationId);
+    if (!pending) return { kind: 'no_match' };
+
+    if (text === QA_SUBMIT_SENTINEL && pending.kind === 'multi_select') {
+      if (pending.selectedValues.length === 0) {
+        return { kind: 'no_match' };
+      }
+      const displayLabel = this.labelsForValues(pending, pending.selectedValues).join(' / ');
+      const submissionValue = pending.selectedValues.join(' / ');
+      this.answerQuestion(conversationId, pending.toolCallId, [{ id: pending.questionId, value: submissionValue, label: displayLabel }]);
+      this.pendingQuestions.delete(conversationId);
+      return { kind: 'multi_submit', displayLabel };
+    }
+
+    if (pending.labelToValue.has(text)) {
+      const value = pending.labelToValue.get(text)!;
+      if (pending.kind === 'single_select') {
+        this.answerQuestion(conversationId, pending.toolCallId, [{ id: pending.questionId, value, label: text }]);
+        this.pendingQuestions.delete(conversationId);
+        return { kind: 'single_done', displayLabel: text };
+      }
+      if (!pending.selectedValues.includes(value)) {
+        pending.selectedValues.push(value);
+      }
+      return { kind: 'multi_select', displayLabel: text };
+    }
+
+    return { kind: 'no_match' };
+  }
+
+  /**
+   * Clear the pending question for a conversation (idempotent).
+   * Called on answered/cancelled outbound update so no stale state remains.
+   */
+  clearPendingQuestion(conversationId: string): void {
+    this.pendingQuestions.delete(conversationId);
+  }
+
+  /**
+   * Map already-selected submission values back to display labels (multi_select).
+   */
+  private labelsForValues(pending: IPendingQuestion, values: string[]): string[] {
+    const valueToLabel = new Map<string, string>();
+    for (const [label, value] of pending.labelToValue) {
+      valueToLabel.set(value, label);
+    }
+    return values.map((v) => valueToLabel.get(v) ?? v);
+  }
+
+  /**
+   * Send answers back to the agent task via answerQuestion (mirrors confirm()).
+   * answerQuestion is provided by AcpAgent; BaseAgent does not declare it, and
+   * acp_question only originates from AcpAgent, so the task is guaranteed to support it.
+   */
+  private answerQuestion(conversationId: string, toolCallId: string, answers: AcpQuestionResponseAnswer[]): void {
+    const task = WorkerManage.getTaskById(conversationId);
+    if (!task) {
+      throw new Error(`Task not found for conversation ${conversationId}`);
+    }
+    const answerable = task as unknown as {
+      answerQuestion?: (toolCallId: string, answers: AcpQuestionResponseAnswer[]) => Promise<void>;
+    };
+    if (typeof answerable.answerQuestion !== 'function') {
+      throw new Error(`Agent does not support answerQuestion for conversation ${conversationId}`);
+    }
+    void answerable.answerQuestion(toolCallId, answers);
   }
 
   /**

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -13,6 +13,7 @@ import { stripGeneratedFilesMarker } from '@/common/generatedFiles';
 import { getDatabase } from '@/process/database';
 import { ProcessConfig } from '@/process/initStorage';
 import { getDataPath } from '@/process/utils';
+import { mainError } from '@/process/utils/mainLogger';
 import { ConversationService } from '@/process/services/conversationService';
 import { transcriptionService } from '@/process/services/transcription/TranscriptionService';
 import type { AcpBackend } from '@/types/acpTypes';
@@ -715,7 +716,8 @@ export class ActionExecutor {
         let answerResult: PendingAnswerResult;
         try {
           answerResult = pendingService.submitAnswer(pendingConvId, text);
-        } catch {
+        } catch (err) {
+          mainError('ActionExecutor', 'submitAnswer threw', err);
           await context.sendMessage({ type: 'text', text: '❌ 提交失败，请重试', parseMode: 'Markdown' });
           return;
         }

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import type { TMessage, AcpQuestionData } from '@/common/chatLib';
 import { database as databaseBridge } from '@/common/ipcBridge';
 import { parseNexusFilesMarker } from '@/common/nexusFiles';
+import { stripGeneratedFilesMarker } from '@/common/generatedFiles';
 import { getDatabase } from '@/process/database';
 import { ProcessConfig } from '@/process/initStorage';
 import { getDataPath } from '@/process/utils';
@@ -225,6 +226,10 @@ function getConfirmationPrompt(details: { type: string; title?: string; [key: st
 function convertTMessageToOutgoing(message: TMessage, platform: PluginType, isComplete = false): IUnifiedOutgoingMessage | null {
   switch (message.type) {
     case 'text': {
+      // [[NEXUS_GENERATED_FILES]] is a renderer-only directive for GeneratedFileCard;
+      // meaningless to IM users (file body already delivered via a separate file_send).
+      if (!stripGeneratedFilesMarker(message.content.content || '').trim()) return null;
+
       // 根据平台格式化文本
       // Format text based on platform
       const rawText = formatTextForPlatform(message.content.content || '', platform);

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -719,14 +719,38 @@ export class ActionExecutor {
           await context.sendMessage({ type: 'text', text: '❌ 提交失败，请重试', parseMode: 'Markdown' });
           return;
         }
-        if (answerResult.kind === 'single_done' || answerResult.kind === 'multi_submit') {
+        if (answerResult.kind === 'item_done') {
+          await context.sendMessage({
+            type: 'text',
+            text: `✅ 已选: ${answerResult.displayLabel}（${answerResult.currentIndex}/${answerResult.totalItems}）`,
+            parseMode: 'Markdown',
+          });
+          // Dispatch the next item's card (sendMessage + immediate editMessage finalize
+          // to stop the AI Card spinner; same pattern as the outbound acp_question branch).
+          const next = pendingService.getPendingForNextRender(pendingConvId);
+          if (next) {
+            const { markdown } = buildDingTalkQuestionMarkdown(next.content, next.itemIndex);
+            const cardMsgId = await context.sendMessage({ type: 'text', text: markdown, parseMode: 'Markdown' });
+            await context.editMessage(cardMsgId, { type: 'text', text: markdown, parseMode: 'Markdown', replyMarkup: {} });
+          }
+          return;
+        }
+        if (answerResult.kind === 'all_done') {
           await context.sendMessage({ type: 'text', text: `✅ 已提交：${answerResult.displayLabel}`, parseMode: 'Markdown' });
           return;
         }
-        if (answerResult.kind === 'multi_select') {
+        if (answerResult.kind === 'multi_select_accumulate') {
           await context.sendMessage({
             type: 'text',
             text: `✅ 已选中：${answerResult.displayLabel}，继续选择或点【提交】`,
+            parseMode: 'Markdown',
+          });
+          return;
+        }
+        if (answerResult.kind === 'stale') {
+          await context.sendMessage({
+            type: 'text',
+            text: `⚠️ 第 ${answerResult.staleQuestionIndex + 1} 题已经回答过了，请回答当前的第 ${answerResult.currentIndex + 1} 题`,
             parseMode: 'Markdown',
           });
           return;
@@ -877,17 +901,21 @@ export class ActionExecutor {
         const now = Date.now();
 
         // acp_question → DingTalk dtmd buttons (dingtalk only).
-        // First insert: render dtmd options (register pending when supported).
+        // First insert: render first item's dtmd options (register pending state when
+        // all items are supported). After sendMessage, immediately editMessage with
+        // a non-undefined replyMarkup so DingTalkPlugin.editMessage's `isFinal=!!replyMarkup`
+        // path runs finishAICard — otherwise the AI Card stays in INPUTING (spinning) forever
+        // because acp_question is typically the last message of the agent turn and there's
+        // no follow-up card whose creation would invoke finalizePendingCards.
         // Update (answered/cancelled): clear pending. Never falls through to
         // convertTMessageToOutgoing's default ('⏳ Processing...').
         if ((context.platform as PluginType) === 'dingtalk' && message.type === 'acp_question') {
           const acpContent = message.content as AcpQuestionData;
           if (isInsert && !acpContent.answered && !acpContent.cancelled) {
-            const { markdown, isSupported } = buildDingTalkQuestionMarkdown(acpContent);
-            if (isSupported) {
-              messageService.registerPendingQuestion(conversationId, acpContent);
-            }
-            await context.sendMessage({ type: 'text', text: markdown, parseMode: 'Markdown' });
+            messageService.registerPendingQuestion(conversationId, acpContent);
+            const { markdown } = buildDingTalkQuestionMarkdown(acpContent, 0);
+            const cardMsgId = await context.sendMessage({ type: 'text', text: markdown, parseMode: 'Markdown' });
+            await context.editMessage(cardMsgId, { type: 'text', text: markdown, parseMode: 'Markdown', replyMarkup: {} });
           } else {
             messageService.clearPendingQuestion(conversationId);
           }

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -6,7 +6,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import type { TMessage } from '@/common/chatLib';
+import type { TMessage, AcpQuestionData } from '@/common/chatLib';
 import { database as databaseBridge } from '@/common/ipcBridge';
 import { parseNexusFilesMarker } from '@/common/nexusFiles';
 import { getDatabase } from '@/process/database';
@@ -20,7 +20,7 @@ import { buildChatErrorResponse, chatActions } from '../actions/ChatActions';
 import { handlePairingShow, platformActions } from '../actions/PlatformActions';
 import { getChannelDefaultModel, systemActions } from '../actions/SystemActions';
 import type { IActionContext, IRegisteredAction } from '../actions/types';
-import { getChannelMessageService } from '../agent/ChannelMessageService';
+import { getChannelMessageService, type PendingAnswerResult } from '../agent/ChannelMessageService';
 import type { SessionManager } from '../core/SessionManager';
 import type { PairingService } from '../pairing/PairingService';
 import type { PluginMessageHandler } from '../plugins/BasePlugin';
@@ -29,7 +29,7 @@ import { resolveChannelConvType } from '../types';
 import { createMainMenuCard, createErrorRecoveryCard, createToolConfirmationCard } from '../plugins/lark/LarkCards';
 import { convertHtmlToLarkMarkdown } from '../plugins/lark/LarkAdapter';
 import { createMainMenuCard as createDingTalkMainMenuCard, createErrorRecoveryCard as createDingTalkErrorRecoveryCard, createResponseActionsCard as createDingTalkResponseActionsCard, createToolConfirmationCard as createDingTalkToolConfirmationCard } from '../plugins/dingtalk/DingTalkCards';
-import { convertHtmlToDingTalkMarkdown } from '../plugins/dingtalk/DingTalkAdapter';
+import { convertHtmlToDingTalkMarkdown, buildDingTalkQuestionMarkdown } from '../plugins/dingtalk/DingTalkAdapter';
 import { createMainMenuKeyboard, createToolConfirmationKeyboard } from '../plugins/telegram/TelegramKeyboards';
 import { escapeHtml } from '../plugins/telegram/TelegramAdapter';
 import { resolveMediaText } from './voiceTranscription';
@@ -699,6 +699,37 @@ export class ActionExecutor {
       });
     }
 
+    // Pending ACP question routing: if this conversation has a pending question
+    // (scode awaiting a button-tap answer), route the user's text to answerQuestion
+    // instead of sendMessage (which would treat the answer as a new turn). Placed
+    // before thinking/lock so a tap reply never spins up a competing AI turn.
+    const pendingConvId = context.conversationId || context.chatId;
+    if (pendingConvId) {
+      const pendingService = getChannelMessageService();
+      if (pendingService.hasPendingQuestion(pendingConvId)) {
+        let answerResult: PendingAnswerResult;
+        try {
+          answerResult = pendingService.submitAnswer(pendingConvId, text);
+        } catch {
+          await context.sendMessage({ type: 'text', text: '❌ 提交失败，请重试', parseMode: 'Markdown' });
+          return;
+        }
+        if (answerResult.kind === 'single_done' || answerResult.kind === 'multi_submit') {
+          await context.sendMessage({ type: 'text', text: `✅ 已提交：${answerResult.displayLabel}`, parseMode: 'Markdown' });
+          return;
+        }
+        if (answerResult.kind === 'multi_select') {
+          await context.sendMessage({
+            type: 'text',
+            text: `✅ 已选中：${answerResult.displayLabel}，继续选择或点【提交】`,
+            parseMode: 'Markdown',
+          });
+          return;
+        }
+        // answerResult.kind === 'no_match': fall through to normal chat flow below
+      }
+    }
+
     // Send "thinking" indicator IMMEDIATELY (before acquiring lock)
     // This ensures the user always sees acknowledgment, even if the conversation is busy.
     const supportsEdit = context.platform !== 'wechat';
@@ -839,6 +870,24 @@ export class ActionExecutor {
       // Send message
       await messageService.sendMessage(sessionId, conversationId, text, files, async (message: TMessage, isInsert: boolean) => {
         const now = Date.now();
+
+        // acp_question → DingTalk dtmd buttons (dingtalk only).
+        // First insert: render dtmd options (register pending when supported).
+        // Update (answered/cancelled): clear pending. Never falls through to
+        // convertTMessageToOutgoing's default ('⏳ Processing...').
+        if ((context.platform as PluginType) === 'dingtalk' && message.type === 'acp_question') {
+          const acpContent = message.content as AcpQuestionData;
+          if (isInsert && !acpContent.answered && !acpContent.cancelled) {
+            const { markdown, isSupported } = buildDingTalkQuestionMarkdown(acpContent);
+            if (isSupported) {
+              messageService.registerPendingQuestion(conversationId, acpContent);
+            }
+            await context.sendMessage({ type: 'text', text: markdown, parseMode: 'Markdown' });
+          } else {
+            messageService.clearPendingQuestion(conversationId);
+          }
+          return;
+        }
 
         // 转换消息格式（根据平台）
         // Convert message format (based on platform)

--- a/src/channels/plugins/dingtalk/DingTalkAdapter.ts
+++ b/src/channels/plugins/dingtalk/DingTalkAdapter.ts
@@ -526,23 +526,24 @@ function buildActionCard(text: string, buttons: IUnifiedOutgoingMessage['buttons
 // ==================== ACP Question (dtmd buttons) ====================
 
 /**
- * Build DingTalk markdown with dtmd buttons for an ACP question (single/multi select).
+ * Build DingTalk markdown with dtmd buttons for an ACP question item.
  *
  * dtmd links make the DingTalk client send the option label back as a plain
  * TOPIC_ROBOT message when tapped, so the bot receives the answer without any
  * cardTemplate — end users only configure the bot (clientId/secret), never the
  * DingTalk backend. (Verified in step 0: tapped content arrives verbatim.)
  *
- * 为 ACP 选项题构造带 dtmd 按钮的钉钉 markdown。仅支持单项 single_select /
- * multi_select（boolean 视作 single_select）；text 与多题降级为纯文本提示。
+ * 为 ACP 选项题构造带 dtmd 按钮的钉钉 markdown。支持 single_select /
+ * multi_select（boolean 视作 single_select）；text 降级为纯文本提示。
+ * 多题问答（items.length > 1）由调用方按 itemIndex 逐题分发渲染。
  */
-export function buildDingTalkQuestionMarkdown(content: AcpQuestionData): { markdown: string; isSupported: boolean } {
+export function buildDingTalkQuestionMarkdown(content: AcpQuestionData, itemIndex = 0): { markdown: string; isSupported: boolean } {
   const items = content.items ?? [];
-  const item = items[0];
+  const item = items[itemIndex];
   const kind = item?.kind;
-  const isSupported = items.length === 1 && (kind === 'single_select' || kind === 'multi_select' || kind === 'boolean');
+  const isSupported = !!item && (kind === 'single_select' || kind === 'multi_select' || kind === 'boolean');
 
-  if (!isSupported || !item) {
+  if (!isSupported) {
     const questionText = content.question || item?.prompt || '请回答';
     return {
       markdown: `${questionText}\n\n此题型暂不支持按钮选择，请直接文字说明。`,
@@ -550,7 +551,16 @@ export function buildDingTalkQuestionMarkdown(content: AcpQuestionData): { markd
     };
   }
 
-  const lines: string[] = [content.question || item.prompt || '请选择', ''];
+  const lines: string[] = [];
+  if (items.length > 1) {
+    lines.push(`**第 ${itemIndex + 1} / ${items.length} 题**`);
+    const header = content.intro || content.question;
+    if (header) lines.push(header);
+    lines.push(item.prompt || '请选择');
+  } else {
+    lines.push(content.question || item.prompt || '请选择');
+  }
+  lines.push('');
   for (const option of item.options ?? []) {
     lines.push(`- [${option.label}](dtmd://dingtalkclient/sendMessage?content=${encodeURIComponent(option.label)})`);
   }

--- a/src/channels/plugins/dingtalk/DingTalkAdapter.ts
+++ b/src/channels/plugins/dingtalk/DingTalkAdapter.ts
@@ -533,15 +533,18 @@ function buildActionCard(text: string, buttons: IUnifiedOutgoingMessage['buttons
  * cardTemplate — end users only configure the bot (clientId/secret), never the
  * DingTalk backend. (Verified in step 0: tapped content arrives verbatim.)
  *
- * 为 ACP 选项题构造带 dtmd 按钮的钉钉 markdown。支持 single_select /
- * multi_select（boolean 视作 single_select）；text 降级为纯文本提示。
+ * 为 ACP 选项题构造钉钉 markdown：
+ * - single_select / multi_select / boolean：渲染 dtmd 按钮（boolean 视作 single_select）。
+ * - text：渲染题干 + 「请直接输入文字回复」提示，不渲染按钮（用户的文字回复由 submitAnswer 直接接收）。
+ * - 其它（kind=undefined / items 为空 / itemIndex 越界）：保留 downgrade 文案兜底。
+ *
  * 多题问答（items.length > 1）由调用方按 itemIndex 逐题分发渲染。
  */
 export function buildDingTalkQuestionMarkdown(content: AcpQuestionData, itemIndex = 0): { markdown: string; isSupported: boolean } {
   const items = content.items ?? [];
   const item = items[itemIndex];
   const kind = item?.kind;
-  const isSupported = !!item && (kind === 'single_select' || kind === 'multi_select' || kind === 'boolean');
+  const isSupported = !!item && (kind === 'single_select' || kind === 'multi_select' || kind === 'boolean' || kind === 'text');
 
   if (!isSupported) {
     const questionText = content.question || item?.prompt || '请回答';
@@ -561,11 +564,16 @@ export function buildDingTalkQuestionMarkdown(content: AcpQuestionData, itemInde
     lines.push(content.question || item.prompt || '请选择');
   }
   lines.push('');
-  for (const option of item.options ?? []) {
-    lines.push(`- [${option.label}](dtmd://dingtalkclient/sendMessage?content=${encodeURIComponent(option.label)})`);
-  }
-  if (kind === 'multi_select') {
-    lines.push('', `- [✅ 提交](dtmd://dingtalkclient/sendMessage?content=${encodeURIComponent('__qa_submit__')})`);
+
+  if (kind === 'text') {
+    lines.push('请直接输入文字回复');
+  } else {
+    for (const option of item.options ?? []) {
+      lines.push(`- [${option.label}](dtmd://dingtalkclient/sendMessage?content=${encodeURIComponent(option.label)})`);
+    }
+    if (kind === 'multi_select') {
+      lines.push('', `- [✅ 提交](dtmd://dingtalkclient/sendMessage?content=${encodeURIComponent('__qa_submit__')})`);
+    }
   }
 
   return { markdown: lines.join('\n'), isSupported: true };

--- a/src/channels/plugins/dingtalk/DingTalkAdapter.ts
+++ b/src/channels/plugins/dingtalk/DingTalkAdapter.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IMessageAction, IUnifiedIncomingMessage, IUnifiedMessageContent, IUnifiedOutgoingMessage, IUnifiedUser } from '../../types';
+import type { AcpQuestionData } from '../../../common/chatLib';
 
 /**
  * DingTalkAdapter - Converts between DingTalk and Unified message formats
@@ -520,6 +521,44 @@ function buildActionCard(text: string, buttons: IUnifiedOutgoingMessage['buttons
     btnOrientation: '1', // Horizontal layout
     btns: btnList,
   };
+}
+
+// ==================== ACP Question (dtmd buttons) ====================
+
+/**
+ * Build DingTalk markdown with dtmd buttons for an ACP question (single/multi select).
+ *
+ * dtmd links make the DingTalk client send the option label back as a plain
+ * TOPIC_ROBOT message when tapped, so the bot receives the answer without any
+ * cardTemplate — end users only configure the bot (clientId/secret), never the
+ * DingTalk backend. (Verified in step 0: tapped content arrives verbatim.)
+ *
+ * 为 ACP 选项题构造带 dtmd 按钮的钉钉 markdown。仅支持单项 single_select /
+ * multi_select（boolean 视作 single_select）；text 与多题降级为纯文本提示。
+ */
+export function buildDingTalkQuestionMarkdown(content: AcpQuestionData): { markdown: string; isSupported: boolean } {
+  const items = content.items ?? [];
+  const item = items[0];
+  const kind = item?.kind;
+  const isSupported = items.length === 1 && (kind === 'single_select' || kind === 'multi_select' || kind === 'boolean');
+
+  if (!isSupported || !item) {
+    const questionText = content.question || item?.prompt || '请回答';
+    return {
+      markdown: `${questionText}\n\n此题型暂不支持按钮选择，请直接文字说明。`,
+      isSupported: false,
+    };
+  }
+
+  const lines: string[] = [content.question || item.prompt || '请选择', ''];
+  for (const option of item.options ?? []) {
+    lines.push(`- [${option.label}](dtmd://dingtalkclient/sendMessage?content=${encodeURIComponent(option.label)})`);
+  }
+  if (kind === 'multi_select') {
+    lines.push('', `- [✅ 提交](dtmd://dingtalkclient/sendMessage?content=${encodeURIComponent('__qa_submit__')})`);
+  }
+
+  return { markdown: lines.join('\n'), isSupported: true };
 }
 
 // ==================== Text Formatting ====================


### PR DESCRIPTION
Extend the DingTalk channel's ACP question support so multi-item and
free-text ACP questions can be answered end-to-end via dtmd buttons /
plain text.

- Pending-question state machine now handles N items: each item is
  dispatched as its own dtmd card, answers are aggregated, and
  answerQuestion is invoked once when the last item is answered.
- Free-text items ('text' kind) are registered with an empty
  labelToValue; submitAnswer treats any user text as the answer and
  advances the flow. The card renders "请直接输入文字回复" instead of
  buttons.
- Detect taps on previously-answered cards and reply with a hint
  instead of falling through to a new agent turn.
- Finalize the first acp_question card immediately via editMessage
  (replyMarkup:{}) so the AI Card spinner stops — previously it stayed
  in INPUTING because acp_question is typically the last message of a
  turn.
- Log the underlying error when submitAnswer throws so failures are
  diagnosable.