### PR TITLE
chore(scode): bump pinned scode engine to 0.1.13

### DIFF
--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -6,5 +6,5 @@
   "nexus-fuse-plugin": "0.5.0",
   "fuse-t": "1.2.7",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
-  "scode": "0.1.12"
+  "scode": "0.1.13"
 }


### PR DESCRIPTION
Makes the cron tool gate actually take effect. Without this bump the gate is merged but inert.

## Why

#992 makes sudowork inject `SUDOCODE_DISABLE_CRON_TOOLS=1` into the scode engine at ACP spawn, so the agent can't create a scode cron that sudowork never ticks (sudowork owns scheduling via its own CronService — a scode cron created from inside sudowork persists in `crons.json` and is never fired).

But we pin `scode: 0.1.12`, and I checked the actual released v0.1.12 asset:

| | released 0.1.12 | released 0.1.13 |
|---|---|---|
| `CronCreate` / `CronDelete` / `CronList` | present | present |
| `SUDOCODE_DISABLE_CRON_TOOLS` gate | **absent** | **present** |

So today sudowork injects the env and the shipped engine ignores it — the orphan-cron gap stays open. 0.1.13 (sudocode #305 + #307) is the first release carrying the gate.

## Verification

- Ran `bun run scode:download` against the new pin: fetches `v0.1.13/scode-windows-x64.zip` successfully.
- Grepped the downloaded artifact: gate present, reports `scode 0.1.13`.
- Real-app e2e on the merged `dev` tree with a gated engine: main log shows `[[ACP scode]] Injected SUDOCODE_DISABLE_CRON_TOOLS: 1` at spawn; the live agent in a real Sudo Code session reports it has no cron tools and no `crons.json` orphan is written. With the pre-gate engine the same session sees the cron tools.
- `scode cron` CLI is unaffected by the gate (agent tools only).