### PR TITLE
fix(update): prepend https scheme to server-driven COS release base

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sudowork",
   "productName": "sudowork",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "新一代企业AI应用平台--AgentOPS|办公专家",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/common/systemConfig.ts
+++ b/src/common/systemConfig.ts
@@ -149,7 +149,10 @@ export function getLogReportBaseUrl(): string {
 }
 
 export function getCosReleaseBase(): string {
-  return resolve(getSystemConfigCache()?.version_update?.cos_domain, BUILD_COS_RELEASE_BASE);
+  // `cos_domain` is dispatched as a bare host (no scheme); prepend https:// so callers can
+  // fetch()/setFeedURL() it directly. Without this the URL fails to parse and update checks silently no-op.
+  const base = resolve(getSystemConfigCache()?.version_update?.cos_domain, BUILD_COS_RELEASE_BASE);
+  return /^https?:\/\//i.test(base) ? base : `https://${base}`;
 }
 
 // ---- feature-switch helpers (fail-open: cache empty => keep current behavior) ----


### PR DESCRIPTION
## 背景

存量 v0.2.8 / v0.2.9 / v0.2.10 用户无法检测到 COS 上的新版本(如 0.2.10),表现为始终"已是最新"。

## 根因

- 服务端 `/api/v1/system-config` 下发的 `version_update.cos_domain` 是**裸域名**(无 `https://`):`sudowork-release-1309794936.cos.ap-beijing.myqcloud.com`。
- `normalizeSudoworkServerUrl()` 只 trim 尾斜杠、不补 scheme,`getCosReleaseBase()` 遂返回无协议头的字符串。
- 于是两条更新路径都在「比对版本之前」就断了:
  - 手动检查:`fetch(ymlUrl)` → `Failed to parse URL` → `parseCOSYml` 返回 null → `updateAvailable: false`。
  - 自动更新:`autoUpdater.setFeedURL({ url: 无 scheme })` → electron-updater 同样失败。
- 版本比对本身(`semver.gt`)无问题。
- 首个受影响版本:**v0.2.8**(引入 server 化 base URL 的 `6d4989e8`);≤ v0.2.7 用 硬编码带 scheme 的常量,不受影响。

## 改动

- `getCosReleaseBase()`:当 resolve 出的 base 缺少 scheme 时补 `https://`。一处修复,手动 + 自动两条路同时恢复。
- bump version → 0.2.11。

## 验证

- 模拟 release 0.2.9 跑完整链路:修复后拉取 `arm64-mac.yml`(0.2.10)成功,`semver.gt(0.2.10, 0.2.9)=true`,dmg 资产 HEAD 返回 HTTP 200(271.2 MB)可下载。
- 改动文件 `eslint` + `tsc --noEmit` 均通过。

## 备注

客户端修复只覆盖未来版本(0.2.11+)。**存量 0.2.8–0.2.10 用户需服务端同步修复**:把 `cos_domain` 改成带 `https://` 的完整 URL,存量客户端下次拉配置即自动恢复,无需重装。