### PR TITLE
fix(ci): rewire pr-e2e-artifacts to the actual Python runner

### DIFF
--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -66,23 +66,46 @@ jobs:
       - name: Build Electron artifacts (main+preload+renderer)
         run: bun run package
 
-      - name: Launch Electron with mock enterprise auth (background) + run e2e runner
-        # Two commands in one xvfb-run so the Electron subprocess shares the same X server.
-        # restart_electron.py kills any stale Electron, seeds ConfigStorage with mock auth,
-        # launches launch-dev.js with NEXUS_CDP_PORT=9232, and polls the CDP endpoint until
-        # ready. Then runner.py connects and iterates cases/*.yaml (filtered).
+      - name: Start Xvfb virtual display
+        # Manually launch Xvfb so both the Electron subprocess (spawned by
+        # restart_electron.py detached) and the runner (spawned in a later step)
+        # can attach to the same $DISPLAY. Wrapping via `xvfb-run bash -c '…'` broke
+        # earlier because xvfb-run cleaned up the display before the runner attached.
         run: |
-          xvfb-run --auto-servernum bash -c '
-            set -euo pipefail
-            cd tests/e2e
-            python restart_electron.py --enterprise --auth --port 9232
-            python runner.py --port 9232 --case "$CASE_FILTER"
-          '
+          Xvfb :99 -screen 0 1920x1080x24 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+          sleep 2
+          echo "xvfb-run pid=$!"
+
+      - name: Launch Electron with mock enterprise auth (background)
+        # restart_electron.py kills any stale Electron, seeds ConfigStorage with
+        # mock auth, launches launch-dev.js with NEXUS_CDP_PORT=9232, and polls
+        # the CDP endpoint until ready. Runs in its OWN step so its stdout/stderr
+        # show up in the CI log if it fails.
+        run: |
+          set -euo pipefail
+          echo "=== env sanity ==="
+          which python && python --version
+          which node && node --version
+          echo "DISPLAY=$DISPLAY"
+          ls tests/e2e/restart_electron.py
+          echo "=== restarting electron ==="
+          python tests/e2e/restart_electron.py --enterprise --auth --port 9232
+        env:
+          CI: true
+          E2E_DEV: '1'
+          NEXUS_EXTENSIONS_PATH: ${{ github.workspace }}/examples
+          NEXUS_CDP_PORT: '9232'
+
+      - name: Run e2e runner against CDP
+        run: |
+          set -euo pipefail
+          cd tests/e2e
+          python runner.py --port 9232 --case "$CASE_FILTER"
         env:
           CI: true
           E2E_DEV: '1'
           E2E_SCREENSHOTS: '1'
-          NEXUS_EXTENSIONS_PATH: ${{ github.workspace }}/examples
           NEXUS_CDP_PORT: '9232'
           CASE_FILTER: ${{ inputs.case_filter || 'interrupt-queue-batched-flush' }}
 

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -1,8 +1,18 @@
 name: '✓PR E2E Artifacts'
 
+# Runs the real Python + YAML e2e infra (tests/e2e/runner.py + tests/e2e/cases/*.yaml)
+# against a headless Electron launched with mock enterprise auth pre-seeded. Kept as
+# workflow_dispatch (opt-in) so the smoke matrix on every PR isn't slowed by full e2e —
+# trigger from Actions UI or `gh workflow run pr-e2e-artifacts.yml --ref <branch>` when
+# a change touches the interrupt+queue / ACP / renderer paths.
+
 on:
   workflow_dispatch:
-
+    inputs:
+      case_filter:
+        description: 'Name substring (matches runner.py --case)'
+        required: false
+        default: 'interrupt-queue-batched-flush'
 
 concurrency:
   group: pr-e2e-artifacts-${{ github.run_id }}
@@ -18,7 +28,7 @@ jobs:
   e2e-artifacts:
     name: E2E Artifacts (Linux)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -34,27 +44,47 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup just
-        uses: extractions/setup-just@v2
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
 
-      - name: Install dependencies
+      - name: Install Python e2e deps
+        run: python -m pip install --upgrade pip pyyaml ai-dev-browser
+
+      - name: Install node dependencies
         run: bun install --no-frozen-lockfile
 
       - name: Run postinstall
         run: npm run postinstall || true
 
-      - name: Install Linux display dependencies (E2E)
+      - name: Install Linux display dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgbm-dev xvfb
 
-      - name: Run E2E tests (with screenshots)
-        run: xvfb-run --auto-servernum just e2e-test
+      - name: Build Electron artifacts (main+preload+renderer)
+        run: bun run package
+
+      - name: Launch Electron with mock enterprise auth (background) + run e2e runner
+        # Two commands in one xvfb-run so the Electron subprocess shares the same X server.
+        # restart_electron.py kills any stale Electron, seeds ConfigStorage with mock auth,
+        # launches launch-dev.js with NEXUS_CDP_PORT=9232, and polls the CDP endpoint until
+        # ready. Then runner.py connects and iterates cases/*.yaml (filtered).
+        run: |
+          xvfb-run --auto-servernum bash -c '
+            set -euo pipefail
+            cd tests/e2e
+            python restart_electron.py --enterprise --auth --port 9232
+            python runner.py --port 9232 --case "$CASE_FILTER"
+          '
         env:
           CI: true
           E2E_DEV: '1'
           E2E_SCREENSHOTS: '1'
           NEXUS_EXTENSIONS_PATH: ${{ github.workspace }}/examples
+          NEXUS_CDP_PORT: '9232'
+          CASE_FILTER: ${{ inputs.case_filter || 'interrupt-queue-batched-flush' }}
 
       - name: Upload E2E report (self-contained with screenshots & traces)
         if: always()

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -58,10 +58,17 @@ jobs:
       - name: Run postinstall
         run: npm run postinstall || true
 
-      - name: Install Linux display dependencies
+      - name: Install Linux display + Electron runtime dependencies
+        # Electron on Linux needs a bunch of system libs (nss, atk, cairo, cups, etc.);
+        # missing any of them makes the main process die on startup with no CDP.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgbm-dev xvfb
+          sudo apt-get install -y \
+            libgbm-dev xvfb \
+            libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 \
+            libxcomposite1 libxdamage1 libxrandr2 libxkbcommon0 \
+            libpangocairo-1.0-0 libpango-1.0-0 libcairo2 \
+            libasound2t64
 
       - name: Build Electron artifacts (main+preload+renderer)
         run: bun run package
@@ -109,6 +116,16 @@ jobs:
           NEXUS_CDP_PORT: '9232'
           CASE_FILTER: ${{ inputs.case_filter || 'interrupt-queue-batched-flush' }}
 
+      - name: Dump launch log on failure
+        # If Electron never came up on CDP, restart_electron.py writes its full
+        # launcher stdout/stderr to $RUNNER_TEMP/e2e-launch.log. Surfacing it in
+        # the job log is the difference between a silent "did not start in time"
+        # and a debuggable stack trace.
+        if: failure()
+        run: |
+          echo "=== e2e-launch.log ==="
+          cat "${RUNNER_TEMP:-/tmp}/e2e-launch.log" 2>&1 | tail -200 || echo "(no launch log)"
+
       - name: Upload E2E report (self-contained with screenshots & traces)
         if: always()
         uses: actions/upload-artifact@v7
@@ -118,5 +135,6 @@ jobs:
             tests/e2e/report/
             tests/e2e/results/
             tests/e2e/screenshots/
+            ${{ runner.temp }}/e2e-launch.log
           retention-days: 14
           if-no-files-found: ignore

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -73,6 +73,23 @@ jobs:
       - name: Build Electron artifacts (main+preload+renderer)
         run: bun run package
 
+      - name: Fix Electron chrome-sandbox permissions
+        # Chromium's SUID sandbox on Linux requires chrome-sandbox to be
+        # root-owned with mode 4755. bun install as a non-root user leaves
+        # it user-owned, and Electron aborts with a FATAL abort at startup
+        # if the binary is present but mis-permissioned (which is exactly
+        # what we hit: FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166).
+        # Chown to root instead of --no-sandbox to keep the security model intact.
+        run: |
+          SB=node_modules/electron/dist/chrome-sandbox
+          if [ -f "$SB" ]; then
+            sudo chown root:root "$SB"
+            sudo chmod 4755 "$SB"
+            ls -l "$SB"
+          else
+            echo "chrome-sandbox not found — nothing to fix" >&2
+          fi
+
       - name: Start Xvfb virtual display
         # Manually launch Xvfb so both the Electron subprocess (spawned by
         # restart_electron.py detached) and the runner (spawned in a later step)

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -89,6 +89,12 @@ jobs:
         # mock auth, launches launch-dev.js with NEXUS_CDP_PORT=9232, and polls
         # the CDP endpoint until ready. Runs in its OWN step so its stdout/stderr
         # show up in the CI log if it fails.
+        #
+        # SUDOWORK_SKIP_PREREQ_CHECK=1 bypasses launch-dev.js's `validatePrereqs`
+        # which insists on native/nexus-napi/nexus-napi.node existing. Building the
+        # NAPI binding needs the napi-rs CLI + Rust toolchain — that is scope for
+        # a heavier smoke tier; the interrupt+queue case doesn't touch VFS so it
+        # runs fine without the native binding. Documented bypass, not a hack.
         run: |
           set -euo pipefail
           echo "=== env sanity ==="
@@ -103,6 +109,7 @@ jobs:
           E2E_DEV: '1'
           NEXUS_EXTENSIONS_PATH: ${{ github.workspace }}/examples
           NEXUS_CDP_PORT: '9232'
+          SUDOWORK_SKIP_PREREQ_CHECK: '1'
 
       - name: Run e2e runner against CDP
         run: |

--- a/tests/e2e/restart_electron.py
+++ b/tests/e2e/restart_electron.py
@@ -27,14 +27,23 @@ from ops._enterprise_config import (
 
 
 def kill_electron():
-    """Kill any running Electron processes."""
+    """Kill any running Electron processes.
+
+    Uses `pkill -x` (exact process-name match) on POSIX rather than `-f` (full
+    argv regex). `-f electron` would match ANY process whose command line
+    contains "electron" — including THIS SCRIPT itself when launched as
+    `python .../restart_electron.py`, causing self-SIGTERM in CI where the
+    launcher's own argv contains the substring. `-x electron` binds to the
+    process's own name (basename of the executable), which the real Electron
+    binary satisfies while python subprocesses do not.
+    """
     print("Killing Electron processes...")
     if sys.platform == 'win32':
         # Use shell=True to avoid Git Bash path-munging of /F, /IM flags
         subprocess.run('taskkill /F /IM electron.exe',
                        shell=True, capture_output=True, timeout=10)
     else:
-        subprocess.run(['pkill', '-f', 'electron'], capture_output=True, timeout=10)
+        subprocess.run(['pkill', '-x', 'electron'], capture_output=True, timeout=10)
     time.sleep(3)
 
 

--- a/tests/e2e/restart_electron.py
+++ b/tests/e2e/restart_electron.py
@@ -48,13 +48,23 @@ def kill_electron():
 
 
 def launch_electron():
-    """Launch Electron app in dev mode."""
+    """Launch Electron app in dev mode.
+
+    Redirects stdout/stderr into a per-launch log file under /tmp so a
+    failing CDP handshake is diagnosable — DEVNULL made prior CI failures
+    show up as bare "did not start in time" with zero signal.
+    """
     project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     launch_script = os.path.join(project_root, 'scripts', 'launch-dev.js')
 
-    print(f"Launching Electron from {project_root}...")
+    log_path = os.environ.get(
+        'E2E_LAUNCH_LOG',
+        os.path.join(os.environ.get('RUNNER_TEMP', '/tmp'), 'e2e-launch.log'),
+    )
+    log_fh = open(log_path, 'wb')
+    print(f"Launching Electron from {project_root} (log: {log_path})...")
     env = os.environ.copy()
-    env['NEXUS_CDP_PORT'] = '9232'
+    env['NEXUS_CDP_PORT'] = env.get('NEXUS_CDP_PORT', '9232')
 
     if sys.platform == 'win32':
         proc = subprocess.Popen(
@@ -62,8 +72,8 @@ def launch_electron():
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
             env=env,
             cwd=project_root,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
         )
     else:
         proc = subprocess.Popen(
@@ -71,13 +81,13 @@ def launch_electron():
             start_new_session=True,
             env=env,
             cwd=project_root,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
         )
     return proc
 
 
-def wait_for_cdp(port=9232, timeout=60):
+def wait_for_cdp(port=9232, timeout=180):
     """Wait for CDP port to be ready."""
     print(f"Waiting for CDP on port {port}...")
     for i in range(timeout // 2):


### PR DESCRIPTION
## Summary

The pr-e2e-artifacts.yml workflow used to dispatch \`just e2e-test\` → \`bunx playwright test --config playwright.config.ts\`, but the config has never existed in this repo. The real e2e infra is Python + YAML (\`tests/e2e/runner.py\` driving \`tests/e2e/cases/*.yaml\` through ai-dev-browser + CDP). Zero e2e cases ever ran in CI as a result.

## What this PR fixes (structural, all systemic — no patch-over-patch)

Round-by-round diagnosis, each fix uncovering the next real error thanks to the log-piping step added in round 3:

1. **Workflow now dispatches the Python runner** instead of the non-existent Playwright suite. Deletes the dead Playwright hook rather than papering over it.
2. **Full Electron system deps installed** — libnss3, libatk1.0-0t64, libatk-bridge2.0-0t64, libcups2t64, libxcomposite1, libxdamage1, libxrandr2, libxkbcommon0, libpangocairo/pango/cairo, libasound2t64. Hosted Ubuntu 24.04 doesn't include them by default.
3. **restart_electron.py 'pkill -f electron' fix (-> -x)** — the launcher was matching its own argv (\`python .../restart_electron.py\`) and self-SIGTERMing in CI. Fixed by binding to exact process name.
4. **Launch stdout/stderr piped to \$RUNNER_TEMP/e2e-launch.log** (was DEVNULL) + \`if: failure()\` dump step so launcher errors are visible.
5. **wait_for_cdp default 60→180s** — CI cold-start needs more room than a dev machine.
6. **SUDOWORK_SKIP_PREREQ_CHECK=1** — launch-dev's validatePrereqs blocks on missing native/nexus-napi/nexus-napi.node. Bypass is the documented workaround; NAPI-touching cases will go in a heavier smoke tier that builds the binding.
7. **chrome-sandbox chowned to root:4755** — Chromium's SUID sandbox aborts if the helper binary is user-owned, which \`bun install\` leaves it as. Kept the sandbox intact (not \`--no-sandbox\`) because it's what makes headless Electron behave.

## Result of the last workflow_dispatch run (branch a7ce2bcdcf...)

- Structural steps 1-13 all green (build, sandbox, xvfb, launch, CDP handshake, runner connect).
- Runner connected to CDP, iterated the case's steps.
- Case fails at step 6 (\`mouse_click "Sudo Code"\`) because a fresh CI Ubuntu image has no Sudo Code assistant registered.
- Case fails at step 20 (\`wait_for_response\`) because ~/.nexus/sudowork.db is empty (schema not yet materialized).

## Follow-up (out of scope for this PR — tracked separately)

The remaining gap is **CI state seeding**: assistants list, sudorouter credentials (or mock LLM), pre-materialized DB schema. Separate concern from the workflow rewire itself, and needs product-side decisions (secrets policy, mock proxy vs. shared internal endpoint). Filed as a fresh task; not blocking this structural fix.

## Test plan

- [x] Iterated 6 workflow_dispatch runs; each surfaced one root cause with visible logs and got fixed systemically (not patched over).
- [x] By run 6, the workflow reaches "Run e2e runner against CDP" successfully — i.e., all pre-runner infrastructure is now correct.
- [x] Full case pass gated on the seeding follow-up.