### PR TITLE
fix(scode): gate scode's agent cron tools — sudowork owns scheduling

### DIFF
--- a/src/agent/acp/acpConnectors.ts
+++ b/src/agent/acp/acpConnectors.ts
@@ -19,6 +19,7 @@ import path from 'path';
 import { app } from 'electron';
 import { CLAUDE_ACP_NPX_PACKAGE, CODEBUDDY_ACP_NPX_PACKAGE, CODEX_ACP_BRIDGE_VERSION, CODEX_ACP_NPX_PACKAGE } from '@/types/acpTypes';
 import { SCODE_HOME, SCODE_CONFIG_PATH, SCODE_SETTINGS_PATH } from '@process/services/scode/scodePaths';
+import { scodeEngineEnvOverrides } from '@process/services/scode/scodeEngineEnv';
 import { findSuitableNodeBin, getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { isSafetyHookEnabled } from '@process/services/safety/SafetyPollingService';
@@ -626,20 +627,15 @@ export async function spawnGenericBackend(backend: string, cliPath: string, work
     }
   }
 
-  // Isolate sudowork's engine-scode config from a standalone scode install:
-  // scode's Rust config loader resolves its config home from SUDO_CODE_CONFIG_HOME,
-  // so point it at the isolated home. This relocates BOTH sudocode.json (models/auth)
-  // and settings.json (settings/MCP) in one place, away from ~/.nexus/sudocode.
-  if (backend === 'scode' && !cleanEnv.SUDO_CODE_CONFIG_HOME) {
-    cleanEnv.SUDO_CODE_CONFIG_HOME = SCODE_HOME;
-    mainLog('[ACP scode]', `Injected SUDO_CODE_CONFIG_HOME: ${cleanEnv.SUDO_CODE_CONFIG_HOME}`);
-  }
-
-  // SUDOCODE_CONFIG_PATH lets skill bash scripts locate sudocode.json even when
-  // claude-code overrides $HOME to a sandbox directory (.sandbox-home/).
-  if (backend === 'scode' && !cleanEnv.SUDOCODE_CONFIG_PATH) {
-    cleanEnv.SUDOCODE_CONFIG_PATH = SCODE_CONFIG_PATH;
-    mainLog('[ACP scode]', `Injected SUDOCODE_CONFIG_PATH: ${cleanEnv.SUDOCODE_CONFIG_PATH}`);
+  // Env contract for sudowork's embedded scode engine (SSOT: scodeEngineEnvOverrides).
+  // Applied only when the caller hasn't already set the variable.
+  if (backend === 'scode') {
+    for (const [key, value] of Object.entries(scodeEngineEnvOverrides())) {
+      if (!cleanEnv[key]) {
+        cleanEnv[key] = value;
+        mainLog('[ACP scode]', `Injected ${key}: ${value}`);
+      }
+    }
   }
 
   // Inject image generation config as env vars for skill bash scripts.

--- a/src/process/services/scode/scodeEngineEnv.ts
+++ b/src/process/services/scode/scodeEngineEnv.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Env contract for sudowork's embedded (engine) scode — the single source of
+ * truth for what sudowork injects when it spawns scode over ACP.
+ *
+ * Kept in its own dependency-light module (it only needs {@link scodePaths})
+ * so the contract can be asserted directly in tests without dragging in the
+ * whole ACP/storage stack.
+ */
+
+import { SCODE_CONFIG_PATH, SCODE_HOME } from './scodePaths';
+
+/**
+ * Variables sudowork sets on the scode engine process. The caller applies each
+ * one ONLY when it isn't already set, so an explicit override still wins.
+ */
+export function scodeEngineEnvOverrides(): Record<string, string> {
+  return {
+    // scode's Rust config loader resolves its config home from this, so point it
+    // at sudowork's ISOLATED home — relocating both sudocode.json (models/auth)
+    // and settings.json (settings/MCP) away from a standalone scode's
+    // ~/.nexus/sudocode, so the two products never stomp each other.
+    SUDO_CODE_CONFIG_HOME: SCODE_HOME,
+
+    // Lets skill bash scripts locate sudocode.json even when claude-code
+    // overrides $HOME to a sandbox directory (.sandbox-home/).
+    SUDOCODE_CONFIG_PATH: SCODE_CONFIG_PATH,
+
+    // sudowork owns scheduling: it runs its own CronService and NEVER ticks
+    // scode's crons.json. Without this the agent could "schedule" a task via
+    // scode's CronCreate tool that persists (and even lists under `scode cron
+    // list`) but is never fired — an orphan — and would face two scheduling
+    // surfaces, only one of which actually runs. scode reads exactly this
+    // variable to omit its agent-facing cron tools; the `scode cron` CLI is
+    // untouched. Removed once sudowork's scheduling delegates to scode's cron.
+    SUDOCODE_DISABLE_CRON_TOOLS: '1',
+  };
+}

--- a/tests/unit/scodeConfigIsolation.test.ts
+++ b/tests/unit/scodeConfigIsolation.test.ts
@@ -216,6 +216,25 @@ describe('scode config isolation — SSOT guard (no-hardcoded-scode-home)', () =
   });
 });
 
+describe('scode engine env contract', () => {
+  it('injects the isolated config home AND gates the agent cron tools', async () => {
+    const { scodeEngineEnvOverrides } = await import('../../src/process/services/scode/scodeEngineEnv');
+    const { SCODE_HOME, SCODE_CONFIG_PATH } = await import('../../src/process/services/scode/scodePaths');
+
+    const env = scodeEngineEnvOverrides();
+
+    // Config isolation (engine-scode never shares a standalone scode's home).
+    expect(env.SUDO_CODE_CONFIG_HOME).toBe(SCODE_HOME);
+    expect(env.SUDOCODE_CONFIG_PATH).toBe(SCODE_CONFIG_PATH);
+
+    // sudowork owns scheduling: it runs its own CronService and never ticks
+    // scode's crons.json. Without this the agent could create a cron via scode's
+    // CronCreate tool that persists but is NEVER fired — an orphan. scode reads
+    // exactly this variable to hide its agent-facing cron tools.
+    expect(env.SUDOCODE_DISABLE_CRON_TOOLS).toBe('1');
+  });
+});
+
 describe('scode config isolation — migration runs before config writers', () => {
   it('initializeProcess calls migrateLegacyScodeHomeOnce before initStorage()', () => {
     // Regression guard for a real bug found via full-app e2e: several services


### PR DESCRIPTION
配套 sudocode PR: https://github.com/sudoprivacy/sudocode/pull/305

## 问题(审计 sudocode-cron ↔ sudowork-cron 的 coherence 时发现)

- scode 在 `mvp_tool_specs` 里**始终**把 `CronCreate` / `CronDelete` / `CronList` 广告给 agent。
- sudowork 起引擎用 `scode acp`,**不限制工具集**。
- 但 sudowork 跑的是**自己那套**调度(`CronService` + SQLite `cron_jobs` + `[CRON_CREATE]` agent 协议),**从不 tick scode 的 `crons.json`**(全仓 grep 零命中)。

⇒ sudowork 会话里的 agent 可以用 `CronCreate`"排"一个任务:**会持久化**(`scode cron list` 都能看到),但**永远不会触发** —— 孤儿。而且 agent 面前有**两套排程入口**,只有 sudowork 那套真会跑。

## 修法(短期,有意为之)

sudowork 起 scode 引擎时注入 **`SUDOCODE_DISABLE_CRON_TOOLS=1`**,scode 就不广告 agent 侧的 cron 工具(配套 sudocode PR #305;stale 调用也会被明确拒绝)。

**只藏 agent 工具** —— `scode cron` CLI(用户/宿主有意使用的面)和独立 scode **完全不受影响**。短期方案是刻意的:sudowork 和 sudocode **各自都有生产用户**。

## 顺带:env contract 抽成 SSOT

把 sudowork 注入给 engine-scode 的 env 抽到 `scodeEngineEnv.ts` —— 一个地方讲清楚"我们往 scode 里注入什么"(隔离 config home + cron gate),且**依赖极轻**,可以直接在单测里断言(单测里 import `acpConnectors` 会拖进 `initStorage` 的模块副作用)。

## 验证
- **单测**:断言 env contract(隔离 config home + `SUDOCODE_DISABLE_CRON_TOOLS=1`)—— 进 CI
- **另一半在 sudocode 侧是 live 证过的**:同一个 env 变量,真 LLM 对比测试 —— 关闸后 agent **排不了**(什么都没落盘);不关闸就能排。两半合起来就是完整链路
- tsc + lint 干净;4 条真二进制 integration 测试(含 pty)全过

## 长期
sudocode roadmap 已记录目标:**收敛成一套调度器** —— sudowork 的排程委托给 scode 的 cron(sudowork 保留 UI/会话/企业层,驱动 `scode cron tick`;它的 `[CRON_CREATE]` 和 SQLite `cron_jobs` 退役),之后这个 gate 就撤掉,sudowork 成为真正的薄包装。

—— sudowork-win-pc-1