### PR TITLE
fix(acp): timeout ConfigStorage.get so a stuck store never blocks a turn

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -57,6 +57,8 @@ import { appendGeneratedFilesMarker, type GeneratedFileEntry } from '@/common/ge
 import { readAssistantResource, ruleFilePattern } from '@process/utils/assistantResources';
 import { protectUnsupportedAcpSlashPrompt } from '@/common/slash/sudoworkCommands';
 import { cdpPort as chromiumCdpPort } from '@/utils/configureChromium';
+import { parseImageCapability, type IImageCapability } from '@/common/imageUtils';
+import { ConfigStorage } from '@/common/storage';
 import { clearSkillsCache, getCustomSkillsDir, ProcessConfig } from '../initStorage';
 import { addMessage, addOrUpdateMessage, nextTickToLocalFinish } from '../message';
 import { handlePreviewOpenEvent } from '../utils/previewUtils';
@@ -92,8 +94,6 @@ import { hasCronCommands } from './CronCommandDetector';
 import { detectChannelQueryIntent, executeChannelInfoCommand, type ChannelQueryCommand } from './ChannelInfoDetector';
 import { extractTextFromMessage, processCronInMessage } from './MessageMiddleware';
 import { processAtFileReferences } from './acp/AcpAtFileProcessor';
-import { parseImageCapability, type IImageCapability } from '@/common/imageUtils';
-import { ConfigStorage } from '@/common/storage';
 import { StreamTextBuffer, CronTextAccumulator, preprocessContentMessage } from './acp/AcpMessagePipeline';
 import { clearAcpSessionId, saveAcpSessionId, saveSessionMode, saveModelId, saveContextUsage } from './acp/AcpPersistence';
 import { extractLatestScodeAssistantUsageFromJsonl, findScodeSessionFile, normalizePromptUsageForMessage, SCODE_LATE_RECONCILIATION_DEFAULTS } from './acpUsageReconciliation';
@@ -982,7 +982,12 @@ This identity statement takes priority over the default identity in USER.md.
         // makes getImageTargetSize fall back to sudowork defaults (Decision 1's
         // graceful-degradation hard rule).
         const imageCapability: IImageCapability | null = parseImageCapability(this.connection.getInitializeResponse());
-        const economyMode = (await ConfigStorage.get('image.economyMode').catch((): boolean | undefined => undefined)) === true;
+        // Never let ConfigStorage.get block the turn (real-e2e caught this
+        // 2026-07-01: on a partially-initialized dev env the get promise
+        // never resolved AND never rejected — .catch() couldn't save us).
+        // 500 ms timeout → fall back to default off (Decision 1's graceful
+        // degradation), so the turn proceeds instead of the whole chat hanging.
+        const economyMode = (await Promise.race([ConfigStorage.get('image.economyMode').catch((): boolean | undefined => undefined), new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 500))])) === true;
 
         const processed = await processAtFileReferences(contentToSend, this.workspace, data.files, this.persistedModelId, {
           capability: imageCapability,


### PR DESCRIPTION
## Summary
Real sudowork UI e2e (2026-07-01) caught: on a dev environment where Nexus core failed to start, `ConfigStorage.get('image.economyMode')` returned a promise that never resolved AND never rejected. The `.catch()` swallow couldn't save us because there was nothing to catch. Result: every send-with-image sat at "正在处理中" indefinitely.

## Fix
`Promise.race` with 500 ms timeout — on timeout, fall back to `economyMode = off` (Decision 1's graceful-degradation hard rule). Turn proceeds; scode still gets the image; user gets a response.

## Verification
Same e2e drive as sudocode fix — fresh conversation, deepseek-v4-flash + PNG paste, response comes back describing the image.

Companion sudocode fix: sudoprivacy/sudocode#TBD (VLM dedicated thread)

## Test plan
- [ ] CI green
- [ ] Manual: `bun run start`, attach image, send, response comes back