### PR TITLE
feat(conversation): resource reaper SSOT + boot orphan sweep

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -99,6 +99,39 @@ jobs:
         # their skillhub token wasn't provisioned.
         run: bunx vitest run tests/unit/hubErrors.test.ts tests/unit/HubEmptyState.dom.test.tsx
 
+  # Job 2c: Conversation resource reaper regression tests
+  unit-tests-conversation-reaper:
+    name: Conversation Reaper Unit Tests
+    if: github.event.action != 'edited'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --no-frozen-lockfile
+
+      - name: Run conversation reaper tests
+        # Guards the conversation-lifecycle cleanup SSOT against regression:
+        # reaper step order + workspace-deletion guard (never delete a user
+        # asset), boot orphan sweeper (referenced kept / aged orphan swept /
+        # fresh skipped), preset-uninstall routing through the reaper, and the
+        # leaked-cache disposers (message timer, telemetry discard). All mocked
+        # / tmp-dir based — no native deps or display. Encodes the behaviors
+        # verified end-to-end against the live app.
+        run: bunx vitest run tests/integration/conversationReaper.test.ts tests/integration/orphanWorkspaceSweeper.test.ts tests/integration/assistantHubUninstallReaper.test.ts tests/unit/conversationTrackerDiscard.test.ts tests/unit/messageDispose.test.ts
+
   # Job 3: Build test across all platforms (parallel with code-quality and unit-tests)
   build-test:
     name: Build Test (${{ matrix.platform }})

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -78,6 +78,10 @@ export const conversation = {
   get: bridge.buildProvider<TChatConversation | undefined, { id: string }>('get-conversation'), // 获取对话信息
   getAssociateConversation: bridge.buildProvider<TChatConversation[], { conversation_id: string }>('get-associated-conversation'), // 获取关联对话
   remove: bridge.buildProvider<boolean, { id: string; deleteWorkspace?: boolean }>('remove-conversation'), // 删除对话
+  // Broadcast from main after a conversation is reaped (all resources released). SSOT
+  // cleanup signal so renderer-side caches can drop their entries regardless of which
+  // delete path (user-delete / assistant-uninstall) triggered it.
+  reaped: bridge.buildEmitter<{ id: string }>('conversation.reaped'),
   update: bridge.buildProvider<boolean, { id: string; updates: Partial<TChatConversation>; mergeExtra?: boolean }>('update-conversation'), // 更新对话信息
   reset: bridge.buildProvider<void, IResetConversationParams>('reset-conversation'), // 重置对话
   stop: bridge.buildProvider<IBridgeResponse<{}>, { conversation_id: string }>('chat.stop.stream'), // 停止会话

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -8,8 +8,8 @@ import fsSync from 'fs';
 import path from 'path';
 import https from 'node:https';
 import http from 'node:http';
-import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import JSZip from 'jszip';
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { ipcBridge } from '@/common';
 import type { IAssistantHubSkill, IAssistantHubListResponse, IAssistantHubDetail, IAssistantInstallResult, ISkillHubSkill, IBridgeResponse, IAssistantHubVersionLike } from '@/common/ipcBridge';
 import { assistantManager } from '@/process/AssistantManager';
@@ -22,6 +22,7 @@ import { ASSISTANTS_ROOT_DIR, ENTERPRISE_ASSISTANT_SUBDIRS } from '@/process/con
 import { getSkillHubBaseUrl } from '@/common/systemConfig';
 import { getSkillhubToken } from '@/process/credentialsCache';
 import { tokenMissingResponse } from '@common/nexus/hubErrors';
+import { reapConversation } from '@/process/services/conversationReaper';
 
 const { existsSync } = fsSync;
 
@@ -294,30 +295,41 @@ export function initAssistantHubBridge(): void {
   });
 
   ipcBridge.assistantHub.uninstallAssistant.provider(async ({ name, category }) => {
-    // Delete associated conversations before uninstalling assistant
+    // Reap associated conversations before uninstalling assistant. This must go
+    // through the reaper SSOT (not a raw DB delete) so live agent processes,
+    // terminals, cron, channel sessions, Moss sessions and workspace dirs are
+    // released — the old raw delete leaked all of them.
     const deletedConversationIds: string[] = [];
     try {
       const db = getDatabase();
-      // The presetAssistantId stored in conversation.extra matches the assistant's name/id
-      // Try both the original name and with 'builtin-' prefix stripped
+      // The presetAssistantId stored in conversation.extra matches the assistant's name/id.
+      // Match both the original name and the 'builtin-' prefix-stripped id.
       const presetAssistantId = name.startsWith('builtin-') ? name.slice('builtin-'.length) : name;
-      const deleteResult = db.deleteConversationsByPresetAssistantId(name);
-      if (!deleteResult.success) {
-        mainWarn('AssistantHub', `Failed to delete associated conversations: ${deleteResult.error}`);
-      } else if (deleteResult.data?.count > 0) {
-        mainLog('AssistantHub', `Deleted ${deleteResult.data.count} conversations associated with assistant ${name}`);
-        deletedConversationIds.push(...deleteResult.data.conversationIds);
-        // Also try deleting with stripped prefix if different
-        if (presetAssistantId !== name) {
-          const altResult = db.deleteConversationsByPresetAssistantId(presetAssistantId);
-          if (altResult.success && altResult.data?.count > 0) {
-            mainLog('AssistantHub', `Deleted additional ${altResult.data.count} conversations with stripped prefix ${presetAssistantId}`);
-            deletedConversationIds.push(...altResult.data.conversationIds);
-          }
+      const idsToReap = new Set<string>();
+      const collect = (key: string) => {
+        const found = db.findConversationIdsByPresetAssistantId(key);
+        if (!found.success) {
+          mainWarn('AssistantHub', `Failed to find associated conversations for ${key}: ${found.error}`);
+          return;
+        }
+        found.data?.conversationIds.forEach((cid) => idsToReap.add(cid));
+      };
+      collect(name);
+      if (presetAssistantId !== name) {
+        collect(presetAssistantId);
+      }
+
+      for (const cid of idsToReap) {
+        const res = await reapConversation(cid, { reason: 'assistant-uninstall' });
+        if (res.dbDeleted) {
+          deletedConversationIds.push(cid);
         }
       }
+      if (deletedConversationIds.length > 0) {
+        mainLog('AssistantHub', `Reaped ${deletedConversationIds.length} conversations associated with assistant ${name}`);
+      }
     } catch (dbError) {
-      mainWarn('AssistantHub', 'Error deleting associated conversations:', dbError);
+      mainWarn('AssistantHub', 'Error reaping associated conversations:', dbError);
     }
 
     const result = await assistantManager.uninstallAssistant(name, category);

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -9,8 +9,12 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import fs from 'fs/promises';
 import { getDatabase } from '@process/database';
-import { cronService } from '@process/services/cron/CronService';
 import { mainError, mainLog, mainWarn } from '@process/utils/mainLogger';
+import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
+import type { IDirOrFile, MossSessionAvailableSkill, MossWorkspaceNode } from '@/common/ipcBridge';
+import type { TChatConversation } from '@/common/storage';
+import { getSudoworkAcpSlashCommands } from '@/common/slash/sudoworkCommands';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { ipcBridge } from '../../common';
 import { uuid } from '../../common/utils';
 import { shouldSyncWorkspaceSkills } from '../../common/utils/workspaceSkillSync';
@@ -30,14 +34,8 @@ import { ConversationManageWithDB } from '../message';
 import { startConversationTracking, endConversationSuccess, endConversationError } from '../telemetry';
 import { getConversationProvider, isRemoteProvider } from '../providers';
 import { getMossApi, getMossApiServerUrl, initMossApi } from '../remote/MossSessionApi';
-import { closeBrowserTabsByConversation } from './browserPanelBridge';
-import { closeTerminalsByConversation } from './terminalBridge';
+import { reapConversation } from '../services/conversationReaper';
 import { migrateConversationToDatabase } from './migrationUtils';
-import { setupChannelResponseRouting } from '@/channels/agent/ChannelResponseRouter';
-import type { IDirOrFile, MossSessionAvailableSkill, MossWorkspaceNode } from '@/common/ipcBridge';
-import type { TChatConversation } from '@/common/storage';
-import { getSudoworkAcpSlashCommands } from '@/common/slash/sudoworkCommands';
-import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 
 const workspaceSkillSyncTasks = new Map<string, Promise<void>>();
 
@@ -464,86 +462,10 @@ export function initConversationBridge(): void {
 
   ipcBridge.conversation.remove.provider(async ({ id, deleteWorkspace }) => {
     try {
-      // Get conversation to check source before deletion
-      const db = getDatabase();
-      const convResult = db.getConversation(id);
-      const conversation = convResult.data;
-      const source = conversation?.source;
-      const workspacePath = (conversation?.extra as { workspace?: string } | undefined)?.workspace;
-      const isCronExecutionConversation = !!(conversation?.extra as { cronJobId?: string } | undefined)?.cronJobId;
-
-      // Kill the running task if exists
-      WorkerManage.kill(id);
-
-      // Reap any right-panel terminals tied to this conversation. Call the
-      // function directly — bridge.invoke from main → main does NOT route to
-      // the local provider (main adapter's emit only broadcasts to renderers).
-      try {
-        closeTerminalsByConversation(id);
-      } catch (err) {
-        mainWarn('conversationBridge', 'closeTerminalsByConversation failed', err);
-      }
-
-      // Reap any right-panel BrowserPanel tabs tied to this conversation.
-      // Same direct-call pattern as closeTerminalsByConversation. The
-      // function also broadcasts rightPanelBrowser.convClosed so the
-      // renderer-side BrowserPanel can drop its module-level state for
-      // this conv.
-      try {
-        closeBrowserTabsByConversation(id);
-      } catch (err) {
-        mainWarn('conversationBridge', 'closeBrowserTabsByConversation failed', err);
-      }
-
-      // Delete associated cron jobs
-      try {
-        if (!isCronExecutionConversation) {
-          const jobs = await cronService.listJobsByConversation(id);
-          for (const job of jobs) {
-            await cronService.removeJob(job.id);
-            ipcBridge.cron.onJobRemoved.emit({ jobId: job.id });
-          }
-        }
-      } catch (cronError) {
-        mainWarn('conversationBridge', 'Failed to cleanup cron jobs:', cronError);
-      }
-
-      // If source is not 'sudowork' (e.g., telegram), cleanup channel resources
-      if (source && source !== 'sudowork') {
-        try {
-          const { getChannelManager } = await import('@/channels/core/ChannelManager');
-          const channelManager = getChannelManager();
-          if (channelManager.isInitialized()) {
-            await channelManager.cleanupConversation(id);
-            mainLog('conversationBridge', `Cleaned up channel resources for ${source} conversation ${id}`);
-          }
-        } catch (cleanupError) {
-          mainWarn('conversationBridge', 'Failed to cleanup channel resources:', cleanupError);
-        }
-      }
-
-      // Delete workspace folder if requested
-      // 如果用户选择了同时删除工作区文件夹，则删除
-      if (deleteWorkspace && workspacePath) {
-        try {
-          await fs.rm(workspacePath, { recursive: true, force: true });
-          mainLog('conversationBridge', `Deleted workspace folder: ${workspacePath}`);
-        } catch (workspaceError) {
-          mainWarn('conversationBridge', `Failed to delete workspace folder ${workspacePath}:`, workspaceError);
-        }
-      }
-
-      // Use Provider abstraction layer for deletion (will cascade delete messages due to foreign key)
-      // 使用 Provider 抽象层删除会话（由于外键约束会级联删除消息）
-      const provider = getConversationProvider();
-      const success = await provider.deleteConversation(id);
-
-      if (!success) {
-        mainError('conversationBridge', 'Failed to delete conversation');
-        return false;
-      }
-
-      return true;
+      // Route all cleanup through the reaper SSOT so every resource this
+      // conversation owns is released in one ordered, DRY path.
+      const res = await reapConversation(id, { reason: 'user-delete', deleteWorkspace });
+      return res.dbDeleted;
     } catch (error) {
       mainError('conversationBridge', 'Failed to remove conversation:', error);
       return false;

--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -1347,6 +1347,25 @@ export class SudoworkDatabase {
   }
 
   /**
+   * Find the ids of all conversations associated with a specific preset assistant.
+   * Read-only; used by the reaper path so the actual delete goes through
+   * reapConversation (which releases every resource, not just DB rows).
+   *
+   * @param presetAssistantId - The assistant ID (UUID or name) to match against extra.presetAssistantId
+   * @returns Query result with the matched conversation ids
+   */
+  findConversationIdsByPresetAssistantId(presetAssistantId: string): IQueryResult<{ conversationIds: string[] }> {
+    try {
+      const findStmt = this.db.prepare(`SELECT id FROM conversations WHERE json_extract(extra, '$.presetAssistantId') = ?`);
+      const rows = findStmt.all(presetAssistantId) as Array<{ id: string }>;
+      return { success: true, data: { conversationIds: rows.map((r) => r.id) } };
+    } catch (error: any) {
+      mainError('Database', 'Failed to find conversations by presetAssistantId:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  /**
    * Delete all conversations associated with a specific preset assistant.
    * Used when deleting a custom assistant to cleanup related conversations.
    *

--- a/src/process/initStorage.ts
+++ b/src/process/initStorage.ts
@@ -1143,6 +1143,14 @@ const initStorage = async () => {
     try {
       getDatabase();
       cleanupOrphanedHealthCheckConversations();
+      // Reconcile leftover `-temp-` workspace dirs with no owning conversation.
+      // Fire-and-forget so boot latency is unaffected. Dynamic import avoids a
+      // load-time cycle (the sweeper reads getSystemDir from this module).
+      void import('./services/orphanWorkspaceSweeper')
+        .then(({ sweepOrphanWorkspaces }) => sweepOrphanWorkspaces())
+        .catch((error) => {
+          mainWarn('Sudowork', 'Orphan workspace sweep failed:', error);
+        });
     } catch (error) {
       mainError('InitStorage', 'Database initialization failed, falling back to file-based storage:', error);
       // The DB layer recovers from file corruption on its own, so reaching here means an

--- a/src/process/message.ts
+++ b/src/process/message.ts
@@ -7,9 +7,9 @@
 import type { TMessage } from '@/common/chatLib';
 import { composeMessage } from '@/common/chatLib';
 import type { AcpBackend } from '@/types/acpTypes';
+import { mainWarn, mainError } from '@process/utils/mainLogger';
 import { getDatabase } from './database/export';
 import { ProcessChat } from './initStorage';
-import { mainWarn, mainError } from '@process/utils/mainLogger';
 
 const Cache = new Map<string, ConversationManageWithDB>();
 
@@ -92,7 +92,30 @@ export class ConversationManageWithDB {
     this.save2DataBase();
     return this.savePromise;
   }
+
+  /**
+   * Release timers and drop the pending write stack without flushing.
+   * Called when the conversation is being reaped — any un-saved messages are
+   * irrelevant because the conversation (and its rows) are about to be deleted.
+   */
+  public dispose(): void {
+    clearTimeout(this.timer);
+    this.stack = [];
+  }
 }
+
+/**
+ * Dispose the in-memory ConversationManageWithDB cache entry for a conversation.
+ * Clears its pending-save timer and removes it from the module cache so the
+ * timer + db handle are not leaked after the conversation is deleted.
+ */
+export const disposeConversation = (conversation_id: string): void => {
+  const manage = Cache.get(conversation_id);
+  if (manage) {
+    manage.dispose();
+    Cache.delete(conversation_id);
+  }
+};
 
 /**
  * Add a new message to the database

--- a/src/process/providers/RemoteConversationProvider.ts
+++ b/src/process/providers/RemoteConversationProvider.ts
@@ -9,13 +9,13 @@ import WorkerManage from '@process/WorkerManage';
 import { initMossApi, type MossSessionApi } from '@process/remote/MossSessionApi';
 import { mainLog, mainError } from '@process/utils/mainLogger';
 import { ProcessConfig } from '@process/initStorage';
-import type { IConversationProvider, IProviderConfig } from './types';
 import type { TChatConversation } from '@/common/storage';
 import type { TMessage } from '@/common/chatLib';
 import type { ICreateConversationParams, IBridgeResponse, ISendMessageParams } from '@/common/ipcBridge';
 import type { AcpModelInfo } from '@/types/acpTypes';
 import { uuid } from '@/common/utils';
 import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
+import type { IConversationProvider, IProviderConfig } from './types';
 
 const HIDDEN_CRON_SESSIONS_KEY = 'remote.hiddenCronSessionIds';
 
@@ -275,6 +275,10 @@ export class RemoteConversationProvider implements IConversationProvider {
         mainError('RemoteProvider', `Failed to delete conversation from local DB: ${result.error}`);
         return false;
       }
+
+      // Drop cached model info so the entry does not leak after deletion
+      // 删除后清理缓存的模型信息，避免泄漏
+      this.cachedModelInfo.delete(id);
 
       mainLog('RemoteProvider', `Deleted conversation ${id} from local DB`);
       return true;

--- a/src/process/services/conversationReaper.ts
+++ b/src/process/services/conversationReaper.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Conversation Resource Reaper — the SSOT for releasing every resource a
+ * conversation owns (DB rows, agent child process, terminals, browser tabs,
+ * cron jobs, channel session, Moss remote session, in-memory caches and the
+ * auto workspace directory on disk).
+ *
+ * Every conversation-lifecycle trigger (user delete, preset-assistant
+ * uninstall, orphan sweep) routes through {@link reapConversation} so there is
+ * a single, ordered, DRY cleanup path — whatever a caller forgets can no longer
+ * leak.
+ *
+ * Step order: process → in-memory → DB/external → filesystem → renderer. The
+ * filesystem removal runs LAST (after the process is dead and the row is gone)
+ * so a crash mid-rm leaves a boot-sweepable orphan dir, never a dangling row.
+ * Each step runs in its own try/catch and records failures into `errors[]`; one
+ * failing step never aborts the rest.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { getDatabase } from '@process/database';
+import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { ipcBridge } from '@/common';
+import type { TChatConversation } from '@/common/storage';
+import WorkerManage from '../WorkerManage';
+import { closeTerminalsByConversation } from '../bridge/terminalBridge';
+import { closeBrowserTabsByConversation } from '../bridge/browserPanelBridge';
+import { disposeConversation } from '../message';
+import { stopConversationTracking } from '../telemetry';
+import { getConversationProvider } from '../providers';
+import { getSystemDir } from '../initStorage';
+import { TEMP_WORKSPACE_REGEX } from '../task/draftsCleanup';
+import { cronService } from './cron/CronService';
+
+export type ReapReason = 'user-delete' | 'assistant-uninstall' | 'orphan-sweep' | 'healthcheck-cleanup';
+
+export interface ReapOptions {
+  reason: ReapReason;
+  /**
+   * Tri-state workspace disposition:
+   * - `true`  → explicit request (checkbox); delete the workspace folder.
+   * - `false` → keep the workspace folder.
+   * - `undefined` → resolve from `extra.customWorkspace`: auto scratch
+   *   (`customWorkspace === false`) is deleted silently, a user-selected folder
+   *   (`customWorkspace === true`) is kept.
+   */
+  deleteWorkspace?: boolean;
+  /** Skip the DB + external delete (caller already removed the row). */
+  skipDbDelete?: boolean;
+  /** Pre-resolved conversation to avoid a redundant DB read. */
+  conversation?: TChatConversation;
+}
+
+export interface ReapResult {
+  id: string;
+  dbDeleted: boolean;
+  workspaceDeleted: boolean;
+  workspacePath?: string;
+  errors: Array<{ step: string; error: unknown }>;
+}
+
+type ReapExtra = NonNullable<TChatConversation['extra']> & {
+  workspace?: string;
+  customWorkspace?: boolean;
+  cronJobId?: string;
+};
+
+/**
+ * Decide whether the workspace directory may be removed. A user asset can never
+ * be auto-deleted even if `customWorkspace` was mis-set: the auto-resolve branch
+ * additionally requires the path to structurally match an auto temp workspace
+ * (directly under workDir, `<backend>-temp-<ts>` basename).
+ */
+function resolveWorkspaceDeletion(workspacePath: string | undefined, customWorkspace: boolean | undefined, deleteWorkspace: boolean | undefined): boolean {
+  if (!workspacePath) return false;
+
+  const resolved = path.resolve(workspacePath);
+  const workDir = path.resolve(getSystemDir().workDir);
+
+  // Never remove the workDir root itself or a filesystem root.
+  if (resolved === workDir || path.dirname(resolved) === resolved) return false;
+
+  if (deleteWorkspace === true) {
+    // Explicit user request (checkbox). Honor it for both custom folders and auto scratch.
+    return true;
+  }
+  if (deleteWorkspace === false) return false;
+
+  // undefined → auto-resolve. Only disposable auto scratch dirs, and only if the
+  // path really is one (defensive guard against a mis-set customWorkspace flag).
+  const isAutoPath = path.dirname(resolved) === workDir && TEMP_WORKSPACE_REGEX.test(path.basename(resolved));
+  return customWorkspace === false && isAutoPath;
+}
+
+/**
+ * Release every resource owned by a conversation. See module docs for step order.
+ */
+export async function reapConversation(id: string, opts: ReapOptions): Promise<ReapResult> {
+  const result: ReapResult = { id, dbDeleted: false, workspaceDeleted: false, errors: [] };
+  const runStep = async (step: string, fn: () => void | Promise<void>): Promise<void> => {
+    try {
+      await fn();
+    } catch (error) {
+      result.errors.push({ step, error });
+      mainWarn('ConversationReaper', `[${opts.reason}] step "${step}" failed for ${id}:`, error);
+    }
+  };
+
+  // 1. Resolve conversation + derive its resource handles.
+  let conversation = opts.conversation;
+  if (!conversation) {
+    try {
+      const convResult = getDatabase().getConversation(id);
+      conversation = convResult.data ?? undefined;
+    } catch (error) {
+      result.errors.push({ step: 'resolve', error });
+    }
+  }
+
+  const extra = conversation?.extra as ReapExtra | undefined;
+  const source = conversation?.source;
+  const workspacePath = extra?.workspace;
+  const isCronExecutionConversation = !!extra?.cronJobId;
+  result.workspacePath = workspacePath;
+
+  if (!conversation) {
+    mainWarn('ConversationReaper', `[${opts.reason}] conversation ${id} not found; nothing to reap`);
+    return result;
+  }
+
+  // 2. Kill the running agent task FIRST so it releases dir handles before rm
+  //    (Windows EBUSY). Use kill(), NOT clear() — clear() detaches remote-agent
+  //    and leaves Moss alive, which is app-exit semantics only.
+  await runStep('kill-worker', () => {
+    WorkerManage.kill(id);
+  });
+
+  // 3. Right-panel terminals.
+  await runStep('close-terminals', () => {
+    closeTerminalsByConversation(id);
+  });
+
+  // 4. Right-panel browser tabs.
+  await runStep('close-browser-tabs', () => {
+    closeBrowserTabsByConversation(id);
+  });
+
+  // 5. Cron jobs owned by this conversation (skip conversations that were
+  //    themselves created by a cron run).
+  if (!isCronExecutionConversation) {
+    await runStep('cron', async () => {
+      const jobs = await cronService.listJobsByConversation(id);
+      for (const job of jobs) {
+        await cronService.removeJob(job.id);
+        ipcBridge.cron.onJobRemoved.emit({ jobId: job.id });
+      }
+    });
+  }
+
+  // 6. Channel resources (telegram / lark / dingtalk sessions).
+  if (source && source !== 'sudowork') {
+    await runStep('channel', async () => {
+      const { getChannelManager } = await import('@/channels/core/ChannelManager');
+      const channelManager = getChannelManager();
+      if (channelManager.isInitialized()) {
+        await channelManager.cleanupConversation(id);
+        mainLog('ConversationReaper', `Cleaned up channel resources for ${source} conversation ${id}`);
+      }
+    });
+  }
+
+  // 7. In-memory disposers for caches that are otherwise never reaped.
+  await runStep('dispose-message-cache', () => {
+    disposeConversation(id);
+  });
+  await runStep('stop-telemetry-tracking', () => {
+    stopConversationTracking(id);
+  });
+
+  // 8. DB + external delete (cascades messages; remote provider also terminates
+  //    the Moss session best-effort and clears cachedModelInfo).
+  if (!opts.skipDbDelete) {
+    await runStep('db-delete', async () => {
+      const provider = getConversationProvider();
+      const success = await provider.deleteConversation(id);
+      result.dbDeleted = success;
+      if (!success) {
+        mainError('ConversationReaper', `[${opts.reason}] provider.deleteConversation returned false for ${id}`);
+      }
+    });
+  }
+
+  // 9. Workspace removal LAST (process dead + row gone).
+  if (resolveWorkspaceDeletion(workspacePath, extra?.customWorkspace, opts.deleteWorkspace)) {
+    await runStep('workspace-rm', async () => {
+      await fs.rm(workspacePath as string, { recursive: true, force: true });
+      result.workspaceDeleted = true;
+      mainLog('ConversationReaper', `[${opts.reason}] deleted workspace folder: ${workspacePath}`);
+    });
+  }
+
+  // 10. Consolidated broadcast so renderer-side caches drop their entries.
+  await runStep('emit-reaped', () => {
+    ipcBridge.conversation.reaped.emit({ id });
+  });
+
+  return result;
+}

--- a/src/process/services/orphanWorkspaceSweeper.ts
+++ b/src/process/services/orphanWorkspaceSweeper.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Boot orphan workspace sweeper.
+ *
+ * Auto workspace scratch dirs (`~/.nexus/<backend>-temp-<ts>/`) are removed when
+ * their conversation is reaped, but a crash mid-reap (or a pre-reaper build) can
+ * leave a `-temp-` dir on disk with no owning conversation. Nothing else ever
+ * reconciles these, so they accumulate. This sweeper runs once at boot and
+ * removes temp dirs directly under the work dir that no live conversation
+ * references.
+ *
+ * Safety guards: only regex-matching dirs directly under the work dir are ever
+ * candidates (user-selected custom workspaces live outside it); a dir younger
+ * than {@link FRESH_THRESHOLD_MS} is skipped (createAcpAgent mkdir's the temp dir
+ * *before* the DB row exists, so a brand-new dir may legitimately have no row
+ * yet); and a path referenced by any live conversation is never deleted.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { getDatabase } from '@process/database';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import { getSystemDir } from '../initStorage';
+import { TEMP_WORKSPACE_REGEX } from '../task/draftsCleanup';
+
+/** A dir younger than this is skipped — its DB row may not exist yet. */
+const FRESH_THRESHOLD_MS = 60_000;
+
+/** Collect the resolved workspace paths of every conversation that has one. */
+function collectLiveWorkspaces(): Set<string> {
+  const live = new Set<string>();
+  const db = getDatabase();
+  const pageSize = 1000;
+  let page = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const result = db.getUserConversations(undefined, page, pageSize);
+    result.data.forEach((conversation) => {
+      const workspace = (conversation.extra as { workspace?: string } | undefined)?.workspace;
+      if (workspace) {
+        live.add(path.resolve(workspace));
+      }
+    });
+    hasMore = result.hasMore;
+    page += 1;
+  }
+
+  return live;
+}
+
+export async function sweepOrphanWorkspaces(): Promise<{ scanned: number; deleted: string[] }> {
+  const deleted: string[] = [];
+  let scanned = 0;
+
+  const root = path.resolve(getSystemDir().workDir);
+
+  let entries: import('fs').Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (error) {
+    mainWarn('OrphanWorkspaceSweeper', `Failed to read work dir ${root}:`, error);
+    return { scanned, deleted };
+  }
+
+  const tempDirs = entries.filter((entry) => entry.isDirectory() && TEMP_WORKSPACE_REGEX.test(entry.name));
+  if (tempDirs.length === 0) {
+    return { scanned, deleted };
+  }
+
+  const live = collectLiveWorkspaces();
+  const now = Date.now();
+
+  for (const entry of tempDirs) {
+    scanned += 1;
+    const dirPath = path.join(root, entry.name);
+
+    // Never delete a path a live conversation still references.
+    if (live.has(path.resolve(dirPath))) continue;
+
+    try {
+      const stat = await fs.stat(dirPath);
+      // Skip fresh dirs — createAcpAgent mkdir's before the DB row is written.
+      if (now - stat.mtimeMs < FRESH_THRESHOLD_MS) continue;
+
+      await fs.rm(dirPath, { recursive: true, force: true });
+      deleted.push(dirPath);
+    } catch (error) {
+      mainWarn('OrphanWorkspaceSweeper', `Failed to sweep orphan workspace ${dirPath}:`, error);
+    }
+  }
+
+  if (deleted.length > 0) {
+    mainLog('OrphanWorkspaceSweeper', `Swept ${deleted.length} orphan workspace dir(s) of ${scanned} scanned`);
+  }
+
+  return { scanned, deleted };
+}

--- a/src/process/task/draftsCleanup.ts
+++ b/src/process/task/draftsCleanup.ts
@@ -13,12 +13,12 @@
  * directly to the workspace root instead of .drafts/.
  */
 
-import { DRAFTS_DIR_ALIASES, DRAFTS_DIR_NAME } from '@/common/constants';
-import { mainLog, mainError } from '@process/utils/mainLogger';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 import type { Dirent } from 'fs';
 import path from 'path';
+import { mainLog, mainError } from '@process/utils/mainLogger';
+import { DRAFTS_DIR_ALIASES, DRAFTS_DIR_NAME } from '@/common/constants';
 import { FileIntentClassifier, detectFileIntent, matchesDraftPattern, matchesFinalPattern, type FileIntent, type FileIntentSource } from './FileIntentClassifier';
 
 /**
@@ -425,7 +425,7 @@ export async function cleanupTrackedDraftsOnCancel(workspace: string, trackedFil
  * Matches any workspace ending with -temp- followed by digits (Unix timestamp)
  * Examples: scode-temp-1234567890, sudoclaw-temp-1234567890, claude-temp-1234567890
  */
-const TEMP_WORKSPACE_REGEX = /-temp-\d+$/;
+export const TEMP_WORKSPACE_REGEX = /-temp-\d+$/;
 
 /**
  * Check if a directory name is a temporary workspace

--- a/src/process/telemetry/ConversationTracker.ts
+++ b/src/process/telemetry/ConversationTracker.ts
@@ -14,8 +14,8 @@
  * - Token 消耗
  */
 
-import { getTelemetryReporter } from './TelemetryBatchReporter';
 import type { ConversationStatus, ConversationData, ModelProvider } from '../../shared/types/telemetry';
+import { getTelemetryReporter } from './TelemetryBatchReporter';
 
 // ============================================================
 // 类型定义
@@ -177,6 +177,23 @@ export class ConversationTracker {
   }
 
   /**
+   * 丢弃对话追踪状态而不上报
+   *
+   * Drop the tracking state without emitting a telemetry record. Used when a
+   * conversation is reaped (deleted) mid-flight — we don't want a spurious
+   * conversation event for a deletion.
+   *
+   * NOTE: the map is keyed by the value passed to startConversationTracking,
+   * which today is the conversation id (see AcpAgent.ts). Callers pass the
+   * conversation id here.
+   *
+   * @param sessionId - 会话 ID（实为 conversation id）
+   */
+  public discardConversation(sessionId: string): void {
+    this.activeConversations.delete(sessionId);
+  }
+
+  /**
    * 获取活跃对话数量
    */
   public getActiveCount(): number {
@@ -223,4 +240,9 @@ export const endConversationError = (sessionId: string, errorCode?: string): voi
 /** 结束对话 - 用户取消 */
 export const endConversationUserCancel = (sessionId: string): void => {
   getConversationTracker().endConversationUserCancel(sessionId);
+};
+
+/** 停止对话追踪（不上报，用于会话被删除时）/ Stop tracking without reporting (used when conversation is reaped) */
+export const stopConversationTracking = (sessionId: string): void => {
+  getConversationTracker().discardConversation(sessionId);
 };

--- a/src/process/telemetry/index.ts
+++ b/src/process/telemetry/index.ts
@@ -22,7 +22,38 @@ import { getSudoLogTelemetryReporter } from './SudoLogTelemetryReporter';
 // 类型导出
 // ============================================================
 
-export type { TelemetryPlatform, TelemetryArch, TelemetryEventType, PerfMetricType, ConversationStatus, TurnStatus, StepStatus, StepType, InstallStatus, InstallType, ModelProvider, AgentType, LoginMode, TelemetryErrorCode, PerfData, ConversationData, TurnData, StepData, InstallData, TelemetryEventBase, PerfTelemetryEvent, ConversationTelemetryEvent, TurnTelemetryEvent, StepTelemetryEvent, InstallTelemetryEvent, TelemetryEvent, TelemetryBatchRequest, TelemetryBatchResponse, TelemetryConfig, StoredTelemetryEvent } from '../../shared/types/telemetry';
+export type {
+  TelemetryPlatform,
+  TelemetryArch,
+  TelemetryEventType,
+  PerfMetricType,
+  ConversationStatus,
+  TurnStatus,
+  StepStatus,
+  StepType,
+  InstallStatus,
+  InstallType,
+  ModelProvider,
+  AgentType,
+  LoginMode,
+  TelemetryErrorCode,
+  PerfData,
+  ConversationData,
+  TurnData,
+  StepData,
+  InstallData,
+  TelemetryEventBase,
+  PerfTelemetryEvent,
+  ConversationTelemetryEvent,
+  TurnTelemetryEvent,
+  StepTelemetryEvent,
+  InstallTelemetryEvent,
+  TelemetryEvent,
+  TelemetryBatchRequest,
+  TelemetryBatchResponse,
+  TelemetryConfig,
+  StoredTelemetryEvent,
+} from '../../shared/types/telemetry';
 
 export { DEFAULT_TELEMETRY_CONFIG, ERROR_CODE_DESCRIPTION, mapElectronArch } from '../../shared/types/telemetry';
 
@@ -36,7 +67,7 @@ export { SudoLogTelemetryReporter, getSudoLogTelemetryReporter, initSudoLogTelem
 
 export { PerfTracker, getPerfTracker, markAppStart, markFirstWindowShow, markRendererReady, startPerfTiming, endPerfTiming, recordFirstToken, flushPerfCachedMetrics, PERF_METRICS } from './PerfTracker';
 
-export { ConversationTracker, getConversationTracker, startConversationTracking, updateConversationTokens, endConversationSuccess, endConversationError, endConversationUserCancel } from './ConversationTracker';
+export { ConversationTracker, getConversationTracker, startConversationTracking, updateConversationTokens, endConversationSuccess, endConversationError, endConversationUserCancel, stopConversationTracking } from './ConversationTracker';
 
 export { InstallTracker, getInstallTracker, initInstallTracking, markInstallSuccess, markInstallFailed, getInstallId, getInstallType } from './InstallTracker';
 

--- a/src/renderer/hooks/useSlashCommands.ts
+++ b/src/renderer/hooks/useSlashCommands.ts
@@ -23,6 +23,14 @@ function getCachedCommands(conversationId: string): SlashCommandItem[] | null {
   return entry.commands;
 }
 
+/**
+ * Drop the cached slash-command entry for a conversation. Called when a
+ * conversation is reaped so the module-level cache does not leak the entry.
+ */
+export function dropSlashCommandCache(conversationId: string): void {
+  slashCommandCache.delete(conversationId);
+}
+
 function setCachedCommands(conversationId: string, commands: SlashCommandItem[]): void {
   // LRU eviction if cache is full
   if (slashCommandCache.size >= MAX_CACHE_SIZE) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -17,6 +17,7 @@ import Router from '@renderer/router';
 import { ErrorBoundary } from '@renderer/components/ErrorBoundary';
 import { ipcBridge } from '@/common';
 import { fetchSystemConfig, isProductImprovementEnabled, type SystemConfig } from '@/common/systemConfig';
+import { dropSlashCommandCache } from '@renderer/hooks/useSlashCommands';
 
 /**
  * Fetch systemConfig in the renderer AND push the snapshot to the main process so the
@@ -68,6 +69,26 @@ const Main = () => {
         });
     }
   }, [initReady, isEnterprise, isOptInChecked]);
+
+  // Global cleanup on the consolidated conversation.reaped broadcast from main.
+  // This covers every delete path (user-delete AND preset-assistant uninstall,
+  // the latter never touching the renderer delete hook), so renderer-side caches
+  // are dropped regardless of how the conversation was reaped. Map deletes are
+  // idempotent, so racing with the invoke return is harmless.
+  useEffect(() => {
+    const unsubscribe = ipcBridge.conversation.reaped.on((payload) => {
+      if (!payload?.id) return;
+      dropSlashCommandCache(payload.id);
+      void import('@/renderer/shared/dify/sessionBinding')
+        .then(({ unbindAssistantSession }) => unbindAssistantSession(payload.id))
+        .catch(() => {
+          /* best-effort */
+        });
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   // Handle opt-in dialog close
   const handleOptInClose = useCallback(async (confirmed: boolean) => {

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversationActions.ts
@@ -116,7 +116,11 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
 
   const handleDeleteClick = useCallback(
     (conversation: TChatConversation) => {
-      const hasWorkspace = !!(conversation.extra as { workspace?: string } | undefined)?.workspace;
+      // Only offer the "delete workspace folder" checkbox for user-selected
+      // project folders (customWorkspace === true). Auto temp scratch dirs are
+      // reaped silently by the main process (deleteWorkspace stays undefined).
+      const extra = conversation.extra as { workspace?: string; customWorkspace?: boolean } | undefined;
+      const showWorkspaceCheckbox = extra?.customWorkspace === true && !!extra?.workspace;
       const deleteWorkspaceRef = { current: false };
 
       Modal.confirm({
@@ -125,7 +129,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
           'div',
           null,
           React.createElement('div', null, t('conversation.history.deleteConfirm')),
-          hasWorkspace &&
+          showWorkspaceCheckbox &&
             React.createElement(
               Checkbox,
               {
@@ -142,7 +146,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
         okButtonProps: { status: 'warning' },
         onOk: async () => {
           try {
-            const success = await removeConversation(conversation, deleteWorkspaceRef.current);
+            const success = await removeConversation(conversation, showWorkspaceCheckbox ? deleteWorkspaceRef.current : undefined);
             if (success) {
               emitter.emit('chat.history.refresh');
               Message.success(t('conversation.history.deleteSuccess'));
@@ -171,7 +175,13 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
 
       const selectedIds = Array.from(selectedConversationIds);
       const selectedConvs = conversations.filter((c) => selectedIds.includes(c.id));
-      const hasAnyWorkspace = selectedConvs.some((c) => !!(c.extra as { workspace?: string } | undefined)?.workspace);
+      // Checkbox applies only to user-selected custom folders; temp scratch dirs
+      // are reaped silently regardless.
+      const isCustomWorkspace = (c: TChatConversation) => {
+        const extra = c.extra as { workspace?: string; customWorkspace?: boolean } | undefined;
+        return extra?.customWorkspace === true && !!extra?.workspace;
+      };
+      const hasAnyCustomWorkspace = selectedConvs.some(isCustomWorkspace);
       const deleteWorkspaceRef = { current: false };
 
       Modal.confirm({
@@ -180,7 +190,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
           'div',
           null,
           React.createElement('div', null, t('conversation.history.batchDeleteConfirm', { count: selectedConversationIds.size })),
-          hasAnyWorkspace &&
+          hasAnyCustomWorkspace &&
             React.createElement(
               Checkbox,
               {
@@ -197,7 +207,7 @@ export const useConversationActions = ({ batchMode, onSessionClick, onBatchModeC
         okButtonProps: { status: 'warning' },
         onOk: async () => {
           try {
-            const results = await Promise.all(selectedConvs.map((conv) => removeConversation(conv, deleteWorkspaceRef.current)));
+            const results = await Promise.all(selectedConvs.map((conv) => removeConversation(conv, isCustomWorkspace(conv) ? deleteWorkspaceRef.current : undefined)));
             const successCount = results.filter(Boolean).length;
             if (successCount > 0) {
               emitter.emit('chat.history.refresh');

--- a/src/renderer/pages/conversation/right-panel/BrowserPanel.tsx
+++ b/src/renderer/pages/conversation/right-panel/BrowserPanel.tsx
@@ -193,15 +193,16 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ active = false, conversatio
     };
   }, [handleOpenBrowserUrl]);
 
-  // Listen for "conversation deleted" cleanup from main (closeBrowserTabsByConversation
-  // → ipcBridge.rightPanelBrowser.convClosed.emit). Drop the matching entry
-  // from the module-level state so its tabs don't reappear if the user later
-  // creates a new conversation that happens to reuse the same id (unlikely
-  // given uuid ids, but cheap to be defensive).
+  // Listen for the consolidated "conversation reaped" broadcast from main. Drop
+  // the matching entry from the module-level state so its tabs don't reappear if
+  // the user later creates a new conversation that happens to reuse the same id
+  // (unlikely given uuid ids, but cheap to be defensive). Using conversation.reaped
+  // (rather than rightPanelBrowser.convClosed) means the preset-uninstall delete
+  // path — which does not route through the renderer hook — is also covered.
   useEffect(() => {
-    const unsubscribe = ipcBridge.rightPanelBrowser.convClosed.on((payload) => {
-      if (!payload?.conversationId) return;
-      dropConvBrowserState(payload.conversationId);
+    const unsubscribe = ipcBridge.conversation.reaped.on((payload) => {
+      if (!payload?.id) return;
+      dropConvBrowserState(payload.id);
     });
     return () => {
       unsubscribe();

--- a/tests/integration/assistantHubUninstallReaper.test.ts
+++ b/tests/integration/assistantHubUninstallReaper.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  registry: new Map<string, (...args: any[]) => any>(),
+  emits: [] as Array<{ path: string; args: any[] }>,
+  reap: vi.fn(async (_id: string) => ({ id: _id, dbDeleted: true, workspaceDeleted: false, errors: [] })),
+  uninstall: vi.fn(async () => ({ success: true })),
+  findIds: vi.fn((key: string) => {
+    if (key === 'builtin-foo') return { success: true, data: { conversationIds: ['c1'] } };
+    if (key === 'foo') return { success: true, data: { conversationIds: ['c2'] } };
+    return { success: true, data: { conversationIds: [] } };
+  }),
+}));
+
+function makeChannelProxy(pathStr: string): any {
+  return new Proxy(() => {}, {
+    get(_t, prop: string) {
+      if (prop === 'provider' || prop === 'on') {
+        return (cb: (...args: any[]) => any) => h.registry.set(`${pathStr}.${prop}`, cb);
+      }
+      if (prop === 'emit') {
+        return (...args: any[]) => h.emits.push({ path: pathStr, args });
+      }
+      return makeChannelProxy(pathStr ? `${pathStr}.${String(prop)}` : String(prop));
+    },
+  });
+}
+
+vi.mock('@/common', () => ({ ipcBridge: makeChannelProxy('') }));
+vi.mock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn(), mainError: vi.fn() }));
+vi.mock('@/process/services/conversationReaper', () => ({ reapConversation: h.reap }));
+vi.mock('@/process/AssistantManager', () => ({ assistantManager: { uninstallAssistant: h.uninstall } }));
+vi.mock('@/process/database', () => ({ getDatabase: () => ({ findConversationIdsByPresetAssistantId: h.findIds }) }));
+vi.mock('@/process/initStorage', () => ({
+  getAssistantsDir: () => '/tmp/a',
+  getHubAssistantsDir: () => '/tmp/h',
+  getSystemAssistantsDir: () => '/tmp/s',
+  getCustomAssistantsDir: () => '/tmp/c',
+}));
+vi.mock('@/process/SkillManager', () => ({ skillManager: {} }));
+vi.mock('@/types/acpTypes', () => ({ DEFAULT_PRESET_AGENT_TYPE: 'scode', normalizePresetAgentType: (v: unknown) => v }));
+vi.mock('@/common/enterpriseDebugConfig', () => ({ isEnterpriseMode: () => false }));
+vi.mock('@/process/constants/enterpriseStorage', () => ({ ASSISTANTS_ROOT_DIR: 'assistants', ENTERPRISE_ASSISTANT_SUBDIRS: {} }));
+vi.mock('@/common/systemConfig', () => ({ getSkillHubBaseUrl: () => 'https://hub.example' }));
+vi.mock('@/process/credentialsCache', () => ({ getSkillhubToken: () => '' }));
+vi.mock('@common/nexus/hubErrors', () => ({ tokenMissingResponse: () => ({ success: false }) }));
+
+describe('assistantHub uninstall routes through the reaper', () => {
+  beforeEach(async () => {
+    h.registry.clear();
+    h.emits.length = 0;
+    h.reap.mockClear();
+    h.uninstall.mockClear();
+    h.findIds.mockClear();
+    const { initAssistantHubBridge } = await import('../../src/process/bridge/assistantHubBridge');
+    initAssistantHubBridge();
+  });
+
+  it('reaps conversations for both the name and the builtin-stripped id', async () => {
+    const cb = h.registry.get('assistantHub.uninstallAssistant.provider');
+    expect(cb).toBeTypeOf('function');
+
+    const result = await cb!({ name: 'builtin-foo', category: 'custom' });
+
+    // Both matched ids reaped through the SSOT (not a raw DB delete).
+    expect(h.reap).toHaveBeenCalledWith('c1', { reason: 'assistant-uninstall' });
+    expect(h.reap).toHaveBeenCalledWith('c2', { reason: 'assistant-uninstall' });
+    // Looked up under both the raw name and the stripped id.
+    expect(h.findIds).toHaveBeenCalledWith('builtin-foo');
+    expect(h.findIds).toHaveBeenCalledWith('foo');
+    // Assistant itself uninstalled + list-refresh events emitted per reaped id.
+    expect(h.uninstall).toHaveBeenCalledWith('builtin-foo', 'custom');
+    const changedEmits = h.emits.filter((e) => e.path === 'database.conversationChanged');
+    expect(changedEmits.length).toBe(2);
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+});

--- a/tests/integration/conversationReaper.test.ts
+++ b/tests/integration/conversationReaper.test.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const h = vi.hoisted(() => ({
+  workDir: '',
+  conversation: null as any,
+  deleteResult: true,
+  jobs: [] as Array<{ id: string }>,
+  kill: vi.fn(),
+  clear: vi.fn(),
+  closeTerminals: vi.fn(),
+  closeBrowser: vi.fn(),
+  dispose: vi.fn(),
+  stopTelemetry: vi.fn(),
+  deleteConversation: vi.fn(async () => h.deleteResult),
+  listJobs: vi.fn(async () => h.jobs),
+  removeJob: vi.fn(async () => {}),
+  onJobRemovedEmit: vi.fn(),
+  reapedEmit: vi.fn(),
+}));
+
+vi.mock('@process/database', () => ({
+  getDatabase: () => ({ getConversation: () => ({ success: !!h.conversation, data: h.conversation }) }),
+}));
+vi.mock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn(), mainError: vi.fn() }));
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    cron: { onJobRemoved: { emit: h.onJobRemovedEmit } },
+    conversation: { reaped: { emit: h.reapedEmit } },
+  },
+}));
+vi.mock('@process/WorkerManage', () => ({ default: { kill: h.kill, clear: h.clear } }));
+vi.mock('@process/bridge/terminalBridge', () => ({ closeTerminalsByConversation: h.closeTerminals }));
+vi.mock('@process/bridge/browserPanelBridge', () => ({ closeBrowserTabsByConversation: h.closeBrowser }));
+vi.mock('@process/message', () => ({ disposeConversation: h.dispose }));
+vi.mock('@process/telemetry', () => ({ stopConversationTracking: h.stopTelemetry }));
+vi.mock('@process/providers', () => ({ getConversationProvider: () => ({ deleteConversation: h.deleteConversation }) }));
+vi.mock('@process/initStorage', () => ({ getSystemDir: () => ({ workDir: h.workDir }) }));
+vi.mock('@process/task/draftsCleanup', () => ({ TEMP_WORKSPACE_REGEX: /-temp-\d+$/ }));
+vi.mock('@process/services/cron/CronService', () => ({ cronService: { listJobsByConversation: h.listJobs, removeJob: h.removeJob } }));
+
+async function importReaper() {
+  return import('../../src/process/services/conversationReaper');
+}
+
+function makeConversation(extra: Record<string, unknown>, source = 'sudowork') {
+  return { id: 'conv-1', name: 'c', type: 'acp', source, extra };
+}
+
+describe('conversationReaper', () => {
+  beforeEach(() => {
+    h.workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reaper-'));
+    h.conversation = null;
+    h.deleteResult = true;
+    h.jobs = [];
+    Object.values(h).forEach((v) => {
+      if (typeof v === 'function' && 'mockClear' in v) (v as any).mockClear();
+    });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(h.workDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('reaps a temp (customWorkspace=false) conversation: dir removed, row gone, kill + disposers called', async () => {
+    const ws = path.join(h.workDir, 'scode-temp-1700000000000');
+    fs.mkdirSync(ws, { recursive: true });
+    h.conversation = makeConversation({ workspace: ws, customWorkspace: false });
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('conv-1', { reason: 'user-delete' });
+
+    expect(res.dbDeleted).toBe(true);
+    expect(res.workspaceDeleted).toBe(true);
+    expect(fs.existsSync(ws)).toBe(false);
+    expect(h.kill).toHaveBeenCalledWith('conv-1');
+    expect(h.clear).not.toHaveBeenCalled();
+    expect(h.closeTerminals).toHaveBeenCalledWith('conv-1');
+    expect(h.closeBrowser).toHaveBeenCalledWith('conv-1');
+    expect(h.dispose).toHaveBeenCalledWith('conv-1');
+    expect(h.stopTelemetry).toHaveBeenCalledWith('conv-1');
+    expect(h.deleteConversation).toHaveBeenCalledWith('conv-1');
+    expect(h.reapedEmit).toHaveBeenCalledWith({ id: 'conv-1' });
+  });
+
+  it('keeps a custom workspace folder when no delete flag is given', async () => {
+    const ws = path.join(h.workDir, 'my-project');
+    fs.mkdirSync(ws, { recursive: true });
+    h.conversation = makeConversation({ workspace: ws, customWorkspace: true });
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('conv-1', { reason: 'user-delete' });
+
+    expect(res.workspaceDeleted).toBe(false);
+    expect(fs.existsSync(ws)).toBe(true);
+    expect(res.dbDeleted).toBe(true);
+  });
+
+  it('deletes a custom workspace folder when deleteWorkspace=true (explicit)', async () => {
+    const ws = path.join(h.workDir, 'my-project');
+    fs.mkdirSync(ws, { recursive: true });
+    h.conversation = makeConversation({ workspace: ws, customWorkspace: true });
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('conv-1', { reason: 'user-delete', deleteWorkspace: true });
+
+    expect(res.workspaceDeleted).toBe(true);
+    expect(fs.existsSync(ws)).toBe(false);
+  });
+
+  it('guard: does not auto-delete a customWorkspace=false path with a non-temp basename', async () => {
+    const ws = path.join(h.workDir, 'not-a-temp-dir');
+    fs.mkdirSync(ws, { recursive: true });
+    h.conversation = makeConversation({ workspace: ws, customWorkspace: false });
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('conv-1', { reason: 'user-delete' });
+
+    expect(res.workspaceDeleted).toBe(false);
+    expect(fs.existsSync(ws)).toBe(true);
+  });
+
+  it('guard: does not auto-delete a temp-named dir that lives outside workDir', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'outside-'));
+    const ws = path.join(outside, 'scode-temp-1700000000000');
+    fs.mkdirSync(ws, { recursive: true });
+    h.conversation = makeConversation({ workspace: ws, customWorkspace: false });
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('conv-1', { reason: 'user-delete' });
+
+    expect(res.workspaceDeleted).toBe(false);
+    expect(fs.existsSync(ws)).toBe(true);
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('one step throwing does not abort the rest; errors[] is populated and dbDeleted stays true', async () => {
+    const ws = path.join(h.workDir, 'scode-temp-1700000000000');
+    fs.mkdirSync(ws, { recursive: true });
+    h.conversation = makeConversation({ workspace: ws, customWorkspace: false });
+    h.closeTerminals.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('conv-1', { reason: 'user-delete' });
+
+    expect(res.errors.some((e) => e.step === 'close-terminals')).toBe(true);
+    expect(res.dbDeleted).toBe(true);
+    expect(h.deleteConversation).toHaveBeenCalled();
+    expect(res.workspaceDeleted).toBe(true);
+    expect(fs.existsSync(ws)).toBe(false);
+  });
+
+  it('cleans up cron jobs for a non-cron conversation', async () => {
+    h.jobs = [{ id: 'job-1' }, { id: 'job-2' }];
+    h.conversation = makeConversation({ customWorkspace: true });
+
+    const { reapConversation } = await importReaper();
+    await reapConversation('conv-1', { reason: 'user-delete' });
+
+    expect(h.removeJob).toHaveBeenCalledWith('job-1');
+    expect(h.removeJob).toHaveBeenCalledWith('job-2');
+    expect(h.onJobRemovedEmit).toHaveBeenCalledWith({ jobId: 'job-1' });
+    expect(h.onJobRemovedEmit).toHaveBeenCalledWith({ jobId: 'job-2' });
+  });
+
+  it('skips the DB delete when skipDbDelete is set', async () => {
+    h.conversation = makeConversation({ customWorkspace: true });
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('conv-1', { reason: 'orphan-sweep', skipDbDelete: true });
+
+    expect(h.deleteConversation).not.toHaveBeenCalled();
+    expect(res.dbDeleted).toBe(false);
+  });
+
+  it('routes remote-agent delete through the provider and uses kill (not clear)', async () => {
+    h.conversation = { id: 'conv-1', name: 'c', type: 'remote-agent', source: 'sudowork', extra: { customWorkspace: true } };
+
+    const { reapConversation } = await importReaper();
+    await reapConversation('conv-1', { reason: 'user-delete' });
+
+    expect(h.deleteConversation).toHaveBeenCalledWith('conv-1');
+    expect(h.kill).toHaveBeenCalledWith('conv-1');
+    expect(h.clear).not.toHaveBeenCalled();
+  });
+
+  it('returns early when the conversation cannot be resolved', async () => {
+    h.conversation = null;
+
+    const { reapConversation } = await importReaper();
+    const res = await reapConversation('missing', { reason: 'user-delete' });
+
+    expect(res.dbDeleted).toBe(false);
+    expect(h.deleteConversation).not.toHaveBeenCalled();
+    expect(h.kill).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/orphanWorkspaceSweeper.test.ts
+++ b/tests/integration/orphanWorkspaceSweeper.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const h = vi.hoisted(() => ({
+  workDir: '',
+  pages: [] as Array<{ data: Array<{ extra?: { workspace?: string } }>; hasMore: boolean }>,
+}));
+
+vi.mock('@process/database', () => ({
+  getDatabase: () => ({
+    getUserConversations: (_userId: unknown, page: number) => h.pages[page] ?? { data: [], hasMore: false },
+  }),
+}));
+vi.mock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn() }));
+vi.mock('@process/initStorage', () => ({ getSystemDir: () => ({ workDir: h.workDir }) }));
+vi.mock('@process/task/draftsCleanup', () => ({ TEMP_WORKSPACE_REGEX: /-temp-\d+$/ }));
+
+async function importSweeper() {
+  return import('../../src/process/services/orphanWorkspaceSweeper');
+}
+
+/** Create a dir and back-date its mtime so the freshness guard treats it as old. */
+function makeAgedDir(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  const old = new Date(Date.now() - 5 * 60 * 1000);
+  fs.utimesSync(dir, old, old);
+}
+
+describe('orphanWorkspaceSweeper', () => {
+  beforeEach(() => {
+    h.workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sweep-'));
+    h.pages = [{ data: [], hasMore: false }];
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(h.workDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('deletes an unreferenced aged temp dir', async () => {
+    const orphan = path.join(h.workDir, 'scode-temp-1700000000000');
+    makeAgedDir(orphan);
+
+    const { sweepOrphanWorkspaces } = await importSweeper();
+    const res = await sweepOrphanWorkspaces();
+
+    expect(res.deleted).toContain(orphan);
+    expect(fs.existsSync(orphan)).toBe(false);
+  });
+
+  it('keeps a temp dir that is still referenced by a live conversation', async () => {
+    const referenced = path.join(h.workDir, 'scode-temp-1700000000001');
+    makeAgedDir(referenced);
+    h.pages = [{ data: [{ extra: { workspace: referenced } }], hasMore: false }];
+
+    const { sweepOrphanWorkspaces } = await importSweeper();
+    const res = await sweepOrphanWorkspaces();
+
+    expect(res.deleted).not.toContain(referenced);
+    expect(fs.existsSync(referenced)).toBe(true);
+  });
+
+  it('skips a fresh temp dir (mtime younger than the threshold)', async () => {
+    const fresh = path.join(h.workDir, 'scode-temp-1700000000002');
+    fs.mkdirSync(fresh, { recursive: true }); // current mtime → treated as fresh
+
+    const { sweepOrphanWorkspaces } = await importSweeper();
+    const res = await sweepOrphanWorkspaces();
+
+    expect(res.deleted).not.toContain(fresh);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  it('never touches non-temp (custom) dirs', async () => {
+    const custom = path.join(h.workDir, 'my-project');
+    makeAgedDir(custom);
+
+    const { sweepOrphanWorkspaces } = await importSweeper();
+    const res = await sweepOrphanWorkspaces();
+
+    expect(res.deleted).not.toContain(custom);
+    expect(fs.existsSync(custom)).toBe(true);
+    expect(res.scanned).toBe(0);
+  });
+});

--- a/tests/unit/conversationTrackerDiscard.test.ts
+++ b/tests/unit/conversationTrackerDiscard.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+const recordMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/process/telemetry/TelemetryBatchReporter', () => ({
+  getTelemetryReporter: () => ({ record: recordMock }),
+}));
+
+describe('ConversationTracker.discardConversation', () => {
+  it('removes tracking state without emitting a telemetry record', async () => {
+    const { getConversationTracker, stopConversationTracking } = await import('../../src/process/telemetry/ConversationTracker');
+    const tracker = getConversationTracker();
+
+    tracker.startConversation('conv-x', 'model-1');
+    expect(tracker.getConversationState('conv-x')).toBeTruthy();
+
+    recordMock.mockClear();
+    stopConversationTracking('conv-x');
+
+    expect(tracker.getConversationState('conv-x')).toBeUndefined();
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it('endConversationSuccess (the report variant) DOES emit a record', async () => {
+    const { getConversationTracker, endConversationSuccess } = await import('../../src/process/telemetry/ConversationTracker');
+    const tracker = getConversationTracker();
+
+    tracker.startConversation('conv-y', 'model-1');
+    recordMock.mockClear();
+    endConversationSuccess('conv-y');
+
+    expect(recordMock).toHaveBeenCalledTimes(1);
+    expect(tracker.getConversationState('conv-y')).toBeUndefined();
+  });
+});

--- a/tests/unit/messageDispose.test.ts
+++ b/tests/unit/messageDispose.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getConversation: vi.fn(() => ({ success: true, data: { id: 'c', extra: {} } })),
+  getConversationMessages: vi.fn(() => ({ data: [] })),
+  insertMessage: vi.fn(() => ({ success: true })),
+  updateMessage: vi.fn(() => ({ success: true })),
+}));
+
+vi.mock('@process/database/export', () => ({
+  getDatabase: () => ({
+    getConversation: h.getConversation,
+    getConversationMessages: h.getConversationMessages,
+    insertMessage: h.insertMessage,
+    updateMessage: h.updateMessage,
+    createConversation: vi.fn(() => ({ success: true })),
+  }),
+}));
+vi.mock('@process/initStorage', () => ({ ProcessChat: { get: vi.fn(async () => []) } }));
+vi.mock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn(), mainError: vi.fn() }));
+
+const message = { id: 'm1', position: 'left', content: [{ type: 'text', text: 'hi' }] } as any;
+
+describe('message disposeConversation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.values(h).forEach((fn) => (fn as any).mockClear?.());
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears the pending-save timer so no flush happens after dispose', async () => {
+    const { addOrUpdateMessage, disposeConversation } = await import('../../src/process/message');
+
+    addOrUpdateMessage('c', message); // schedules a 2000ms debounce timer
+    disposeConversation('c');
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(h.getConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it('control: without dispose the debounce timer fires and flushes', async () => {
+    const { addOrUpdateMessage } = await import('../../src/process/message');
+
+    addOrUpdateMessage('c2', message);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(h.getConversationMessages).toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,6 +61,8 @@ export default defineConfig({
         'src/process/database/corruptionError.ts',
         'src/process/startupNotice.ts',
         'src/process/services/autoUpdaterService.ts',
+        'src/process/services/conversationReaper.ts',
+        'src/process/services/orphanWorkspaceSweeper.ts',
         'src/process/services/conversionService.ts',
         'src/process/services/scode/scodeProxyModels.ts',
         'src/process/services/sudoclaw/sudoclawRuntimeSync.ts',


### PR DESCRIPTION
## Conversation Resource Reaper — systematic cleanup

**Problem.** Every chat owns ~24 resources across 8+ modules (DB rows, an auto workspace dir, an scode/ACP child process, terminals, browser tabs, cron jobs, channel/Moss sessions, several in-memory caches). Cleanup was hand-wired inline in `conversation.remove`, so anything the author forgot leaked. The second delete path — `deleteConversationsByPresetAssistantId` (assistant uninstall) — was a pure DB delete that bypassed *all* of it. No boot reconciliation existed for orphaned `~/.nexus/*-temp-*` dirs.

**This PR** introduces one SSOT `reapConversation()` that every lifecycle trigger routes through, disposers for the previously-leaked caches, and a boot orphan sweep.

### Key behavior change
Workspace disposition keys off `extra.customWorkspace`:
- `customWorkspace === false` (auto `~/.nexus/<backend>-temp-<ts>` scratch) → **deleted by default, silently, on delete** + swept at boot if orphaned. Guarded: only removed when directly under `workDir` **and** matching `TEMP_WORKSPACE_REGEX`.
- `customWorkspace === true` (user-selected folder — a user asset) → **never auto-deleted.** The opt-in "delete workspace folder" checkbox now shows **only** for these.

### Commits (ordered, no squash)
1. `feat(reaper)`: disposers for leaked caches (message, telemetry, remote cachedModelInfo, exported regex)
2. `feat(reaper)`: `conversationReaper` SSOT module (+ tests)
3. `refactor(conversation)`: route `conversation.remove` through the reaper
4. `fix(assistant-hub)`: route preset-assistant delete through the reaper — the correctness fix
5. `feat(boot)`: orphan workspace sweeper (+ `initStorage` wiring, tests)
6. `feat(ui)`: checkbox only for custom workspaces + consolidated `conversation.reaped` broadcast + renderer subscribers

### Verification
- `tsc --noEmit`, Prettier `--check`, eslint (0 new errors) all clean.
- 21 new unit/integration tests pass (reaper, sweeper, assistant-hub uninstall, telemetry discard, message dispose).
- **Real end-to-end in a live dev build on Windows:**
  - Boot sweeper: planted an aged orphan `*-temp-*` dir → app logged `Swept 1 orphan workspace dir(s) of 80 scanned`; orphan gone, referenced dir kept.
  - Reaper (via live IPC): temp-workspace chat delete → temp dir removed (`[ConversationReaper] [user-delete] deleted workspace folder: …`); custom-folder chat delete without flag → folder kept; both DB rows gone.
  - Decision logic replayed over all 152 real conversations: **0 user assets auto-deleted**.

### Note
The plan's "~69 pre-existing orphan dirs" premise is stale on current data — all `*-temp-*` dirs are presently referenced, so the boot sweep reclaims a backlog of 0 today. The value is preventing *future* orphans + reaping on delete.

