### PR TITLE
fix(assistant): match imported skill selections

### DIFF
--- a/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
+++ b/src/renderer/components/SettingsModal/contents/AgentModalContent.tsx
@@ -23,7 +23,7 @@ import coworkSvg from '@/renderer/assets/cowork.svg';
 import EmojiPicker from '@/renderer/components/EmojiPicker';
 import MarkdownView from '@/renderer/components/Markdown';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
-import { getSelectableAssistantSkills, isAutoInjectedBuiltinSkill, sanitizeAssistantEnabledSkills } from '@/renderer/pages/settings/assistantSkillSelection';
+import { getSelectableAssistantSkills, isAssistantSkillSelected, isAutoInjectedBuiltinSkill, sanitizeAssistantEnabledSkills, toggleAssistantSkillSelection } from '@/renderer/pages/settings/assistantSkillSelection';
 import { getInstalledSkillDisplay, normalizeSkillVersion, handleSkillIconError } from '@/renderer/utils/skillDisplay';
 import { COS_HUB_BASE } from '@/shared/cos';
 import { isElectronDesktop, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
@@ -2669,15 +2669,10 @@ const AgentModalContent: React.FC = () => {
                       <SkillCard
                         key={skill.name}
                         skill={skill}
-                        checked={selectedSkills.includes(skill.meta?.id || skill.name)}
+                        checked={isAssistantSkillSelected(selectedSkills, skill)}
                         onToggle={() => {
-                          const skillId = skill.meta?.id || skill.name;
                           if (isReadonlyAssistant) return;
-                          if (selectedSkills.includes(skillId)) {
-                            setSelectedSkills(selectedSkills.filter((s) => s !== skillId));
-                          } else {
-                            setSelectedSkills([...selectedSkills, skillId]);
-                          }
+                          setSelectedSkills(toggleAssistantSkillSelection(selectedSkills, skill));
                         }}
                         disabled={isReadonlyAssistant}
                       />
@@ -2691,15 +2686,10 @@ const AgentModalContent: React.FC = () => {
                       <SkillCard
                         key={skill.name}
                         skill={skill}
-                        checked={selectedSkills.includes(skill.meta?.id || skill.name)}
+                        checked={isAssistantSkillSelected(selectedSkills, skill)}
                         onToggle={() => {
-                          const skillId = skill.meta?.id || skill.name;
                           if (isReadonlyAssistant) return;
-                          if (selectedSkills.includes(skillId)) {
-                            setSelectedSkills(selectedSkills.filter((s) => s !== skillId));
-                          } else {
-                            setSelectedSkills([...selectedSkills, skillId]);
-                          }
+                          setSelectedSkills(toggleAssistantSkillSelection(selectedSkills, skill));
                         }}
                         disabled={isReadonlyAssistant}
                       />

--- a/src/renderer/pages/guid/components/AssistantEditDrawer.tsx
+++ b/src/renderer/pages/guid/components/AssistantEditDrawer.tsx
@@ -28,6 +28,7 @@ import EmojiPicker from '@/renderer/components/EmojiPicker';
 import MarkdownView from '@/renderer/components/Markdown';
 import coworkSvg from '@/renderer/assets/cowork.svg';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
+import { isAssistantSkillSelected, sanitizeAssistantEnabledSkills, toggleAssistantSkillSelection } from '@/renderer/pages/settings/assistantSkillSelection';
 
 type AssistantEditDrawerProps = {
   visible: boolean;
@@ -154,7 +155,6 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
         setEditDescription(found.descriptionI18n?.[localeKey] || found.description || '');
         setEditAvatar(found.avatar || '');
         setEditAgent(normalizePresetAgentType(found.presetAgentType) || DEFAULT_PRESET_AGENT_TYPE);
-        setSelectedSkills(found.enabledSkills || []);
 
         // Load rules content
         try {
@@ -172,11 +172,15 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
           try {
             const res = await skillHub.getInstalledSkills.invoke();
             if (!cancelled && res.success && res.data) {
-              setInstalledSkills(res.data.filter((s) => s.isBuiltin || s.enabled !== false));
+              const availableSkills = res.data.filter((s) => s.isBuiltin || s.enabled !== false);
+              setInstalledSkills(availableSkills);
+              setSelectedSkills(sanitizeAssistantEnabledSkills(found.enabledSkills || [], availableSkills));
             }
           } catch {
             if (!cancelled) setInstalledSkills([]);
           }
+        } else {
+          setSelectedSkills(found.enabledSkills || []);
         }
       } catch (error) {
         console.error('Failed to load assistant for editing:', error);
@@ -238,7 +242,7 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
           descriptionI18n: editDescription ? { 'zh-CN': editDescription } : undefined,
           avatar: editAvatar,
           presetAgentType: normalizePresetAgentType(editAgent) || DEFAULT_PRESET_AGENT_TYPE,
-          enabledSkills: selectedSkills,
+          enabledSkills: sanitizeAssistantEnabledSkills(selectedSkills, installedSkills),
         },
       });
 
@@ -273,7 +277,7 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
       console.error('Failed to save assistant:', error);
       Message.error(t('common.failed', { defaultValue: 'Failed' }));
     }
-  }, [assistant, isReadonly, isEnterprise, editName, editDescription, editAvatar, editAgent, editContext, selectedSkills, localeKey, onSaved, onClose, t]);
+  }, [assistant, isReadonly, isEnterprise, editName, editDescription, editAvatar, editAgent, editContext, selectedSkills, installedSkills, localeKey, onSaved, onClose, t]);
 
   const editAvatarImage = resolveAvatarImage(editAvatar);
 
@@ -406,18 +410,13 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
                     .map((skill) => {
                       const { displayName, description, icon, emoji } = getInstalledSkillDisplay(skill);
                       const displayVersion = normalizeSkillVersion(skill.version);
-                      const skillId = skill.meta?.id || skill.name;
                       return (
                         <div key={skill.name} className={`bg-fill-1 rd-12px border p-12px flex items-start gap-12px relative ${isReadonly ? 'opacity-50 cursor-not-allowed' : ''}`}>
                           <Checkbox
-                            checked={selectedSkills.includes(skillId)}
+                            checked={isAssistantSkillSelected(selectedSkills, skill)}
                             onChange={() => {
                               if (isReadonly) return;
-                              if (selectedSkills.includes(skillId)) {
-                                setSelectedSkills(selectedSkills.filter((s) => s !== skillId));
-                              } else {
-                                setSelectedSkills([...selectedSkills, skillId]);
-                              }
+                              setSelectedSkills(toggleAssistantSkillSelection(selectedSkills, skill));
                             }}
                             disabled={isReadonly}
                             className={`mt-2px ${isReadonly ? '' : 'cursor-pointer'}`}
@@ -464,18 +463,13 @@ const AssistantEditDrawer: React.FC<AssistantEditDrawerProps> = ({ visible, assi
                     .filter((s) => s.isBuiltin)
                     .map((skill) => {
                       const { displayName, description, icon, emoji } = getInstalledSkillDisplay(skill);
-                      const skillId = skill.meta?.id || skill.name;
                       return (
                         <div key={skill.name} className={`bg-fill-1 rd-12px border p-12px flex items-start gap-12px relative ${isReadonly ? 'opacity-50 cursor-not-allowed' : ''}`}>
                           <Checkbox
-                            checked={selectedSkills.includes(skillId)}
+                            checked={isAssistantSkillSelected(selectedSkills, skill)}
                             onChange={() => {
                               if (isReadonly) return;
-                              if (selectedSkills.includes(skillId)) {
-                                setSelectedSkills(selectedSkills.filter((s) => s !== skillId));
-                              } else {
-                                setSelectedSkills([...selectedSkills, skillId]);
-                              }
+                              setSelectedSkills(toggleAssistantSkillSelection(selectedSkills, skill));
                             }}
                             disabled={isReadonly}
                             className={`mt-2px ${isReadonly ? '' : 'cursor-pointer'}`}

--- a/src/renderer/pages/settings/assistantSkillSelection.ts
+++ b/src/renderer/pages/settings/assistantSkillSelection.ts
@@ -8,8 +8,39 @@ export function getSelectableAssistantSkills(installedSkills: IInstalledSkillInf
   return installedSkills.filter((skill) => !isAutoInjectedBuiltinSkill(skill) && (skill.isBuiltin || skill.enabled !== false));
 }
 
+export function getAssistantSkillId(skill: IInstalledSkillInfo): string {
+  return skill.meta?.id || skill.name;
+}
+
+export function getAssistantSkillAliases(skill: IInstalledSkillInfo): string[] {
+  return Array.from(new Set([getAssistantSkillId(skill), skill.name].filter(Boolean)));
+}
+
+export function isAssistantSkillSelected(selectedSkills: string[], skill: IInstalledSkillInfo): boolean {
+  return selectedSkills.includes(getAssistantSkillId(skill));
+}
+
+export function toggleAssistantSkillSelection(selectedSkills: string[], skill: IInstalledSkillInfo): string[] {
+  const aliases = getAssistantSkillAliases(skill);
+  if (aliases.some((alias) => selectedSkills.includes(alias))) {
+    return selectedSkills.filter((selected) => !aliases.includes(selected));
+  }
+  return [...selectedSkills, getAssistantSkillId(skill)];
+}
+
 export function sanitizeAssistantEnabledSkills(enabledSkills: string[] | undefined, installedSkills: IInstalledSkillInfo[]): string[] {
-  // Build a set of selectable skill IDs (using meta.id if available, fallback to name)
-  const selectableIds = new Set(getSelectableAssistantSkills(installedSkills).map((skill) => skill.meta?.id || skill.name));
-  return (enabledSkills || []).filter((skillId) => selectableIds.has(skillId));
+  const canonicalByAlias = new Map<string, string | null>();
+  getSelectableAssistantSkills(installedSkills).forEach((skill) => {
+    const skillId = getAssistantSkillId(skill);
+    getAssistantSkillAliases(skill).forEach((alias) => {
+      const existing = canonicalByAlias.get(alias);
+      if (existing && existing !== skillId) {
+        canonicalByAlias.set(alias, null);
+        return;
+      }
+      canonicalByAlias.set(alias, skillId);
+    });
+  });
+  const sanitized = (enabledSkills || []).map((skillId) => canonicalByAlias.get(skillId)).filter((skillId): skillId is string => typeof skillId === 'string');
+  return Array.from(new Set(sanitized));
 }

--- a/tests/unit/assistantSkillSelection.test.ts
+++ b/tests/unit/assistantSkillSelection.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { getSelectableAssistantSkills, isAutoInjectedBuiltinSkill, sanitizeAssistantEnabledSkills } from '@/renderer/pages/settings/assistantSkillSelection';
+import { getSelectableAssistantSkills, isAssistantSkillSelected, isAutoInjectedBuiltinSkill, sanitizeAssistantEnabledSkills, toggleAssistantSkillSelection } from '@/renderer/pages/settings/assistantSkillSelection';
 
 describe('assistantSkillSelection', () => {
   const installedSkills = [
@@ -29,5 +29,39 @@ describe('assistantSkillSelection', () => {
 
   it('strips only _builtin selections from persisted enabledSkills', () => {
     expect(sanitizeAssistantEnabledSkills(['cron', 'pptx', 'browser', 'system-tool', 'missing'], installedSkills)).toEqual(['pptx', 'system-tool']);
+  });
+
+  it('matches imported assistant skills stored by name when installed skills have IDs', () => {
+    const skill = {
+      name: 'jiangzhao-s1-requirement',
+      isBuiltin: false,
+      enabled: true,
+      meta: { id: 'bea928a7-75d7-4d4e-b651-61509170de85' },
+    } as any;
+
+    const sanitized = sanitizeAssistantEnabledSkills(['jiangzhao-s1-requirement'], [skill]);
+    expect(sanitized).toEqual(['bea928a7-75d7-4d4e-b651-61509170de85']);
+    expect(isAssistantSkillSelected(sanitized, skill)).toBe(true);
+    expect(toggleAssistantSkillSelection(['jiangzhao-s1-requirement'], skill)).toEqual([]);
+  });
+
+  it('does not map skill names when duplicate installed skills share the same name', () => {
+    const duplicateSkills = [
+      {
+        name: 'jiangzhao-s1-requirement',
+        isBuiltin: false,
+        enabled: true,
+        meta: { id: 'bea928a7-75d7-4d4e-b651-61509170de85' },
+      },
+      {
+        name: 'jiangzhao-s1-requirement',
+        isBuiltin: false,
+        enabled: true,
+        meta: { id: '11111111-2222-3333-4444-555555555555' },
+      },
+    ] as any;
+
+    expect(sanitizeAssistantEnabledSkills(['jiangzhao-s1-requirement'], duplicateSkills)).toEqual([]);
+    expect(sanitizeAssistantEnabledSkills(['11111111-2222-3333-4444-555555555555'], duplicateSkills)).toEqual(['11111111-2222-3333-4444-555555555555']);
   });
 });


### PR DESCRIPTION
## Summary
- support matching imported assistant skill selections by canonical skill ID after resolving legacy skill names
- keep Guide and Settings assistant editors consistent when rendering selected skills
- avoid mapping ambiguous duplicate skill names to the wrong installed skill

## Tests
- bunx vitest run tests/unit/assistantSkillSelection.test.ts
- bunx tsc --noEmit
- bunx eslint src/renderer/pages/settings/assistantSkillSelection.ts src/renderer/components/SettingsModal/contents/AgentModalContent.tsx src/renderer/pages/guid/components/AssistantEditDrawer.tsx tests/unit/assistantSkillSelection.test.ts --fix