### PR TITLE
refactor(acp): drop scode model-switch restart fallback (live session/set_model as SSOT)

### DIFF
--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -2309,22 +2309,18 @@ This identity statement takes priority over the default identity in USER.md.
       };
     }
 
-    let result: AcpModelInfo | null = null;
-    try {
-      result = await this.setModelByConfigOption(normalizedModelId);
-    } catch (error) {
-      if (this.options.backend !== 'scode') {
-        throw error;
-      }
-      mainWarn('[AcpAgent]', `scode: setModel("${normalizedModelId}") failed, restarting connection to apply model/auth mode: ${error instanceof Error ? error.message : String(error)}`);
-      try {
-        await this.restartAndConnect();
-        result = this.getModelInfo();
-      } catch (restartError) {
-        mainWarn('[AcpAgent]', `scode: restart after model switch failed: ${restartError instanceof Error ? restartError.message : String(restartError)}`);
-        throw error;
-      }
-    }
+    // The live `session/set_model` RPC is the single authoritative model-switch
+    // path: scode's handle_acp_model_switch rebuilds the runtime with the new
+    // model + auth mode in place, keeping the session intact (the "not connected"
+    // guard above already reconnects a dropped socket first). A failure here is a
+    // real switch failure and surfaces to the caller — we no longer respawn the
+    // engine as a fallback. That legacy fallback existed only to make the process
+    // re-read the model from env at startup; the live RPC now applies model + auth
+    // in place, so it was redundant. Recovering a hung/dead connection is a
+    // separate concern with its own path (conversation.restart-and-connect / the
+    // "Restart & Connect" action), and the resume fix (session/load) means a
+    // switch never needs a restart to keep context.
+    const result = await this.setModelByConfigOption(normalizedModelId);
 
     if (result) {
       this.persistedModelId = result.currentModelId || normalizedModelId;


### PR DESCRIPTION
Follow-up to the session-resume hotfix (#957) — the "Layer 3" cleanup, done systematically rather than as a comment.

## What
Remove the `restartAndConnect` fallback from `AcpAgent.setModel` for scode. The live `session/set_model` RPC is now the single authoritative model-switch path.

## Why it's safe + correct (SSOT)
- scode's `handle_acp_model_switch` rebuilds the runtime with the new **model + auth mode** in place, preserving the session — the live RPC already does everything the restart did.
- `setModel` reconnects a dropped socket *before* switching (the `!isConnected` guard), so a failure reaching the catch is a real switch error (bad model / scode logic) that a respawn wouldn't fix anyway — surfacing it lets the user retry / pick a valid model.
- The restart was a **legacy hack** to make the engine re-read `SUDOCODE_CURRENT_MODEL_ID` from env at startup. The live RPC applies model+auth in place, so the env channel is redundant — this removes the second config channel in favor of the live RPC as source of truth.
- Recovering a hung/dead connection is a **separate concern** with its own path (`conversation.restart-and-connect` / the "Restart & Connect" action). `restartAndConnect` the method stays (used there + by RemoteAgent).
- Amnesia risk is gone regardless: #957 routes scode through `session/load`, so even a restart preserves context.

Verified end-to-end earlier: switching auto → deepseek-v4-pro recalled prior context via the live path (no restart). tsc + eslint clean; no test asserted the old restart-on-switch behavior.