### PR TITLE
feat(scode): isolate embedded engine-scode config/binary from standalone install

### DIFF
--- a/.github/workflows/pr-integration-smoke.yml
+++ b/.github/workflows/pr-integration-smoke.yml
@@ -234,3 +234,52 @@ jobs:
           if [ -n "${CLUSTER_PID:-}" ]; then
             kill "$CLUSTER_PID" 2>/dev/null || true
           fi
+
+  scode-config-isolation:
+    # Real cross-repo contract: sudowork isolates its engine-scode by spawning
+    # the scode binary with SUDO_CODE_CONFIG_HOME → ~/.nexus/sudowork/sudocode.
+    # This job downloads + extracts the ACTUAL scode binary and drives
+    # `scode config --output-format json` to prove the user-scope config home
+    # follows the env var and never leaks to the standalone ~/.nexus/sudocode.
+    # Runs on Windows because scode ships macOS + Windows only (no Linux release),
+    # and Windows is sudowork's primary target. See
+    # tests/integration/scodeConfigHomeIsolation.integration.test.ts.
+    name: Scode Config-Home Isolation
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Download scode binary (windows archive)
+        run: bun run scode:download
+
+      - name: Extract scode binary and export SCODE_BIN
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem resources -Filter '*scode-windows*.zip' | Select-Object -First 1
+          if (-not $zip) { throw 'no scode windows archive downloaded (empty release?)' }
+          if ($zip.Length -eq 0) { throw "scode archive is an empty placeholder ($($zip.Name)) — no binary published for this version" }
+          $dest = Join-Path $env:RUNNER_TEMP 'scode-extracted'
+          Expand-Archive -Path $zip.FullName -DestinationPath $dest -Force
+          $exe = Get-ChildItem $dest -Recurse -Filter 'scode.exe' | Select-Object -First 1
+          if (-not $exe) { throw 'scode.exe not found in archive' }
+          "SCODE_BIN=$($exe.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "SCODE_BIN=$($exe.FullName)"
+
+      - name: Run scode config-home isolation integration test
+        run: bunx vitest run tests/integration/scodeConfigHomeIsolation.integration.test.ts

--- a/src/agent/acp/AcpDetector.ts
+++ b/src/agent/acp/AcpDetector.ts
@@ -17,16 +17,17 @@ import { ExtensionRegistry } from '@/extensions';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
 import { SUDOCLAW_BIN_DIR } from '@/process/services/sudoclaw/SudoclawInstallService';
 import { getScodePath } from '@/process/services/scode/ScodeInstallService';
+import { SCODE_HOME } from '@/process/services/scode/scodePaths';
 
 const execAsync = promisify(exec);
 
 /** Nexus bin directory for Claude/Gemini CLI symlinks */
 const NEXUS_BIN_DIR = path.join(os.homedir(), '.nexus', 'bin');
 
-/** Sudo Code runtime directory for the managed scode CLI */
-const SCODE_BIN_DIR = path.join(os.homedir(), '.nexus', 'sudocode');
+/** sudowork's isolated engine-scode dir (binary lives here). SSOT: scodePaths.ts */
+const SCODE_BIN_DIR = SCODE_HOME;
 
-/** Priority bin directories for CLI detection (scode first to prefer ~/.nexus/sudocode over ~/.nexus/bin) */
+/** Priority bin directories for CLI detection (scode first to prefer the isolated engine-scode dir over ~/.nexus/bin) */
 const PRIORITY_BIN_DIRS = [SCODE_BIN_DIR, NEXUS_BIN_DIR, SUDOCLAW_BIN_DIR];
 
 interface DetectedAgent {

--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -18,6 +18,7 @@ import os from 'os';
 import path from 'path';
 import { app } from 'electron';
 import { CLAUDE_ACP_NPX_PACKAGE, CODEBUDDY_ACP_NPX_PACKAGE, CODEX_ACP_BRIDGE_VERSION, CODEX_ACP_NPX_PACKAGE } from '@/types/acpTypes';
+import { SCODE_HOME, SCODE_CONFIG_PATH, SCODE_SETTINGS_PATH } from '@process/services/scode/scodePaths';
 import { findSuitableNodeBin, getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { isSafetyHookEnabled } from '@process/services/safety/SafetyPollingService';
@@ -142,7 +143,7 @@ export function resolveScodeAuthModeFromConfig(config: unknown, settings: unknow
 
 function readScodeAuthModeFromDisk(modelOverride?: string | null): ScodeAuthMode | null {
   try {
-    const scodeDir = path.join(os.homedir(), '.nexus', 'sudocode');
+    const scodeDir = SCODE_HOME;
     const configPath = path.join(scodeDir, 'sudocode.json');
     const settingsPath = path.join(scodeDir, 'settings.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as unknown;
@@ -541,7 +542,7 @@ async function prepareCodebuddy(customEnv?: Record<string, string>): Promise<Npx
  */
 function readProxyCredsFromSudocode(): { apiKey: string; baseUrl: string } | null {
   try {
-    const configPath = path.join(os.homedir(), '.nexus', 'sudocode', 'sudocode.json');
+    const configPath = SCODE_CONFIG_PATH;
     const content = readFileSync(configPath, 'utf-8');
     const config = JSON.parse(content);
     const sudorouter = config?.auth_modes?.proxy?.sudorouter;
@@ -625,10 +626,19 @@ export async function spawnGenericBackend(backend: string, cliPath: string, work
     }
   }
 
-  // Inject SUDOCODE_CONFIG_PATH for scode so skill bash scripts can locate sudocode.json
-  // even when claude-code overrides $HOME to a sandbox directory (.sandbox-home/).
+  // Isolate sudowork's engine-scode config from a standalone scode install:
+  // scode's Rust config loader resolves its config home from SUDO_CODE_CONFIG_HOME,
+  // so point it at the isolated home. This relocates BOTH sudocode.json (models/auth)
+  // and settings.json (settings/MCP) in one place, away from ~/.nexus/sudocode.
+  if (backend === 'scode' && !cleanEnv.SUDO_CODE_CONFIG_HOME) {
+    cleanEnv.SUDO_CODE_CONFIG_HOME = SCODE_HOME;
+    mainLog('[ACP scode]', `Injected SUDO_CODE_CONFIG_HOME: ${cleanEnv.SUDO_CODE_CONFIG_HOME}`);
+  }
+
+  // SUDOCODE_CONFIG_PATH lets skill bash scripts locate sudocode.json even when
+  // claude-code overrides $HOME to a sandbox directory (.sandbox-home/).
   if (backend === 'scode' && !cleanEnv.SUDOCODE_CONFIG_PATH) {
-    cleanEnv.SUDOCODE_CONFIG_PATH = path.join(os.homedir(), '.nexus', 'sudocode', 'sudocode.json');
+    cleanEnv.SUDOCODE_CONFIG_PATH = SCODE_CONFIG_PATH;
     mainLog('[ACP scode]', `Injected SUDOCODE_CONFIG_PATH: ${cleanEnv.SUDOCODE_CONFIG_PATH}`);
   }
 
@@ -685,7 +695,7 @@ export async function spawnGenericBackend(backend: string, cliPath: string, work
   // This prevents a death loop: crash → reconnect → read bad settings.json → crash again.
   if (backend === 'scode') {
     try {
-      const scodeDir = path.join(os.homedir(), '.nexus', 'sudocode');
+      const scodeDir = SCODE_HOME;
       const settingsPath = path.join(scodeDir, 'settings.json');
       let settings: Record<string, unknown> = {};
       try {

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -855,7 +855,7 @@ export const sudoclaw = {
   wechatInstallProgress: bridge.buildEmitter<{ phase: 'installing' | 'qrcode' | 'scanning' | 'success' | 'error'; message?: string; qrData?: string; qrUrl?: string }>('sudoclaw.wechat-install-progress'),
 };
 
-// Scode config (~/.nexus/sudocode/sudocode.json)
+// Scode config (~/.nexus/sudowork/sudocode/sudocode.json)
 // Matches sudocode.json schema: auth_modes, models, default_model
 export type ScodeModelProvider = {
   provider?: string;
@@ -894,9 +894,9 @@ export type ScodeConfig = {
 };
 
 export const scode = {
-  /** Read scode config from ~/.nexus/sudocode/sudocode.json */
+  /** Read scode config from ~/.nexus/sudowork/sudocode/sudocode.json */
   getConfig: bridge.buildProvider<IBridgeResponse<ScodeConfig>, void>('scode.get-config'),
-  /** Save full scode config to ~/.nexus/sudocode/sudocode.json (overwrite) */
+  /** Save full scode config to ~/.nexus/sudowork/sudocode/sudocode.json (overwrite) */
   saveConfig: bridge.buildProvider<IBridgeResponse<void>, { config: ScodeConfig }>('scode.save-config'),
   /** Save custom OpenAI-compatible scode model providers for the signed-in user */
   saveCustomModelProviders: bridge.buildProvider<IBridgeResponse<void>, { userId: string; providers: ScodeCustomModelProvider[] }>('scode.save-custom-model-providers'),

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -23,10 +23,24 @@ import { initializeSudoworkLogUploader } from './utils/sudoworkLogUploader';
 import { refreshEnterpriseCache } from '@/common/enterpriseDebugConfig';
 // Crash bridge must be initialized early to handle renderer errors before other bridges
 import { initCrashBridge } from './bridge/crashBridge';
+import { migrateLegacyScodeHomeOnce } from './services/scode/ScodeInstallService';
 
 export const initializeProcess = async () => {
   const totalStart = Date.now();
   mainLog('Process', 'Initializing process...');
+
+  // 0. Isolate engine-scode config BEFORE anything reads or writes it. On first
+  // upgrade this copies a prior sudowork install's config from the legacy shared
+  // home (~/.nexus/sudocode) into the isolated home (~/.nexus/sudowork/sudocode).
+  // It MUST run before storage/bridges/auth — several of them write to the isolated
+  // sudocode.json (image model, user keys, …). If a writer creates that file first,
+  // the copy's no-clobber guard skips the real config and the user loses their
+  // models/auth on upgrade. Marker-guarded, so this is a no-op after the first run.
+  try {
+    migrateLegacyScodeHomeOnce();
+  } catch (error) {
+    mainError('Process', 'scode-home migration failed (non-fatal)', error);
+  }
 
   // Keep ~/.sudowork/electron-path fresh so CLI wrappers always find the binary
   syncElectronPath();

--- a/src/process/services/mcpServices/agents/ScodeMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/ScodeMcpAgent.ts
@@ -10,10 +10,11 @@ import type { IMcpServer } from '@/common/storage';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
+import { SCODE_SETTINGS_PATH } from '@process/services/scode/scodePaths';
 
 const TAG = 'ScodeMcpAgent';
-export const SCODE_SETTINGS_PATH = path.join(os.homedir(), '.nexus', 'sudocode', 'settings.json');
+// scode's settings.json — single source of truth in scodePaths.ts; re-exported for existing importers.
+export { SCODE_SETTINGS_PATH };
 const SCODE_DISABLED_MCP_SERVERS = new Set<string>();
 
 function isDisabledForScode(serverName: string): boolean {

--- a/src/process/services/scode/ScodeInstallService.ts
+++ b/src/process/services/scode/ScodeInstallService.ts
@@ -7,8 +7,10 @@
 /**
  * Scode Install Service
  *
- * Installs the bundled/downloaded scode CLI into its dedicated runtime root at
- * ~/.nexus/sudocode so startup can verify the default ACP runtime.
+ * Installs the bundled/downloaded scode CLI into its dedicated, isolated runtime
+ * root at ~/.nexus/sudowork/sudocode so startup can verify the default ACP runtime.
+ * This is isolated from a standalone scode install (~/.nexus/sudocode) so the two
+ * products don't share config/binary. See scodePaths.ts for the SSOT.
  */
 
 import { app } from 'electron';
@@ -18,6 +20,7 @@ import * as path from 'path';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import runtimeVersions from '@/shared/runtime-versions.json';
 import { extractTarGzWithProgress, extractZipWithProgress, listTarGzEntries, listZipEntries } from '../archiveProgress';
+import { SCODE_HOME, LEGACY_SCODE_HOME, SCODE_MIGRATED_ENTRY_NAMES } from './scodePaths';
 
 const TAG = 'ScodeInstallService';
 
@@ -26,8 +29,13 @@ const SCODE_OS_NAME_MAP: Record<string, string> = { darwin: 'macos', win32: 'win
 /** Architecture mapping: Node.js process.arch → scode archive arch name */
 const SCODE_ARCH_NAME_MAP: Record<string, string> = { arm64: 'arm64', x64: 'x64' };
 
-/** Scode root: ~/.nexus/sudocode */
-export const SCODE_DIR = path.join(os.homedir(), '.nexus', 'sudocode');
+/**
+ * Scode root = sudowork's **isolated** engine-scode home (`~/.nexus/sudowork/sudocode`).
+ * SSOT is {@link SCODE_HOME} in scodePaths.ts; re-exported here as `SCODE_DIR` for
+ * back-compat with existing importers. Isolated from standalone scode
+ * (`~/.nexus/sudocode`) so the two products don't stomp each other.
+ */
+export const SCODE_DIR = SCODE_HOME;
 
 /** Marker filename to record installed version */
 const SCODE_READY_MARKER = '.scode-bin-ready';
@@ -371,8 +379,46 @@ function getGitHubDownloadUrl(): string {
  * Install scode from bundled resources or download from GitHub.
  * Silent installation - no UI, just background install.
  */
+/** Marker recording that the legacy→isolated config migration already ran. */
+const SCODE_MIGRATION_MARKER = '.sudowork-config-migrated';
+
+/**
+ * One-time migration for sudowork's engine-scode home moving from the shared
+ * `~/.nexus/sudocode` to the isolated `~/.nexus/sudowork/sudocode`.
+ *
+ * Copies (never moves) the user's config so upgrading sudowork users don't lose
+ * their settings; the legacy copy stays intact for a standalone scode install.
+ * Only migrates config that a PRIOR SUDOWORK INSTALL left at the legacy home
+ * (detected by sudowork's own ready-marker / binary) — a legacy home holding only
+ * a *standalone* scode's config is NOT auto-imported, honouring the
+ * "default full isolation" decision. Runs at most once (marker-guarded) and never
+ * clobbers a file already present in the isolated home.
+ */
+export function migrateLegacyScodeHomeOnce(home: string = SCODE_HOME, legacy: string = LEGACY_SCODE_HOME): void {
+  if (home === legacy) return; // nothing to isolate
+  const marker = path.join(home, SCODE_MIGRATION_MARKER);
+  if (fs.existsSync(marker)) return;
+  try {
+    const legacyWasSudoworkInstall = fs.existsSync(path.join(legacy, SCODE_READY_MARKER)) || fs.existsSync(path.join(legacy, getScodeExeName()));
+    fs.mkdirSync(home, { recursive: true });
+    if (legacyWasSudoworkInstall) {
+      for (const name of SCODE_MIGRATED_ENTRY_NAMES) {
+        const src = path.join(legacy, name);
+        const dest = path.join(home, name);
+        if (!fs.existsSync(src) || fs.existsSync(dest)) continue; // never clobber
+        fs.cpSync(src, dest, { recursive: true });
+        mainLog(TAG, `Migrated ${name}: legacy sudowork scode home -> isolated home`);
+      }
+    }
+    fs.writeFileSync(marker, new Date().toISOString(), 'utf-8');
+  } catch (e) {
+    mainWarn(TAG, `scode-home migration skipped (non-fatal): ${String(e)}`);
+  }
+}
+
 export async function ensureScodeInstalled(options?: { forceReinstall?: boolean; onProgress?: (percent: number) => void }): Promise<boolean> {
   const forceReinstall = options?.forceReinstall === true;
+  migrateLegacyScodeHomeOnce();
   cleanupLegacyManagedScodeSkills();
 
   if (!forceReinstall && isScodeInstalled()) {

--- a/src/process/services/scode/ScodeInstallService.ts
+++ b/src/process/services/scode/ScodeInstallService.ts
@@ -389,17 +389,23 @@ const SCODE_MIGRATION_MARKER = '.sudowork-config-migrated';
  * Copies (never moves) the user's config so upgrading sudowork users don't lose
  * their settings; the legacy copy stays intact for a standalone scode install.
  * Only migrates config that a PRIOR SUDOWORK INSTALL left at the legacy home
- * (detected by sudowork's own ready-marker / binary) — a legacy home holding only
- * a *standalone* scode's config is NOT auto-imported, honouring the
- * "default full isolation" decision. Runs at most once (marker-guarded) and never
- * clobbers a file already present in the isolated home.
+ * (detected by sudowork's own ready-marker — NOT the scode binary, which a
+ * standalone install also has) — a legacy home holding only a *standalone*
+ * scode's config is NOT auto-imported, honouring the "default full isolation"
+ * decision. Runs at most once (marker-guarded) and never clobbers a file already
+ * present in the isolated home.
  */
 export function migrateLegacyScodeHomeOnce(home: string = SCODE_HOME, legacy: string = LEGACY_SCODE_HOME): void {
   if (home === legacy) return; // nothing to isolate
   const marker = path.join(home, SCODE_MIGRATION_MARKER);
   if (fs.existsSync(marker)) return;
   try {
-    const legacyWasSudoworkInstall = fs.existsSync(path.join(legacy, SCODE_READY_MARKER)) || fs.existsSync(path.join(legacy, getScodeExeName()));
+    // ONLY a prior SUDOWORK install writes SCODE_READY_MARKER; a standalone scode
+    // has scode.exe but never writes it. So the marker — not the binary — is the
+    // only safe signal that the legacy config is ours to migrate. Keying off
+    // scode.exe would misclassify a standalone install and import its config,
+    // breaking the "default full isolation / no auto-import" decision.
+    const legacyWasSudoworkInstall = fs.existsSync(path.join(legacy, SCODE_READY_MARKER));
     fs.mkdirSync(home, { recursive: true });
     if (legacyWasSudoworkInstall) {
       for (const name of SCODE_MIGRATED_ENTRY_NAMES) {

--- a/src/process/services/scode/scodePaths.ts
+++ b/src/process/services/scode/scodePaths.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Single source of truth for where sudowork's **embedded (engine) scode** keeps
+ * its binary and config.
+ *
+ * sudowork drives scode as an internal engine; a user may ALSO install standalone
+ * scode from its own installer. Sharing one directory (the old behaviour) made the
+ * two stomp each other's config + binary. So sudowork's engine-scode is isolated
+ * here, mirroring how Claude Desktop and Claude Code keep separate config homes:
+ *
+ *   - sudowork engine-scode → ~/.nexus/sudowork/sudocode/   (this file)
+ *   - standalone scode      → ~/.nexus/sudocode/            (its own default; untouched)
+ *
+ * Every path below is derived from {@link SCODE_HOME}. Do NOT re-derive
+ * `~/.nexus/sudowork/sudocode` (or the legacy `~/.nexus/sudocode`) anywhere else —
+ * import from this module. The `no-hardcoded-scode-home` guard test enforces it.
+ *
+ * scode's own config loader (Rust) resolves its config home from the
+ * `SUDO_CODE_CONFIG_HOME` env var, so sudowork launches scode with that set to
+ * {@link SCODE_HOME}; see acpConnectors. That relocates BOTH `sudocode.json`
+ * (models/auth) and `settings.json` (settings/MCP) in one place.
+ */
+
+import os from 'os';
+import path from 'path';
+
+/** Isolated home for sudowork's embedded scode (binary + config live here). */
+export const SCODE_HOME = path.join(os.homedir(), '.nexus', 'sudowork', 'sudocode');
+
+/**
+ * Legacy shared home = standalone scode's default config home
+ * (`SUDO_CODE_CONFIG_HOME` default in sudocode `config.rs`). Referenced ONLY for
+ * the one-time first-run migration (copy → isolate) in ScodeInstallService.
+ */
+export const LEGACY_SCODE_HOME = path.join(os.homedir(), '.nexus', 'sudocode');
+
+/** `sudocode.json` — models / auth / providers (scode `load_sudocode_config`). */
+export const SCODE_CONFIG_PATH = path.join(SCODE_HOME, 'sudocode.json');
+
+/** `settings.json` — runtime settings + MCP servers (scode `discover`). */
+export const SCODE_SETTINGS_PATH = path.join(SCODE_HOME, 'settings.json');
+
+/** Config files copied once from {@link LEGACY_SCODE_HOME} on first isolation. */
+export const SCODE_MIGRATED_ENTRY_NAMES = ['sudocode.json', 'scode.json', 'settings.json', 'settings.local.json', 'AGENTS.md', 'skills'] as const;

--- a/src/process/services/scode/scodeProxyModels.ts
+++ b/src/process/services/scode/scodeProxyModels.ts
@@ -8,10 +8,9 @@ import { getDefaultAcpModelId } from '@/common/acp/defaultModels';
 import { isVisionModel } from '@/common/imageUtils';
 import type { AcpModelInfo } from '@/types/acpTypes';
 import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import { SCODE_CONFIG_PATH } from './scodePaths';
 
-const SUDOCODE_CONFIG_PATH = path.join(os.homedir(), '.nexus', 'sudocode', 'sudocode.json');
+const SUDOCODE_CONFIG_PATH = SCODE_CONFIG_PATH;
 
 type ScodeConfiguredModel = {
   id: string;

--- a/src/renderer/pages/settings/about/components/OpsModal.tsx
+++ b/src/renderer/pages/settings/about/components/OpsModal.tsx
@@ -27,7 +27,7 @@ const OpsModal: React.FC<OpsModalProps> = ({ visible, onClose, onConfigSaved }) 
     setConfigLoading(true);
     try {
       const homeDir = await ipcBridge.application.getPath.invoke({ name: 'home' });
-      const configFilePath = `${homeDir}/.nexus/sudocode/sudocode.json`;
+      const configFilePath = `${homeDir}/.nexus/sudowork/sudocode/sudocode.json`;
       setConfigPath(configFilePath);
 
       const res = await ipcBridge.scode.getConfig.invoke();
@@ -92,7 +92,7 @@ const OpsModal: React.FC<OpsModalProps> = ({ visible, onClose, onConfigSaved }) 
           <div className='flex items-center justify-between p-3 border-light rd-8px'>
             <div className='flex-1'>
               <div className='text-14px text-foreground font-500'>{t('settings.ops.configFile', 'Sudo Code 配置文件')}</div>
-              <Tooltip content='~/.nexus/sudocode/sudocode.json'>
+              <Tooltip content='~/.nexus/sudowork/sudocode/sudocode.json'>
                 <div className='text-12px text-secondary mt-0.5'>{t('settings.ops.editConfigFile', '直接编辑配置文件')}</div>
               </Tooltip>
             </div>

--- a/tests/integration/scodeConfigHomeIsolation.integration.test.ts
+++ b/tests/integration/scodeConfigHomeIsolation.integration.test.ts
@@ -129,10 +129,28 @@ describeMaybe('scode config-home isolation (real binary)', () => {
     fs.rmSync(homeB, { recursive: true, force: true });
   });
 
-  it('without the env var, scode falls back to the standalone ~/.nexus/sudocode home', () => {
-    const userFiles = readConfigReport(undefined).files.filter((f) => f.source === 'user');
-    // default (no isolation) → the legacy shared home. This is the behaviour we
-    // are moving sudowork OFF of, and it must stay the standalone default.
-    expect(userFiles.every((f) => normalize(f.path).startsWith(normalize(LEGACY_SCODE_HOME)))).toBe(true);
+  it('without the env var, scode falls back to HOME/.nexus/sudocode (the standalone default)', () => {
+    // scode's default_config_home() reads $HOME (not os.homedir()); on Windows CI
+    // HOME is often unset, so pin it explicitly to make the fallback deterministic
+    // and cross-platform. This is the shared home we are moving sudowork OFF of —
+    // it must stay the standalone default when SUDO_CODE_CONFIG_HOME is absent.
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'scode-iso-home2-'));
+    const env = { ...process.env };
+    delete env.SUDO_CODE_CONFIG_HOME;
+    env.HOME = fakeHome;
+    env.USERPROFILE = fakeHome; // belt-and-braces on Windows
+
+    const out = execFileSync(scodeBin as string, ['config', '--output-format', 'json'], {
+      cwd: workspace,
+      env,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    const userFiles = (JSON.parse(out) as ConfigReport).files.filter((f) => f.source === 'user');
+    const expectedHome = path.join(fakeHome, '.nexus', 'sudocode');
+    expect(userFiles.length).toBeGreaterThan(0);
+    expect(userFiles.every((f) => normalize(f.path).startsWith(normalize(expectedHome)))).toBe(true);
+
+    fs.rmSync(fakeHome, { recursive: true, force: true });
   });
 });

--- a/tests/integration/scodeConfigHomeIsolation.integration.test.ts
+++ b/tests/integration/scodeConfigHomeIsolation.integration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2026 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Real cross-repo contract test for sudowork ↔ scode config isolation.
+ *
+ * sudowork isolates its embedded engine-scode by spawning the scode binary with
+ * `SUDO_CODE_CONFIG_HOME` pointed at `~/.nexus/sudowork/sudocode` (see
+ * scodePaths.ts + acpConnectors). That only actually isolates anything if the
+ * REAL scode binary honours the env var. Rather than trust the contract, this
+ * test drives the actual binary:
+ *
+ *   scode config --output-format json   (a read-only merged-config report)
+ *
+ * and asserts that the user-scope config files (`scode.json` / `settings.json`)
+ * resolve UNDER the home we point the env var at — and, crucially, NOT under the
+ * standalone `~/.nexus/sudocode` — proving a standalone scode install and
+ * sudowork's engine-scode read different config homes.
+ *
+ * The binary is resolved from where sudowork installs it (or an explicit
+ * SCODE_BIN override); if no binary is available (e.g. a bare CI checkout that
+ * skipped `scode:download`) the suite skips rather than failing red. CI wires a
+ * download+extract step so it runs for real there.
+ */
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SCODE_HOME, LEGACY_SCODE_HOME } from '../../src/process/services/scode/scodePaths';
+
+const exeName = process.platform === 'win32' ? 'scode.exe' : 'scode';
+
+/** Resolve a runnable scode binary, or null to skip. */
+function resolveScodeBinary(): string | null {
+  const candidates = [
+    process.env.SCODE_BIN,
+    path.join(SCODE_HOME, exeName), // sudowork's isolated install
+    path.join(LEGACY_SCODE_HOME, exeName), // standalone / pre-isolation install
+  ].filter((p): p is string => !!p);
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+type ConfigReport = {
+  cwd: string;
+  files: Array<{ loaded: boolean; path: string; source: string }>;
+  kind: string;
+};
+
+function normalize(p: string): string {
+  return p.replace(/\\/g, '/').toLowerCase();
+}
+
+const scodeBin = resolveScodeBinary();
+const describeMaybe = scodeBin ? describe : describe.skip;
+
+describeMaybe('scode config-home isolation (real binary)', () => {
+  let workspace: string; // clean cwd so repo project-config doesn't add noise
+
+  beforeAll(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'scode-iso-ws-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  /** Run `scode config --output-format json` with a given config home. */
+  function readConfigReport(configHome: string | undefined): ConfigReport {
+    const env = { ...process.env };
+    if (configHome) {
+      env.SUDO_CODE_CONFIG_HOME = configHome;
+    } else {
+      delete env.SUDO_CODE_CONFIG_HOME;
+    }
+    const out = execFileSync(scodeBin as string, ['config', '--output-format', 'json'], {
+      cwd: workspace,
+      env,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    return JSON.parse(out) as ConfigReport;
+  }
+
+  it('routes the user-scope config home to SUDO_CODE_CONFIG_HOME (and reads a file placed there)', () => {
+    const isoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'scode-iso-home-'));
+    // a real settings.json the engine should pick up from the isolated home
+    fs.writeFileSync(path.join(isoHome, 'settings.json'), '{}');
+
+    const report = readConfigReport(isoHome);
+    const userFiles = report.files.filter((f) => f.source === 'user');
+    expect(userFiles.length).toBeGreaterThan(0);
+
+    // every user-scope file resolves UNDER the isolated home we requested...
+    for (const f of userFiles) {
+      expect(normalize(f.path).startsWith(normalize(isoHome))).toBe(true);
+    }
+    // ...and NONE leaks to the standalone ~/.nexus/sudocode home
+    for (const f of userFiles) {
+      expect(normalize(f.path).startsWith(normalize(LEGACY_SCODE_HOME) + '/')).toBe(false);
+    }
+    // the settings.json we placed in the isolated home was actually loaded (data flow, not just path)
+    const loadedSettings = userFiles.find((f) => normalize(f.path).endsWith('/settings.json'));
+    expect(loadedSettings?.loaded).toBe(true);
+
+    fs.rmSync(isoHome, { recursive: true, force: true });
+  });
+
+  it('two different config homes are fully isolated — neither sees the other', () => {
+    const homeA = fs.mkdtempSync(path.join(os.tmpdir(), 'scode-iso-A-'));
+    const homeB = fs.mkdtempSync(path.join(os.tmpdir(), 'scode-iso-B-'));
+
+    const userA = readConfigReport(homeA).files.filter((f) => f.source === 'user');
+    const userB = readConfigReport(homeB).files.filter((f) => f.source === 'user');
+
+    // A's user config lives under A only; B's under B only — no cross-bleed
+    expect(userA.every((f) => normalize(f.path).startsWith(normalize(homeA)))).toBe(true);
+    expect(userA.some((f) => normalize(f.path).startsWith(normalize(homeB)))).toBe(false);
+    expect(userB.every((f) => normalize(f.path).startsWith(normalize(homeB)))).toBe(true);
+
+    fs.rmSync(homeA, { recursive: true, force: true });
+    fs.rmSync(homeB, { recursive: true, force: true });
+  });
+
+  it('without the env var, scode falls back to the standalone ~/.nexus/sudocode home', () => {
+    const userFiles = readConfigReport(undefined).files.filter((f) => f.source === 'user');
+    // default (no isolation) → the legacy shared home. This is the behaviour we
+    // are moving sudowork OFF of, and it must stay the standalone default.
+    expect(userFiles.every((f) => normalize(f.path).startsWith(normalize(LEGACY_SCODE_HOME)))).toBe(true);
+  });
+});

--- a/tests/integration/scodeConfigHomeIsolation.integration.test.ts
+++ b/tests/integration/scodeConfigHomeIsolation.integration.test.ts
@@ -28,6 +28,7 @@
 
 import { execFileSync } from 'child_process';
 import fs from 'fs';
+import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -60,6 +61,26 @@ function normalize(p: string): string {
 
 const scodeBin = resolveScodeBinary();
 const describeMaybe = scodeBin ? describe : describe.skip;
+
+// node-pty is a native addon; load it defensively so an ABI mismatch on some CI
+// runner degrades to a skip instead of failing the whole suite.
+function loadPty(): typeof import('node-pty') | null {
+  try {
+    const require = createRequire(import.meta.url);
+    return require('node-pty');
+  } catch {
+    return null;
+  }
+}
+const pty = loadPty();
+/* eslint-disable no-control-regex -- stripping terminal control sequences is the point */
+const stripAnsi = (s: string): string =>
+  s
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b[[\]][0-9;?=]*[a-zA-Z]/g, '')
+    .replace(/\x1b[=>]/g, '')
+    .replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '');
+/* eslint-enable no-control-regex */
 
 describeMaybe('scode config-home isolation (real binary)', () => {
   let workspace: string; // clean cwd so repo project-config doesn't add noise
@@ -152,5 +173,46 @@ describeMaybe('scode config-home isolation (real binary)', () => {
     expect(userFiles.every((f) => normalize(f.path).startsWith(normalize(expectedHome)))).toBe(true);
 
     fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+});
+
+// Same contract, driven through a REAL pseudo-terminal (ConPTY on Windows) — the
+// engine sudowork actually spawns runs in a pty, so this exercises the isolation
+// the way a user's terminal would, not just a captured pipe.
+const describePty = scodeBin && pty ? describe : describe.skip;
+
+describePty('scode config-home isolation (real pty / ConPTY)', () => {
+  function runInPty(args: string[], env: NodeJS.ProcessEnv, cwd: string): Promise<string> {
+    return new Promise((resolve) => {
+      let buf = '';
+      const p = pty!.spawn(scodeBin as string, args, {
+        name: 'xterm-color',
+        cols: 120,
+        rows: 40,
+        cwd,
+        env: { ...process.env, ...env } as { [key: string]: string },
+      });
+      p.onData((d) => (buf += d));
+      p.onExit(() => resolve(buf));
+    });
+  }
+
+  it('routes the user config home to SUDO_CODE_CONFIG_HOME when run in a terminal', async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'scode-pty-ws-'));
+    const isoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'scode-pty-home-'));
+    fs.writeFileSync(path.join(isoHome, 'settings.json'), '{}');
+
+    const raw = await runInPty(['config', '--output-format', 'json'], { SUDO_CODE_CONFIG_HOME: isoHome }, workspace);
+    const clean = stripAnsi(raw);
+    const report = JSON.parse(clean.slice(clean.indexOf('{'), clean.lastIndexOf('}') + 1)) as ConfigReport;
+    const userFiles = report.files.filter((f) => f.source === 'user');
+
+    expect(userFiles.length).toBeGreaterThan(0);
+    expect(userFiles.every((f) => normalize(f.path).startsWith(normalize(isoHome)))).toBe(true);
+    // the settings.json placed in the isolated home is actually loaded through the pty
+    expect(userFiles.some((f) => normalize(f.path).endsWith('/settings.json') && f.loaded)).toBe(true);
+
+    fs.rmSync(workspace, { recursive: true, force: true });
+    fs.rmSync(isoHome, { recursive: true, force: true });
   });
 });

--- a/tests/unit/scodeConfigIsolation.test.ts
+++ b/tests/unit/scodeConfigIsolation.test.ts
@@ -125,6 +125,22 @@ describe('scode config isolation — first-run migration', () => {
     expect(fs.existsSync(path.join(home, MIGRATION_MARKER))).toBe(true);
   });
 
+  it('does NOT treat a standalone scode (has scode.exe but no sudowork marker) as migratable', async () => {
+    const { migrateLegacyScodeHomeOnce } = await import('../../src/process/services/scode/ScodeInstallService');
+
+    // The exact customer scenario: a standalone scode install — scode binary
+    // present, real config present, but NO sudowork ready-marker. Detection must
+    // key off the sudowork marker, not the (shared) binary, or it would import.
+    const exeName = process.platform === 'win32' ? 'scode.exe' : 'scode';
+    fs.writeFileSync(path.join(legacy, exeName), 'binary');
+    fs.writeFileSync(path.join(legacy, 'sudocode.json'), '{"default_model":"standalone-secret"}');
+
+    migrateLegacyScodeHomeOnce(home, legacy);
+
+    expect(fs.existsSync(path.join(home, 'sudocode.json'))).toBe(false);
+    expect(fs.existsSync(path.join(home, MIGRATION_MARKER))).toBe(true);
+  });
+
   it('never clobbers config already present in the isolated home', async () => {
     const { migrateLegacyScodeHomeOnce } = await import('../../src/process/services/scode/ScodeInstallService');
 

--- a/tests/unit/scodeConfigIsolation.test.ts
+++ b/tests/unit/scodeConfigIsolation.test.ts
@@ -215,3 +215,19 @@ describe('scode config isolation — SSOT guard (no-hardcoded-scode-home)', () =
     expect(offenders, `home-level scode paths must come from scodePaths.ts, found:\n${offenders.join('\n')}`).toEqual([]);
   });
 });
+
+describe('scode config isolation — migration runs before config writers', () => {
+  it('initializeProcess calls migrateLegacyScodeHomeOnce before initStorage()', () => {
+    // Regression guard for a real bug found via full-app e2e: several services
+    // (image model, user-key sync, auth) write to the isolated sudocode.json during
+    // init. If migration runs AFTER any of them, its no-clobber guard skips the real
+    // copy and the user loses their models/auth on upgrade. Migration must therefore
+    // be the FIRST thing initializeProcess does — before storage/bridges/auth.
+    const src = fs.readFileSync(path.resolve(__dirname, '..', '..', 'src', 'process', 'index.ts'), 'utf-8');
+    const migrateIdx = src.indexOf('migrateLegacyScodeHomeOnce(');
+    const storageIdx = src.indexOf('initStorage(');
+    expect(migrateIdx, 'initializeProcess must call migrateLegacyScodeHomeOnce()').toBeGreaterThan(-1);
+    expect(storageIdx, 'initializeProcess must call initStorage()').toBeGreaterThan(-1);
+    expect(migrateIdx).toBeLessThan(storageIdx);
+  });
+});

--- a/tests/unit/scodeConfigIsolation.test.ts
+++ b/tests/unit/scodeConfigIsolation.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2026 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Config/binary isolation between sudowork's embedded (engine) scode and a
+ * user-installed standalone scode.
+ *
+ * Background: both products default their config home to `~/.nexus/sudocode`, so
+ * installing both on one machine made them stomp each other's `sudocode.json`
+ * (models/auth), `settings.json` (settings/MCP) and the binary. sudowork now
+ * isolates its engine-scode under `~/.nexus/sudowork/sudocode` (mirroring how
+ * Claude Desktop / Claude Code keep separate config homes) and drives scode with
+ * `SUDO_CODE_CONFIG_HOME` pointed there.
+ *
+ * These tests lock in the three load-bearing guarantees:
+ *   1. the path SSOT is isolated and self-consistent;
+ *   2. first-run migration copies a PRIOR SUDOWORK install's config once, never
+ *      clobbers, never auto-imports a standalone scode's config, and is idempotent;
+ *   3. no code outside the SSOT re-derives a home-level `~/.nexus/sudocode` path.
+ */
+
+import fs from 'fs';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getAppPath: () => '/mock-app',
+  },
+}));
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+
+const READY_MARKER = '.scode-bin-ready';
+const MIGRATION_MARKER = '.sudowork-config-migrated';
+
+describe('scode config isolation — path SSOT', () => {
+  it('isolates the engine-scode home under ~/.nexus/sudowork/sudocode', async () => {
+    const { SCODE_HOME, LEGACY_SCODE_HOME, SCODE_CONFIG_PATH, SCODE_SETTINGS_PATH } = await import('../../src/process/services/scode/scodePaths');
+
+    // engine home lives under the isolated sudowork/ namespace, not the shared one
+    expect(SCODE_HOME).toContain(os.homedir());
+    expect(SCODE_HOME.endsWith(path.join('.nexus', 'sudowork', 'sudocode'))).toBe(true);
+
+    // standalone scode's default home (used only as the migration source)
+    expect(LEGACY_SCODE_HOME.endsWith(path.join('.nexus', 'sudocode'))).toBe(true);
+
+    // the whole point: the two homes must differ, else there is no isolation
+    expect(SCODE_HOME).not.toBe(LEGACY_SCODE_HOME);
+    expect(SCODE_HOME.startsWith(LEGACY_SCODE_HOME + path.sep)).toBe(false);
+
+    // config + settings are derived from the isolated home (one relocation, both files)
+    expect(SCODE_CONFIG_PATH).toBe(path.join(SCODE_HOME, 'sudocode.json'));
+    expect(SCODE_SETTINGS_PATH).toBe(path.join(SCODE_HOME, 'settings.json'));
+  });
+
+  it('ScodeInstallService.SCODE_DIR is an alias of the SSOT home (no duplicate literal)', async () => {
+    const paths = await import('../../src/process/services/scode/scodePaths');
+    const install = await import('../../src/process/services/scode/ScodeInstallService');
+
+    // SCODE_DIR is re-exported from the SSOT, not an independently-computed string.
+    expect(install.SCODE_DIR).toBe(paths.SCODE_HOME);
+  });
+});
+
+describe('scode config isolation — first-run migration', () => {
+  let tempRoot: string;
+  let home: string; // isolated ~/.nexus/sudowork/sudocode stand-in
+  let legacy: string; // shared ~/.nexus/sudocode stand-in
+
+  beforeEach(async () => {
+    tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'sudowork-scode-iso-'));
+    home = path.join(tempRoot, 'sudowork', 'sudocode');
+    legacy = path.join(tempRoot, 'sudocode');
+    await fsp.mkdir(legacy, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('copies config from a PRIOR SUDOWORK install and leaves the legacy copy intact', async () => {
+    const { migrateLegacyScodeHomeOnce } = await import('../../src/process/services/scode/ScodeInstallService');
+
+    // legacy home was a sudowork install (has sudowork's ready-marker) with real config
+    fs.writeFileSync(path.join(legacy, READY_MARKER), '0.1.1');
+    fs.writeFileSync(path.join(legacy, 'sudocode.json'), '{"default_model":"gpt"}');
+    fs.writeFileSync(path.join(legacy, 'settings.json'), '{"mcp":{}}');
+    fs.mkdirSync(path.join(legacy, 'skills', 'demo'), { recursive: true });
+    fs.writeFileSync(path.join(legacy, 'skills', 'demo', 'SKILL.md'), '# demo');
+
+    migrateLegacyScodeHomeOnce(home, legacy);
+
+    // config copied into the isolated home (data-flow assertion, not just existence)
+    expect(fs.readFileSync(path.join(home, 'sudocode.json'), 'utf-8')).toBe('{"default_model":"gpt"}');
+    expect(fs.readFileSync(path.join(home, 'settings.json'), 'utf-8')).toBe('{"mcp":{}}');
+    expect(fs.readFileSync(path.join(home, 'skills', 'demo', 'SKILL.md'), 'utf-8')).toBe('# demo');
+    // migration is a COPY, not a move — legacy stays usable for a standalone scode
+    expect(fs.existsSync(path.join(legacy, 'sudocode.json'))).toBe(true);
+    // marker written so it never runs again
+    expect(fs.existsSync(path.join(home, MIGRATION_MARKER))).toBe(true);
+  });
+
+  it("does NOT auto-import a standalone scode's config (default full isolation)", async () => {
+    const { migrateLegacyScodeHomeOnce } = await import('../../src/process/services/scode/ScodeInstallService');
+
+    // legacy home is a STANDALONE scode: has config but NO sudowork ready-marker/binary
+    fs.writeFileSync(path.join(legacy, 'sudocode.json'), '{"default_model":"standalone-secret"}');
+
+    migrateLegacyScodeHomeOnce(home, legacy);
+
+    // isolation wins: the standalone config must not leak into the engine home
+    expect(fs.existsSync(path.join(home, 'sudocode.json'))).toBe(false);
+    // but migration is still marked done so we don't re-scan on every launch
+    expect(fs.existsSync(path.join(home, MIGRATION_MARKER))).toBe(true);
+  });
+
+  it('never clobbers config already present in the isolated home', async () => {
+    const { migrateLegacyScodeHomeOnce } = await import('../../src/process/services/scode/ScodeInstallService');
+
+    fs.writeFileSync(path.join(legacy, READY_MARKER), '0.1.1');
+    fs.writeFileSync(path.join(legacy, 'sudocode.json'), '{"from":"legacy"}');
+    // user already has an isolated config (e.g. re-run after partial migration)
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(path.join(home, 'sudocode.json'), '{"from":"isolated"}');
+
+    migrateLegacyScodeHomeOnce(home, legacy);
+
+    expect(fs.readFileSync(path.join(home, 'sudocode.json'), 'utf-8')).toBe('{"from":"isolated"}');
+  });
+
+  it('is idempotent — a second run does not re-copy after the marker exists', async () => {
+    const { migrateLegacyScodeHomeOnce } = await import('../../src/process/services/scode/ScodeInstallService');
+
+    fs.writeFileSync(path.join(legacy, READY_MARKER), '0.1.1');
+    fs.writeFileSync(path.join(legacy, 'sudocode.json'), '{"v":1}');
+
+    migrateLegacyScodeHomeOnce(home, legacy);
+    // user edits the isolated config after migration; legacy also changes
+    fs.writeFileSync(path.join(home, 'sudocode.json'), '{"v":2}');
+    fs.writeFileSync(path.join(legacy, 'sudocode.json'), '{"v":99}');
+
+    migrateLegacyScodeHomeOnce(home, legacy);
+
+    // second run is a no-op: user's post-migration edit is preserved
+    expect(fs.readFileSync(path.join(home, 'sudocode.json'), 'utf-8')).toBe('{"v":2}');
+  });
+
+  it('no-ops when home and legacy are the same path (isolation disabled)', async () => {
+    const { migrateLegacyScodeHomeOnce } = await import('../../src/process/services/scode/ScodeInstallService');
+    fs.writeFileSync(path.join(legacy, READY_MARKER), '0.1.1');
+
+    migrateLegacyScodeHomeOnce(legacy, legacy);
+
+    // must not write a migration marker into the shared home when nothing to isolate
+    expect(fs.existsSync(path.join(legacy, MIGRATION_MARKER))).toBe(false);
+  });
+});
+
+describe('scode config isolation — SSOT guard (no-hardcoded-scode-home)', () => {
+  it('no file except scodePaths.ts derives a home-level ~/.nexus/sudocode path', () => {
+    const srcRoot = path.resolve(__dirname, '..', '..', 'src');
+    const ssot = path.join('process', 'services', 'scode', 'scodePaths.ts');
+
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!/\.(ts|tsx)$/.test(entry.name)) continue;
+        const rel = path.relative(srcRoot, full);
+        if (rel.split(path.sep).join('/') === ssot.split(path.sep).join('/')) continue; // SSOT is allowed
+        const lines = fs.readFileSync(full, 'utf-8').split('\n');
+        lines.forEach((line, i) => {
+          // Home-level constructions always combine homedir() with sudocode on one
+          // path.join line. Workspace-level paths use a `workspace`/cwd variable and
+          // never homedir(), so they are (correctly) not flagged.
+          if (/homedir\s*\(/.test(line) && /sudocode/.test(line)) {
+            offenders.push(`${rel}:${i + 1}: ${line.trim()}`);
+          }
+        });
+      }
+    };
+    walk(srcRoot);
+
+    expect(offenders, `home-level scode paths must come from scodePaths.ts, found:\n${offenders.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 背景 / Why

客户机器(商飞)同时装了**独立 scode**(自带安装包)和 **sudowork**。两者的 scode 都默认把 config home 指向 `~/.nexus/sudocode`,于是:
- `sudocode.json`(模型/鉴权)、`settings.json`(设置/MCP)互相覆盖;
- 连二进制都装在同一个 `SCODE_DIR`,装/更新一个会盖掉另一个的版本。

方案已在 ShareOne 与 @白桂东 对齐(5 条结论:方向=隔离、位置=`~/.nexus/sudowork/sudocode/`、迁移=首次复制一份、共享=默认全隔离+显式导入、范围=不动独立安装包)。参照 Claude Desktop / Claude Code —— 两套配置本来就是隔离的。

## 改动 / What

- **`scodePaths.ts`(新)**= 引擎-scode home 的**单一事实来源**,隔离到 `~/.nexus/sudowork/sudocode`。所有 home 级触点(`ScodeInstallService.SCODE_DIR`、`acpConnectors`、`AcpDetector`、`ScodeMcpAgent`、`scodeProxyModels`、`OpsModal`)统一从它派生,消除重复字面量(SSOT/DRY)。
- **`acpConnectors`**:起 scode 时注入 `SUDO_CODE_CONFIG_HOME=SCODE_HOME` —— 这正是 scode Rust 端 `default_config_home()` 解析的 env(核对过 `runtime/src/config.rs`:设了就**独占**使用,不再回落 `~/.nexus/sudocode`)。一处注入,`sudocode.json` + `settings.json` 一起搬。
- **首次迁移**(复制一次、marker 守卫):只把"**以前确实是 sudowork 装的**"那份配置(用 sudowork 自己的 ready-marker/二进制判定)复制进隔离 home。只复制不搬移、不覆盖已有、**不导入独立 scode 的配置**(对齐"默认全隔离")。

## 范围 / Scope

- **不动**独立 scode 安装包 —— 它继续用 `~/.nexus/sudocode`。
- **workspace 级**(cwd)`.nexus/sudocode` 项目配置**保持共享**(正确,scode 从 cwd 读项目配置)。
- 已知可接受:scode 的 skills/commands/agents **发现**仍会只读并集 legacy home(scode 二进制自身逻辑,范围内不动)—— 加性、非覆盖;若要连 skills 也完全隔离,是 scode 侧后续改动,另开。

## 测试 / Tests(对齐验收标准:真实 e2e + 进 CI)

- `tests/unit/scodeConfigIsolation.test.ts`:SSOT 不变式 + 迁移 5 场景(复制/不覆盖/不导入独立配置/幂等/同路径 no-op)+ **`no-hardcoded-scode-home` guard**(禁止别处再硬编码 home 级 `~/.nexus/sudocode`)。
- `tests/integration/scodeConfigHomeIsolation.integration.test.ts`:**驱动真实 scode 二进制**(`scode config --output-format json`),断言 user 级 config home 跟随 `SUDO_CODE_CONFIG_HOME`、绝不泄漏到 `~/.nexus/sudocode`;两个不同 home 互不可见;无 env 时回落 legacy。已接入 `pr-integration-smoke`(**windows runner**,因 scode 只发 macOS+Windows)。
- 本地:12/12 绿;`tsc --noEmit` 干净(仅一个与本 PR 无关的既有 `@vitejs/plugin-react` 缺失);全量单测的其余 failing 已用 `git stash` 基线核实为 **dev 分支既有环境失败,非本改动引入**。

## Boundary note

`OpsModal.tsx`(renderer)目前仍硬编码展示路径字符串(renderer 用不了主进程的 `os`)。本 PR 先同步为新路径;更干净的做法是走 IPC 暴露解析后的路径,已在此标注,可作后续小重构。

—— sudowork-win-pc-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)