### PR TITLE
feat(renderer): refine skill selector and file preview UI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@xmldom/xmldom": "^0.8.11",
         "@xterm/addon-fit": "^0.11.0",
+        "ahooks": "^3.9.7",
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^12.4.1",
         "buffer": "^6.0.3",
@@ -1530,6 +1531,8 @@
 
     "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "https://registry.npmmirror.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
 
+    "@types/js-cookie": ["@types/js-cookie@3.0.6", "", {}, "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="],
+
     "@types/json5": ["@types/json5@0.0.29", "https://registry.npmmirror.com/@types/json5/-/json5-0.0.29.tgz", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "https://registry.npmmirror.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
@@ -1755,6 +1758,8 @@
     "acorn-walk": ["acorn-walk@8.3.5", "https://registry.npmmirror.com/acorn-walk/-/acorn-walk-8.3.5.tgz", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
 
     "agent-base": ["agent-base@8.0.0", "https://registry.npmmirror.com/agent-base/-/agent-base-8.0.0.tgz", {}, "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg=="],
+
+    "ahooks": ["ahooks@3.9.7", "", { "dependencies": { "@babel/runtime": "^7.21.0", "@types/js-cookie": "^3.0.6", "dayjs": "^1.9.1", "intersection-observer": "^0.12.0", "js-cookie": "^3.0.5", "lodash": "^4.17.21", "react-fast-compare": "^3.2.2", "resize-observer-polyfill": "^1.5.1", "screenfull": "^5.0.0", "tslib": "^2.4.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw=="],
 
     "ajv": ["ajv@6.14.0", "https://registry.npmmirror.com/ajv/-/ajv-6.14.0.tgz", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
@@ -2666,6 +2671,8 @@
 
     "internmap": ["internmap@2.0.3", "https://registry.npmmirror.com/internmap/-/internmap-2.0.3.tgz", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
+    "intersection-observer": ["intersection-observer@0.12.2", "", {}, "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg=="],
+
     "ip-address": ["ip-address@10.0.1", "https://registry.npmmirror.com/ip-address/-/ip-address-10.0.1.tgz", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
@@ -2831,6 +2838,8 @@
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.1.3", "https://registry.npmmirror.com/jose/-/jose-6.1.3.tgz", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
+    "js-cookie": ["js-cookie@3.0.8", "", {}, "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw=="],
 
     "js-tokens": ["js-tokens@10.0.0", "https://registry.npmmirror.com/js-tokens/-/js-tokens-10.0.0.tgz", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
@@ -3408,6 +3417,8 @@
 
     "react-dom": ["react-dom@19.2.4", "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.4.tgz", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
+
     "react-focus-lock": ["react-focus-lock@2.13.7", "https://registry.npmmirror.com/react-focus-lock/-/react-focus-lock-2.13.7.tgz", { "dependencies": { "@babel/runtime": "^7.0.0", "focus-lock": "^1.3.6", "prop-types": "^15.6.2", "react-clientside-effect": "^1.2.7", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og=="],
 
     "react-i18next": ["react-i18next@14.1.3", "https://registry.npmmirror.com/react-i18next/-/react-i18next-14.1.3.tgz", { "dependencies": { "@babel/runtime": "^7.23.9", "html-parse-stringify": "^3.0.1" }, "peerDependencies": { "i18next": ">= 23.2.3", "react": ">= 16.8.0" } }, "sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw=="],
@@ -3589,6 +3600,8 @@
     "saxes": ["saxes@6.0.0", "https://registry.npmmirror.com/saxes/-/saxes-6.0.0.tgz", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "screenfull": ["screenfull@5.2.0", "", {}, "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="],
 
     "scroll-into-view-if-needed": ["scroll-into-view-if-needed@2.2.31", "https://registry.npmmirror.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz", { "dependencies": { "compute-scroll-into-view": "^1.0.20" } }, "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA=="],
 

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@xmldom/xmldom": "^0.8.11",
     "@xterm/addon-fit": "^0.11.0",
+    "ahooks": "^3.9.7",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^12.4.1",
     "buffer": "^6.0.3",

--- a/src/renderer/avatar/App.tsx
+++ b/src/renderer/avatar/App.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useEffect, useState } from 'react';
 import staticLogo from '../assets/sudowork-icon-dark.svg';
 import thinkingGif from '../assets/sudoclaw_transparent_large.gif';

--- a/src/renderer/avatar/index.ts
+++ b/src/renderer/avatar/index.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';

--- a/src/renderer/avatar/types.d.ts
+++ b/src/renderer/avatar/types.d.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { AvatarBridgeMessage } from '@/common/avatarBridge';
 
 declare global {

--- a/src/renderer/bootstrap/crashHandler.ts
+++ b/src/renderer/bootstrap/crashHandler.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Renderer Crash Handler - 渲染进程 Crash/异常处理
  *
  * 功能:

--- a/src/renderer/bootstrap/devTriggers.ts
+++ b/src/renderer/bootstrap/devTriggers.ts
@@ -1,11 +1,5 @@
 /// <reference types="vite/client" />
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Renderer-side dev-mode debug triggers, attached at
  * `window.__sudoworkDebug`. Gated by Vite's `import.meta.env.DEV` so the
  * production renderer bundle ships zero of this code — the entire

--- a/src/renderer/bootstrap/runtimePatches.ts
+++ b/src/renderer/bootstrap/runtimePatches.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 // 集中管理 renderer 端的运行时补丁，使入口文件保持整洁
 // Centralize renderer runtime patches so the entry file stays tidy
 

--- a/src/renderer/components/AcpConfigSelector.tsx
+++ b/src/renderer/components/AcpConfigSelector.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Dropdown, Menu } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';

--- a/src/renderer/components/AcpModelSelector.tsx
+++ b/src/renderer/components/AcpModelSelector.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Dropdown, Message, Tooltip } from '@arco-design/web-react';
 import { IconRefresh } from '@arco-design/web-react/icon';
 import classNames from 'classnames';

--- a/src/renderer/components/AgentModeSelector.tsx
+++ b/src/renderer/components/AgentModeSelector.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Dropdown, Message, Tooltip } from '@arco-design/web-react';
 import { Down, Robot } from '@icon-park/react';
 import classNames from 'classnames';

--- a/src/renderer/components/AgentStatusBanner.tsx
+++ b/src/renderer/components/AgentStatusBanner.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Dropdown, Menu, Message } from '@arco-design/web-react';
 import { Connection, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';

--- a/src/renderer/components/CollapsibleContent.tsx
+++ b/src/renderer/components/CollapsibleContent.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Down, Up } from '@icon-park/react';
 import classNames from 'classnames';
 import React, { useEffect, useMemo, useRef, useState } from 'react';

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 

--- a/src/renderer/components/ContextUsageIndicator.tsx
+++ b/src/renderer/components/ContextUsageIndicator.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/renderer/components/DirectorySelectionModal.tsx
+++ b/src/renderer/components/DirectorySelectionModal.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Modal, Spin } from '@arco-design/web-react';
 import { IconFile, IconFolder, IconUp } from '@arco-design/web-react/icon';
 import React, { useCallback, useEffect, useState } from 'react';

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { ErrorInfo, ReactNode } from 'react';
 import React, { Component } from 'react';
 import { Button } from '@arco-design/web-react';

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -135,21 +135,17 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
   if (isImage) {
     return (
       <div className='relative inline-block'>
-        <div className='rd-8px overflow-hidden border border-solid b-color-border-2'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : <div className='w-60px h-60px'></div>}</div>
+        <div className='rd-xl overflow-hidden border'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : <div className='size-15'></div>}</div>
         {!readonly && <Button shape='circle' size='mini' className='absolute -top-2 -right-2 z-10 bg-subtle! border! size-6!' icon={<IconClose className='text-13px text-foreground' />} onClick={handleRemove} />}
       </div>
     );
   }
 
   return (
-    <div className='relative inline-block mb-10px'>
-      <div
-        className={readonly && !fileError ? 'h-60px flex items-center gap-12px px-12px rd-8px border border-solid cursor-pointer select-none' : 'h-60px flex items-center gap-12px px-12px rd-8px border border-solid'}
-        style={{ borderColor: 'var(--border-default)', boxShadow: 'var(--shadow-sm)' }}
-        onClick={handlePreviewClick}
-      >
-        <div className='w-40px h-40px rd-8px f-center flex-shrink-0'>{resolveFileIcon(fileName, { size: 28, theme: 'filled' })}</div>
-        <div className='flex flex-col gap-2px min-w-0'>
+    <div className='relative inline-block mb-2.5'>
+      <div className={readonly && !fileError ? 'h-15 flex items-center gap-3 px-3 rd-xl border cursor-pointer' : 'h-15 flex items-center gap-3 px-3 rd-xl border'} onClick={handlePreviewClick}>
+        <div className='size-10 rd-xl f-center flex-shrink-0'>{resolveFileIcon(fileName, { size: 28, theme: 'filled' })}</div>
+        <div className='flex flex-col gap-0.5 min-w-0'>
           <span className='text-14px text-foreground max-w-150px truncate'>{fileName}</span>
           <span className='text-12px text-secondary'>
             {fileExt}: {fileSize || '...'}

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -1,6 +1,6 @@
-import { Close } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Image } from '@arco-design/web-react';
+import { IconClose } from '@arco-design/web-react/icon';
+import { Button, Image } from '@arco-design/web-react';
 import type { PreviewContentType } from '@/common/types/preview';
 import { getFileExtension } from '@/renderer/services/FileService';
 import { ipcBridge } from '@/common';
@@ -59,17 +59,11 @@ interface FilePreviewProps {
 }
 
 const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = false }) => {
-  // Defensive check: ensure path is a string
-  if (typeof path !== 'string') {
-    console.error('[FilePreview] Invalid path type:', typeof path, path);
-    return null;
-  }
-
-  const isImage = isImageFile(path);
+  const isImage = typeof path === 'string' && isImageFile(path);
   // 直接从路径中提取文件名，不清理时间戳后缀
   // Extract filename directly from path without cleaning timestamp suffix
-  const fileName = path.split(/[\\/]/).pop() || '';
-  const fileExt = getFileExtension(path).toUpperCase().replace('.', '');
+  const fileName = typeof path === 'string' ? path.split(/[\\/]/).pop() || '' : '';
+  const fileExt = typeof path === 'string' ? getFileExtension(path).toUpperCase().replace('.', '') : '';
   const [imageUrl, setImageUrl] = useState<string>('');
   const [fileSize, setFileSize] = useState<string>('');
   // Track whether the file was not found (ENOENT) so we don't retry on
@@ -133,7 +127,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
     };
   }, [path, isImage]);
 
-  const handleRemove = (e: React.MouseEvent) => {
+  const handleRemove = (e: Event) => {
     e.stopPropagation();
     onRemove();
   };
@@ -142,11 +136,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
     return (
       <div className='relative inline-block'>
         <div className='rd-8px overflow-hidden border border-solid b-color-border-2'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : <div className='w-60px h-60px'></div>}</div>
-        {!readonly && (
-          <div className='absolute -top-4px -right-4px w-16px h-16px rd-50% bg-white dark:bg-gray-700 cursor-pointer f-center shadow-md hover:shadow-lg transition-all z-10 border border-solid border-gray-200 dark:border-gray-600' onClick={handleRemove}>
-            <Close theme='filled' size='10' fill='#666' />
-          </div>
-        )}
+        {!readonly && <Button shape='circle' size='mini' className='absolute -top-4px -right-4px w-16px! h-16px! min-w-0! z-10' icon={<Close theme='filled' size='10' fill='#666' />} onClick={handleRemove} />}
       </div>
     );
   }
@@ -166,11 +156,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
           </span>
         </div>
       </div>
-      {!readonly && (
-        <div className='absolute -top-4px -right-4px w-16px h-16px rd-50% bg-white dark:bg-gray-700 cursor-pointer f-center shadow-md hover:shadow-lg transition-all z-10 border border-solid border-gray-200 dark:border-gray-600' onClick={handleRemove}>
-          <Close theme='filled' size='10' fill='#666' />
-        </div>
-      )}
+      {!readonly && <Button shape='circle' size='mini' className='absolute -top-4px -right-4px w-16px! h-16px! min-w-0! z-10' icon={<Close theme='filled' size='10' fill='#666' />} onClick={handleRemove} />}
     </div>
   );
 };

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Close } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { Image } from '@arco-design/web-react';

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -136,7 +136,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
     return (
       <div className='relative inline-block'>
         <div className='rd-8px overflow-hidden border border-solid b-color-border-2'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : <div className='w-60px h-60px'></div>}</div>
-        {!readonly && <Button shape='circle' size='mini' className='absolute -top-4px -right-4px w-16px! h-16px! min-w-0! z-10' icon={<Close theme='filled' size='10' fill='#666' />} onClick={handleRemove} />}
+        {!readonly && <Button shape='circle' size='mini' className='absolute -top-2 -right-2 z-10 bg-subtle! border! size-6!' icon={<IconClose className='text-13px text-foreground' />} onClick={handleRemove} />}
       </div>
     );
   }
@@ -156,7 +156,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
           </span>
         </div>
       </div>
-      {!readonly && <Button shape='circle' size='mini' className='absolute -top-4px -right-4px w-16px! h-16px! min-w-0! z-10' icon={<Close theme='filled' size='10' fill='#666' />} onClick={handleRemove} />}
+      {!readonly && <Button shape='circle' size='mini' className='absolute -top-2 -right-2 z-10 bg-subtle! border! size-6!' icon={<IconClose className='text-13px text-foreground' />} onClick={handleRemove} />}
     </div>
   );
 };

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -134,7 +134,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
 
   if (isImage) {
     return (
-      <div className='relative inline-block'>
+      <div className='relative f-center'>
         <div className='rd-xl overflow-hidden border'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : <div className='size-15'></div>}</div>
         {!readonly && <Button shape='circle' size='mini' className='absolute -top-2 -right-2 z-10 bg-subtle! border! size-6!' icon={<IconClose className='text-13px text-foreground' />} onClick={handleRemove} />}
       </div>

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -134,15 +134,15 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
 
   if (isImage) {
     return (
-      <div className='relative f-center'>
-        <div className='rd-xl overflow-hidden border'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : <div className='size-15'></div>}</div>
+      <div className='relative inline-block'>
+        <div className='size-15 rd-xl overflow-hidden border f-center'>{imageUrl ? <Image src={imageUrl} alt={fileName} width={60} height={60} className='object-cover cursor-pointer' preview /> : null}</div>
         {!readonly && <Button shape='circle' size='mini' className='absolute -top-2 -right-2 z-10 bg-subtle! border! size-6!' icon={<IconClose className='text-13px text-foreground' />} onClick={handleRemove} />}
       </div>
     );
   }
 
   return (
-    <div className='relative inline-block mb-2.5'>
+    <div className='relative inline-block'>
       <div className={readonly && !fileError ? 'h-15 flex items-center gap-3 px-3 rd-xl border cursor-pointer' : 'h-15 flex items-center gap-3 px-3 rd-xl border'} onClick={handlePreviewClick}>
         <div className='size-10 rd-xl f-center flex-shrink-0'>{resolveFileIcon(fileName, { size: 28, theme: 'filled' })}</div>
         <div className='flex flex-col gap-0.5 min-w-0'>

--- a/src/renderer/components/FlexFullContainer.tsx
+++ b/src/renderer/components/FlexFullContainer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 

--- a/src/renderer/components/HorizontalFileList.tsx
+++ b/src/renderer/components/HorizontalFileList.tsx
@@ -111,7 +111,7 @@ const HorizontalFileList: React.FC<HorizontalFileListProps> = ({ children }) => 
       {/* 横向滚动容器，隐藏滚动条 */}
       <div
         ref={scrollContainerRef}
-        className='flex items-center gap-2 overflow-x-auto overflow-y-hidden scrollbar-hide py-1.25'
+        className='flex items-center gap-3 overflow-x-auto overflow-y-hidden scrollbar-hide py-1.25'
         style={{
           scrollbarWidth: 'none', // Firefox
           msOverflowStyle: 'none', // IE/Edge

--- a/src/renderer/components/HorizontalFileList.tsx
+++ b/src/renderer/components/HorizontalFileList.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { IconLeft, IconRight } from '@arco-design/web-react/icon';
 import React, { useRef, useState, useEffect } from 'react';
 

--- a/src/renderer/components/HubEmptyState.tsx
+++ b/src/renderer/components/HubEmptyState.tsx
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Empty-state display for AssistantHub / SkillHub catalog views.
  *
  * Differentiates between three "I see nothing here" causes so users

--- a/src/renderer/components/IconParkHOC.tsx
+++ b/src/renderer/components/IconParkHOC.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import { IconProvider, DEFAULT_ICON_CONFIGS } from '@icon-park/react/es/runtime';
 import { theme } from '@office-ai/platform';

--- a/src/renderer/components/InitLoading.tsx
+++ b/src/renderer/components/InitLoading.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useRef, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 
 import SyntaxHighlighter from 'react-syntax-highlighter';

--- a/src/renderer/components/PwdLoginApprovalModal.tsx
+++ b/src/renderer/components/PwdLoginApprovalModal.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Modal } from '@arco-design/web-react';
 import { IconLock } from '@arco-design/web-react/icon';
 import React from 'react';

--- a/src/renderer/components/Sendbox.tsx
+++ b/src/renderer/components/Sendbox.tsx
@@ -408,6 +408,7 @@ const SendBox: React.FC<{
       onVisibleChange={(v) => {
         if (!v) onSkillPopoverClose();
       }}
+      showTabs
       title={t('messages.skills.title', { defaultValue: 'Skills' })}
       items={skillPopoverItems}
       selectedKeys={selectedSkills}

--- a/src/renderer/components/Sendbox.tsx
+++ b/src/renderer/components/Sendbox.tsx
@@ -249,7 +249,6 @@ const SendBox: React.FC<{
   const [selectedSkills, setSelectedSkills] = useState<string[]>(() => initialSelectedSkills);
   const [loadingSkills, setLoadingSkills] = useState(false);
   const [isSkillPopoverOpen, setIsSkillPopoverOpen] = useState(false);
-  const [skillPopoverActiveIndex, setSkillPopoverActiveIndex] = useState(0);
   const [skillPopoverSearchQuery, setSkillPopoverSearchQuery] = useState('');
 
   // Fetch installed skills on mount and after agent-created skills are installed.
@@ -405,7 +404,6 @@ const SendBox: React.FC<{
 
   const onSkillPopoverClose = useCallback(() => {
     setIsSkillPopoverOpen(false);
-    setSkillPopoverActiveIndex(0);
     setSkillPopoverSearchQuery('');
   }, []);
 
@@ -420,10 +418,8 @@ const SendBox: React.FC<{
       title={t('messages.skills.title', { defaultValue: 'Skills' })}
       items={skillPopoverItems}
       selectedKeys={selectedSkills}
-      activeIndex={skillPopoverActiveIndex}
       loading={loadingSkills}
       loadingText={t('messages.skills.loading', { defaultValue: 'Loading skills...' })}
-      onHoverItem={setSkillPopoverActiveIndex}
       onSelectItem={(item) => {
         if (!selectedSkills.includes(item.key)) {
           setSelectedSkills((prev) => [...prev, item.key]);
@@ -432,10 +428,7 @@ const SendBox: React.FC<{
       }}
       emptyText={t('messages.skills.empty', { defaultValue: 'No skills found' })}
       searchQuery={skillPopoverSearchQuery}
-      onSearchChange={(q) => {
-        setSkillPopoverSearchQuery(q);
-        setSkillPopoverActiveIndex(0);
-      }}
+      onSearchChange={setSkillPopoverSearchQuery}
       onDismiss={onSkillPopoverClose}
       fileItems={skillPopoverFileItems}
       onSelectFile={(file) => {
@@ -606,15 +599,14 @@ const SendBox: React.FC<{
               title={t('messages.skills.title', { defaultValue: 'Skills' })}
               items={skillMenuItems}
               selectedKeys={selectedSkills}
-              activeIndex={skillSelectorController.activeIndex}
               loading={loadingSkills}
               loadingText={t('messages.skills.loading', { defaultValue: 'Loading skills...' })}
-              onHoverItem={skillSelectorController.setActiveIndex}
               onSelectItem={(item) => {
-                const targetIndex = skillSelectorController.filteredSkills.findIndex((skill) => skill.name === item.name);
-                if (targetIndex >= 0) {
-                  skillSelectorController.onSelectByIndex(targetIndex);
+                if (!selectedSkills.includes(item.key)) {
+                  setSelectedSkills((prev) => [...prev, item.key]);
                 }
+                setInput(stripAtQuery(input, cursorPosition));
+                skillSelectorController.setDismissed(true);
               }}
               emptyText={t('messages.skills.empty', { defaultValue: 'No skills found' })}
               showTabs={skillSelectorController.showTabs}
@@ -622,10 +614,10 @@ const SendBox: React.FC<{
               onTabChange={skillSelectorController.setActiveTab}
               fileItems={skillSelectorController.filteredFiles}
               onSelectFile={(file) => {
-                const fileIndex = skillSelectorController.filteredFiles.findIndex((f) => f.relativePath === file.relativePath);
-                if (fileIndex >= 0) {
-                  skillSelectorController.onSelectByIndex(fileIndex);
-                }
+                const newInput = replaceAtQuery(input, `@${file.relativePath}`, cursorPosition);
+                setInput(newInput);
+                onAtFileSelected?.(file);
+                skillSelectorController.setDismissed(true);
               }}
               skillsTabTitle={t('messages.skills.tabSkills', { defaultValue: 'Skills' })}
               filesTabTitle={t('messages.skills.tabFiles', { defaultValue: 'Files' })}
@@ -639,6 +631,7 @@ const SendBox: React.FC<{
               skillsSearchPlaceholder={t('messages.skills.searchSkills', { defaultValue: '搜索技能...' })}
               filesSearchPlaceholder={t('messages.skills.searchFiles', { defaultValue: '搜索文件...' })}
               noSearchResultsText={t('messages.skills.noSearchResults', { defaultValue: '未找到匹配结果' })}
+              isVisible={skillSelectorController.isOpen}
             />
           </div>
         )}

--- a/src/renderer/components/Sendbox.tsx
+++ b/src/renderer/components/Sendbox.tsx
@@ -390,12 +390,6 @@ const SendBox: React.FC<{
         onAtFileSelected?.(file);
         onSkillPopoverClose();
       }}
-      skillsTabTitle={t('messages.skills.tabSkills', { defaultValue: 'Skills' })}
-      filesTabTitle={t('messages.skills.tabFiles', { defaultValue: 'Files' })}
-      filesEmptyText={t('messages.skills.filesEmpty', { defaultValue: 'No files in workspace' })}
-      skillsSearchPlaceholder={t('messages.skills.searchSkills', { defaultValue: '搜索技能...' })}
-      filesSearchPlaceholder={t('messages.skills.searchFiles', { defaultValue: '搜索文件...' })}
-      noSearchResultsText={t('messages.skills.noSearchResults', { defaultValue: '未找到匹配结果' })}
     >
       <Tooltip content={t('conversation.welcome.addSkill', { defaultValue: '添加技能 / 文件' })} position='top'>
         <span className='inline-flex ml-3'>
@@ -571,16 +565,10 @@ const SendBox: React.FC<{
                 onAtFileSelected?.(file);
                 skillSelectorController.setDismissed(true);
               }}
-              skillsTabTitle={t('messages.skills.tabSkills', { defaultValue: 'Skills' })}
-              filesTabTitle={t('messages.skills.tabFiles', { defaultValue: 'Files' })}
-              filesEmptyText={t('messages.skills.filesEmpty', { defaultValue: 'No files in workspace' })}
               onDismiss={() => {
                 skillSelectorController.setDismissed(true);
                 setInput(stripAtQuery(input, cursorPosition));
               }}
-              skillsSearchPlaceholder={t('messages.skills.searchSkills', { defaultValue: '搜索技能...' })}
-              filesSearchPlaceholder={t('messages.skills.searchFiles', { defaultValue: '搜索文件...' })}
-              noSearchResultsText={t('messages.skills.noSearchResults', { defaultValue: '未找到匹配结果' })}
               isVisible={skillSelectorController.isOpen}
               query={skillSelectorController.query}
             />

--- a/src/renderer/components/Sendbox.tsx
+++ b/src/renderer/components/Sendbox.tsx
@@ -356,6 +356,14 @@ const SendBox: React.FC<{
   // Items for the popover button (all enabled skills, keyed by name)
   const skillPopoverItems = useMemo<SkillSelectorMenuItem[]>(() => skillSelectorItems.map((skill) => ({ ...skill, key: skill.name })), [skillSelectorItems]);
 
+  // Filtered workspace files for the popover button, based on search query
+  const skillPopoverFileItems = useMemo(() => {
+    if (!workspaceFiles) return [];
+    const keyword = skillPopoverSearchQuery.trim().toLowerCase();
+    if (!keyword) return workspaceFiles;
+    return workspaceFiles.filter((f) => f.name.toLowerCase().includes(keyword) || f.relativePath.toLowerCase().includes(keyword));
+  }, [workspaceFiles, skillPopoverSearchQuery]);
+
   const skillSelectorController = useSkillSelectorController({
     input,
     cursorPosition,
@@ -429,6 +437,17 @@ const SendBox: React.FC<{
         setSkillPopoverActiveIndex(0);
       }}
       onDismiss={onSkillPopoverClose}
+      fileItems={skillPopoverFileItems}
+      onSelectFile={(file) => {
+        onAtFileSelected?.(file);
+        onSkillPopoverClose();
+      }}
+      skillsTabTitle={t('messages.skills.tabSkills', { defaultValue: 'Skills' })}
+      filesTabTitle={t('messages.skills.tabFiles', { defaultValue: 'Files' })}
+      filesEmptyText={t('messages.skills.filesEmpty', { defaultValue: 'No files in workspace' })}
+      skillsSearchPlaceholder={t('messages.skills.searchSkills', { defaultValue: '搜索技能...' })}
+      filesSearchPlaceholder={t('messages.skills.searchFiles', { defaultValue: '搜索文件...' })}
+      noSearchResultsText={t('messages.skills.noSearchResults', { defaultValue: '未找到匹配结果' })}
     >
       <Tooltip content={t('conversation.welcome.addSkill', { defaultValue: '添加技能 / 文件' })} position='top'>
         <span className='inline-flex ml-3'>

--- a/src/renderer/components/Sendbox.tsx
+++ b/src/renderer/components/Sendbox.tsx
@@ -6,7 +6,7 @@ import { IconPaste } from '@arco-design/web-react/icon';
 import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
 import SlashCommandMenu, { type SlashCommandMenuItem } from '@/renderer/components/SlashCommandMenu';
 import { useSlashCommandController } from '@/renderer/hooks/useSlashCommandController';
-import SkillSelectorPopover, { SkillSelectorMenuContent, type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorPopover';
+import SkillSelectorPopover, { SkillSelectorMenuContent } from '@/renderer/components/SkillSelectorPopover';
 import { useSkillSelectorController, type SkillSelectorItem, stripAtQuery, replaceAtQuery } from '@/renderer/hooks/useSkillSelectorController';
 import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
@@ -249,7 +249,6 @@ const SendBox: React.FC<{
   const [selectedSkills, setSelectedSkills] = useState<string[]>(() => initialSelectedSkills);
   const [loadingSkills, setLoadingSkills] = useState(false);
   const [isSkillPopoverOpen, setIsSkillPopoverOpen] = useState(false);
-  const [skillPopoverSearchQuery, setSkillPopoverSearchQuery] = useState('');
 
   // Fetch installed skills on mount and after agent-created skills are installed.
   useEffect(() => {
@@ -352,59 +351,18 @@ const SendBox: React.FC<{
     return Array.from(new Map(items.map((item) => [item.name, item])).values());
   }, [installedSkills]);
 
-  // Items for the popover button (all enabled skills, keyed by name)
-  const skillPopoverItems = useMemo<SkillSelectorMenuItem[]>(() => skillSelectorItems.map((skill) => ({ ...skill, key: skill.name })), [skillSelectorItems]);
-
-  // Filtered workspace files for the popover button, based on search query
-  const skillPopoverFileItems = useMemo(() => {
-    if (!workspaceFiles) return [];
-    const keyword = skillPopoverSearchQuery.trim().toLowerCase();
-    if (!keyword) return workspaceFiles;
-    return workspaceFiles.filter((f) => f.name.toLowerCase().includes(keyword) || f.relativePath.toLowerCase().includes(keyword));
-  }, [workspaceFiles, skillPopoverSearchQuery]);
-
   const skillSelectorController = useSkillSelectorController({
     input,
     cursorPosition,
-    skills: skillSelectorItems,
     selectedSkills,
-    onSelectSkill: (skillName) => {
-      if (!selectedSkills.includes(skillName)) {
-        setSelectedSkills([...selectedSkills, skillName]);
-      }
-      // Strip the @query from input when selecting a skill
-      setInput(stripAtQuery(input, cursorPosition));
-    },
     onRemoveSkill: (skillName) => {
       setSelectedSkills(selectedSkills.filter((s) => s !== skillName));
     },
     workspaceFiles,
-    onSelectFile: (file) => {
-      // Replace @query with @relativePath in input
-      const newInput = replaceAtQuery(input, `@${file.relativePath}`, cursorPosition);
-      setInput(newInput);
-      onAtFileSelected?.(file);
-    },
   });
-
-  // Transform to menu items for rendering
-  const skillMenuItems = useMemo<SkillSelectorMenuItem[]>(
-    () =>
-      skillSelectorController.filteredSkills.map((skill) => ({
-        key: skill.name,
-        name: skill.name,
-        displayName: skill.displayName,
-        description: skill.description,
-        icon: skill.icon,
-        emoji: skill.emoji,
-        enabled: skill.enabled,
-      })),
-    [skillSelectorController.filteredSkills]
-  );
 
   const onSkillPopoverClose = useCallback(() => {
     setIsSkillPopoverOpen(false);
-    setSkillPopoverSearchQuery('');
   }, []);
 
   // Skill trigger button - shown when running in Electron desktop
@@ -414,23 +372,20 @@ const SendBox: React.FC<{
       onVisibleChange={(v) => {
         if (!v) onSkillPopoverClose();
       }}
-      showTabs
       title={t('messages.skills.title', { defaultValue: 'Skills' })}
-      items={skillPopoverItems}
+      skills={skillSelectorItems}
       selectedKeys={selectedSkills}
       loading={loadingSkills}
       loadingText={t('messages.skills.loading', { defaultValue: 'Loading skills...' })}
-      onSelectItem={(item) => {
-        if (!selectedSkills.includes(item.key)) {
-          setSelectedSkills((prev) => [...prev, item.key]);
+      onSelectItem={(skill) => {
+        if (!selectedSkills.includes(skill.name)) {
+          setSelectedSkills((prev) => [...prev, skill.name]);
         }
         onSkillPopoverClose();
       }}
       emptyText={t('messages.skills.empty', { defaultValue: 'No skills found' })}
-      searchQuery={skillPopoverSearchQuery}
-      onSearchChange={setSkillPopoverSearchQuery}
       onDismiss={onSkillPopoverClose}
-      fileItems={skillPopoverFileItems}
+      workspaceFiles={workspaceFiles ?? undefined}
       onSelectFile={(file) => {
         onAtFileSelected?.(file);
         onSkillPopoverClose();
@@ -597,22 +552,19 @@ const SendBox: React.FC<{
           <div className='absolute left-12px bottom-[calc(100%+8px)] z-70 bg-[var(--color-bg-popup)] px-3 rd-xl shadow-lg'>
             <SkillSelectorMenuContent
               title={t('messages.skills.title', { defaultValue: 'Skills' })}
-              items={skillMenuItems}
+              skills={skillSelectorItems}
               selectedKeys={selectedSkills}
               loading={loadingSkills}
               loadingText={t('messages.skills.loading', { defaultValue: 'Loading skills...' })}
-              onSelectItem={(item) => {
-                if (!selectedSkills.includes(item.key)) {
-                  setSelectedSkills((prev) => [...prev, item.key]);
+              onSelectItem={(skill) => {
+                if (!selectedSkills.includes(skill.name)) {
+                  setSelectedSkills((prev) => [...prev, skill.name]);
                 }
                 setInput(stripAtQuery(input, cursorPosition));
                 skillSelectorController.setDismissed(true);
               }}
               emptyText={t('messages.skills.empty', { defaultValue: 'No skills found' })}
-              showTabs={skillSelectorController.showTabs}
-              activeTab={skillSelectorController.activeTab}
-              onTabChange={skillSelectorController.setActiveTab}
-              fileItems={skillSelectorController.filteredFiles}
+              workspaceFiles={workspaceFiles ?? undefined}
               onSelectFile={(file) => {
                 const newInput = replaceAtQuery(input, `@${file.relativePath}`, cursorPosition);
                 setInput(newInput);
@@ -622,8 +574,6 @@ const SendBox: React.FC<{
               skillsTabTitle={t('messages.skills.tabSkills', { defaultValue: 'Skills' })}
               filesTabTitle={t('messages.skills.tabFiles', { defaultValue: 'Files' })}
               filesEmptyText={t('messages.skills.filesEmpty', { defaultValue: 'No files in workspace' })}
-              searchQuery={skillSelectorController.searchQuery}
-              onSearchChange={skillSelectorController.setSearchQuery}
               onDismiss={() => {
                 skillSelectorController.setDismissed(true);
                 setInput(stripAtQuery(input, cursorPosition));
@@ -632,6 +582,7 @@ const SendBox: React.FC<{
               filesSearchPlaceholder={t('messages.skills.searchFiles', { defaultValue: '搜索文件...' })}
               noSearchResultsText={t('messages.skills.noSearchResults', { defaultValue: '未找到匹配结果' })}
               isVisible={skillSelectorController.isOpen}
+              query={skillSelectorController.query}
             />
           </div>
         )}

--- a/src/renderer/components/Sendbox.tsx
+++ b/src/renderer/components/Sendbox.tsx
@@ -601,10 +601,9 @@ const SendBox: React.FC<{
         )}
         {/* Skill Selector Menu (with optional file tabs) */}
         {skillSelectorController.isOpen && (
-          <div className='absolute left-12px right-12px bottom-[calc(100%+8px)] z-70'>
+          <div className='absolute left-12px bottom-[calc(100%+8px)] z-70 bg-[var(--color-bg-popup)] px-3 rd-xl shadow-lg'>
             <SkillSelectorMenuContent
               title={t('messages.skills.title', { defaultValue: 'Skills' })}
-              hint={t('messages.skills.hint', { defaultValue: 'Type @ to select skills' })}
               items={skillMenuItems}
               selectedKeys={selectedSkills}
               activeIndex={skillSelectorController.activeIndex}

--- a/src/renderer/components/SkillSelectorMenu.tsx
+++ b/src/renderer/components/SkillSelectorMenu.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -99,7 +99,7 @@ export function SkillSelectorMenuContent({
   return (
     <div className='w-72'>
       {/* Header with optional tabs */}
-      <div className='flex items-center justify-between gap-2 px-2 py-1'>
+      <div className='flex items-center justify-between gap-2 px-2'>
         {showTabs ? (
           <Tabs
             variant='line'
@@ -203,7 +203,7 @@ export function SkillSelectorMenuContent({
 
 export default function SkillSelectorPopover({ popupVisible, onVisibleChange, children, ...contentProps }: ISkillSelectorPopoverProps) {
   return (
-    <Popover popupVisible={popupVisible} trigger={[]} position='top' onVisibleChange={onVisibleChange} content={<SkillSelectorMenuContent {...contentProps} />} style={{ padding: 0, background: 'transparent', boxShadow: 'none' }}>
+    <Popover popupVisible={popupVisible} trigger={[]} position='top' onVisibleChange={onVisibleChange} content={<SkillSelectorMenuContent {...contentProps} />} className='[&_.arco-popover-content]:!py-1 [&_.arco-popover-content]:!px-3'>
       {children}
     </Popover>
   );

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -11,27 +11,7 @@ import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import SkillSelectorSkeleton from './base/SkillSelectorSkeleton';
 import Tabs from './ui/Tabs';
 
-export function SkillSelectorMenuContent({
-  title,
-  skills,
-  selectedKeys,
-  loading = false,
-  loadingText,
-  onSelectItem,
-  emptyText,
-  workspaceFiles,
-  onSelectFile,
-  filesTabTitle = 'Files',
-  skillsTabTitle = 'Skills',
-  filesEmptyText = 'No files',
-  onDismiss,
-  skillsSearchPlaceholder,
-  filesSearchPlaceholder,
-  noSearchResultsText,
-  isVisible = false,
-  query = null,
-  filterDisabled = false,
-}: ISkillSelectorMenuContentProps) {
+export function SkillSelectorMenuContent({ title, skills, selectedKeys, loading = false, loadingText, onSelectItem, emptyText, workspaceFiles, onSelectFile, onDismiss, isVisible = false, query = null, filterDisabled = false }: ISkillSelectorMenuContentProps) {
   const { t } = useTranslation();
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -41,9 +21,6 @@ export function SkillSelectorMenuContent({
 
   const showTabs = workspaceFiles != null;
 
-  const resolvedSkillsSearchPlaceholder = skillsSearchPlaceholder || t('messages.skills.searchSkills', '搜索技能...');
-  const resolvedFilesSearchPlaceholder = filesSearchPlaceholder || t('messages.skills.searchFiles', '搜索文件...');
-  const resolvedNoSearchResultsText = noSearchResultsText || t('messages.skills.noSearchResults', '未找到匹配结果');
   const resolvedLoadingText = loadingText || t('common.loadingSkills');
 
   // Reset search and tab when menu opens
@@ -137,8 +114,8 @@ export function SkillSelectorMenuContent({
             className='gap-0.5'
             value={activeTab}
             items={[
-              { value: 'skills', label: skillsTabTitle },
-              { value: 'files', label: filesTabTitle },
+              { value: 'skills', label: t('messages.skills.tabSkills', 'Skills') },
+              { value: 'files', label: t('messages.skills.tabFiles', 'Files') },
             ]}
             onChange={(v) => setActiveTab(v as AtMentionTab)}
             onMouseDown={(e) => e.preventDefault()}
@@ -150,7 +127,7 @@ export function SkillSelectorMenuContent({
       </div>
 
       {/* Search box */}
-      <Input className='my-3' size='small' prefix={<IconSearch />} allowClear placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder} value={searchQuery} onChange={setSearchQuery} onKeyDown={handleSearchKeyDown} />
+      <Input className='my-3' size='small' prefix={<IconSearch />} allowClear placeholder={activeTab === 'skills' ? t('messages.skills.searchSkills', '搜索技能...') : t('messages.skills.searchFiles', '搜索文件...')} value={searchQuery} onChange={setSearchQuery} onKeyDown={handleSearchKeyDown} />
 
       {/* Content area */}
       <div role='listbox' aria-busy={loading} className='overflow-y-auto h-260px'>
@@ -158,7 +135,7 @@ export function SkillSelectorMenuContent({
           <>
             {loading && filteredSkills.length === 0 && <SkillSelectorSkeleton count={4} />}
             {loading && filteredSkills.length > 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{resolvedLoadingText}</div>}
-            {!loading && filteredSkills.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? resolvedNoSearchResultsText : emptyText}</div>}
+            {!loading && filteredSkills.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? t('messages.skills.noSearchResults', '未找到匹配结果') : emptyText}</div>}
             {!loading &&
               filteredSkills.map((skill, index) => {
                 const isSelected = selectedKeys.includes(skill.name);
@@ -197,7 +174,7 @@ export function SkillSelectorMenuContent({
         {/* Files tab */}
         {activeTab === 'files' && (
           <>
-            {filteredFiles.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? resolvedNoSearchResultsText : filesEmptyText}</div>}
+            {filteredFiles.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? t('messages.skills.noSearchResults', '未找到匹配结果') : t('messages.skills.filesEmpty', 'No files in workspace')}</div>}
             {filteredFiles.map((file, index) => (
               <button
                 key={file.relativePath}
@@ -260,13 +237,7 @@ interface ISkillSelectorMenuContentProps {
   emptyText: string;
   workspaceFiles?: WorkspaceFileItem[];
   onSelectFile?: (file: WorkspaceFileItem) => void;
-  filesTabTitle?: string;
-  skillsTabTitle?: string;
-  filesEmptyText?: string;
   onDismiss?: () => void;
-  skillsSearchPlaceholder?: string;
-  filesSearchPlaceholder?: string;
-  noSearchResultsText?: string;
   /** Whether the menu is currently visible — activates keyboard listener */
   isVisible?: boolean;
   /** The @-mention query string for initial filtering */

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -8,6 +8,7 @@ import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 import { handleSkillIconError } from '@/renderer/utils/skillDisplay';
 import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import SkillSelectorSkeleton from './base/SkillSelectorSkeleton';
+import Tabs from './ui/Tabs';
 
 export function SkillSelectorMenuContent({
   title,
@@ -101,30 +102,18 @@ export function SkillSelectorMenuContent({
       {/* Header with optional tabs */}
       <div className='pb-2 border-b flex items-center justify-between gap-2'>
         {showTabs ? (
-          <div className='flex items-center gap-0.5'>
-            <button
-              type='button'
-              className={classNames('py-1 rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
-                'bg-primary text-white': activeTab === 'skills',
-                'bg-transparent text-secondary hover:text-foreground hover:bg-fill-2': activeTab !== 'skills',
-              })}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => handleTabChange('skills')}
-            >
-              {skillsTabTitle}
-            </button>
-            <button
-              type='button'
-              className={classNames('py-1 rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
-                'bg-primary text-white': activeTab === 'files',
-                'bg-transparent text-secondary hover:text-foreground hover:bg-fill-2': activeTab !== 'files',
-              })}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => handleTabChange('files')}
-            >
-              {filesTabTitle}
-            </button>
-          </div>
+          <Tabs
+            variant='pill'
+            className='gap-0.5'
+            itemClassName='text-13px'
+            value={activeTab}
+            items={[
+              { value: 'skills', label: skillsTabTitle },
+              { value: 'files', label: filesTabTitle },
+            ]}
+            onChange={(v) => handleTabChange(v as AtMentionTab)}
+            onMouseDown={(e) => e.preventDefault()}
+          />
         ) : (
           <div className='text-13px font-semibold text-foreground'>{title}</div>
         )}

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -1,4 +1,5 @@
-import { Popover } from '@arco-design/web-react';
+import { Input, Popover } from '@arco-design/web-react';
+import { IconSearch } from '@arco-design/web-react/icon';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -122,7 +123,7 @@ export function SkillSelectorMenuContent({
   return (
     <div>
       {/* Header with optional tabs */}
-      <div className='py-2 border-b flex items-center justify-between gap-2'>
+      <div className='pb-2 border-b flex items-center justify-between gap-2'>
         {showTabs ? (
           <div className='flex items-center gap-0.5'>
             <button
@@ -156,36 +157,10 @@ export function SkillSelectorMenuContent({
       </div>
 
       {/* Search box */}
-      {onSearchChange && (
-        <div
-          className='flex items-center gap-1.5 px-2 my-3 rounded-8px'
-          style={{
-            background: 'color-mix(in srgb, var(--color-fill-2) 60%, transparent)',
-          }}
-        >
-          <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' className='shrink-0 text-tertiary'>
-            <circle cx='11' cy='11' r='8' />
-            <path d='m21 21-4.35-4.35' />
-          </svg>
-          <input
-            type='text'
-            className='flex-1 min-w-0 text-13px bg-transparent border-none outline-none text-foreground placeholder:text-tertiary'
-            style={{ caretColor: 'var(--color-primary)' }}
-            placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder}
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            onKeyDown={handleSearchKeyDown}
-          />
-          {searchQuery && (
-            <button type='button' className='shrink-0 size-4 f-center rounded-full text-tertiary hover:text-secondary cursor-pointer border-none outline-none text-11px bg-transparent' onMouseDown={(e) => e.preventDefault()} onClick={() => onSearchChange('')}>
-              ✕
-            </button>
-          )}
-        </div>
-      )}
+      {onSearchChange && <Input className='my-3' size='small' prefix={<IconSearch />} allowClear placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder} value={searchQuery} onChange={onSearchChange} onKeyDown={handleSearchKeyDown} />}
 
       {/* Content area */}
-      <div role='listbox' aria-busy={loading} className='overflow-y-auto py-1.5' style={{ maxHeight: 'min(34vh, 260px)' }}>
+      <div role='listbox' aria-busy={loading} className='overflow-y-auto py-1.5 h-260px'>
         {/* Skills tab content */}
         {activeTab === 'skills' && (
           <>

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -9,43 +9,6 @@ import { handleSkillIconError } from '@/renderer/utils/skillDisplay';
 import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import SkillSelectorSkeleton from './base/SkillSelectorSkeleton';
 
-export interface SkillSelectorMenuItem {
-  key: string;
-  name: string;
-  displayName: string;
-  description?: string;
-  icon?: string;
-  emoji?: string;
-  enabled?: boolean;
-}
-
-interface ISkillSelectorMenuContentProps {
-  title: string;
-  hint?: string;
-  items: SkillSelectorMenuItem[];
-  selectedKeys: string[];
-  activeIndex: number;
-  loading?: boolean;
-  loadingText?: string;
-  onHoverItem: (index: number) => void;
-  onSelectItem: (item: SkillSelectorMenuItem) => void;
-  emptyText: string;
-  showTabs?: boolean;
-  activeTab?: AtMentionTab;
-  onTabChange?: (tab: AtMentionTab) => void;
-  fileItems?: WorkspaceFileItem[];
-  onSelectFile?: (file: WorkspaceFileItem) => void;
-  filesTabTitle?: string;
-  skillsTabTitle?: string;
-  filesEmptyText?: string;
-  searchQuery?: string;
-  onSearchChange?: (query: string) => void;
-  onDismiss?: () => void;
-  skillsSearchPlaceholder?: string;
-  filesSearchPlaceholder?: string;
-  noSearchResultsText?: string;
-}
-
 export function SkillSelectorMenuContent({
   title,
   hint,
@@ -239,6 +202,14 @@ export function SkillSelectorMenuContent({
   );
 }
 
+export default function SkillSelectorPopover({ popupVisible, onVisibleChange, children, ...contentProps }: ISkillSelectorPopoverProps) {
+  return (
+    <Popover popupVisible={popupVisible} trigger={[]} position='top' onVisibleChange={onVisibleChange} content={<SkillSelectorMenuContent {...contentProps} />} style={{ padding: 0, background: 'transparent', boxShadow: 'none' }}>
+      {children}
+    </Popover>
+  );
+}
+
 interface ISkillSelectorPopoverProps extends ISkillSelectorMenuContentProps {
   /** Controls popover visibility */
   popupVisible: boolean;
@@ -248,10 +219,39 @@ interface ISkillSelectorPopoverProps extends ISkillSelectorMenuContentProps {
   children: React.ReactNode;
 }
 
-export default function SkillSelectorPopover({ popupVisible, onVisibleChange, children, ...contentProps }: ISkillSelectorPopoverProps) {
-  return (
-    <Popover popupVisible={popupVisible} trigger={[]} position='top' onVisibleChange={onVisibleChange} content={<SkillSelectorMenuContent {...contentProps} />} style={{ padding: 0, background: 'transparent', boxShadow: 'none' }}>
-      {children}
-    </Popover>
-  );
+export interface SkillSelectorMenuItem {
+  key: string;
+  name: string;
+  displayName: string;
+  description?: string;
+  icon?: string;
+  emoji?: string;
+  enabled?: boolean;
+}
+
+interface ISkillSelectorMenuContentProps {
+  title: string;
+  hint?: string;
+  items: SkillSelectorMenuItem[];
+  selectedKeys: string[];
+  activeIndex: number;
+  loading?: boolean;
+  loadingText?: string;
+  onHoverItem: (index: number) => void;
+  onSelectItem: (item: SkillSelectorMenuItem) => void;
+  emptyText: string;
+  showTabs?: boolean;
+  activeTab?: AtMentionTab;
+  onTabChange?: (tab: AtMentionTab) => void;
+  fileItems?: WorkspaceFileItem[];
+  onSelectFile?: (file: WorkspaceFileItem) => void;
+  filesTabTitle?: string;
+  skillsTabTitle?: string;
+  filesEmptyText?: string;
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
+  onDismiss?: () => void;
+  skillsSearchPlaceholder?: string;
+  filesSearchPlaceholder?: string;
+  noSearchResultsText?: string;
 }

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -160,8 +160,7 @@ export function SkillSelectorMenuContent({
       {onSearchChange && <Input className='my-3' size='small' prefix={<IconSearch />} allowClear placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder} value={searchQuery} onChange={onSearchChange} onKeyDown={handleSearchKeyDown} />}
 
       {/* Content area */}
-      <div role='listbox' aria-busy={loading} className='overflow-y-auto py-1.5 h-260px'>
-        {/* Skills tab content */}
+      <div role='listbox' aria-busy={loading} className='overflow-y-auto h-260px'>
         {activeTab === 'skills' && (
           <>
             {loading && items.length === 0 && <SkillSelectorSkeleton count={4} />}
@@ -179,22 +178,14 @@ export function SkillSelectorMenuContent({
                     ref={(node) => {
                       itemRefs.current[index] = node;
                     }}
-                    className={classNames('w-full text-left px-2.5 py-1.5 rounded-8px transition-all border outline-none cursor-pointer mb-0.5 last:mb-0', {
-                      'border-light': index === activeIndex,
-                      'border-transparent hover:bg-fill-1': index !== activeIndex,
-                    })}
-                    style={{
-                      minHeight: '42px',
-                      background: index === activeIndex ? 'color-mix(in srgb, var(--aou-2) 88%, transparent)' : isSelected ? 'color-mix(in srgb, var(--color-primary-light-1) 50%, transparent)' : 'transparent',
-                      boxShadow: undefined,
-                    }}
+                    className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer hover:bg-subtle')}
                     onMouseDown={(e) => e.preventDefault()}
                     onMouseEnter={() => onHoverItem(index)}
                     onClick={() => onSelectItem(item)}
                   >
                     <div className='flex items-center gap-2'>
-                      <div className='size-7 flex-shrink-0 rd-6px overflow-hidden bg-fill-2 f-center text-16px'>{item.icon ? <img src={item.icon} alt={item.displayName} className='w-full h-full object-cover' onError={handleSkillIconError} /> : <span>{item.emoji || '⚡'}</span>}</div>
-                      <div className='min-w-0 flex-1'>
+                      <div className='size-8 flex-shrink-0 rd-6px f-center text-16px'>{item.icon ? <img src={item.icon} alt={item.displayName} className='w-full h-full object-cover' onError={handleSkillIconError} /> : <span>{item.emoji || '⚡'}</span>}</div>
+                      <div className='min-w-0 flex-1 space-y-1'>
                         <div className='flex items-center gap-1.5 min-w-0'>
                           <span className={classNames('text-14px truncate', index === activeIndex ? 'text-foreground font-semibold' : 'text-foreground font-medium')}>{item.displayName}</span>
                           {isSelected && <span className='px-1 py-0 bg-primary text-white text-9px rd-3px whitespace-nowrap flex-shrink-0 leading-14px'>{t('messages.skills.added', '已添加')}</span>}
@@ -220,14 +211,7 @@ export function SkillSelectorMenuContent({
                 ref={(node) => {
                   itemRefs.current[index] = node;
                 }}
-                className={classNames('w-full text-left px-2.5 py-1.5 rounded-8px transition-all border outline-none cursor-pointer mb-0.5 last:mb-0', {
-                  'border-light': index === activeIndex,
-                  'border-transparent hover:bg-fill-1': index !== activeIndex,
-                })}
-                style={{
-                  minHeight: '38px',
-                  background: index === activeIndex ? 'color-mix(in srgb, var(--aou-2) 88%, transparent)' : 'transparent',
-                }}
+                className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer hover:bg-subtle')}
                 onMouseDown={(e) => e.preventDefault()}
                 onMouseEnter={() => onHoverItem(index)}
                 onClick={() => onSelectFile?.(file)}

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -12,7 +12,6 @@ import Tabs from './ui/Tabs';
 
 export function SkillSelectorMenuContent({
   title,
-  hint,
   items,
   selectedKeys,
   activeIndex,
@@ -98,14 +97,13 @@ export function SkillSelectorMenuContent({
   );
 
   return (
-    <div>
+    <div className='w-72'>
       {/* Header with optional tabs */}
-      <div className='pb-2 border-b flex items-center justify-between gap-2'>
+      <div className='flex items-center justify-between gap-2 px-2 py-1'>
         {showTabs ? (
           <Tabs
-            variant='pill'
+            variant='line'
             className='gap-0.5'
-            itemClassName='text-13px'
             value={activeTab}
             items={[
               { value: 'skills', label: skillsTabTitle },
@@ -117,7 +115,6 @@ export function SkillSelectorMenuContent({
         ) : (
           <div className='text-13px font-semibold text-foreground'>{title}</div>
         )}
-        {hint && !showTabs && <div className='text-13px text-secondary truncate'>{hint}</div>}
         {showTabs && <div className='text-11px text-secondary truncate'>{t('messages.skills.tabToSwitch', 'Tab 切换')}</div>}
       </div>
 
@@ -233,7 +230,6 @@ export interface SkillSelectorMenuItem {
 
 interface ISkillSelectorMenuContentProps {
   title: string;
-  hint?: string;
   items: SkillSelectorMenuItem[];
   selectedKeys: string[];
   activeIndex: number;

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -159,7 +159,7 @@ export function SkillSelectorMenuContent({ title, skills, selectedKeys, loading 
                       <div className='size-8 flex-shrink-0 rd-6px f-center text-16px'>{skill.icon ? <img src={skill.icon} alt={skill.displayName} className='w-full h-full object-cover' onError={handleSkillIconError} /> : <span>{skill.emoji || '⚡'}</span>}</div>
                       <div className='min-w-0 flex-1 space-y-1'>
                         <div className='flex items-center gap-1.5 min-w-0'>
-                          <span className={classNames('text-14px truncate', index === activeIndex ? 'text-foreground font-semibold' : 'text-foreground font-medium')}>{skill.displayName}</span>
+                          <span className={classNames('text-14px truncate text-foreground font-medium')}>{skill.displayName}</span>
                           {isSelected && <span className='px-1 py-0 bg-primary text-white text-9px rd-3px whitespace-nowrap flex-shrink-0 leading-14px'>{t('messages.skills.added', '已添加')}</span>}
                         </div>
                         {skill.description && <div className='text-11px text-secondary truncate mt-px'>{skill.description}</div>}
@@ -194,7 +194,7 @@ export function SkillSelectorMenuContent({ title, skills, selectedKeys, loading 
                   <div className='size-6 flex-shrink-0 rd-4px bg-fill-2 f-center overflow-hidden'>{resolveFileIcon(file.name, { size: 16, theme: 'filled' })}</div>
                   <div className='min-w-0 flex-1'>
                     <div className='flex items-center gap-1.5 min-w-0'>
-                      <span className={classNames('text-13px truncate', index === activeIndex ? 'text-foreground font-semibold' : 'text-foreground font-medium')}>{file.name}</span>
+                      <span className={classNames('text-13px truncate text-foreground font-medium')}>{file.name}</span>
                       {file.isDraft && (
                         <span className='px-1 py-0 text-9px rd-3px whitespace-nowrap flex-shrink-0 leading-14px' style={{ background: 'var(--warning-soft)', color: 'var(--warning)' }}>
                           {t('conversation.workspace.drafts.badge', { defaultValue: '草稿' })}

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -14,10 +14,8 @@ export function SkillSelectorMenuContent({
   title,
   items,
   selectedKeys,
-  activeIndex,
   loading = false,
   loadingText,
-  onHoverItem,
   onSelectItem,
   emptyText,
   showTabs = false,
@@ -34,11 +32,12 @@ export function SkillSelectorMenuContent({
   skillsSearchPlaceholder,
   filesSearchPlaceholder,
   noSearchResultsText,
+  isVisible = false,
 }: ISkillSelectorMenuContentProps) {
   const { t } = useTranslation();
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
   const [internalActiveTab, setInternalActiveTab] = useState<AtMentionTab>('skills');
-  // Controlled when activeTabProp is provided, otherwise use internal state
   const activeTab = activeTabProp ?? internalActiveTab;
 
   const handleTabChange = useCallback(
@@ -56,29 +55,37 @@ export function SkillSelectorMenuContent({
   const resolvedNoSearchResultsText = noSearchResultsText || t('messages.skills.noSearchResults', '未找到匹配结果');
   const resolvedLoadingText = loadingText || t('common.loadingSkills');
 
+  // Reset active index when item list or active tab changes
   useEffect(() => {
-    const current = itemRefs.current[activeIndex];
-    if (current) {
-      current.scrollIntoView({ block: 'nearest' });
-    }
-  }, [activeIndex, items.length, fileItems.length, activeTab]);
+    setActiveIndex(0);
+  }, [items.length, fileItems.length, activeTab]);
 
-  const handleSearchKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
+  // Scroll active item into view
+  useEffect(() => {
+    itemRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  // Global capture-phase keydown — intercepts before the textarea when visible
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const handler = (e: KeyboardEvent) => {
       const currentItems = activeTab === 'skills' ? items : fileItems;
-      const itemCount = currentItems?.length ?? 0;
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        onHoverItem(Math.min(activeIndex + 1, itemCount - 1));
+        setActiveIndex((prev) => Math.min(prev + 1, currentItems.length - 1));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        onHoverItem(Math.max(activeIndex - 1, 0));
+        setActiveIndex((prev) => Math.max(prev - 1, 0));
+      } else if (e.key === 'Tab' && showTabs) {
+        e.preventDefault();
+        handleTabChange(activeTab === 'skills' ? 'files' : 'skills');
       } else if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         if (activeTab === 'skills' && items[activeIndex]) {
           onSelectItem(items[activeIndex]);
-        } else if (activeTab === 'files' && fileItems?.[activeIndex]) {
+        } else if (activeTab === 'files' && fileItems[activeIndex]) {
           onSelectFile?.(fileItems[activeIndex]);
         }
       } else if (e.key === 'Escape') {
@@ -88,12 +95,21 @@ export function SkillSelectorMenuContent({
         } else {
           onDismiss?.();
         }
-      } else if (e.key === 'Tab' && showTabs) {
-        e.preventDefault();
-        handleTabChange(activeTab === 'skills' ? 'files' : 'skills');
+      }
+    };
+
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [isVisible, activeTab, items, fileItems, activeIndex, showTabs, handleTabChange, onSelectItem, onSelectFile, onDismiss, onSearchChange, searchQuery]);
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Navigation is handled by the global listener; only intercept Escape to clear search
+      if (e.key === 'Escape' && searchQuery) {
+        e.stopPropagation();
       }
     },
-    [activeTab, items, fileItems, activeIndex, onHoverItem, onSelectItem, onSelectFile, onDismiss, onSearchChange, searchQuery, showTabs, handleTabChange]
+    [searchQuery]
   );
 
   return (
@@ -142,7 +158,7 @@ export function SkillSelectorMenuContent({
                     }}
                     className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer hover:bg-subtle')}
                     onMouseDown={(e) => e.preventDefault()}
-                    onMouseEnter={() => onHoverItem(index)}
+                    onMouseEnter={() => setActiveIndex(index)}
                     onClick={() => onSelectItem(item)}
                   >
                     <div className='flex items-center gap-2'>
@@ -175,7 +191,7 @@ export function SkillSelectorMenuContent({
                 }}
                 className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer hover:bg-subtle')}
                 onMouseDown={(e) => e.preventDefault()}
-                onMouseEnter={() => onHoverItem(index)}
+                onMouseEnter={() => setActiveIndex(index)}
                 onClick={() => onSelectFile?.(file)}
               >
                 <div className='flex items-center gap-2'>
@@ -203,7 +219,7 @@ export function SkillSelectorMenuContent({
 
 export default function SkillSelectorPopover({ popupVisible, onVisibleChange, children, ...contentProps }: ISkillSelectorPopoverProps) {
   return (
-    <Popover popupVisible={popupVisible} trigger={[]} position='top' onVisibleChange={onVisibleChange} content={<SkillSelectorMenuContent {...contentProps} />} className='[&_.arco-popover-content]:!py-1 [&_.arco-popover-content]:!px-3'>
+    <Popover popupVisible={popupVisible} trigger={[]} position='top' onVisibleChange={onVisibleChange} content={<SkillSelectorMenuContent {...contentProps} isVisible={popupVisible} />} className='[&_.arco-popover-content]:!py-1 [&_.arco-popover-content]:!px-3'>
       {children}
     </Popover>
   );
@@ -230,12 +246,11 @@ export interface SkillSelectorMenuItem {
 
 interface ISkillSelectorMenuContentProps {
   title: string;
+  hint?: string;
   items: SkillSelectorMenuItem[];
   selectedKeys: string[];
-  activeIndex: number;
   loading?: boolean;
   loadingText?: string;
-  onHoverItem: (index: number) => void;
   onSelectItem: (item: SkillSelectorMenuItem) => void;
   emptyText: string;
   showTabs?: boolean;
@@ -252,4 +267,6 @@ interface ISkillSelectorMenuContentProps {
   skillsSearchPlaceholder?: string;
   filesSearchPlaceholder?: string;
   noSearchResultsText?: string;
+  /** Whether the menu is currently visible — activates keyboard listener */
+  isVisible?: boolean;
 }

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -1,77 +1,100 @@
 import { Input, Popover } from '@arco-design/web-react';
 import { IconSearch } from '@arco-design/web-react/icon';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { AtMentionTab } from '@/renderer/hooks/useSkillSelectorController';
+import type { AtMentionTab, SkillSelectorItem } from '@/renderer/hooks/useSkillSelectorController';
 import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 import { handleSkillIconError } from '@/renderer/utils/skillDisplay';
 import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import SkillSelectorSkeleton from './base/SkillSelectorSkeleton';
 import Tabs from './ui/Tabs';
 
+const DEBOUNCE_DELAY = 150;
+
 export function SkillSelectorMenuContent({
   title,
-  items,
+  skills,
   selectedKeys,
   loading = false,
   loadingText,
   onSelectItem,
   emptyText,
-  showTabs = false,
-  activeTab: activeTabProp,
-  onTabChange,
-  fileItems = [],
+  workspaceFiles,
   onSelectFile,
   filesTabTitle = 'Files',
   skillsTabTitle = 'Skills',
   filesEmptyText = 'No files',
-  searchQuery = '',
-  onSearchChange,
   onDismiss,
   skillsSearchPlaceholder,
   filesSearchPlaceholder,
   noSearchResultsText,
   isVisible = false,
+  query = null,
+  filterDisabled = false,
 }: ISkillSelectorMenuContentProps) {
   const { t } = useTranslation();
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const [activeIndex, setActiveIndex] = useState(0);
-  const [internalActiveTab, setInternalActiveTab] = useState<AtMentionTab>('skills');
-  const activeTab = activeTabProp ?? internalActiveTab;
+  const [activeTab, setActiveTab] = useState<AtMentionTab>('skills');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
 
-  const handleTabChange = useCallback(
-    (tab: AtMentionTab) => {
-      if (activeTabProp === undefined) {
-        setInternalActiveTab(tab);
-      }
-      onTabChange?.(tab);
-    },
-    [activeTabProp, onTabChange]
-  );
+  const showTabs = workspaceFiles != null;
 
   const resolvedSkillsSearchPlaceholder = skillsSearchPlaceholder || t('messages.skills.searchSkills', '搜索技能...');
   const resolvedFilesSearchPlaceholder = filesSearchPlaceholder || t('messages.skills.searchFiles', '搜索文件...');
   const resolvedNoSearchResultsText = noSearchResultsText || t('messages.skills.noSearchResults', '未找到匹配结果');
   const resolvedLoadingText = loadingText || t('common.loadingSkills');
 
-  // Reset active index when item list or active tab changes
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery), DEBOUNCE_DELAY);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Reset search and tab when menu opens (query changes from null to non-null)
+  useEffect(() => {
+    if (isVisible) {
+      setSearchQuery('');
+      setActiveTab('skills');
+    }
+  }, [isVisible]);
+
+  const filteredSkills = useMemo(() => {
+    const result = filterDisabled ? skills.filter((s) => s.enabled !== false) : skills;
+    const keyword = (debouncedSearch.trim() || (query ?? '').trim()).toLowerCase();
+    if (!keyword) return result;
+    return result.filter((s) => {
+      const raw = debouncedSearch.trim() || (query ?? '').trim();
+      return s.name.toLowerCase().includes(keyword) || s.displayName.toLowerCase().includes(keyword) || (s.description?.toLowerCase().includes(keyword) ?? false) || s.displayName.includes(raw);
+    });
+  }, [skills, debouncedSearch, query, filterDisabled]);
+
+  const filteredFiles = useMemo(() => {
+    if (!workspaceFiles) return [];
+    const keyword = (debouncedSearch.trim() || (query ?? '').trim()).toLowerCase();
+    if (!keyword) return workspaceFiles;
+    return workspaceFiles.filter((f) => f.name.toLowerCase().includes(keyword) || f.relativePath.toLowerCase().includes(keyword));
+  }, [workspaceFiles, debouncedSearch, query]);
+
+  const currentItems = activeTab === 'skills' ? filteredSkills : filteredFiles;
+
+  // Reset active index when list or tab changes
   useEffect(() => {
     setActiveIndex(0);
-  }, [items.length, fileItems.length, activeTab]);
+  }, [filteredSkills.length, filteredFiles.length, activeTab]);
 
   // Scroll active item into view
   useEffect(() => {
     itemRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' });
   }, [activeIndex]);
 
-  // Global capture-phase keydown — intercepts before the textarea when visible
+  // Global capture-phase keydown
   useEffect(() => {
     if (!isVisible) return;
 
     const handler = (e: KeyboardEvent) => {
-      const currentItems = activeTab === 'skills' ? items : fileItems;
-
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setActiveIndex((prev) => Math.min(prev + 1, currentItems.length - 1));
@@ -80,18 +103,18 @@ export function SkillSelectorMenuContent({
         setActiveIndex((prev) => Math.max(prev - 1, 0));
       } else if (e.key === 'Tab' && showTabs) {
         e.preventDefault();
-        handleTabChange(activeTab === 'skills' ? 'files' : 'skills');
+        setActiveTab((prev) => (prev === 'skills' ? 'files' : 'skills'));
       } else if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        if (activeTab === 'skills' && items[activeIndex]) {
-          onSelectItem(items[activeIndex]);
-        } else if (activeTab === 'files' && fileItems[activeIndex]) {
-          onSelectFile?.(fileItems[activeIndex]);
+        if (activeTab === 'skills' && filteredSkills[activeIndex]) {
+          onSelectItem(filteredSkills[activeIndex]);
+        } else if (activeTab === 'files' && filteredFiles[activeIndex]) {
+          onSelectFile?.(filteredFiles[activeIndex]);
         }
       } else if (e.key === 'Escape') {
         e.preventDefault();
         if (searchQuery) {
-          onSearchChange?.('');
+          setSearchQuery('');
         } else {
           onDismiss?.();
         }
@@ -100,11 +123,10 @@ export function SkillSelectorMenuContent({
 
     document.addEventListener('keydown', handler, true);
     return () => document.removeEventListener('keydown', handler, true);
-  }, [isVisible, activeTab, items, fileItems, activeIndex, showTabs, handleTabChange, onSelectItem, onSelectFile, onDismiss, onSearchChange, searchQuery]);
+  }, [isVisible, activeTab, filteredSkills, filteredFiles, activeIndex, showTabs, onSelectItem, onSelectFile, onDismiss, searchQuery, currentItems.length]);
 
   const handleSearchKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // Navigation is handled by the global listener; only intercept Escape to clear search
       if (e.key === 'Escape' && searchQuery) {
         e.stopPropagation();
       }
@@ -114,7 +136,7 @@ export function SkillSelectorMenuContent({
 
   return (
     <div className='w-72'>
-      {/* Header with optional tabs */}
+      {/* Header */}
       <div className='flex items-center justify-between gap-2 px-2'>
         {showTabs ? (
           <Tabs
@@ -125,7 +147,7 @@ export function SkillSelectorMenuContent({
               { value: 'skills', label: skillsTabTitle },
               { value: 'files', label: filesTabTitle },
             ]}
-            onChange={(v) => handleTabChange(v as AtMentionTab)}
+            onChange={(v) => setActiveTab(v as AtMentionTab)}
             onMouseDown={(e) => e.preventDefault()}
           />
         ) : (
@@ -135,21 +157,21 @@ export function SkillSelectorMenuContent({
       </div>
 
       {/* Search box */}
-      {onSearchChange && <Input className='my-3' size='small' prefix={<IconSearch />} allowClear placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder} value={searchQuery} onChange={onSearchChange} onKeyDown={handleSearchKeyDown} />}
+      <Input className='my-3' size='small' prefix={<IconSearch />} allowClear placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder} value={searchQuery} onChange={setSearchQuery} onKeyDown={handleSearchKeyDown} />
 
       {/* Content area */}
       <div role='listbox' aria-busy={loading} className='overflow-y-auto h-260px'>
         {activeTab === 'skills' && (
           <>
-            {loading && items.length === 0 && <SkillSelectorSkeleton count={4} />}
-            {loading && items.length > 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{resolvedLoadingText}</div>}
-            {!loading && items.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? resolvedNoSearchResultsText : emptyText}</div>}
+            {loading && filteredSkills.length === 0 && <SkillSelectorSkeleton count={4} />}
+            {loading && filteredSkills.length > 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{resolvedLoadingText}</div>}
+            {!loading && filteredSkills.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? resolvedNoSearchResultsText : emptyText}</div>}
             {!loading &&
-              items.map((item, index) => {
-                const isSelected = selectedKeys.includes(item.key);
+              filteredSkills.map((skill, index) => {
+                const isSelected = selectedKeys.includes(skill.name);
                 return (
                   <button
-                    key={item.key}
+                    key={skill.name}
                     type='button'
                     role='option'
                     aria-selected={isSelected}
@@ -161,16 +183,16 @@ export function SkillSelectorMenuContent({
                     })}
                     onMouseDown={(e) => e.preventDefault()}
                     onMouseEnter={() => setActiveIndex(index)}
-                    onClick={() => onSelectItem(item)}
+                    onClick={() => onSelectItem(skill)}
                   >
                     <div className='flex items-center gap-2'>
-                      <div className='size-8 flex-shrink-0 rd-6px f-center text-16px'>{item.icon ? <img src={item.icon} alt={item.displayName} className='w-full h-full object-cover' onError={handleSkillIconError} /> : <span>{item.emoji || '⚡'}</span>}</div>
+                      <div className='size-8 flex-shrink-0 rd-6px f-center text-16px'>{skill.icon ? <img src={skill.icon} alt={skill.displayName} className='w-full h-full object-cover' onError={handleSkillIconError} /> : <span>{skill.emoji || '⚡'}</span>}</div>
                       <div className='min-w-0 flex-1 space-y-1'>
                         <div className='flex items-center gap-1.5 min-w-0'>
-                          <span className={classNames('text-14px truncate', index === activeIndex ? 'text-foreground font-semibold' : 'text-foreground font-medium')}>{item.displayName}</span>
+                          <span className={classNames('text-14px truncate', index === activeIndex ? 'text-foreground font-semibold' : 'text-foreground font-medium')}>{skill.displayName}</span>
                           {isSelected && <span className='px-1 py-0 bg-primary text-white text-9px rd-3px whitespace-nowrap flex-shrink-0 leading-14px'>{t('messages.skills.added', '已添加')}</span>}
                         </div>
-                        {item.description && <div className='text-11px text-secondary truncate mt-px'>{item.description}</div>}
+                        {skill.description && <div className='text-11px text-secondary truncate mt-px'>{skill.description}</div>}
                       </div>
                     </div>
                   </button>
@@ -179,11 +201,11 @@ export function SkillSelectorMenuContent({
           </>
         )}
 
-        {/* Files tab content */}
+        {/* Files tab */}
         {activeTab === 'files' && (
           <>
-            {fileItems.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? resolvedNoSearchResultsText : filesEmptyText}</div>}
-            {fileItems.map((file, index) => (
+            {filteredFiles.length === 0 && <div className='px-2.5 py-3 text-13px text-secondary'>{searchQuery ? resolvedNoSearchResultsText : filesEmptyText}</div>}
+            {filteredFiles.map((file, index) => (
               <button
                 key={file.relativePath}
                 type='button'
@@ -230,47 +252,32 @@ export default function SkillSelectorPopover({ popupVisible, onVisibleChange, ch
 }
 
 interface ISkillSelectorPopoverProps extends ISkillSelectorMenuContentProps {
-  /** Controls popover visibility */
   popupVisible: boolean;
-  /** Callback when visibility changes (e.g. click outside) */
   onVisibleChange?: (visible: boolean) => void;
-  /** Trigger element */
   children: React.ReactNode;
-}
-
-export interface SkillSelectorMenuItem {
-  key: string;
-  name: string;
-  displayName: string;
-  description?: string;
-  icon?: string;
-  emoji?: string;
-  enabled?: boolean;
 }
 
 interface ISkillSelectorMenuContentProps {
   title: string;
-  hint?: string;
-  items: SkillSelectorMenuItem[];
+  skills: SkillSelectorItem[];
   selectedKeys: string[];
   loading?: boolean;
   loadingText?: string;
-  onSelectItem: (item: SkillSelectorMenuItem) => void;
+  onSelectItem: (skill: SkillSelectorItem) => void;
   emptyText: string;
-  showTabs?: boolean;
-  activeTab?: AtMentionTab;
-  onTabChange?: (tab: AtMentionTab) => void;
-  fileItems?: WorkspaceFileItem[];
+  workspaceFiles?: WorkspaceFileItem[];
   onSelectFile?: (file: WorkspaceFileItem) => void;
   filesTabTitle?: string;
   skillsTabTitle?: string;
   filesEmptyText?: string;
-  searchQuery?: string;
-  onSearchChange?: (query: string) => void;
   onDismiss?: () => void;
   skillsSearchPlaceholder?: string;
   filesSearchPlaceholder?: string;
   noSearchResultsText?: string;
   /** Whether the menu is currently visible — activates keyboard listener */
   isVisible?: boolean;
+  /** The @-mention query string for initial filtering */
+  query?: string | null;
+  /** Filter out disabled skills */
+  filterDisabled?: boolean;
 }

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -1,7 +1,7 @@
 import { Input, Popover } from '@arco-design/web-react';
 import { IconSearch } from '@arco-design/web-react/icon';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AtMentionTab } from '@/renderer/hooks/useSkillSelectorController';
 import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
@@ -21,7 +21,7 @@ export function SkillSelectorMenuContent({
   onSelectItem,
   emptyText,
   showTabs = false,
-  activeTab = 'skills',
+  activeTab: activeTabProp,
   onTabChange,
   fileItems = [],
   onSelectFile,
@@ -37,6 +37,19 @@ export function SkillSelectorMenuContent({
 }: ISkillSelectorMenuContentProps) {
   const { t } = useTranslation();
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [internalActiveTab, setInternalActiveTab] = useState<AtMentionTab>('skills');
+  // Controlled when activeTabProp is provided, otherwise use internal state
+  const activeTab = activeTabProp ?? internalActiveTab;
+
+  const handleTabChange = useCallback(
+    (tab: AtMentionTab) => {
+      if (activeTabProp === undefined) {
+        setInternalActiveTab(tab);
+      }
+      onTabChange?.(tab);
+    },
+    [activeTabProp, onTabChange]
+  );
 
   const resolvedSkillsSearchPlaceholder = skillsSearchPlaceholder || t('messages.skills.searchSkills', '搜索技能...');
   const resolvedFilesSearchPlaceholder = filesSearchPlaceholder || t('messages.skills.searchFiles', '搜索文件...');
@@ -75,12 +88,12 @@ export function SkillSelectorMenuContent({
         } else {
           onDismiss?.();
         }
-      } else if (e.key === 'Tab' && showTabs && onTabChange) {
+      } else if (e.key === 'Tab' && showTabs) {
         e.preventDefault();
-        onTabChange(activeTab === 'skills' ? 'files' : 'skills');
+        handleTabChange(activeTab === 'skills' ? 'files' : 'skills');
       }
     },
-    [activeTab, items, fileItems, activeIndex, onHoverItem, onSelectItem, onSelectFile, onDismiss, onSearchChange, searchQuery, showTabs, onTabChange]
+    [activeTab, items, fileItems, activeIndex, onHoverItem, onSelectItem, onSelectFile, onDismiss, onSearchChange, searchQuery, showTabs, handleTabChange]
   );
 
   return (
@@ -96,7 +109,7 @@ export function SkillSelectorMenuContent({
                 'bg-transparent text-secondary hover:text-foreground hover:bg-fill-2': activeTab !== 'skills',
               })}
               onMouseDown={(e) => e.preventDefault()}
-              onClick={() => onTabChange?.('skills')}
+              onClick={() => handleTabChange('skills')}
             >
               {skillsTabTitle}
             </button>
@@ -107,7 +120,7 @@ export function SkillSelectorMenuContent({
                 'bg-transparent text-secondary hover:text-foreground hover:bg-fill-2': activeTab !== 'files',
               })}
               onMouseDown={(e) => e.preventDefault()}
-              onClick={() => onTabChange?.('files')}
+              onClick={() => handleTabChange('files')}
             >
               {filesTabTitle}
             </button>

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -158,36 +158,29 @@ export function SkillSelectorMenuContent({
       {/* Search box */}
       {onSearchChange && (
         <div
-          className='py-1.5 border-b'
+          className='flex items-center gap-1.5 px-2 my-3 rounded-8px'
           style={{
-            borderColor: 'color-mix(in srgb, var(--color-border-2) 56%, transparent)',
+            background: 'color-mix(in srgb, var(--color-fill-2) 60%, transparent)',
           }}
         >
-          <div
-            className='flex items-center gap-1.5 px-2 py-1 rounded-8px'
-            style={{
-              background: 'color-mix(in srgb, var(--color-fill-2) 60%, transparent)',
-            }}
-          >
-            <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' className='shrink-0 text-tertiary'>
-              <circle cx='11' cy='11' r='8' />
-              <path d='m21 21-4.35-4.35' />
-            </svg>
-            <input
-              type='text'
-              className='flex-1 min-w-0 text-13px bg-transparent border-none outline-none text-foreground placeholder:text-tertiary'
-              style={{ caretColor: 'var(--color-primary)' }}
-              placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder}
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              onKeyDown={handleSearchKeyDown}
-            />
-            {searchQuery && (
-              <button type='button' className='shrink-0 size-4 f-center rounded-full text-tertiary hover:text-secondary cursor-pointer border-none outline-none text-11px bg-transparent' onMouseDown={(e) => e.preventDefault()} onClick={() => onSearchChange('')}>
-                ✕
-              </button>
-            )}
-          </div>
+          <svg width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' className='shrink-0 text-tertiary'>
+            <circle cx='11' cy='11' r='8' />
+            <path d='m21 21-4.35-4.35' />
+          </svg>
+          <input
+            type='text'
+            className='flex-1 min-w-0 text-13px bg-transparent border-none outline-none text-foreground placeholder:text-tertiary'
+            style={{ caretColor: 'var(--color-primary)' }}
+            placeholder={activeTab === 'skills' ? resolvedSkillsSearchPlaceholder : resolvedFilesSearchPlaceholder}
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+          />
+          {searchQuery && (
+            <button type='button' className='shrink-0 size-4 f-center rounded-full text-tertiary hover:text-secondary cursor-pointer border-none outline-none text-11px bg-transparent' onMouseDown={(e) => e.preventDefault()} onClick={() => onSearchChange('')}>
+              ✕
+            </button>
+          )}
         </div>
       )}
 

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -1,3 +1,4 @@
+import { Popover } from '@arco-design/web-react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +18,7 @@ export interface SkillSelectorMenuItem {
   enabled?: boolean;
 }
 
-interface SkillSelectorMenuProps {
+interface ISkillSelectorMenuContentProps {
   title: string;
   hint?: string;
   items: SkillSelectorMenuItem[];
@@ -28,37 +29,23 @@ interface SkillSelectorMenuProps {
   onHoverItem: (index: number) => void;
   onSelectItem: (item: SkillSelectorMenuItem) => void;
   emptyText: string;
-  /** Whether to show tabs (skills/files) */
   showTabs?: boolean;
-  /** Current active tab */
   activeTab?: AtMentionTab;
-  /** Callback when tab changes */
   onTabChange?: (tab: AtMentionTab) => void;
-  /** File items for the files tab */
   fileItems?: WorkspaceFileItem[];
-  /** Callback when a file item is selected */
   onSelectFile?: (file: WorkspaceFileItem) => void;
-  /** Text for files tab title */
   filesTabTitle?: string;
-  /** Text for skills tab title */
   skillsTabTitle?: string;
-  /** Empty text for files tab */
   filesEmptyText?: string;
-  /** Search query for filtering */
   searchQuery?: string;
-  /** Callback when search query changes */
   onSearchChange?: (query: string) => void;
-  /** Callback to dismiss/close the menu */
   onDismiss?: () => void;
-  /** Placeholder text for skills search */
   skillsSearchPlaceholder?: string;
-  /** Placeholder text for files search */
   filesSearchPlaceholder?: string;
-  /** Text shown when search has no results */
   noSearchResultsText?: string;
 }
 
-const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({
+export function SkillSelectorMenuContent({
   title,
   hint,
   items,
@@ -83,30 +70,13 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({
   skillsSearchPlaceholder,
   filesSearchPlaceholder,
   noSearchResultsText,
-}) => {
+}: ISkillSelectorMenuContentProps) {
   const { t } = useTranslation();
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const menuRef = useRef<HTMLDivElement>(null);
 
-  // Use i18n for default text values
   const resolvedSkillsSearchPlaceholder = skillsSearchPlaceholder || t('messages.skills.searchSkills', '搜索技能...');
   const resolvedFilesSearchPlaceholder = filesSearchPlaceholder || t('messages.skills.searchFiles', '搜索文件...');
   const resolvedNoSearchResultsText = noSearchResultsText || t('messages.skills.noSearchResults', '未找到匹配结果');
-
-  // Close menu when clicking outside
-  const onDismissRef = useRef(onDismiss);
-  onDismissRef.current = onDismiss;
-  useEffect(() => {
-    const handleMouseDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onDismissRef.current?.();
-      }
-    };
-    document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, []);
-
-  // Use i18n loading text if not provided
   const resolvedLoadingText = loadingText || t('common.loadingSkills');
 
   useEffect(() => {
@@ -151,7 +121,6 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({
 
   return (
     <div
-      ref={menuRef}
       className='rounded-14px border shadow-[0_8px_24px_rgba(0,0,0,0.12)] overflow-hidden'
       style={{
         borderColor: 'var(--color-border-2)',
@@ -273,9 +242,7 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({
                     onClick={() => onSelectItem(item)}
                   >
                     <div className='flex items-center gap-2'>
-                      {/* Icon / Emoji */}
                       <div className='size-7 flex-shrink-0 rd-6px overflow-hidden bg-fill-2 f-center text-16px'>{item.icon ? <img src={item.icon} alt={item.displayName} className='w-full h-full object-cover' onError={handleSkillIconError} /> : <span>{item.emoji || '⚡'}</span>}</div>
-                      {/* Content */}
                       <div className='min-w-0 flex-1'>
                         <div className='flex items-center gap-1.5 min-w-0'>
                           <span className={classNames('text-14px truncate', index === activeIndex ? 'text-foreground font-semibold' : 'text-foreground font-medium')}>{item.displayName}</span>
@@ -335,6 +302,21 @@ const SkillSelectorMenu: React.FC<SkillSelectorMenuProps> = ({
       </div>
     </div>
   );
-};
+}
 
-export default SkillSelectorMenu;
+interface ISkillSelectorPopoverProps extends ISkillSelectorMenuContentProps {
+  /** Controls popover visibility */
+  popupVisible: boolean;
+  /** Callback when visibility changes (e.g. click outside) */
+  onVisibleChange?: (visible: boolean) => void;
+  /** Trigger element */
+  children: React.ReactNode;
+}
+
+export default function SkillSelectorPopover({ popupVisible, onVisibleChange, children, ...contentProps }: ISkillSelectorPopoverProps) {
+  return (
+    <Popover popupVisible={popupVisible} trigger={[]} position='top' onVisibleChange={onVisibleChange} content={<SkillSelectorMenuContent {...contentProps} />} style={{ padding: 0, background: 'transparent', boxShadow: 'none' }}>
+      {children}
+    </Popover>
+  );
+}

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -156,7 +156,9 @@ export function SkillSelectorMenuContent({
                     ref={(node) => {
                       itemRefs.current[index] = node;
                     }}
-                    className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer hover:bg-subtle')}
+                    className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer', {
+                      'bg-fill-2': index === activeIndex,
+                    })}
                     onMouseDown={(e) => e.preventDefault()}
                     onMouseEnter={() => setActiveIndex(index)}
                     onClick={() => onSelectItem(item)}
@@ -189,7 +191,9 @@ export function SkillSelectorMenuContent({
                 ref={(node) => {
                   itemRefs.current[index] = node;
                 }}
-                className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer hover:bg-subtle')}
+                className={classNames('w-full bg-transparent text-left p-2.5 rounded-xl transition-all cursor-pointer', {
+                  'bg-fill-2': index === activeIndex,
+                })}
                 onMouseDown={(e) => e.preventDefault()}
                 onMouseEnter={() => setActiveIndex(index)}
                 onClick={() => onSelectFile?.(file)}

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -120,31 +120,14 @@ export function SkillSelectorMenuContent({
   );
 
   return (
-    <div
-      className='rounded-14px border shadow-[0_8px_24px_rgba(0,0,0,0.12)] overflow-hidden'
-      style={{
-        borderColor: 'var(--color-border-2)',
-        background: 'color-mix(in srgb, var(--color-bg-1) 78%, transparent)',
-        backdropFilter: 'blur(14px) saturate(1.1)',
-        WebkitBackdropFilter: 'blur(14px) saturate(1.1)',
-        maxWidth: 'min(380px, calc(100vw - 64px))',
-        width: 'max-content',
-        minWidth: '240px',
-      }}
-    >
+    <div>
       {/* Header with optional tabs */}
-      <div
-        className='px-3 py-2 border-b flex items-center justify-between gap-2'
-        style={{
-          borderColor: 'color-mix(in srgb, var(--color-border-2) 56%, transparent)',
-          background: 'color-mix(in srgb, var(--color-bg-1) 84%, transparent)',
-        }}
-      >
+      <div className='py-2 border-b flex items-center justify-between gap-2'>
         {showTabs ? (
           <div className='flex items-center gap-0.5'>
             <button
               type='button'
-              className={classNames('px-2.5 py-1 rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
+              className={classNames('py-1 rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
                 'bg-primary text-white': activeTab === 'skills',
                 'bg-transparent text-secondary hover:text-foreground hover:bg-fill-2': activeTab !== 'skills',
               })}
@@ -155,7 +138,7 @@ export function SkillSelectorMenuContent({
             </button>
             <button
               type='button'
-              className={classNames('px-2.5 py-1 rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
+              className={classNames('py-1 rounded-8px text-13px font-medium cursor-pointer border-none outline-none transition-colors', {
                 'bg-primary text-white': activeTab === 'files',
                 'bg-transparent text-secondary hover:text-foreground hover:bg-fill-2': activeTab !== 'files',
               })}
@@ -175,7 +158,7 @@ export function SkillSelectorMenuContent({
       {/* Search box */}
       {onSearchChange && (
         <div
-          className='px-2 py-1.5 border-b'
+          className='py-1.5 border-b'
           style={{
             borderColor: 'color-mix(in srgb, var(--color-border-2) 56%, transparent)',
           }}
@@ -209,7 +192,7 @@ export function SkillSelectorMenuContent({
       )}
 
       {/* Content area */}
-      <div role='listbox' aria-busy={loading} className='overflow-y-auto p-1.5' style={{ maxHeight: 'min(34vh, 260px)' }}>
+      <div role='listbox' aria-busy={loading} className='overflow-y-auto py-1.5' style={{ maxHeight: 'min(34vh, 260px)' }}>
         {/* Skills tab content */}
         {activeTab === 'skills' && (
           <>

--- a/src/renderer/components/SkillSelectorPopover.tsx
+++ b/src/renderer/components/SkillSelectorPopover.tsx
@@ -1,5 +1,6 @@
 import { Input, Popover } from '@arco-design/web-react';
 import { IconSearch } from '@arco-design/web-react/icon';
+import { useDebounce } from 'ahooks';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,8 +10,6 @@ import { handleSkillIconError } from '@/renderer/utils/skillDisplay';
 import { resolveFileIcon } from '@/renderer/utils/fileIcon';
 import SkillSelectorSkeleton from './base/SkillSelectorSkeleton';
 import Tabs from './ui/Tabs';
-
-const DEBOUNCE_DELAY = 150;
 
 export function SkillSelectorMenuContent({
   title,
@@ -38,7 +37,7 @@ export function SkillSelectorMenuContent({
   const [activeIndex, setActiveIndex] = useState(0);
   const [activeTab, setActiveTab] = useState<AtMentionTab>('skills');
   const [searchQuery, setSearchQuery] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const debouncedSearch = useDebounce(searchQuery, { wait: 150 });
 
   const showTabs = workspaceFiles != null;
 
@@ -47,13 +46,7 @@ export function SkillSelectorMenuContent({
   const resolvedNoSearchResultsText = noSearchResultsText || t('messages.skills.noSearchResults', '未找到匹配结果');
   const resolvedLoadingText = loadingText || t('common.loadingSkills');
 
-  // Debounce search input
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(searchQuery), DEBOUNCE_DELAY);
-    return () => clearTimeout(timer);
-  }, [searchQuery]);
-
-  // Reset search and tab when menu opens (query changes from null to non-null)
+  // Reset search and tab when menu opens
   useEffect(() => {
     if (isVisible) {
       setSearchQuery('');

--- a/src/renderer/components/SlashCommandMenu.tsx
+++ b/src/renderer/components/SlashCommandMenu.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import classNames from 'classnames';
 import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/components/ThoughtDisplay.tsx
+++ b/src/renderer/components/ThoughtDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Tag, Spin } from '@arco-design/web-react';
 import React, { useMemo, useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/components/WebviewHost.tsx
+++ b/src/renderer/components/WebviewHost.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Left, Right, Refresh, Loading } from '@icon-park/react';

--- a/src/renderer/components/base/AionScrollArea.tsx
+++ b/src/renderer/components/base/AionScrollArea.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import classNames from 'classnames';
 import React from 'react';
 

--- a/src/renderer/components/base/BdpanImportFilePicker.tsx
+++ b/src/renderer/components/base/BdpanImportFilePicker.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Input, Message, Modal, Spin } from '@arco-design/web-react';
 import { FileDisplayOne, FolderOpen, Refresh } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';

--- a/src/renderer/components/base/FileChangesPanel.tsx
+++ b/src/renderer/components/base/FileChangesPanel.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import { Down, PreviewOpen } from '@icon-park/react';

--- a/src/renderer/components/base/PageWrapper.tsx
+++ b/src/renderer/components/base/PageWrapper.tsx
@@ -13,7 +13,7 @@ export default function PageWrapper({ children, className, contentClassName, tit
           </div>
         )}
         {(title || subtitle || actions) && (
-          <div className='flex items-start justify-between gap-4 mb-2'>
+          <div className='flex items-start justify-between gap-4 mb-4'>
             <div className='flex flex-col gap-0.5'>
               {title && <h2 className='text-24px font-600 text-foreground my-0'>{title}</h2>}
               {subtitle && <div className='text-13px text-secondary'>{subtitle}</div>}

--- a/src/renderer/components/base/SkillSelectorSkeleton.tsx
+++ b/src/renderer/components/base/SkillSelectorSkeleton.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import styles from '../../pages/guid/index.module.css';
 

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -6,7 +6,7 @@ import { IconPaste } from '@arco-design/web-react/icon';
 import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
 import SlashCommandMenu, { type SlashCommandMenuItem } from '@/renderer/components/SlashCommandMenu';
 import { useSlashCommandController } from '@/renderer/hooks/useSlashCommandController';
-import SkillSelectorMenu, { type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorMenu';
+import { SkillSelectorMenuContent, type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorPopover';
 import { useSkillSelectorController, type SkillSelectorItem, stripAtQuery, replaceAtQuery } from '@/renderer/hooks/useSkillSelectorController';
 import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
@@ -558,7 +558,7 @@ const SendBox: React.FC<{
         {/* Skill Selector Menu (with optional file tabs) */}
         {skillSelectorController.isOpen && (
           <div className='absolute left-12px right-12px bottom-[calc(100%+8px)] z-70'>
-            <SkillSelectorMenu
+            <SkillSelectorMenuContent
               title={t('messages.skills.title', { defaultValue: 'Skills' })}
               hint={t('messages.skills.hint', { defaultValue: 'Type @ to select skills' })}
               items={skillMenuItems}

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -628,18 +628,7 @@ const SendBox: React.FC<{
                       .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
                       .join(' ');
                   return (
-                    <Tag
-                      key={skillName}
-                      closable
-                      closeIcon={<CloseSmall theme='outline' size='12' />}
-                      onClose={() => setSelectedSkills(selectedSkills.filter((s) => s !== skillName))}
-                      className='text-12px b-1 b-solid rd-4px'
-                      style={{
-                        backgroundColor: 'rgba(var(--ui-accent-orange-rgb), 0.1)',
-                        borderColor: 'rgba(var(--ui-accent-orange-rgb), 0.32)',
-                      }}
-                    >
-                      <Lightning size='12' className='mr-4px text-[var(--ui-accent-orange)]' />
+                    <Tag key={skillName} closable onClose={() => setSelectedSkills(selectedSkills.filter((s) => s !== skillName))} className='text-12px rd-full' icon={<Lightning size='12' className='mr-4px text-[var(--ui-accent-orange)]' />}>
                       {displayName}
                     </Tag>
                   );

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -6,7 +6,7 @@ import { IconPaste } from '@arco-design/web-react/icon';
 import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
 import SlashCommandMenu, { type SlashCommandMenuItem } from '@/renderer/components/SlashCommandMenu';
 import { useSlashCommandController } from '@/renderer/hooks/useSlashCommandController';
-import { SkillSelectorMenuContent, type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorPopover';
+import SkillSelectorPopover, { SkillSelectorMenuContent, type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorPopover';
 import { useSkillSelectorController, type SkillSelectorItem, stripAtQuery, replaceAtQuery } from '@/renderer/hooks/useSkillSelectorController';
 import type { WorkspaceFileItem } from '@/renderer/hooks/useWorkspaceFiles';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
@@ -248,6 +248,9 @@ const SendBox: React.FC<{
   const [installedSkills, setInstalledSkills] = useState<IInstalledSkillInfo[]>([]);
   const [selectedSkills, setSelectedSkills] = useState<string[]>(() => initialSelectedSkills);
   const [loadingSkills, setLoadingSkills] = useState(false);
+  const [isSkillPopoverOpen, setIsSkillPopoverOpen] = useState(false);
+  const [skillPopoverActiveIndex, setSkillPopoverActiveIndex] = useState(0);
+  const [skillPopoverSearchQuery, setSkillPopoverSearchQuery] = useState('');
 
   // Fetch installed skills on mount and after agent-created skills are installed.
   useEffect(() => {
@@ -350,6 +353,9 @@ const SendBox: React.FC<{
     return Array.from(new Map(items.map((item) => [item.name, item])).values());
   }, [installedSkills]);
 
+  // Items for the popover button (all enabled skills, keyed by name)
+  const skillPopoverItems = useMemo<SkillSelectorMenuItem[]>(() => skillSelectorItems.map((skill) => ({ ...skill, key: skill.name })), [skillSelectorItems]);
+
   const skillSelectorController = useSkillSelectorController({
     input,
     cursorPosition,
@@ -389,28 +395,46 @@ const SendBox: React.FC<{
     [skillSelectorController.filteredSkills]
   );
 
-  // Trigger skill selector via @ button (conversation interface)
-  const handleTriggerSkillSelector = useCallback(() => {
-    const newInput = input.trim() ? `${input} @` : '@';
-    setInput(newInput);
-    // Focus the textarea after setting input
-    setTimeout(() => {
-      const textarea = containerRef.current?.querySelector('textarea');
-      if (textarea) {
-        textarea.focus();
-        const len = newInput.length;
-        textarea.setSelectionRange(len, len);
-      }
-    }, 0);
-  }, [input, setInput]);
+  const onSkillPopoverClose = useCallback(() => {
+    setIsSkillPopoverOpen(false);
+    setSkillPopoverActiveIndex(0);
+    setSkillPopoverSearchQuery('');
+  }, []);
 
   // Skill trigger button - shown when running in Electron desktop
   const skillTriggerButton = isElectronDesktop() ? (
-    <Tooltip content={t('conversation.welcome.addSkill', { defaultValue: '添加技能 / 文件' })} position='top'>
-      <span className='inline-flex ml-3'>
-        <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('messages.skills.triggerLabel', { defaultValue: 'Skills / Files' })} onClick={handleTriggerSkillSelector} />
-      </span>
-    </Tooltip>
+    <SkillSelectorPopover
+      popupVisible={isSkillPopoverOpen}
+      onVisibleChange={(v) => {
+        if (!v) onSkillPopoverClose();
+      }}
+      title={t('messages.skills.title', { defaultValue: 'Skills' })}
+      items={skillPopoverItems}
+      selectedKeys={selectedSkills}
+      activeIndex={skillPopoverActiveIndex}
+      loading={loadingSkills}
+      loadingText={t('messages.skills.loading', { defaultValue: 'Loading skills...' })}
+      onHoverItem={setSkillPopoverActiveIndex}
+      onSelectItem={(item) => {
+        if (!selectedSkills.includes(item.key)) {
+          setSelectedSkills((prev) => [...prev, item.key]);
+        }
+        onSkillPopoverClose();
+      }}
+      emptyText={t('messages.skills.empty', { defaultValue: 'No skills found' })}
+      searchQuery={skillPopoverSearchQuery}
+      onSearchChange={(q) => {
+        setSkillPopoverSearchQuery(q);
+        setSkillPopoverActiveIndex(0);
+      }}
+      onDismiss={onSkillPopoverClose}
+    >
+      <Tooltip content={t('conversation.welcome.addSkill', { defaultValue: '添加技能 / 文件' })} position='top'>
+        <span className='inline-flex ml-3'>
+          <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('messages.skills.triggerLabel', { defaultValue: 'Skills / Files' })} onClick={() => setIsSkillPopoverOpen(true)} />
+        </span>
+      </Tooltip>
+    </SkillSelectorPopover>
   ) : null;
 
   // 使用共享的输入法合成处理

--- a/src/renderer/components/sendbox.tsx
+++ b/src/renderer/components/sendbox.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Input, Message, Tag, Tooltip } from '@arco-design/web-react';
 import { ArrowUp, CloseSmall, Lightning } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/src/renderer/components/ui/ActionChip.tsx
+++ b/src/renderer/components/ui/ActionChip.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import classNames from 'classnames';
 import React, { forwardRef } from 'react';
 

--- a/src/renderer/components/ui/Tabs.tsx
+++ b/src/renderer/components/ui/Tabs.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-export default function Tabs({ items, value, onChange, className, itemClassName, ariaLabel, variant = 'pill' }: ITabsProps) {
+export default function Tabs({ items, value, onChange, onMouseDown, className, itemClassName, ariaLabel, variant = 'pill' }: ITabsProps) {
   return (
     <div role='tablist' aria-label={ariaLabel} className={classNames('flex flex-wrap', variant === 'pill' && 'gap-2', variant === 'line' && 'items-end gap-5 border-b border-fill-3', className)}>
       {items.map((item) => {
@@ -22,6 +22,7 @@ export default function Tabs({ items, value, onChange, className, itemClassName,
               item.isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
               itemClassName
             )}
+            onMouseDown={onMouseDown}
             onClick={() => {
               if (!item.isDisabled) onChange(item.value);
             }}
@@ -48,6 +49,7 @@ interface ITabsProps {
   items: ITabItem[];
   value: string;
   onChange: (value: string) => void;
+  onMouseDown?: React.MouseEventHandler<HTMLButtonElement>;
   variant?: 'pill' | 'line';
   className?: string;
   itemClassName?: string;

--- a/src/renderer/context/ConversationContext.tsx
+++ b/src/renderer/context/ConversationContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { createContext, useContext } from 'react';
 
 /**

--- a/src/renderer/context/InitContext.tsx
+++ b/src/renderer/context/InitContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { init, type InitStatus } from '@/common/ipcBridge';
 

--- a/src/renderer/context/TenantConfigContext.tsx
+++ b/src/renderer/context/TenantConfigContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ipcBridge } from '@/common';
 import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';

--- a/src/renderer/context/ThemeContext.tsx
+++ b/src/renderer/context/ThemeContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 // context/ThemeContext.tsx - Unified Theme Management Context 统一主题管理上下文
 import type { PropsWithChildren } from 'react';
 import React, { createContext, useContext } from 'react';

--- a/src/renderer/hooks/useAppMode.ts
+++ b/src/renderer/hooks/useAppMode.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useState } from 'react';
 import { getAppMode, setAppMode } from '@/common/eeclawMode';
 

--- a/src/renderer/hooks/useAutoScroll.ts
+++ b/src/renderer/hooks/useAutoScroll.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect } from 'react';
 
 interface UseAutoScrollOptions {

--- a/src/renderer/hooks/useCronEnabled.ts
+++ b/src/renderer/hooks/useCronEnabled.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useTenantConfig } from '@/renderer/context/TenantConfigContext';
 

--- a/src/renderer/hooks/useDeepLink.ts
+++ b/src/renderer/hooks/useDeepLink.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ipcBridge } from '@/common';

--- a/src/renderer/hooks/useDiffPreviewHandlers.ts
+++ b/src/renderer/hooks/useDiffPreviewHandlers.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback } from 'react';
 import type { FileChangeItem } from '@/renderer/components/base/FileChangesPanel';
 import { usePreviewLauncher } from '@/renderer/hooks/usePreviewLauncher';

--- a/src/renderer/hooks/useDirectorySelection.tsx
+++ b/src/renderer/hooks/useDirectorySelection.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { bridge } from '@office-ai/platform';
 import React, { useCallback, useEffect, useState } from 'react';
 import { SHOW_OPEN_REQUEST_EVENT } from '../../adapter/constant';

--- a/src/renderer/hooks/useDragUpload.ts
+++ b/src/renderer/hooks/useDragUpload.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Message } from '@arco-design/web-react';

--- a/src/renderer/hooks/useEnterpriseSessionMode.ts
+++ b/src/renderer/hooks/useEnterpriseSessionMode.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useState, useCallback, useEffect } from 'react';
 import { ConfigStorage } from '@/common/storage';
 import { ipcBridge } from '@/common';

--- a/src/renderer/hooks/useExtI18n.ts
+++ b/src/renderer/hooks/useExtI18n.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { extensions as extensionsIpc, type IExtensionSettingsTab } from '@/common/ipcBridge';

--- a/src/renderer/hooks/useFontScale.ts
+++ b/src/renderer/hooks/useFontScale.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useState } from 'react';
 import { ipcBridge } from '@/common';
 

--- a/src/renderer/hooks/useGeminiGoogleAuthModels.ts
+++ b/src/renderer/hooks/useGeminiGoogleAuthModels.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';

--- a/src/renderer/hooks/useLatestRef.ts
+++ b/src/renderer/hooks/useLatestRef.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useRef, useLayoutEffect, useCallback } from 'react';
 
 /**

--- a/src/renderer/hooks/usePresetAssistantInfo.ts
+++ b/src/renderer/hooks/usePresetAssistantInfo.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';

--- a/src/renderer/hooks/usePreviewLauncher.ts
+++ b/src/renderer/hooks/usePreviewLauncher.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useState } from 'react';
 import { ipcBridge } from '@/common';
 import { joinPath } from '@/common/chatLib';

--- a/src/renderer/hooks/useResizableSplit.tsx
+++ b/src/renderer/hooks/useResizableSplit.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useState, useCallback } from 'react';
 import type { CSSProperties } from 'react';
 import classNames from 'classnames';

--- a/src/renderer/hooks/useShowToolCalls.ts
+++ b/src/renderer/hooks/useShowToolCalls.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useState } from 'react';
 import { ipcBridge } from '@/common';
 import { useAppMode } from '@/renderer/hooks/useAppMode';

--- a/src/renderer/hooks/useSkillSelectorController.ts
+++ b/src/renderer/hooks/useSkillSelectorController.ts
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { WorkspaceFileItem } from './useWorkspaceFiles';
 
 // Match @ followed by query text, ending at the current cursor position
-// Matches @ at start of input or after whitespace
 const AT_QUERY_RE = /(?:^|\s)@([^\s@]*)$/;
 
 /**
@@ -72,122 +71,32 @@ export interface SkillSelectorItem {
 interface UseSkillSelectorControllerOptions {
   input: string;
   cursorPosition?: number;
-  skills: SkillSelectorItem[];
   selectedSkills: string[];
-  onSelectSkill: (skillName: string) => void;
   onRemoveSkill?: (skillName: string) => void;
   /** Workspace files for @ file references */
   workspaceFiles?: WorkspaceFileItem[];
-  /** Callback when a file is selected */
-  onSelectFile?: (file: WorkspaceFileItem) => void;
-  /** Whether to filter out disabled skills (for guide page) */
-  filterDisabled?: boolean;
 }
 
-// 防抖延迟时间（毫秒）
-const DEBOUNCE_DELAY = 150;
-
 export function useSkillSelectorController(options: UseSkillSelectorControllerOptions) {
-  const { input, cursorPosition, skills, selectedSkills, onRemoveSkill, workspaceFiles = [], filterDisabled = false } = options;
+  const { input, cursorPosition, selectedSkills, onRemoveSkill, workspaceFiles } = options;
   const query = useMemo(() => matchSkillQuery(input, cursorPosition), [input, cursorPosition]);
   const [dismissed, setDismissed] = useState(false);
-  const [activeTab, setActiveTab] = useState<AtMentionTab>('skills');
-  const [searchQuery, setSearchQuery] = useState('');
   const prevQueryRef = useRef<string | null>(null);
 
-  // 防抖状态：用于延迟过滤技能/文件列表
-  const [debouncedQuery, setDebouncedQuery] = useState<string | null>(query);
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  // Reset dismissed state when a new @ query appears
+  if (query !== prevQueryRef.current) {
+    if (query !== null) setDismissed(false);
+    prevQueryRef.current = query;
+  }
 
-  // 防抖定时器 ref
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // 清理定时器
-  const clearDebounceTimer = useCallback(() => {
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = null;
-    }
-  }, []);
-
-  // 组件卸载时清理定时器
-  useEffect(() => {
-    return clearDebounceTimer;
-  }, [clearDebounceTimer]);
-
-  // 防抖处理：延迟更新过滤条件，减少频繁计算
-  useEffect(() => {
-    clearDebounceTimer();
-    debounceTimerRef.current = setTimeout(() => {
-      setDebouncedQuery(query);
-      setDebouncedSearchQuery(searchQuery);
-    }, DEBOUNCE_DELAY);
-  }, [query, searchQuery, clearDebounceTimer]);
-
-  // Determine if tabs should be shown (always show when in conversation with workspace)
-  // Per user request: remove workspaceFiles.length > 0 condition
   const showTabs = workspaceFiles != null;
-
-  // Reset state when debounced query changes
-  useEffect(() => {
-    if (debouncedQuery !== prevQueryRef.current) {
-      setDismissed(false);
-      setSearchQuery('');
-      prevQueryRef.current = debouncedQuery;
-    }
-  }, [debouncedQuery]);
-
-  const filteredSkills = useMemo(() => {
-    if (debouncedQuery === null) {
-      return [];
-    }
-    const rawKeyword = debouncedSearchQuery.trim() || debouncedQuery.trim();
-    const keyword = rawKeyword.toLowerCase();
-
-    let result = skills;
-    if (filterDisabled) {
-      result = skills.filter((skill) => skill.enabled !== false);
-    }
-
-    if (!keyword) {
-      return result;
-    }
-
-    return result.filter((skill) => {
-      const nameMatch = skill.name.toLowerCase().includes(keyword);
-      const displayNameMatch = skill.displayName.toLowerCase().includes(keyword);
-      const descriptionMatch = skill.description?.toLowerCase().includes(keyword) ?? false;
-      const chineseMatch = rawKeyword ? skill.displayName.includes(rawKeyword) : false;
-      return nameMatch || displayNameMatch || descriptionMatch || chineseMatch;
-    });
-  }, [skills, debouncedQuery, debouncedSearchQuery, filterDisabled]);
-
-  const filteredFiles = useMemo(() => {
-    if (debouncedQuery === null) {
-      return [];
-    }
-    const rawKeyword = debouncedSearchQuery.trim() || debouncedQuery.trim();
-    const keyword = rawKeyword.toLowerCase();
-    if (!keyword) {
-      return workspaceFiles;
-    }
-    return workspaceFiles.filter((file) => {
-      const nameMatch = file.name.toLowerCase().includes(keyword);
-      const pathMatch = file.relativePath.toLowerCase().includes(keyword);
-      return nameMatch || pathMatch;
-    });
-  }, [workspaceFiles, debouncedQuery, debouncedSearchQuery]);
-
-  // Menu is open when query is detected and not dismissed, and either tab has content or tabs are shown
-  const hasAnyContent = filteredSkills.length > 0 || filteredFiles.length > 0;
-  const isOpen = query !== null && !dismissed && (hasAnyContent || showTabs);
+  const isOpen = query !== null && !dismissed;
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {
       if (!isOpen) return false;
 
-      // Backspace with empty query removes the last selected skill
-      if (event.key === 'Backspace' && debouncedQuery === '') {
+      if (event.key === 'Backspace' && query === '') {
         if (selectedSkills.length > 0) {
           onRemoveSkill?.(selectedSkills[selectedSkills.length - 1]);
           return true;
@@ -196,22 +105,14 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
 
       return false;
     },
-    [isOpen, debouncedQuery, selectedSkills, onRemoveSkill]
+    [isOpen, query, selectedSkills, onRemoveSkill]
   );
 
   return {
     isOpen,
-    filteredSkills,
-    filteredFiles,
-    activeTab,
+    query,
     showTabs,
-    setActiveTab: (tab: AtMentionTab) => {
-      setActiveTab(tab);
-      setSearchQuery('');
-    },
-    searchQuery,
-    setSearchQuery,
-    onKeyDown,
     setDismissed,
+    onKeyDown,
   };
 }

--- a/src/renderer/hooks/useSkillSelectorController.ts
+++ b/src/renderer/hooks/useSkillSelectorController.ts
@@ -127,7 +127,7 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
 
   // Determine if tabs should be shown (always show when in conversation with workspace)
   // Per user request: remove workspaceFiles.length > 0 condition
-  const showTabs = workspaceFiles !== undefined && workspaceFiles !== null;
+  const showTabs = workspaceFiles != null;
 
   // Reset state when debounced query changes
   useEffect(() => {

--- a/src/renderer/hooks/useSkillSelectorController.ts
+++ b/src/renderer/hooks/useSkillSelectorController.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { WorkspaceFileItem } from './useWorkspaceFiles';

--- a/src/renderer/hooks/useSkillSelectorController.ts
+++ b/src/renderer/hooks/useSkillSelectorController.ts
@@ -88,9 +88,8 @@ interface UseSkillSelectorControllerOptions {
 const DEBOUNCE_DELAY = 150;
 
 export function useSkillSelectorController(options: UseSkillSelectorControllerOptions) {
-  const { input, cursorPosition, skills, selectedSkills, onSelectSkill, onRemoveSkill, workspaceFiles = [], onSelectFile, filterDisabled = false } = options;
+  const { input, cursorPosition, skills, selectedSkills, onRemoveSkill, workspaceFiles = [], filterDisabled = false } = options;
   const query = useMemo(() => matchSkillQuery(input, cursorPosition), [input, cursorPosition]);
-  const [activeIndex, setActiveIndex] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const [activeTab, setActiveTab] = useState<AtMentionTab>('skills');
   const [searchQuery, setSearchQuery] = useState('');
@@ -132,43 +131,32 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
   // Reset state when debounced query changes
   useEffect(() => {
     if (debouncedQuery !== prevQueryRef.current) {
-      setActiveIndex(0);
       setDismissed(false);
       setSearchQuery('');
       prevQueryRef.current = debouncedQuery;
     }
   }, [debouncedQuery]);
 
-  // Reset active index when search query changes
-  useEffect(() => {
-    setActiveIndex(0);
-  }, [searchQuery]);
-
   const filteredSkills = useMemo(() => {
     if (debouncedQuery === null) {
       return [];
     }
-    // Use searchQuery if available, otherwise fall back to @ query
     const rawKeyword = debouncedSearchQuery.trim() || debouncedQuery.trim();
     const keyword = rawKeyword.toLowerCase();
 
-    // Start with all skills, or filter by enabled status if filterDisabled is true
     let result = skills;
     if (filterDisabled) {
       result = skills.filter((skill) => skill.enabled !== false);
     }
 
     if (!keyword) {
-      // Show all (enabled) skills when query is empty
       return result;
     }
 
-    // Filter by display name, internal name, or description
     return result.filter((skill) => {
       const nameMatch = skill.name.toLowerCase().includes(keyword);
       const displayNameMatch = skill.displayName.toLowerCase().includes(keyword);
       const descriptionMatch = skill.description?.toLowerCase().includes(keyword) ?? false;
-      // Also support Chinese character matching
       const chineseMatch = rawKeyword ? skill.displayName.includes(rawKeyword) : false;
       return nameMatch || displayNameMatch || descriptionMatch || chineseMatch;
     });
@@ -178,7 +166,6 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
     if (debouncedQuery === null) {
       return [];
     }
-    // Use searchQuery if available, otherwise fall back to @ query
     const rawKeyword = debouncedSearchQuery.trim() || debouncedQuery.trim();
     const keyword = rawKeyword.toLowerCase();
     if (!keyword) {
@@ -191,77 +178,16 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
     });
   }, [workspaceFiles, debouncedQuery, debouncedSearchQuery]);
 
-  // Get items for current tab
-  const currentTabItems = activeTab === 'skills' ? filteredSkills : filteredFiles;
-
   // Menu is open when query is detected and not dismissed, and either tab has content or tabs are shown
   const hasAnyContent = filteredSkills.length > 0 || filteredFiles.length > 0;
   const isOpen = query !== null && !dismissed && (hasAnyContent || showTabs);
 
-  const executeSkill = useCallback(
-    (index: number) => {
-      if (activeTab === 'skills') {
-        const skill = filteredSkills[index];
-        if (!skill) return false;
-        onSelectSkill(skill.name);
-        setDismissed(true);
-        return true;
-      } else {
-        const file = filteredFiles[index];
-        if (!file) return false;
-        onSelectFile?.(file);
-        setDismissed(true);
-        return true;
-      }
-    },
-    [activeTab, filteredSkills, filteredFiles, onSelectSkill, onSelectFile, input, cursorPosition]
-  );
-
-  const switchTab = useCallback(() => {
-    if (!showTabs) return;
-    setActiveTab((prev) => (prev === 'skills' ? 'files' : 'skills'));
-    setActiveIndex(0);
-    setSearchQuery('');
-  }, [showTabs]);
-
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {
-      if (!isOpen) {
-        return false;
-      }
+      if (!isOpen) return false;
 
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        setDismissed(true);
-        return true;
-      }
-
-      // Tab key switches between tabs
-      if (event.key === 'Tab' && showTabs) {
-        event.preventDefault();
-        switchTab();
-        return true;
-      }
-
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        setActiveIndex((prev) => Math.min(prev + 1, currentTabItems.length - 1));
-        return true;
-      }
-
-      if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        setActiveIndex((prev) => Math.max(prev - 1, 0));
-        return true;
-      }
-
-      if (event.key === 'Enter' && !event.shiftKey) {
-        event.preventDefault();
-        return executeSkill(activeIndex);
-      }
-
+      // Backspace with empty query removes the last selected skill
       if (event.key === 'Backspace' && debouncedQuery === '') {
-        // Remove last selected skill when pressing backspace with empty query
         if (selectedSkills.length > 0) {
           onRemoveSkill?.(selectedSkills[selectedSkills.length - 1]);
           return true;
@@ -270,26 +196,22 @@ export function useSkillSelectorController(options: UseSkillSelectorControllerOp
 
       return false;
     },
-    [activeIndex, executeSkill, currentTabItems.length, isOpen, debouncedQuery, selectedSkills, onRemoveSkill, showTabs, switchTab]
+    [isOpen, debouncedQuery, selectedSkills, onRemoveSkill]
   );
 
   return {
     isOpen,
-    activeIndex,
     filteredSkills,
     filteredFiles,
     activeTab,
     showTabs,
     setActiveTab: (tab: AtMentionTab) => {
       setActiveTab(tab);
-      setActiveIndex(0);
       setSearchQuery('');
     },
     searchQuery,
     setSearchQuery,
     onKeyDown,
-    onSelectByIndex: executeSkill,
     setDismissed,
-    setActiveIndex,
   };
 }

--- a/src/renderer/hooks/useTerminalActiveCount.ts
+++ b/src/renderer/hooks/useTerminalActiveCount.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useState } from 'react';
 import { ipcBridge } from '@/common';
 

--- a/src/renderer/hooks/useTextSelection.ts
+++ b/src/renderer/hooks/useTextSelection.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useState, useEffect, useCallback } from 'react';
 
 // 选中文本的位置信息 / Selection position information

--- a/src/renderer/hooks/useTypingAnimation.ts
+++ b/src/renderer/hooks/useTypingAnimation.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useRef, useState } from 'react';
 
 interface UseTypingAnimationOptions {

--- a/src/renderer/hooks/useWorkspaceFiles.ts
+++ b/src/renderer/hooks/useWorkspaceFiles.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import './bootstrap/runtimePatches';
 import './bootstrap/crashHandler';
 import './bootstrap/devTriggers';

--- a/src/renderer/layouts/components/DebugPanel.tsx
+++ b/src/renderer/layouts/components/DebugPanel.tsx
@@ -1,10 +1,4 @@
 /// <reference types="vite/client" />
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Descriptions, Popover, Select } from '@arco-design/web-react';
 import { IconMoon, IconSun } from '@arco-design/web-react/icon';
 import { DndContext, PointerSensor, useDraggable, useSensor, useSensors } from '@dnd-kit/core';

--- a/src/renderer/layouts/components/SidebarNavItem.tsx
+++ b/src/renderer/layouts/components/SidebarNavItem.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import classNames from 'classnames';
 import React from 'react';
 

--- a/src/renderer/layouts/layout.tsx
+++ b/src/renderer/layouts/layout.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Layout as ArcoLayout } from '@arco-design/web-react';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useState, useEffect, useCallback } from 'react';
 import AppLoader from '@renderer/components/AppLoader';
 import InitLoading from '@renderer/components/InitLoading';

--- a/src/renderer/messages/GeneratedFileCard.tsx
+++ b/src/renderer/messages/GeneratedFileCard.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { FolderOpen, ShareOne } from '@icon-park/react';
 import { Message, Tooltip } from '@arco-design/web-react';
 import classNames from 'classnames';

--- a/src/renderer/messages/MessageAgentStatus.tsx
+++ b/src/renderer/messages/MessageAgentStatus.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Badge, Typography } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/messages/MessageCronBadge.tsx
+++ b/src/renderer/messages/MessageCronBadge.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { AlarmClock } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/messages/MessageFileSend.tsx
+++ b/src/renderer/messages/MessageFileSend.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Picture } from '@icon-park/react';
 import React, { useCallback } from 'react';
 import type { IMessageFileSend } from '@/common/chatLib';

--- a/src/renderer/messages/MessageList.tsx
+++ b/src/renderer/messages/MessageList.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Image, Message } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
 import classNames from 'classnames';

--- a/src/renderer/messages/MessageTimeSeparator.tsx
+++ b/src/renderer/messages/MessageTimeSeparator.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatMessageTime } from '@/renderer/utils/messageTime';

--- a/src/renderer/messages/MessageTips.tsx
+++ b/src/renderer/messages/MessageTips.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Attention, CheckOne } from '@icon-park/react';
 import { theme } from '@office-ai/platform';
 import classNames from 'classnames';

--- a/src/renderer/messages/MessageToolCall.tsx
+++ b/src/renderer/messages/MessageToolCall.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Alert } from '@arco-design/web-react';
 import { MessageSearch } from '@icon-park/react';
 import { createTwoFilesPatch } from 'diff';

--- a/src/renderer/messages/MessageToolGroup.tsx
+++ b/src/renderer/messages/MessageToolGroup.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Alert, Button, Image, Message, Radio, Tag, Tooltip } from '@arco-design/web-react';
 import { Copy, Download, LoadingOne } from '@icon-park/react';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';

--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Alert, Message, Tag, Tooltip } from '@arco-design/web-react';
 import { Copy, Lightning } from '@icon-park/react';
 import classNames from 'classnames';

--- a/src/renderer/messages/MessagetText.tsx
+++ b/src/renderer/messages/MessagetText.tsx
@@ -15,7 +15,7 @@ import { stripThinkTags, hasThinkTags } from '../utils/thinkTagFilter';
 import MarkdownView from '../components/Markdown';
 import HorizontalFileList from '../components/HorizontalFileList';
 import FilePreview from '../components/FilePreview';
-import CollapsibleContent from '../components/CollapsibleContent';
+import { CollapsibleContent } from '../components/CollapsibleContent';
 import MessageCronBadge from './MessageCronBadge';
 import GeneratedFileCards from './GeneratedFileCard';
 

--- a/src/renderer/messages/RuntimeErrorBanner.tsx
+++ b/src/renderer/messages/RuntimeErrorBanner.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Attention } from '@icon-park/react';
 import { theme } from '@office-ai/platform';
 import React from 'react';

--- a/src/renderer/messages/TurnActions.tsx
+++ b/src/renderer/messages/TurnActions.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Alert, Message, Tooltip } from '@arco-design/web-react';
 import { Copy, FileWord, ShareOne } from '@icon-park/react';
 import React, { useState, useCallback, useEffect } from 'react';

--- a/src/renderer/messages/acp/MessageAcpPermission.tsx
+++ b/src/renderer/messages/acp/MessageAcpPermission.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Card, Radio, Typography } from '@arco-design/web-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/messages/acp/MessageAcpQuestion.tsx
+++ b/src/renderer/messages/acp/MessageAcpQuestion.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Card, Input, Message, Tag, Typography } from '@arco-design/web-react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/messages/acp/MessageAcpToolCall.tsx
+++ b/src/renderer/messages/acp/MessageAcpToolCall.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Card, Tag } from '@arco-design/web-react';
 import { createTwoFilesPatch } from 'diff';
 import React, { useMemo } from 'react';

--- a/src/renderer/messages/codex/MessageCodexToolCall.tsx
+++ b/src/renderer/messages/codex/MessageCodexToolCall.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import type { IMessageCodexToolCall, CodexToolCallUpdate } from '@/common/chatLib';
 import ExecCommandDisplay from './ToolCallComponent/ExecCommandDisplay';

--- a/src/renderer/messages/codex/MessageFileChanges.tsx
+++ b/src/renderer/messages/codex/MessageFileChanges.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { CodexToolCallUpdate } from '@/common/chatLib';

--- a/src/renderer/messages/codex/ToolCallComponent/BaseToolCallDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/BaseToolCallDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Card, Tag } from '@arco-design/web-react';
 import type { ReactNode } from 'react';
 import React from 'react';

--- a/src/renderer/messages/codex/ToolCallComponent/ExecCommandDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/ExecCommandDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Tag } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/messages/codex/ToolCallComponent/GenericDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/GenericDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Card, Tag } from '@arco-design/web-react';
 import React from 'react';
 import type { CodexToolCallUpdate } from '@/common/chatLib';

--- a/src/renderer/messages/codex/ToolCallComponent/McpToolDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/McpToolDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Tag } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/messages/codex/ToolCallComponent/PatchDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/PatchDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Tag } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/messages/codex/ToolCallComponent/TurnDiffDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/TurnDiffDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { CodexToolCallUpdate } from '@/common/chatLib';

--- a/src/renderer/messages/codex/ToolCallComponent/WebSearchDisplay.tsx
+++ b/src/renderer/messages/codex/ToolCallComponent/WebSearchDisplay.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { CodexToolCallUpdate } from '@/common/chatLib';

--- a/src/renderer/messages/constants.ts
+++ b/src/renderer/messages/constants.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Alert and message display constants
  * Alert 和消息展示常量
  */

--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useRef } from 'react';
 import { ipcBridge } from '@/common';
 import type { TMessage } from '@/common/chatLib';

--- a/src/renderer/messages/types.ts
+++ b/src/renderer/messages/types.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Type definitions for message tool results
  * 消息工具结果类型定义
  */

--- a/src/renderer/messages/useAutoScroll.ts
+++ b/src/renderer/messages/useAutoScroll.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * useAutoScroll - Auto-scroll hook with user scroll detection and a dynamic
  * bottom spacer that pins the latest user prompt to the top of the viewport.
  *

--- a/src/renderer/pages/conversation/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/ChatConversation.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Dropdown, Menu, Tooltip, Typography } from '@arco-design/web-react';
 import { History } from '@icon-park/react';
 import React, { useMemo } from 'react';

--- a/src/renderer/pages/conversation/ChatSider.tsx
+++ b/src/renderer/pages/conversation/ChatSider.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAddEventListener } from '@/renderer/utils/emitter';

--- a/src/renderer/pages/conversation/ConversationTabs.tsx
+++ b/src/renderer/pages/conversation/ConversationTabs.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Dropdown, Menu, Message } from '@arco-design/web-react';
 import { Close, Plus, Robot } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';

--- a/src/renderer/pages/conversation/SafetyChatConfirm.tsx
+++ b/src/renderer/pages/conversation/SafetyChatConfirm.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { type PropsWithChildren } from 'react';
 
 export interface SafetyChatConfirmProps {

--- a/src/renderer/pages/conversation/WorkspaceCollapse.tsx
+++ b/src/renderer/pages/conversation/WorkspaceCollapse.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Down } from '@icon-park/react';
 import classNames from 'classnames';
 import React from 'react';

--- a/src/renderer/pages/conversation/acp/AcpChat.tsx
+++ b/src/renderer/pages/conversation/acp/AcpChat.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useEffect, useState } from 'react';
 import { ConversationProvider } from '@/renderer/context/ConversationContext';
 import type { AcpBackend } from '@/types/acpTypes';

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -7,7 +7,7 @@ import type { AcpBackend } from '@/types/acpTypes';
 import { transformMessage, type TMessage } from '@/common/chatLib';
 import type { IResponseMessage } from '@/common/ipcBridge';
 import { uuid } from '@/common/utils';
-import SendBox from '@/renderer/components/sendbox';
+import SendBox from '@/renderer/components/Sendbox';
 import ThoughtDisplay, { type ThoughtData } from '@/renderer/components/ThoughtDisplay';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/useSendBoxDraft';
 import { createSetUploadFile, useSendBoxFiles } from '@/renderer/hooks/useSendBoxFiles';

--- a/src/renderer/pages/conversation/components/ConversationTitleMinimap.tsx
+++ b/src/renderer/pages/conversation/components/ConversationTitleMinimap.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Empty, Input, Spin } from '@arco-design/web-react';
 import { IconSearch } from '@arco-design/web-react/icon';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';

--- a/src/renderer/pages/conversation/context/ConversationTabsContext.tsx
+++ b/src/renderer/pages/conversation/context/ConversationTabsContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import type { TChatConversation } from '@/common/storage';
 import { STORAGE_KEYS } from '@/common/storageKeys';

--- a/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
+++ b/src/renderer/pages/conversation/grouped-history/ConversationRow.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Checkbox, Dropdown, Menu, Tooltip } from '@arco-design/web-react';
 import { DeleteOne, EditOne, Export, Loading, MessageOne, Pushpin } from '@icon-park/react';
 import classNames from 'classnames';

--- a/src/renderer/pages/conversation/grouped-history/DragOverlayContent.tsx
+++ b/src/renderer/pages/conversation/grouped-history/DragOverlayContent.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { MessageOne } from '@icon-park/react';
 import React from 'react';
 

--- a/src/renderer/pages/conversation/grouped-history/SortableConversationRow.tsx
+++ b/src/renderer/pages/conversation/grouped-history/SortableConversationRow.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import React from 'react';

--- a/src/renderer/pages/conversation/grouped-history/hooks/useBatchSelection.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useBatchSelection.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { TChatConversation } from '@/common/storage';
 import type { ConversationItem } from '../types';

--- a/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useConversations.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';

--- a/src/renderer/pages/conversation/grouped-history/hooks/useDragAndDrop.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useDragAndDrop.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import { PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';

--- a/src/renderer/pages/conversation/grouped-history/hooks/useExport.ts
+++ b/src/renderer/pages/conversation/grouped-history/hooks/useExport.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Message } from '@arco-design/web-react';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/grouped-history/index.tsx
+++ b/src/renderer/pages/conversation/grouped-history/index.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { Empty, Input, Message, Modal } from '@arco-design/web-react';

--- a/src/renderer/pages/conversation/grouped-history/types.ts
+++ b/src/renderer/pages/conversation/grouped-history/types.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { TChatConversation } from '@/common/storage';
 import type { CronJobStatusEnums } from '@/renderer/utils/enum';
 

--- a/src/renderer/pages/conversation/grouped-history/utils/exportHelpers.ts
+++ b/src/renderer/pages/conversation/grouped-history/utils/exportHelpers.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { TMessage } from '@/common/chatLib';
 import type { IDirOrFile } from '@/common/ipcBridge';
 import type { TChatConversation } from '@/common/storage';

--- a/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/grouped-history/utils/groupingHelpers.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { ICronJob } from '@/common/ipcBridge';
 import type { TChatConversation } from '@/common/storage';
 import { getActivityTime, getTimelineLabel } from '@/renderer/utils/timeline';

--- a/src/renderer/pages/conversation/grouped-history/utils/sortOrderHelpers.ts
+++ b/src/renderer/pages/conversation/grouped-history/utils/sortOrderHelpers.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { TChatConversation } from '@/common/storage';
 
 const SORT_ORDER_GAP = 1000;

--- a/src/renderer/pages/conversation/hooks/useConversationAgents.ts
+++ b/src/renderer/pages/conversation/hooks/useConversationAgents.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useMemo } from 'react';
 import useSWR from 'swr';
 import { ipcBridge } from '@/common';

--- a/src/renderer/pages/conversation/preview/components/LibreOfficeInstallPrompt.tsx
+++ b/src/renderer/pages/conversation/preview/components/LibreOfficeInstallPrompt.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Progress } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewConfirmModals.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewConfirmModals.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Modal } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewContextMenu.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewContextMenu.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { PreviewTab } from './PreviewTabs';

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewHistoryDropdown.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewHistoryDropdown.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { PreviewHistoryTarget, PreviewSnapshotInfo } from '@/common/types/preview';

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewPanel.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { Message } from '@arco-design/web-react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewTabs.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewTabs.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Close } from '@icon-park/react';
 import { IconShrink } from '@arco-design/web-react/icon';
 import React from 'react';

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewToolbar.tsx
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/PreviewToolbar.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Dropdown } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/PreviewPanel/index.ts
+++ b/src/renderer/pages/conversation/preview/components/PreviewPanel/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * 预览面板子组件导出
  * Preview panel sub-components exports
  */

--- a/src/renderer/pages/conversation/preview/components/editors/HTMLEditor.tsx
+++ b/src/renderer/pages/conversation/preview/components/editors/HTMLEditor.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { html } from '@codemirror/lang-html';
 import { history, historyKeymap } from '@codemirror/commands';
 import { keymap } from '@codemirror/view';

--- a/src/renderer/pages/conversation/preview/components/editors/MarkdownEditor.tsx
+++ b/src/renderer/pages/conversation/preview/components/editors/MarkdownEditor.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { markdown } from '@codemirror/lang-markdown';
 import CodeMirror from '@uiw/react-codemirror';
 import React, { useRef, useCallback } from 'react';

--- a/src/renderer/pages/conversation/preview/components/editors/TextEditor.tsx
+++ b/src/renderer/pages/conversation/preview/components/editors/TextEditor.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { EditorView } from '@codemirror/view';
 import CodeMirror from '@uiw/react-codemirror';
 import React, { useCallback, useMemo, useRef } from 'react';

--- a/src/renderer/pages/conversation/preview/components/editors/index.ts
+++ b/src/renderer/pages/conversation/preview/components/editors/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * 编辑器组件导出
  * Editor components exports
  *

--- a/src/renderer/pages/conversation/preview/components/index.ts
+++ b/src/renderer/pages/conversation/preview/components/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Preview 组件统一导出
  * Preview components unified exports
  */

--- a/src/renderer/pages/conversation/preview/components/renderers/HTMLRenderer.tsx
+++ b/src/renderer/pages/conversation/preview/components/renderers/HTMLRenderer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ipcBridge } from '@/common';
 import { useTypingAnimation } from '@/renderer/hooks/useTypingAnimation';

--- a/src/renderer/pages/conversation/preview/components/renderers/MermaidDiagram.tsx
+++ b/src/renderer/pages/conversation/preview/components/renderers/MermaidDiagram.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useEffect, useState, useId, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/renderer/pages/conversation/preview/components/renderers/SelectionToolbar.tsx
+++ b/src/renderer/pages/conversation/preview/components/renderers/SelectionToolbar.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/renderers/htmlInspectScript.ts
+++ b/src/renderer/pages/conversation/preview/components/renderers/htmlInspectScript.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 interface InspectMessages {
   copySuccess: string;
 }

--- a/src/renderer/pages/conversation/preview/components/renderers/index.ts
+++ b/src/renderer/pages/conversation/preview/components/renderers/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * 渲染器组件导出
  * Renderer components exports
  *

--- a/src/renderer/pages/conversation/preview/components/viewers/AudioViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/AudioViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { AudioFile } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/viewers/CodeViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/CodeViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import SyntaxHighlighter from 'react-syntax-highlighter';

--- a/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/DiffViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Checkbox } from '@arco-design/web-react';
 import classNames from 'classnames';
 import { html } from 'diff2html';

--- a/src/renderer/pages/conversation/preview/components/viewers/ExcelViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/ExcelViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Message } from '@arco-design/web-react';
 import { IconRefresh } from '@arco-design/web-react/icon';
 import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react';

--- a/src/renderer/pages/conversation/preview/components/viewers/HTMLViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/HTMLViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Message } from '@arco-design/web-react';
 import MonacoEditor from '@monaco-editor/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';

--- a/src/renderer/pages/conversation/preview/components/viewers/ImageViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/ImageViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Image } from '@arco-design/web-react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/viewers/MarkdownViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/MarkdownViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import katex from 'katex';
 import 'katex/dist/katex.min.css';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/src/renderer/pages/conversation/preview/components/viewers/PDFViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/PDFViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Message } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/viewers/PPTViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/PPTViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Message } from '@arco-design/web-react';
 import { IconRefresh } from '@arco-design/web-react/icon';
 import React, { useCallback, useEffect, useRef, useState } from 'react';

--- a/src/renderer/pages/conversation/preview/components/viewers/URLViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/URLViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import WebviewHost from '@/renderer/components/WebviewHost';
 

--- a/src/renderer/pages/conversation/preview/components/viewers/VideoViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/VideoViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { VideoFile } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/components/viewers/WordViewer.tsx
+++ b/src/renderer/pages/conversation/preview/components/viewers/WordViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Message } from '@arco-design/web-react';
 import { IconRefresh } from '@arco-design/web-react/icon';
 import React, { useCallback, useEffect, useState, useRef } from 'react';

--- a/src/renderer/pages/conversation/preview/components/viewers/index.ts
+++ b/src/renderer/pages/conversation/preview/components/viewers/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * 预览器组件导出
  * Viewer components exports
  *

--- a/src/renderer/pages/conversation/preview/constants.ts
+++ b/src/renderer/pages/conversation/preview/constants.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * 预览面板相关常量定义
  * Preview panel related constants
  */

--- a/src/renderer/pages/conversation/preview/context/PreviewContext.tsx
+++ b/src/renderer/pages/conversation/preview/context/PreviewContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ipcBridge } from '@/common';
 import type { PreviewContentType } from '@/common/types/preview';

--- a/src/renderer/pages/conversation/preview/context/PreviewToolbarExtrasContext.tsx
+++ b/src/renderer/pages/conversation/preview/context/PreviewToolbarExtrasContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { createContext, useContext, type ReactNode } from 'react';
 
 /**

--- a/src/renderer/pages/conversation/preview/context/index.ts
+++ b/src/renderer/pages/conversation/preview/context/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Preview Context 导出
  * Preview context exports
  */

--- a/src/renderer/pages/conversation/preview/hooks/index.ts
+++ b/src/renderer/pages/conversation/preview/hooks/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * 预览面板自定义 Hooks 导出
  * Preview panel custom hooks exports
  */

--- a/src/renderer/pages/conversation/preview/hooks/usePreviewHistory.ts
+++ b/src/renderer/pages/conversation/preview/hooks/usePreviewHistory.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Message } from '@arco-design/web-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/preview/hooks/usePreviewKeyboardShortcuts.ts
+++ b/src/renderer/pages/conversation/preview/hooks/usePreviewKeyboardShortcuts.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect } from 'react';
 
 /**

--- a/src/renderer/pages/conversation/preview/hooks/useScrollSync.ts
+++ b/src/renderer/pages/conversation/preview/hooks/useScrollSync.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useRef } from 'react';
 import { SCROLL_SYNC_DEBOUNCE } from '../constants';
 

--- a/src/renderer/pages/conversation/preview/hooks/useScrollSyncHelpers.ts
+++ b/src/renderer/pages/conversation/preview/hooks/useScrollSyncHelpers.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useCallback } from 'react';
 
 /**

--- a/src/renderer/pages/conversation/preview/hooks/useTabOverflow.ts
+++ b/src/renderer/pages/conversation/preview/hooks/useTabOverflow.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TAB_OVERFLOW_THRESHOLD } from '../constants';
 

--- a/src/renderer/pages/conversation/preview/hooks/useThemeDetection.ts
+++ b/src/renderer/pages/conversation/preview/hooks/useThemeDetection.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useState } from 'react';
 
 /**

--- a/src/renderer/pages/conversation/preview/index.ts
+++ b/src/renderer/pages/conversation/preview/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Preview 模块统一导出
  * Preview module unified exports
  *

--- a/src/renderer/pages/conversation/preview/types/index.ts
+++ b/src/renderer/pages/conversation/preview/types/index.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Preview 模块类型定义
  * Preview module type definitions
  *

--- a/src/renderer/pages/conversation/preview/utils/fileUtils.ts
+++ b/src/renderer/pages/conversation/preview/utils/fileUtils.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { PreviewContentType } from '@/common/types/preview';
 
 /**

--- a/src/renderer/pages/conversation/right-panel/DeliverablesPanel.tsx
+++ b/src/renderer/pages/conversation/right-panel/DeliverablesPanel.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { FileCabinet } from '@icon-park/react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/conversation/utils/createConversationParams.ts
+++ b/src/renderer/pages/conversation/utils/createConversationParams.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { ConfigStorage } from '@/common/storage';
 import type { ICreateConversationParams } from '@/common/ipcBridge';
 import type { TProviderWithModel } from '@/common/storage';

--- a/src/renderer/pages/conversation/utils/newConversationName.ts
+++ b/src/renderer/pages/conversation/utils/newConversationName.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2026 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Force new-session entry points to start from the localized default title.
  */
 export function applyDefaultConversationName<T extends object>(conversation: T, defaultName: string): Omit<T, 'name'> & { name: string } {

--- a/src/renderer/pages/conversation/workspace/WorkspaceSkills.tsx
+++ b/src/renderer/pages/conversation/workspace/WorkspaceSkills.tsx
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * WorkspaceSkills — renders the "可用技能" tab inside the right-side workspace
  * card. Visual layout mirrors `components/skill-grid.tsx` from the ui.zip
  * reference: a 2-column grid of `rounded-lg` cards, each with a 32×32 rounded

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceDragImport.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceDragImport.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useRef, useState } from 'react';
 import type { DragEvent } from 'react';
 import { Message } from '@arco-design/web-react';

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceEvents.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useRef } from 'react';
 import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback } from 'react';
 import { Message } from '@arco-design/web-react';
 import { ipcBridge } from '@/common';

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceModals.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceModals.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useState } from 'react';
 import type { ContextMenuState, RenameModalState, DeleteModalState, PasteConfirmState } from '../types';
 

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspacePaste.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useState } from 'react';
 import { Message } from '@arco-design/web-react';
 import { ipcBridge } from '@/common';

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceTree.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ipcBridge } from '@/common';
 import type { IDirOrFile } from '@/common/ipcBridge';

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Checkbox, Input, Message, Modal, Tooltip, Tree } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
 import { Cloudy, DownSmall, FileText, FolderOpen, Magic, Refresh, Search } from '@icon-park/react';

--- a/src/renderer/pages/conversation/workspace/skillRoots.ts
+++ b/src/renderer/pages/conversation/workspace/skillRoots.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 export type WorkspaceSkillSource = 'skills' | 'claude-skills' | 'scode-skills';
 
 export function resolveWorkspaceSkillRoot(workspace: string, backend?: string): { path: string; source: WorkspaceSkillSource } {

--- a/src/renderer/pages/conversation/workspace/types.ts
+++ b/src/renderer/pages/conversation/workspace/types.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { NodeInstance } from '@arco-design/web-react/es/Tree/interface';
 import type { IDirOrFile } from '@/common/ipcBridge';
 

--- a/src/renderer/pages/conversation/workspace/utils/treeHelpers.ts
+++ b/src/renderer/pages/conversation/workspace/utils/treeHelpers.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { NodeInstance } from '@arco-design/web-react/es/Tree/interface';
 import type { IDirOrFile } from '@/common/ipcBridge';
 import { DRAFTS_DIR_NAME } from '@/common/constants';

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -518,7 +518,6 @@ const GuidPage: React.FC = () => {
 
   // Popover-button path: independent state, does NOT touch the input
   const [skillPopoverSearchQuery, setSkillPopoverSearchQuery] = useState('');
-  const [skillPopoverActiveIndex, setSkillPopoverActiveIndex] = useState(0);
 
   const skillPopoverItems = useMemo<SkillSelectorMenuItem[]>(() => {
     const kw = skillPopoverSearchQuery.trim().toLowerCase();
@@ -542,7 +541,6 @@ const GuidPage: React.FC = () => {
   const onSkillPopoverClose = useCallback(() => {
     setIsSkillPopoverOpen(false);
     setSkillPopoverSearchQuery('');
-    setSkillPopoverActiveIndex(0);
   }, []);
 
   // Build the skill trigger node (@button wrapped in SkillSelectorPopover)
@@ -555,8 +553,6 @@ const GuidPage: React.FC = () => {
       title={t('guid.skillSelectorTitle')}
       items={skillPopoverItems}
       selectedKeys={selectedSkills}
-      activeIndex={skillPopoverActiveIndex}
-      onHoverItem={(index) => setSkillPopoverActiveIndex(index)}
       onSelectItem={(item) => {
         if (!selectedSkills.includes(item.key)) {
           setSelectedSkills((prev) => [...prev, item.key]);
@@ -565,10 +561,7 @@ const GuidPage: React.FC = () => {
       }}
       emptyText={t('guid.noSkills')}
       searchQuery={skillPopoverSearchQuery}
-      onSearchChange={(q) => {
-        setSkillPopoverSearchQuery(q);
-        setSkillPopoverActiveIndex(0);
-      }}
+      onSearchChange={setSkillPopoverSearchQuery}
       onDismiss={onSkillPopoverClose}
     >
       <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('conversation.welcome.skill', { defaultValue: '技能' })} onClick={() => setIsSkillPopoverOpen(true)} />
@@ -782,9 +775,13 @@ const GuidPage: React.FC = () => {
                 title={t('guid.skillSelectorTitle')}
                 items={skillMenuItems}
                 selectedKeys={selectedSkills}
-                activeIndex={skillSelectorController.activeIndex}
-                onHoverItem={(index) => skillSelectorController.setActiveIndex(index)}
-                onSelectItem={(_item) => skillSelectorController.onSelectByIndex(skillSelectorController.activeIndex)}
+                onSelectItem={(item) => {
+                  if (!selectedSkills.includes(item.key)) {
+                    setSelectedSkills((prev) => [...prev, item.key]);
+                  }
+                  skillSelectorController.setDismissed(true);
+                  guidInput.setInput(stripAtQuery(guidInput.input, cursorPosition));
+                }}
                 emptyText={t('guid.noSkills')}
                 searchQuery={skillSelectorController.searchQuery}
                 onSearchChange={skillSelectorController.setSearchQuery}
@@ -792,6 +789,7 @@ const GuidPage: React.FC = () => {
                   skillSelectorController.setDismissed(true);
                   guidInput.setInput(stripAtQuery(guidInput.input, cursorPosition));
                 }}
+                isVisible={skillSelectorController.isOpen}
               />
             ) : null
           }

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Message } from '@arco-design/web-react';
 import { EditTwo, Left, Robot } from '@icon-park/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -10,7 +10,7 @@ import { skillHub } from '@/common/ipcBridge';
 import { useAuth } from '@/renderer/context/AuthContext';
 import { ipcBridge } from '@/common';
 import { resolveAssistantName } from '@/renderer/shared/agents/assistantAdapter';
-import SkillSelectorPopover, { SkillSelectorMenuContent, type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorPopover';
+import SkillSelectorPopover, { SkillSelectorMenuContent } from '@/renderer/components/SkillSelectorPopover';
 import { useSkillSelectorController, type SkillSelectorItem, stripAtQuery } from '@/renderer/hooks/useSkillSelectorController';
 import { getInstalledSkillDisplay, resolveSkillIcon } from '@/renderer/utils/skillDisplay';
 import { useConversationTabs } from '@/renderer/pages/conversation/context/ConversationTabsContext';
@@ -210,35 +210,11 @@ const GuidPage: React.FC = () => {
   const skillSelectorController = useSkillSelectorController({
     input: guidInput.input,
     cursorPosition,
-    skills: skillSelectorItems,
     selectedSkills,
-    onSelectSkill: (skillName) => {
-      if (!selectedSkills.includes(skillName)) {
-        setSelectedSkills([...selectedSkills, skillName]);
-      }
-      // Strip the @query from input when selecting a skill, preserving user's other text
-      guidInput.setInput(stripAtQuery(guidInput.input, cursorPosition));
-    },
     onRemoveSkill: (skillName) => {
       setSelectedSkills(selectedSkills.filter((s) => s !== skillName));
     },
-    filterDisabled: true, // Guide page should not show disabled skills
   });
-
-  // Convert to menu items for rendering
-  const skillMenuItems = useMemo<SkillSelectorMenuItem[]>(
-    () =>
-      skillSelectorController.filteredSkills.map((skill) => ({
-        key: skill.name,
-        name: skill.name,
-        displayName: skill.displayName,
-        description: skill.description,
-        icon: skill.icon,
-        emoji: skill.emoji,
-        enabled: skill.enabled,
-      })),
-    [skillSelectorController.filteredSkills]
-  );
 
   const mention = useGuidMention({
     availableAgents: agentSelection.mentionAvailableAgents,
@@ -517,30 +493,9 @@ const GuidPage: React.FC = () => {
   );
 
   // Popover-button path: independent state, does NOT touch the input
-  const [skillPopoverSearchQuery, setSkillPopoverSearchQuery] = useState('');
-
-  const skillPopoverItems = useMemo<SkillSelectorMenuItem[]>(() => {
-    const kw = skillPopoverSearchQuery.trim().toLowerCase();
-    return skillSelectorItems
-      .filter((s) => s.enabled !== false)
-      .filter((s) => {
-        if (!kw) return true;
-        return s.name.toLowerCase().includes(kw) || s.displayName.toLowerCase().includes(kw) || (s.description?.toLowerCase().includes(kw) ?? false);
-      })
-      .map((skill) => ({
-        key: skill.name,
-        name: skill.name,
-        displayName: skill.displayName,
-        description: skill.description,
-        icon: skill.icon,
-        emoji: skill.emoji,
-        enabled: skill.enabled,
-      }));
-  }, [skillSelectorItems, skillPopoverSearchQuery]);
 
   const onSkillPopoverClose = useCallback(() => {
     setIsSkillPopoverOpen(false);
-    setSkillPopoverSearchQuery('');
   }, []);
 
   // Build the skill trigger node (@button wrapped in SkillSelectorPopover)
@@ -551,18 +506,17 @@ const GuidPage: React.FC = () => {
         if (!v) onSkillPopoverClose();
       }}
       title={t('guid.skillSelectorTitle')}
-      items={skillPopoverItems}
+      skills={skillSelectorItems}
       selectedKeys={selectedSkills}
-      onSelectItem={(item) => {
-        if (!selectedSkills.includes(item.key)) {
-          setSelectedSkills((prev) => [...prev, item.key]);
+      onSelectItem={(skill) => {
+        if (!selectedSkills.includes(skill.name)) {
+          setSelectedSkills((prev) => [...prev, skill.name]);
         }
         onSkillPopoverClose();
       }}
       emptyText={t('guid.noSkills')}
-      searchQuery={skillPopoverSearchQuery}
-      onSearchChange={setSkillPopoverSearchQuery}
       onDismiss={onSkillPopoverClose}
+      filterDisabled
     >
       <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('conversation.welcome.skill', { defaultValue: '技能' })} onClick={() => setIsSkillPopoverOpen(true)} />
     </SkillSelectorPopover>
@@ -773,23 +727,23 @@ const GuidPage: React.FC = () => {
             skillSelectorController.isOpen ? (
               <SkillSelectorMenuContent
                 title={t('guid.skillSelectorTitle')}
-                items={skillMenuItems}
+                skills={skillSelectorItems}
                 selectedKeys={selectedSkills}
-                onSelectItem={(item) => {
-                  if (!selectedSkills.includes(item.key)) {
-                    setSelectedSkills((prev) => [...prev, item.key]);
+                onSelectItem={(skill) => {
+                  if (!selectedSkills.includes(skill.name)) {
+                    setSelectedSkills((prev) => [...prev, skill.name]);
                   }
                   skillSelectorController.setDismissed(true);
                   guidInput.setInput(stripAtQuery(guidInput.input, cursorPosition));
                 }}
                 emptyText={t('guid.noSkills')}
-                searchQuery={skillSelectorController.searchQuery}
-                onSearchChange={skillSelectorController.setSearchQuery}
                 onDismiss={() => {
                   skillSelectorController.setDismissed(true);
                   guidInput.setInput(stripAtQuery(guidInput.input, cursorPosition));
                 }}
                 isVisible={skillSelectorController.isOpen}
+                query={skillSelectorController.query}
+                filterDisabled
               />
             ) : null
           }

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -324,7 +324,7 @@ const GuidPage: React.FC = () => {
         textarea.setSelectionRange(len, len);
       }
     }, 0);
-  }, [guidInput.input, guidInput.setInput]);
+  }, [guidInput]);
 
   // --- Coordinated handlers (depend on multiple hooks) ---
   const handleInputChange = useCallback(

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -10,7 +10,7 @@ import { skillHub } from '@/common/ipcBridge';
 import { useAuth } from '@/renderer/context/AuthContext';
 import { ipcBridge } from '@/common';
 import { resolveAssistantName } from '@/renderer/shared/agents/assistantAdapter';
-import SkillSelectorMenu, { type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorMenu';
+import SkillSelectorPopover, { SkillSelectorMenuContent, type SkillSelectorMenuItem } from '@/renderer/components/SkillSelectorPopover';
 import { useSkillSelectorController, type SkillSelectorItem, stripAtQuery } from '@/renderer/hooks/useSkillSelectorController';
 import { getInstalledSkillDisplay, resolveSkillIcon } from '@/renderer/utils/skillDisplay';
 import { useConversationTabs } from '@/renderer/pages/conversation/context/ConversationTabsContext';
@@ -18,6 +18,7 @@ import { openExternalUrl, isElectronDesktop, resolveExtensionAssetUrl } from '@/
 import { useInputFocusRing } from '@/renderer/hooks/useInputFocusRing';
 import { resolveLocaleKey } from '@/common/utils';
 import { DEFAULT_PRESET_AGENT_TYPE, normalizePresetAgentType } from '@/types/acpTypes';
+import ActionChip from '@/renderer/components/ui/ActionChip';
 import AssistantEditDrawer from './components/AssistantEditDrawer';
 import AssistantSelectionArea from './components/AssistantSelectionArea';
 import AssistantAgentDropdown from './components/AssistantAgentDropdown';
@@ -61,6 +62,8 @@ const GuidPage: React.FC = () => {
   const [installedSkills, setInstalledSkills] = useState<any[]>([]);
   const [selectedSkills, setSelectedSkills] = useState<string[]>(draft?.selectedSkills ?? []);
   const [cursorPosition, setCursorPosition] = useState(0);
+  // Independent visibility state for the @-button Popover (separate from input @-trigger)
+  const [isSkillPopoverOpen, setIsSkillPopoverOpen] = useState(false);
 
   // Edit drawer state
   const [editDrawerVisible, setEditDrawerVisible] = useState(false);
@@ -513,6 +516,65 @@ const GuidPage: React.FC = () => {
     />
   );
 
+  // Popover-button path: independent state, does NOT touch the input
+  const [skillPopoverSearchQuery, setSkillPopoverSearchQuery] = useState('');
+  const [skillPopoverActiveIndex, setSkillPopoverActiveIndex] = useState(0);
+
+  const skillPopoverItems = useMemo<SkillSelectorMenuItem[]>(() => {
+    const kw = skillPopoverSearchQuery.trim().toLowerCase();
+    return skillSelectorItems
+      .filter((s) => s.enabled !== false)
+      .filter((s) => {
+        if (!kw) return true;
+        return s.name.toLowerCase().includes(kw) || s.displayName.toLowerCase().includes(kw) || (s.description?.toLowerCase().includes(kw) ?? false);
+      })
+      .map((skill) => ({
+        key: skill.name,
+        name: skill.name,
+        displayName: skill.displayName,
+        description: skill.description,
+        icon: skill.icon,
+        emoji: skill.emoji,
+        enabled: skill.enabled,
+      }));
+  }, [skillSelectorItems, skillPopoverSearchQuery]);
+
+  const onSkillPopoverClose = useCallback(() => {
+    setIsSkillPopoverOpen(false);
+    setSkillPopoverSearchQuery('');
+    setSkillPopoverActiveIndex(0);
+  }, []);
+
+  // Build the skill trigger node (@button wrapped in SkillSelectorPopover)
+  const skillTriggerNode = (
+    <SkillSelectorPopover
+      popupVisible={isSkillPopoverOpen}
+      onVisibleChange={(v) => {
+        if (!v) onSkillPopoverClose();
+      }}
+      title={t('guid.skillSelectorTitle')}
+      items={skillPopoverItems}
+      selectedKeys={selectedSkills}
+      activeIndex={skillPopoverActiveIndex}
+      onHoverItem={(index) => setSkillPopoverActiveIndex(index)}
+      onSelectItem={(item) => {
+        if (!selectedSkills.includes(item.key)) {
+          setSelectedSkills((prev) => [...prev, item.key]);
+        }
+        onSkillPopoverClose();
+      }}
+      emptyText={t('guid.noSkills')}
+      searchQuery={skillPopoverSearchQuery}
+      onSearchChange={(q) => {
+        setSkillPopoverSearchQuery(q);
+        setSkillPopoverActiveIndex(0);
+      }}
+      onDismiss={onSkillPopoverClose}
+    >
+      <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('conversation.welcome.skill', { defaultValue: '技能' })} onClick={() => setIsSkillPopoverOpen(true)} />
+    </SkillSelectorPopover>
+  );
+
   // Build the action row
   const actionRowNode = (
     <GuidActionRow
@@ -533,7 +595,7 @@ const GuidPage: React.FC = () => {
         guidInput.setInput('');
         prefilledAssistantRef.current = null;
       }}
-      onTriggerSkillSelector={handleTriggerSkillSelector}
+      skillTriggerNode={skillTriggerNode}
       loading={guidInput.loading}
       isButtonDisabled={send.isButtonDisabled}
       onSend={() => {
@@ -716,7 +778,7 @@ const GuidPage: React.FC = () => {
           skillSelectorOpen={skillSelectorController.isOpen}
           skillSelectorMenu={
             skillSelectorController.isOpen ? (
-              <SkillSelectorMenu
+              <SkillSelectorMenuContent
                 title={t('guid.skillSelectorTitle')}
                 items={skillMenuItems}
                 selectedKeys={selectedSkills}

--- a/src/renderer/pages/guid/components/AgentPillBar.tsx
+++ b/src/renderer/pages/guid/components/AgentPillBar.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Robot } from '@icon-park/react';
 import React from 'react';
 import { getAgentLogo } from '@/renderer/utils/agentLogo';

--- a/src/renderer/pages/guid/components/AssistantAgentDropdown.tsx
+++ b/src/renderer/pages/guid/components/AssistantAgentDropdown.tsx
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Dropdown for switching the main agent (backend) of the selected assistant.
  * Shown on the right side of the assistant header in the GUID page.
  */

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Plus, Robot } from '@icon-park/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Dropdown, Tooltip } from '@arco-design/web-react';
 import { ArrowUp, FolderOpen, Plus, Shield, UploadOne } from '@icon-park/react';
 import React, { useState } from 'react';

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -147,9 +147,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
 
           {onTriggerSkillSelector && (
             <Tooltip content={t('guid.addSkillTooltip', { defaultValue: '添加技能' })} position='top'>
-              <span>
-                <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('conversation.welcome.skill', { defaultValue: '技能' })} onClick={onTriggerSkillSelector} />
-              </span>
+              <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('conversation.welcome.skill', { defaultValue: '技能' })} onClick={onTriggerSkillSelector} />
             </Tooltip>
           )}
 

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -1,11 +1,10 @@
-import { Button, Dropdown, Tooltip } from '@arco-design/web-react';
+import { Button, Dropdown } from '@arco-design/web-react';
 import { ArrowUp, FolderOpen, Plus, Shield, UploadOne } from '@icon-park/react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import AgentModeSelector from '@/renderer/components/AgentModeSelector';
 import { getAgentModes, supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/agentModes';
-import ActionChip from '@/renderer/components/ui/ActionChip';
 import BdpanLogo from '@/renderer/assets/logos/bdpan.png';
 import BdpanImportFilePicker from '@/renderer/components/base/BdpanImportFilePicker';
 import styles from '../index.module.css';
@@ -34,8 +33,8 @@ type GuidActionRowProps = {
   localeKey: string;
   onClosePresetTag: () => void;
 
-  // Skill selector trigger
-  onTriggerSkillSelector?: () => void;
+  // Skill selector trigger node (Popover-wrapped button built by parent)
+  skillTriggerNode?: React.ReactNode;
 
   // Send button
   loading: boolean;
@@ -57,7 +56,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
   customAgents,
   localeKey,
   onClosePresetTag,
-  onTriggerSkillSelector,
+  skillTriggerNode,
   loading,
   isButtonDisabled,
   onSend,
@@ -145,11 +144,7 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
             </span>
           </Dropdown>
 
-          {onTriggerSkillSelector && (
-            <Tooltip content={t('guid.addSkillTooltip', { defaultValue: '添加技能' })} position='top'>
-              <ActionChip icon={<span className='text-14px font-700 leading-none'>@</span>} label={t('conversation.welcome.skill', { defaultValue: '技能' })} onClick={onTriggerSkillSelector} />
-            </Tooltip>
-          )}
+          {skillTriggerNode}
 
           {modelSelectorNode}
 

--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -201,7 +201,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
         </div>
       )}
       {files.length > 0 && (
-        <div className='flex flex-wrap items-center gap-2 my-3'>
+        <div className='flex flex-wrap items-center gap-3 my-3'>
           {files.map((path) => (
             <FilePreview key={path} path={path} onRemove={() => onRemoveFile(path)} />
           ))}

--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Input, Tag, Tooltip } from '@arco-design/web-react';
 import { IconClose, IconPaste } from '@arco-design/web-react/icon';
 import { CloseSmall, FolderOpen, Lightning } from '@icon-park/react';

--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -1,6 +1,6 @@
 import { Input, Tag, Tooltip } from '@arco-design/web-react';
 import { IconClose, IconPaste } from '@arco-design/web-react/icon';
-import { CloseSmall, FolderOpen, Lightning } from '@icon-park/react';
+import { FolderOpen, Lightning } from '@icon-park/react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCompositionInput } from '@/renderer/hooks/useCompositionInput';
@@ -149,7 +149,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
       {selectedSkills && selectedSkills.length > 0 && (
         <div className='flex flex-col gap-6px mb-8px'>
           <div className='flex items-center gap-4px text-11px text-secondary'>
-            <Lightning size='12' className='text-[var(--ui-accent-orange)]' />
+            <Lightning size='12' />
             <span>当前使用技能</span>
           </div>
           <div className='flex flex-wrap gap-6px'>
@@ -157,18 +157,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
               const skillInfo = getSkillDisplayName?.(skillName);
               const displayName = skillInfo?.displayName || skillName;
               return (
-                <Tag
-                  key={skillName}
-                  closable
-                  closeIcon={<CloseSmall theme='outline' size='12' />}
-                  onClose={() => onRemoveSkill?.(skillName)}
-                  className='text-12px b-1 b-solid rd-4px'
-                  style={{
-                    backgroundColor: 'rgba(var(--ui-accent-orange-rgb), 0.1)',
-                    borderColor: 'rgba(var(--ui-accent-orange-rgb), 0.32)',
-                  }}
-                >
-                  <Lightning size='12' className='mr-4px text-[var(--ui-accent-orange)]' />
+                <Tag key={skillName} closable onClose={() => onRemoveSkill?.(skillName)} className='text-12px rd-full' icon={<Lightning size='12' className='mr-4px text-[var(--ui-accent-orange)]' />}>
                   {displayName}
                 </Tag>
               );

--- a/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -201,7 +201,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
         </div>
       )}
       {files.length > 0 && (
-        <div className='flex flex-wrap items-center gap-8px mt-12px mb-12px'>
+        <div className='flex flex-wrap items-center gap-2 my-3'>
           {files.map((path) => (
             <FilePreview key={path} path={path} onRemove={() => onRemoveFile(path)} />
           ))}

--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Dropdown, Tooltip } from '@arco-design/web-react';
 import { Brain, Plus, Right } from '@icon-park/react';
 import classNames from 'classnames';

--- a/src/renderer/pages/guid/components/GuidSkeleton.tsx
+++ b/src/renderer/pages/guid/components/GuidSkeleton.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 import styles from '../index.module.css';
 

--- a/src/renderer/pages/guid/components/MentionDropdown.tsx
+++ b/src/renderer/pages/guid/components/MentionDropdown.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Menu } from '@arco-design/web-react';
 import { Robot } from '@icon-park/react';
 import React from 'react';

--- a/src/renderer/pages/guid/components/MentionSelectorBadge.tsx
+++ b/src/renderer/pages/guid/components/MentionSelectorBadge.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Dropdown } from '@arco-design/web-react';
 import { Down } from '@icon-park/react';
 import React from 'react';

--- a/src/renderer/pages/guid/components/PresetAgentTag.tsx
+++ b/src/renderer/pages/guid/components/PresetAgentTag.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { IconClose } from '@arco-design/web-react/icon';
 import { Robot } from '@icon-park/react';
 import React from 'react';

--- a/src/renderer/pages/guid/components/PromptTemplates.tsx
+++ b/src/renderer/pages/guid/components/PromptTemplates.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useState } from 'react';
 import { Button } from '@arco-design/web-react';
 import { useTranslation } from 'react-i18next';

--- a/src/renderer/pages/guid/components/QuickActionButtons.tsx
+++ b/src/renderer/pages/guid/components/QuickActionButtons.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React from 'react';
 
 type QuickActionButtonsProps = {

--- a/src/renderer/pages/guid/constants.ts
+++ b/src/renderer/pages/guid/constants.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import coworkSvg from '@/renderer/assets/cowork.svg';
 import type { PromptCategory } from './types';
 

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import { ipcBridge } from '@/common';

--- a/src/renderer/pages/guid/hooks/useGuidDraft.ts
+++ b/src/renderer/pages/guid/hooks/useGuidDraft.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 export type GuidDraftState = {
   input: string;
   files: string[];

--- a/src/renderer/pages/guid/hooks/useGuidInput.ts
+++ b/src/renderer/pages/guid/hooks/useGuidInput.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useState } from 'react';
 import { useDragUpload } from '@/renderer/hooks/useDragUpload';
 import { usePasteService } from '@/renderer/hooks/usePasteService';

--- a/src/renderer/pages/guid/hooks/useGuidMention.ts
+++ b/src/renderer/pages/guid/hooks/useGuidMention.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getAgentLogo } from '@/renderer/utils/agentLogo';
 import { CUSTOM_AVATAR_IMAGE_MAP } from '../constants';

--- a/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { ipcBridge } from '@/common';

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Message } from '@arco-design/web-react';
 import { useCallback } from 'react';
 import { type TFunction } from 'i18next';

--- a/src/renderer/pages/guid/hooks/useTypewriterPlaceholder.ts
+++ b/src/renderer/pages/guid/hooks/useTypewriterPlaceholder.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { useEffect, useState } from 'react';
 
 /**

--- a/src/renderer/pages/guid/index.tsx
+++ b/src/renderer/pages/guid/index.tsx
@@ -1,7 +1,1 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 export { default } from './GuidPage';

--- a/src/renderer/pages/guid/types.ts
+++ b/src/renderer/pages/guid/types.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { AcpBackend, AcpBackendAll, AcpBackendConfig, AcpModelInfo, PresetAgentType } from '@/types/acpTypes';
 
 /**

--- a/src/renderer/pages/guid/utils/caretUtils.ts
+++ b/src/renderer/pages/guid/utils/caretUtils.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Measure the vertical coordinate of a given position in a textarea.
  * @param textarea - Target textarea element
  * @param position - Text position (character index)

--- a/src/renderer/pages/guid/utils/modelUtils.ts
+++ b/src/renderer/pages/guid/utils/modelUtils.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { IProvider } from '@/common/storage';
 import { hasSpecificModelCapability } from '@/renderer/utils/modelCapabilities';
 

--- a/src/renderer/pages/moss-session/MossSessionPage.tsx
+++ b/src/renderer/pages/moss-session/MossSessionPage.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Input, Spin, Typography } from '@arco-design/web-react';
 import { SendOne } from '@icon-park/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';

--- a/src/renderer/pages/security/index.tsx
+++ b/src/renderer/pages/security/index.tsx
@@ -227,7 +227,7 @@ export default function SecurityPage() {
 
   return (
     <PageWrapper title={t('settings.security')} subtitle={t('settings.securitySettings.subtitle')}>
-      <div className='flex flex-col gap-3 mt-4'>
+      <div className='flex flex-col gap-3'>
         <SecurityItem
           icon={<Shield size={22} />}
           title={t('settings.securitySettings.envProtection.title')}

--- a/src/renderer/pages/settings/about/index.tsx
+++ b/src/renderer/pages/settings/about/index.tsx
@@ -59,7 +59,7 @@ const About: React.FC = () => {
           <Button size='small' type='outline' onClick={() => window.dispatchEvent(new Event('sudowork-open-update-modal'))}>
             {t('settings.checkForUpdates', '检查更新')}
           </Button>
-          <Button type='text' className='opacity-50 hover:opacity-100 transition-opacity' onClick={() => setOpsVisible(true)} icon={<IconSettings fontSize={20} />} />
+          <Button type='text' onClick={() => setOpsVisible(true)} icon={<IconSettings style={{ fontSize: 20 }} />} />
         </div>
       </div>
 

--- a/src/renderer/pages/settings/channels/index.tsx
+++ b/src/renderer/pages/settings/channels/index.tsx
@@ -19,7 +19,7 @@ const Page: React.FC = () => {
 
   return (
     <PageWrapper title={t('common.siderMenu.webui')}>
-      <div className='flex flex-col h-full w-full mt-4'>
+      <div className='flex flex-col h-full w-full'>
         <div className='settings-remote-tabs mb-3'>
           <Tabs activeTab={activeTab} onChange={onTabChange} type='line'>
             <Tabs.TabPane

--- a/src/renderer/pages/settings/display/index.tsx
+++ b/src/renderer/pages/settings/display/index.tsx
@@ -29,7 +29,7 @@ const DisplaySettings: React.FC = () => {
         {/* 内容区域 / Content Area */}
         <AionScrollArea className='flex-1 min-h-0 pb-4' disableOverflow>
           <div className='space-y-4'>
-            <div className='py-3.5 md:py-4 rd-16px space-y-2.5 md:space-y-3'>
+            <div className='space-y-3'>
               <div className='w-full flex flex-col divide-y divide-light'>
                 {displayItems.map((item) => (
                   <PreferenceRow key={item.key} label={item.label}>

--- a/src/renderer/pages/settings/enterprise/index.tsx
+++ b/src/renderer/pages/settings/enterprise/index.tsx
@@ -6,7 +6,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Button, Input, Message, Spin } from '@arco-design/web-react';
-import { BuildingTwo, Success, Close } from '@icon-park/react';
+import { Building2, CheckCircle, XCircle } from 'lucide-react';
 import { ConfigStorage } from '@/common/storage';
 import { ipcBridge } from '@/common';
 import { TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@/common/types/tenantConfig';
@@ -104,7 +104,7 @@ const EnterpriseSettings: React.FC = () => {
       {/* Card 1: Enterprise Connection Info */}
       <div className='mb-6 rd-16px bg-muted p-6'>
         <div className='flex items-center gap-2 mb-5'>
-          <BuildingTwo theme='outline' size={20} className='text-2' />
+          <Building2 size={20} className='text-secondary' />
           <h3 className='text-16px font-600 text-foreground m-0'>企业连接信息</h3>
         </div>
 
@@ -112,7 +112,7 @@ const EnterpriseSettings: React.FC = () => {
           {/* Tenant Name (read-only) */}
           <div className='flex items-center justify-between py-2'>
             <div className='flex items-center gap-2'>
-              <BuildingTwo theme='outline' size={16} className='text-3' />
+              <Building2 size={16} className='text-secondary' />
               <span className='text-14px text-secondary'>企业名称</span>
             </div>
             <span className='text-14px text-foreground font-500'>{tenantName || '--'}</span>
@@ -121,7 +121,7 @@ const EnterpriseSettings: React.FC = () => {
           {/* Connection Status */}
           <div className='flex items-center justify-between py-2'>
             <div className='flex items-center gap-2'>
-              {connectionStatus === 'connected' ? <Success theme='filled' size={16} fill={['#00b42a']} /> : connectionStatus === 'checking' ? <Spin size={16} /> : <Close theme='filled' size={16} fill={['#f53f3f']} />}
+              {connectionStatus === 'connected' ? <CheckCircle size={16} className='text-success' /> : connectionStatus === 'checking' ? <Spin size={16} /> : <XCircle size={16} className='text-danger' />}
               <span className='text-14px text-secondary'>连接状态</span>
             </div>
             <span className={`text-14px font-500 ${connectionStatus === 'connected' ? 'text-success' : connectionStatus === 'disconnected' ? 'text-danger' : 'text-3'}`}>{connectionStatus === 'connected' ? '已连接' : connectionStatus === 'checking' ? '检查中...' : '未连接'}</span>

--- a/src/renderer/pages/settings/enterprise/index.tsx
+++ b/src/renderer/pages/settings/enterprise/index.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useEffect, useState } from 'react';
 import { Button, Input, Message, Spin } from '@arco-design/web-react';
 import { Building2, CheckCircle, XCircle } from 'lucide-react';

--- a/src/renderer/pages/settings/enterprise_mcps/components/McpIcon.tsx
+++ b/src/renderer/pages/settings/enterprise_mcps/components/McpIcon.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Connection } from '@icon-park/react';
+import { Cable } from 'lucide-react';
 import { ConfigStorage } from '@/common/storage';
 
 interface McpIconProps {
@@ -44,7 +44,7 @@ const McpIcon: React.FC<McpIconProps> = ({ icon, size = 36, className = '' }) =>
 
   return (
     <div className={`rounded-8px bg-fill-2 f-center flex-shrink-0 overflow-hidden ${className}`} style={{ width: size, height: size }}>
-      {showImage ? <img src={url} alt='' className='w-full h-full object-contain' onError={() => setErrored(true)} /> : <Connection theme='outline' size={Math.floor(size * 0.5)} className='text-tertiary' />}
+      {showImage ? <img src={url} alt='' className='w-full h-full object-contain' onError={() => setErrored(true)} /> : <Cable size={Math.floor(size * 0.5)} className='text-tertiary' />}
     </div>
   );
 };

--- a/src/renderer/pages/settings/enterprise_mcps/tabs/McpLibraryTab.tsx
+++ b/src/renderer/pages/settings/enterprise_mcps/tabs/McpLibraryTab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Input, Button, Tag, Message } from '@arco-design/web-react';
 import { IconCheck, IconDownload } from '@arco-design/web-react/icon';
-import { Search, CheckOne } from '@icon-park/react';
+import { Search } from '@icon-park/react';
 import EmptyState from '@/renderer/components/base/EmptyState';
 import McpIcon from '../components/McpIcon';
 import RiskLevelTag from '../components/RiskLevelTag';
@@ -90,7 +90,7 @@ const McpLibraryTab: React.FC<McpLibraryTabProps> = ({ templates, installedTempl
                     <span className='text-14px font-500 text-foreground truncate'>{tpl.name}</span>
                     <RiskLevelTag level={tpl.risk_level} />
                     {installed && (
-                      <Tag size='small' color='green' icon={<CheckOne theme='outline' size='12' />}>
+                      <Tag size='small' color='green' icon={<IconCheck style={{ fontSize: 12 }} />}>
                         已安装
                       </Tag>
                     )}

--- a/src/renderer/pages/settings/enterprise_mcps/tabs/McpLibraryTab.tsx
+++ b/src/renderer/pages/settings/enterprise_mcps/tabs/McpLibraryTab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Input, Button, Tag, Message } from '@arco-design/web-react';
 import { IconCheck, IconDownload } from '@arco-design/web-react/icon';
-import { Search } from '@icon-park/react';
+import { Search } from 'lucide-react';
 import EmptyState from '@/renderer/components/base/EmptyState';
 import McpIcon from '../components/McpIcon';
 import RiskLevelTag from '../components/RiskLevelTag';
@@ -73,7 +73,7 @@ const McpLibraryTab: React.FC<McpLibraryTabProps> = ({ templates, installedTempl
     <div className='flex flex-col gap-3'>
       {/* Filter bar */}
       <div className='flex items-center gap-2'>
-        <Input allowClear placeholder='搜索模板名称或描述' value={search} onChange={setSearch} prefix={<Search theme='outline' size='14' />} style={{ flex: 1 }} />
+        <Input allowClear placeholder='搜索模板名称或描述' value={search} onChange={setSearch} prefix={<Search size={14} />} style={{ flex: 1 }} />
       </div>
 
       {!loading && filtered.length === 0 ? (

--- a/src/renderer/pages/settings/members/index.tsx
+++ b/src/renderer/pages/settings/members/index.tsx
@@ -193,7 +193,7 @@ const MemberManagement: React.FC = () => {
         </Badge>
       }
     >
-      <div className='flex flex-col gap-6 py-2'>
+      <div className='flex flex-col gap-6 pb-2'>
         <Tabs activeTab={activeTab} onChange={setActiveTab} type='capsule'>
           <Tabs.TabPane key='pending' title={t('settings.memberPendingTab', { count: pendingUsers.length, defaultValue: '待审批 ({{count}})' })}>
             <div className='mt-4 bg-muted min-h-50'>

--- a/src/renderer/pages/settings/models/index.tsx
+++ b/src/renderer/pages/settings/models/index.tsx
@@ -175,7 +175,7 @@ const SudocodeModelSettings: React.FC = () => {
                     <Space>
                       <Tag bordered>{maskSecret(provider.apiKey) || t('common.notSet', '未设置')}</Tag>
                       <Popconfirm title={t('settings.sudocodeModel.deleteProviderConfirm', '删除该第三方提供商及其模型？')} onOk={() => void handleRemoveProvider(provider.id)}>
-                        <Button status='danger' icon={<IconDelete className='text-16px' />} loading={saving}>
+                        <Button status='danger' icon={<IconDelete style={{ fontSize: 16 }} />} loading={saving}>
                           {t('common.delete', '删除')}
                         </Button>
                       </Popconfirm>

--- a/src/renderer/pages/settings/models/index.tsx
+++ b/src/renderer/pages/settings/models/index.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Button, Message, Popconfirm, Space, Spin, Tag, Typography } from '@arco-design/web-react';
 import { IconCloud, IconDelete, IconEdit, IconPlus, IconRefresh, IconSettings } from '@arco-design/web-react/icon';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';

--- a/src/renderer/pages/settings/profile/components/ChangePasswordModal.tsx
+++ b/src/renderer/pages/settings/profile/components/ChangePasswordModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Modal, Input, Message } from '@arco-design/web-react';
-import { Lock } from '@icon-park/react';
+import { Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { validatePassword } from '@/renderer/utils/passwordValidation';
 import { useAuth } from '@renderer/context/AuthContext';
@@ -63,12 +63,12 @@ const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({ visible, onCl
       <div className='flex flex-col gap-4'>
         <div className='flex flex-col gap-2'>
           <div className='text-12px font-600 text-secondary ml-1'>{t('settings.changePassword.oldPasswordLabel', '原始密码')}</div>
-          <Input.Password size='large' prefix={<Lock className='text-tertiary' />} placeholder={t('settings.changePassword.oldPasswordPlaceholder', '请输入原始密码')} value={oldPassword} onChange={setOldPassword} maxLength={20} className='!rd-12px h-10' />
+          <Input.Password size='large' prefix={<Lock size={16} />} placeholder={t('settings.changePassword.oldPasswordPlaceholder', '请输入原始密码')} value={oldPassword} onChange={setOldPassword} maxLength={20} className='!rd-12px h-10' />
         </div>
         <div className='flex flex-col gap-2'>
           <div className='text-12px font-600 text-secondary ml-1'>{t('settings.changePassword.newPasswordLabel', '新密码')}</div>
-          <Input.Password size='large' prefix={<Lock className='text-tertiary' />} placeholder={t('settings.changePassword.newPasswordPlaceholder', '8-20 位，含大写、小写、数字')} value={newPassword} onChange={setNewPassword} maxLength={20} className='!rd-12px h-10' />
-          <div className='text-12px text-tertiary ml-1'>{t('settings.changePassword.ruleHint', '8-20 位，需同时包含大写字母、小写字母和数字。')}</div>
+          <Input.Password size='large' prefix={<Lock size={16} />} placeholder={t('settings.changePassword.newPasswordPlaceholder', '8-20 位，含大写、小写、数字')} value={newPassword} onChange={setNewPassword} maxLength={20} className='!rd-12px h-10' />
+          <div className='text-12px text-secondary ml-1'>{t('settings.changePassword.ruleHint', '8-20 位，需同时包含大写字母、小写字母和数字。')}</div>
         </div>
       </div>
     </Modal>

--- a/src/renderer/pages/settings/profile/index.tsx
+++ b/src/renderer/pages/settings/profile/index.tsx
@@ -216,15 +216,15 @@ const UserProfile: React.FC = () => {
               <div className='grid grid-cols-3 gap-4'>
                 <div className='text-center'>
                   <div className='text-24px font-700 text-foreground min-h-8 f-center'>{stats === null ? <Spin size={20} /> : (stats.usage_today?.tokens?.toLocaleString() ?? '0')}</div>
-                  <div className='text-12px text-tertiary'>{t('settings.userProfile.tokens', 'Tokens')}</div>
+                  <div className='text-12px text-secondary'>{t('settings.userProfile.tokens', 'Tokens')}</div>
                 </div>
                 <div className='text-center'>
                   <div className='text-24px font-700 text-primary min-h-8 f-center'>{stats === null ? <Spin size={20} /> : todayPoints}</div>
-                  <div className='text-12px text-tertiary'>{t('settings.userProfile.consumedPoints', '消耗积分')}</div>
+                  <div className='text-12px text-secondary'>{t('settings.userProfile.consumedPoints', '消耗积分')}</div>
                 </div>
                 <div className='text-center'>
                   <div className='text-24px font-700 text-foreground min-h-8 f-center'>{stats === null ? <Spin size={20} /> : (stats.usage_today?.requests ?? 0)}</div>
-                  <div className='text-12px text-tertiary'>{t('settings.userProfile.requests', '请求数')}</div>
+                  <div className='text-12px text-secondary'>{t('settings.userProfile.requests', '请求数')}</div>
                 </div>
               </div>
             </div>

--- a/src/renderer/pages/settings/profile/index.tsx
+++ b/src/renderer/pages/settings/profile/index.tsx
@@ -146,7 +146,7 @@ const UserProfile: React.FC = () => {
 
   return (
     <PageWrapper title={t('settings.profile', '用户中心')}>
-      <div className='flex flex-col gap-6 py-2'>
+      <div className='flex flex-col gap-6 pb-2'>
         {isEnterprise ? (
           <>
             {/* Enterprise: Identity */}

--- a/src/renderer/pages/settings/recharge/index.tsx
+++ b/src/renderer/pages/settings/recharge/index.tsx
@@ -506,7 +506,7 @@ const RechargeCenter: React.FC = () => {
 
   return (
     <PageWrapper title={t('settings.rechargeCenter', '充值中心')}>
-      <div className='flex flex-col gap-6 py-2'>
+      <div className='flex flex-col gap-6 pb-2'>
         {statsLoading ? (
           <div className='flex justify-center py-10'>
             <Spin />

--- a/src/renderer/pages/settings/runtime/components/RuntimeToolRow.tsx
+++ b/src/renderer/pages/settings/runtime/components/RuntimeToolRow.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@arco-design/web-react';
 import React from 'react';
 import classNames from 'classnames';
-import { ShareOne } from '@icon-park/react';
+import { Share2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ToolRow } from '../types';
 import { badgeColors, getRuntimeActions, getStatusInfo, isInstalled } from '../utils';
@@ -23,9 +23,7 @@ export default function RuntimeToolRow({ record }: IRuntimeToolRowProps) {
     <div className='py-3.5 first:pt-0 last:pb-0'>
       <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4'>
         <div className='flex items-center gap-3 min-w-0 flex-1'>
-          <div className={classNames('w-7 h-7 rd-8px f-center flex-shrink-0 text-9px md:text-10px font-700 shadow-sm', badgeColors[record.key] || 'bg-blue-1 color-blue-6 border border-blue-3')}>
-            {record.key === 'shareone' ? <ShareOne theme='outline' size={16} className='block' /> : record.badge}
-          </div>
+          <div className={classNames('w-7 h-7 rd-8px f-center flex-shrink-0 text-9px md:text-10px font-700 shadow-sm', badgeColors[record.key] || 'bg-blue-1 color-blue-6 border border-blue-3')}>{record.key === 'shareone' ? <Share2 size={16} /> : record.badge}</div>
 
           <div className='min-w-0 flex-1 space-y-1'>
             <div className='flex flex-col gap-1 lg:flex-row lg:items-center lg:gap-2'>

--- a/src/renderer/pages/settings/runtime/index.tsx
+++ b/src/renderer/pages/settings/runtime/index.tsx
@@ -589,7 +589,7 @@ export default function RuntimeSettings() {
     <PageWrapper title={t('settings.runtimeSettings.title')} subtitle={t('settings.runtimeSettings.description')}>
       <div className='flex flex-col h-full w-full'>
         <AionScrollArea className='flex-1 min-h-0 pb-4' disableOverflow>
-          <div className='space-y-4 pt-4'>
+          <div className='space-y-4'>
             <div className='bg-muted rd-16px border px-4 md:px-6 lg:px-7 py-4 md:py-4.5'>
               <div className='flex flex-col divide-y divide-light'>
                 {tableData.map((record) => (

--- a/src/renderer/pages/settings/system/components/OptInDialog.tsx
+++ b/src/renderer/pages/settings/system/components/OptInDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { Button, Modal } from '@arco-design/web-react';
 import { useTranslation } from 'react-i18next';
-import { Shield } from '@icon-park/react';
+import { ShieldCheck } from 'lucide-react';
 
 /**
  * 产品体验改进计划弹窗组件
@@ -33,8 +33,8 @@ export default function OptInDialog({ isOpen, onClose }: IOptInDialogProps) {
         <div className='text-14px text-secondary leading-relaxed'>{t('settings.productImprovement.description', '帮助我们持续优化产品体验，为您带来更好的服务。')}</div>
 
         {/* 隐私保障 */}
-        <div className='flex items-start gap-2.5 p-3 rd-10px bg-muted'>
-          <Shield size={18} fill='var(--success)' className='flex-shrink-0 mt-px' />
+        <div className='flex items-start gap-2.5 p-3 rd-10px bg-control'>
+          <ShieldCheck size={18} className='flex-shrink-0 mt-px text-success' />
           <div className='text-13px text-secondary leading-relaxed'>{t('settings.productImprovement.privacy', '开启后将匿名收集 SudoWork 性能指标，仅用于产品改进，不会收集您的对话内容或个人信息。您可以随时关闭此功能。')}</div>
         </div>
       </div>

--- a/src/renderer/pages/settings/system/index.tsx
+++ b/src/renderer/pages/settings/system/index.tsx
@@ -450,7 +450,7 @@ const SystemSettings: React.FC = () => {
         <AionScrollArea className='flex-1 min-h-0 pb-4' disableOverflow>
           <div className='space-y-4'>
             {/* 偏好设置与高级设置合并展示 / Combined preferences and advanced settings */}
-            <div className='py-4 rd-16px space-y-3'>
+            <div className='pb-4 rd-16px space-y-3'>
               <div className='w-full flex flex-col divide-y divide-light'>
                 {preferenceItems.map((item) => (
                   <PreferenceRow key={item.key} label={item.label} hint={item.hint}>

--- a/src/renderer/pages/settings/tools/components/McpAgentStatusDisplay.tsx
+++ b/src/renderer/pages/settings/tools/components/McpAgentStatusDisplay.tsx
@@ -1,5 +1,5 @@
 import { Tag, Tooltip } from '@arco-design/web-react';
-import { LoadingOne } from '@icon-park/react';
+import { Loader2 } from 'lucide-react';
 import React from 'react';
 import { getAgentLogo } from '@/renderer/utils/agentLogo';
 
@@ -22,7 +22,7 @@ const McpAgentStatusDisplay: React.FC<McpAgentStatusDisplayProps> = ({ serverNam
     <div className='flex items-center isolate'>
       <div className='flex items-center'>
         {isLoadingAgentStatus ? (
-          <LoadingOne fill={'var(--foreground)'} className='h-4 w-4' />
+          <Loader2 size={16} className='animate-spin text-foreground' />
         ) : (
           agents.map((agent, index) => {
             const logo = getAgentLogo(agent);

--- a/src/renderer/pages/settings/tools/components/McpManagementSection.tsx
+++ b/src/renderer/pages/settings/tools/components/McpManagementSection.tsx
@@ -1,6 +1,5 @@
 import { Button, Dropdown, Menu, Message, Modal } from '@arco-design/web-react';
 import { IconPlus } from '@arco-design/web-react/icon';
-import { Plus } from '@icon-park/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { acpConversation } from '@/common/ipcBridge';
@@ -154,8 +153,10 @@ export default function McpManagementSection() {
             </Menu>
           }
         >
-          <Plus fill='var(--primary)' size={18} />
-          {t('settings.mcpAddServer', '手动添加')}
+          <span className='f-center gap-1.5'>
+            <IconPlus />
+            {t('settings.mcpAddServer', '手动添加')}
+          </span>
         </Dropdown.Button>
       );
     }

--- a/src/renderer/pages/settings/tools/components/McpServerHeader.tsx
+++ b/src/renderer/pages/settings/tools/components/McpServerHeader.tsx
@@ -1,7 +1,6 @@
 import { Button, Dropdown, Menu, Switch, Tooltip } from '@arco-design/web-react';
 import { IconRefresh, IconSettings } from '@arco-design/web-react/icon';
-import { Check, CloseOne, CloseSmall, LoadingOne, Write, DeleteFour } from '@icon-park/react';
-import { LogIn } from 'lucide-react';
+import { Check, Loader2, LogIn, Pencil, Trash2, X } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { IMcpServer } from '@/common/storage';
@@ -26,11 +25,11 @@ interface McpServerHeaderProps {
 
 const getStatusIcon = (status?: IMcpServer['status'], oauthStatus?: IMcpOAuthStatus) => {
   if (status === 'testing' || oauthStatus?.isChecking) {
-    return <LoadingOne fill={'var(--foreground)'} />;
+    return <Loader2 size={16} className='animate-spin text-foreground' />;
   }
 
   if (status === 'error') {
-    return <CloseSmall fill={'var(--danger)'} />;
+    return <X size={16} className='text-danger' />;
   }
 
   if (oauthStatus?.needsLogin) {
@@ -38,10 +37,10 @@ const getStatusIcon = (status?: IMcpServer['status'], oauthStatus?: IMcpOAuthSta
   }
 
   if (status === 'connected' || oauthStatus?.isAuthenticated) {
-    return <Check fill={'var(--success)'} className='items-center' />;
+    return <Check size={16} className='text-success' />;
   }
 
-  return <CloseOne fill={'var(--text-secondary)'} />;
+  return <X size={16} className='text-secondary' />;
 };
 
 const getStatusText = (status?: IMcpServer['status'], oauthStatus?: IMcpOAuthStatus, t?: any) => {
@@ -99,16 +98,16 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({ server, agentInstallS
             <Dropdown
               trigger='hover'
               droplist={
-                <Menu>
+                <Menu className={'w-32'}>
                   <Menu.Item key='edit' onClick={() => onEditServer(server)}>
-                    <div className='flex items-center gap-2'>
-                      <Write size={'14'} />
+                    <div className='flex items-center gap-3'>
+                      <Pencil size={14} />
                       {t('settings.mcpEditServer', '编辑')}
                     </div>
                   </Menu.Item>
                   <Menu.Item key='delete' onClick={() => onDeleteServer(server.id)}>
-                    <div className='flex items-center gap-2 text-danger'>
-                      <DeleteFour size={'14'} />
+                    <div className='flex items-center gap-3 text-danger'>
+                      <Trash2 size={14} />
                       {t('settings.mcpDeleteServer', '删除')}
                     </div>
                   </Menu.Item>

--- a/src/renderer/pages/settings/tools/components/OneClickImportModal.tsx
+++ b/src/renderer/pages/settings/tools/components/OneClickImportModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal, Select, Spin, Steps } from '@arco-design/web-react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check } from '@icon-park/react';
+import { Check } from 'lucide-react';
 import { acpConversation, mcpService } from '@/common/ipcBridge';
 import type { IMcpServer, IMcpTool } from '@/common/storage';
 import type { IDetectedAgent } from '../types';
@@ -166,7 +166,7 @@ const OneClickImportModal: React.FC<OneClickImportModalProps> = ({ visible, onCa
       ) : importableServers.length > 0 ? (
         <div>
           <div className='mb-3 flex items-center gap-2'>
-            <Check theme='filled' size={20} fill={'var(--success)'} />
+            <Check className='text-success size-5' />
             <span className='text-foreground'>{t('settings.mcpToolsLoaded', { count: importableServers.length, defaultValue: '读取到{{count}}个工具' })}</span>
           </div>
           <div className='bg-control rounded-lg max-h-50 overflow-y-auto divide-y divide-light'>
@@ -190,7 +190,7 @@ const OneClickImportModal: React.FC<OneClickImportModalProps> = ({ visible, onCa
       {importableServers.length > 0 ? (
         <div>
           <div className='mb-3 flex items-center gap-2'>
-            <Check theme='filled' size={20} fill={'var(--success)'} />
+            <Check className='text-success size-5' />
             <span className='text-foreground'>{t('settings.mcpImportedSuccess', { count: importableServers.length, defaultValue: '已导入{{count}}个工具' })}</span>
           </div>
           <div className='bg-control rounded-lg max-h-50 overflow-y-auto divide-y divide-light'>
@@ -245,8 +245,8 @@ const OneClickImportModal: React.FC<OneClickImportModalProps> = ({ visible, onCa
 
         <div className='mb-6'>
           <Steps current={currentStep} size='small'>
-            <Steps.Step title={t('settings.mcpStepSelectAgent', '选择Agent')} icon={currentStep > 1 ? <Check theme='filled' size={16} /> : undefined} />
-            <Steps.Step title={t('settings.mcpStepFetchTools', '获取mcp')} icon={currentStep > 2 ? <Check theme='filled' size={16} /> : undefined} />
+            <Steps.Step title={t('settings.mcpStepSelectAgent', '选择Agent')} />
+            <Steps.Step title={t('settings.mcpStepFetchTools', '获取mcp')} />
             <Steps.Step title={t('settings.mcpStepImportSuccess', '导入成功')} />
           </Steps>
         </div>

--- a/src/renderer/pages/settings/tools/index.tsx
+++ b/src/renderer/pages/settings/tools/index.tsx
@@ -71,7 +71,7 @@ export default function ToolsSettings() {
 
   return (
     <PageWrapper contentClassName='max-w-300' title={t('settings.tools', '工具')}>
-      <div className='flex flex-col h-full w-full pt-4'>
+      <div className='flex flex-col h-full w-full'>
         <AionScrollArea className='flex-1 min-h-0 pb-4' disableOverflow>
           <div className='space-y-4'>
             <div className='px-3 md:px-8 py-6 bg-muted rd-12px md:rd-16px flex flex-col min-h-0 border border-light'>

--- a/src/renderer/pages/setup/ModeSetup.tsx
+++ b/src/renderer/pages/setup/ModeSetup.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Input, Message } from '@arco-design/web-react';

--- a/src/renderer/services/FileService.ts
+++ b/src/renderer/services/FileService.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { ipcBridge } from '@/common';
 // Simple formatBytes implementation moved from deleted updateConfig
 function formatBytes(bytes: number, decimals = 2): string {

--- a/src/renderer/services/PasteService.ts
+++ b/src/renderer/services/PasteService.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { ipcBridge } from '@/common';
 import type { FileMetadata } from './FileService';
 import { getFileExtension } from './FileService';

--- a/src/renderer/shared/agents/assistantAdapter.ts
+++ b/src/renderer/shared/agents/assistantAdapter.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Adapter: IAssistantInfo (filesystem SSOT) → AcpBackendConfig (renderer compat).
  *
  * Renderer code still uses AcpBackendConfig for state/props.

--- a/src/renderer/shared/agents/availableAgents.ts
+++ b/src/renderer/shared/agents/availableAgents.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { AvailableAgent } from './types';
 
 export const AVAILABLE_AGENTS_SWR_KEY = 'acp.agents.available';

--- a/src/renderer/shared/agents/presetAssistantResources.ts
+++ b/src/renderer/shared/agents/presetAssistantResources.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { ipcBridge } from '@/common';
 import { getPresetById } from '@/common/presets/presetResolver';
 

--- a/src/renderer/shared/agents/types.ts
+++ b/src/renderer/shared/agents/types.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { AcpBackend, PresetAgentType } from '@/types/acpTypes';
 
 /**

--- a/src/renderer/shared/dify/sessionBinding.ts
+++ b/src/renderer/shared/dify/sessionBinding.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Renderer-side helpers for wiring a chat session into the Dify enhancement
  * orchestrator running in the main process.
  *

--- a/src/renderer/types/tool-confirmation.ts
+++ b/src/renderer/types/tool-confirmation.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Tool confirmation outcome enum
  * This is a local copy to avoid importing the entire tools module from aioncli-core
  * which contains Node.js dependencies (node:crypto) that cannot be bundled in the renderer process.

--- a/src/renderer/utils/HOC.tsx
+++ b/src/renderer/utils/HOC.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 

--- a/src/renderer/utils/agentModes.ts
+++ b/src/renderer/utils/agentModes.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Agent mode option interface
  * 代理模式选项接口
  */

--- a/src/renderer/utils/agentUiDisplay.ts
+++ b/src/renderer/utils/agentUiDisplay.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 export const isDefaultModel = (value?: string | null, label?: string | null): boolean => {
   const text = `${value || ''} ${label || ''}`.toLowerCase();
   return text.includes('default') || text.includes('recommended') || text.includes('默认');

--- a/src/renderer/utils/clipboard.ts
+++ b/src/renderer/utils/clipboard.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Copy text to clipboard with fallback for non-secure contexts (e.g. WebUI over HTTP).
  * Uses navigator.clipboard when available, otherwise falls back to document.execCommand('copy').
  */

--- a/src/renderer/utils/createContext.tsx
+++ b/src/renderer/utils/createContext.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { FunctionComponent, PropsWithChildren } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 

--- a/src/renderer/utils/diffUtils.ts
+++ b/src/renderer/utils/diffUtils.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * 从 diff 内容中解析文件路径
  * Parse file path from diff content
  *

--- a/src/renderer/utils/emitter.ts
+++ b/src/renderer/utils/emitter.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import EventEmitter from 'eventemitter3';
 import type { DependencyList } from 'react';
 import { useEffect } from 'react';

--- a/src/renderer/utils/enum.ts
+++ b/src/renderer/utils/enum.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 export enum CronJobStatusEnums {
   None = 'none',
   Active = 'active',

--- a/src/renderer/utils/fileIcon.tsx
+++ b/src/renderer/utils/fileIcon.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { AudioFile, FileCode, FileExcel, FileGif, FileJpg, FilePdf, FilePpt, FileText, FileTxt, FileWord, FileZip, VideoFile } from '@icon-park/react';
 import type { Theme } from '@icon-park/react/es/runtime';
 import React from 'react';

--- a/src/renderer/utils/fileSelection.ts
+++ b/src/renderer/utils/fileSelection.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { FileOrFolderItem } from '@/renderer/types/files';
 
 export type FileSelectionItem = string | FileOrFolderItem;

--- a/src/renderer/utils/fileType.ts
+++ b/src/renderer/utils/fileType.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { PreviewContentType } from '@/common/types/preview';
 
 interface FileTypeInfo {

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 export const removeStack = (...args: Array<() => void>) => {
   return () => {
     const list = args.slice();

--- a/src/renderer/utils/messageTime.ts
+++ b/src/renderer/utils/messageTime.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Smart message time formatting utilities
  * 智能消息时间格式化工具函数
  *

--- a/src/renderer/utils/modelCapabilities.ts
+++ b/src/renderer/utils/modelCapabilities.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { IProvider, ModelType } from '@/common/storage';
 
 /**

--- a/src/renderer/utils/platform.ts
+++ b/src/renderer/utils/platform.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Platform detection utilities
  * 平台检测工具函数
  */

--- a/src/renderer/utils/shareNotify.tsx
+++ b/src/renderer/utils/shareNotify.tsx
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Notification } from '@arco-design/web-react';
 import { Copy } from '@icon-park/react';
 import React from 'react';

--- a/src/renderer/utils/skillDisplay.ts
+++ b/src/renderer/utils/skillDisplay.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import type { IInstalledSkillInfo } from '@/common/ipcBridge';
 import defaultSkillIcon from '@/renderer/assets/icon-catalogue.svg';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';

--- a/src/renderer/utils/thinkTagFilter.ts
+++ b/src/renderer/utils/thinkTagFilter.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Frontend think tag filter
  * Filters think tags from message content before rendering
  * This handles historical messages that were saved before the filter was implemented

--- a/src/renderer/utils/timeline.ts
+++ b/src/renderer/utils/timeline.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Timeline utility functions for conversation history grouping
  * 会话历史分组的时间线工具函数
  */

--- a/src/renderer/utils/workspace.ts
+++ b/src/renderer/utils/workspace.ts
@@ -1,10 +1,4 @@
 /**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
  * Workspace utility functions
  * 工作空间工具函数
  */

--- a/src/renderer/utils/workspaceFs.ts
+++ b/src/renderer/utils/workspaceFs.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { ipcBridge } from '@/common';
 
 interface IBridgeResponse<D = unknown> {

--- a/src/renderer/utils/workspaceHistory.ts
+++ b/src/renderer/utils/workspaceHistory.ts
@@ -1,9 +1,3 @@
-/**
- * @license
- * Copyright 2025 Sudowork (sudowork.ai)
- * SPDX-License-Identifier: Apache-2.0
- */
-
 const WORKSPACE_UPDATE_TIME_KEY = 'sudowork_workspace_update_time';
 
 /**


### PR DESCRIPTION
## Summary
- replace the guid skill selector menu with SkillSelectorPopover and wire Sendbox file selection into the popover flow
- simplify skill selector state, keyboard navigation, tabs, spacing, and file preview styling
- clean up renderer license headers and migrate remaining icon/style details in settings-related UI

## Tests
- bunx tsc --noEmit