### PR TITLE
refactor(e2e): pin mock to scode's sudocode tag; mouse_click delegates upstream

### DIFF
--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -73,12 +73,17 @@ jobs:
         run: echo "SUDOCODE_REF=$(python -m tests.e2e.ci_setup.spawn_mock_llm --print-ref)" >> "$GITHUB_ENV"
 
       - name: Cache cargo build (sudocode mock-anthropic-service)
+        # CARGO_TARGET_DIR deliberately lives OUTSIDE the sudocode checkout.
+        # spawn_mock_llm wipes a non-git checkout dir before cloning, so a
+        # target/ nested inside it would be deleted immediately after the cache
+        # restored it — which is exactly what happened: the cache reported a hit
+        # and every run still paid a ~3min cold rebuild.
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ${{ runner.temp }}/sudocode-src/rust/target
+            ${{ runner.temp }}/cargo-target
           key: mock-anthropic-service-${{ runner.os }}-${{ env.SUDOCODE_REF }}
           restore-keys: |
             mock-anthropic-service-${{ runner.os }}-
@@ -137,10 +142,15 @@ jobs:
         run: bun run scode:download
 
       - name: Spawn mock-anthropic-service (background)
-        # Builds sudocode's mock-anthropic-service from source (cached), spawns
-        # it on 127.0.0.1:0, and writes MOCK_ANTHROPIC_BASE_URL to $GITHUB_ENV
-        # + a URL file for the next step. --detach so this step returns as soon
-        # as the URL is captured; the child stays alive until the job ends.
+        # Builds sudocode's mock-anthropic-service at the pinned tag (cached),
+        # spawns it on 127.0.0.1:0, and writes MOCK_ANTHROPIC_BASE_URL to
+        # $GITHUB_ENV + a URL file for the next step. --detach so this step
+        # returns as soon as the URL is captured; the child stays alive until
+        # the job ends.
+        env:
+          # Must match the cached path above, and must sit outside the sudocode
+          # checkout that spawn_mock_llm wipes before cloning.
+          CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-target
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}"

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -84,9 +84,14 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ${{ runner.temp }}/cargo-target
-          key: mock-anthropic-service-${{ runner.os }}-${{ env.SUDOCODE_REF }}
+          # `v2` is a cache-format epoch, and it is load-bearing: actions/cache
+          # does NOT save when the primary key hits exactly. The v1 entries were
+          # archived from the old in-checkout target/ path, so without a new key
+          # they would be restored (as a "hit") into paths cargo never reads,
+          # forever, and the corrected path would never be populated.
+          key: mock-anthropic-service-v2-${{ runner.os }}-${{ env.SUDOCODE_REF }}
           restore-keys: |
-            mock-anthropic-service-${{ runner.os }}-
+            mock-anthropic-service-v2-${{ runner.os }}-
 
       - name: Install node dependencies
         run: bun install --no-frozen-lockfile

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -58,11 +58,19 @@ jobs:
         run: python -m pip install --upgrade pip pyyaml 'ai-dev-browser>=0.13.0'
 
       - name: Install Rust toolchain (for mock-anthropic-service)
-        # The mock LLM upstream (sudocode's mock-anthropic-service) is built
-        # from source here — a released binary would be faster but adds a
-        # cross-repo release contract we don't want yet. Cargo cache keeps
-        # the wall-clock down after the first run.
+        # The mock LLM upstream (sudocode's mock-anthropic-service) is a test
+        # crate, not a release artifact — so we build it from source at a
+        # pinned tag rather than inventing a cross-repo release contract for it.
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve pinned sudocode ref
+        # spawn_mock_llm derives the sudocode tag from the scode engine version
+        # in src/shared/runtime-versions.json (SSOT) — e.g. scode 0.1.13 → v0.1.13,
+        # so the mock and the scode binary under test come from ONE commit.
+        # Asking the script for it (rather than re-deriving in YAML) keeps that
+        # rule in one place, and gives the cache a key that invalidates exactly
+        # when the pinned revision moves and on nothing else.
+        run: echo "SUDOCODE_REF=$(python -m tests.e2e.ci_setup.spawn_mock_llm --print-ref)" >> "$GITHUB_ENV"
 
       - name: Cache cargo build (sudocode mock-anthropic-service)
         uses: actions/cache@v4
@@ -71,7 +79,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ${{ runner.temp }}/sudocode-src/rust/target
-          key: mock-anthropic-service-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-e2e-artifacts.yml') }}
+          key: mock-anthropic-service-${{ runner.os }}-${{ env.SUDOCODE_REF }}
           restore-keys: |
             mock-anthropic-service-${{ runner.os }}-
 

--- a/tests/e2e/cases/sidebar-nav-by-text.yaml
+++ b/tests/e2e/cases/sidebar-nav-by-text.yaml
@@ -1,0 +1,69 @@
+name: "sidebar nav by visible text"
+description: >
+  Guards sidebar navigation, and in doing so exercises the `mouse_click` op
+  against exactly the DOM shape that used to defeat it.
+
+  Every sidebar entry is an icon + label (`<Icon/><span>Skill Store</span>`),
+  so the element has no direct child text node. The old hand-rolled matcher in
+  ops/mouse_click.py required one, with a `children.length < 3` fallback — it
+  reported "Element not found" on buttons that were plainly on screen (that is
+  how the interrupt+queue case lost several CI rounds to a red herring). The op
+  now delegates to ai-dev-browser's accessible-name locator; this case is the
+  standing proof that the delegation resolves real nested labels.
+
+  Assertions are on the route (HashRouter), not on rendered text: a click that
+  "worked" but landed on the wrong element would still change no route.
+
+steps:
+  - op: dismiss_init_dialog
+    timeout: 300
+  - op: wait_for_app_ready
+    timeout: 120
+
+  # ── Skill Store ──
+  - op: mouse_click
+    text: "Skill Store"
+  - op: pause
+    duration: 1500
+  - op: js_eval
+    code: |
+      (() => {
+        const h = window.location.hash;
+        if (!h.includes('/skill')) {
+          throw new Error(`clicking "Skill Store" did not route to skills; hash=${h}`);
+        }
+        return h;
+      })()
+
+  # ── Security ──
+  - op: mouse_click
+    text: "Security"
+  - op: pause
+    duration: 1500
+  - op: js_eval
+    code: |
+      (() => {
+        const h = window.location.hash;
+        if (!h.includes('/security')) {
+          throw new Error(`clicking "Security" did not route to security; hash=${h}`);
+        }
+        return h;
+      })()
+
+  # ── Back to a new conversation ──
+  - op: mouse_click
+    text: "New Chat"
+  - op: pause
+    duration: 1500
+  - op: js_eval
+    code: |
+      (() => {
+        const ta = document.querySelector('textarea');
+        if (!ta || ta.offsetHeight === 0) {
+          throw new Error(`clicking "New Chat" did not return to a conversation view with a send-box (hash=${window.location.hash})`);
+        }
+        return {hash: window.location.hash, sendbox: true};
+      })()
+
+  - op: screenshot
+    path: "screenshots/sidebar-nav-by-text.png"

--- a/tests/e2e/ci_setup/spawn_mock_llm.py
+++ b/tests/e2e/ci_setup/spawn_mock_llm.py
@@ -84,13 +84,21 @@ def _clone_or_update(src: Path, ref: str) -> None:
 
 
 def _cargo_build(src: Path) -> Path:
+    """Build the mock crate. Honours CARGO_TARGET_DIR.
+
+    Callers that cache build artifacts MUST set CARGO_TARGET_DIR to a path
+    outside `src`: _clone_or_update wipes a non-git checkout dir, which would
+    otherwise delete the very artifacts the cache just restored (it did — the
+    cache silently never hit, and every run paid a ~3min cold rebuild).
+    """
     rust_root = src / "rust"
     subprocess.check_call(
         ["cargo", "build", "--release", "-p", "mock-anthropic-service"],
         cwd=rust_root,
     )
     exe_name = "mock-anthropic-service.exe" if sys.platform == "win32" else "mock-anthropic-service"
-    built = rust_root / "target" / "release" / exe_name
+    target_dir = Path(os.environ["CARGO_TARGET_DIR"]) if os.environ.get("CARGO_TARGET_DIR") else rust_root / "target"
+    built = target_dir / "release" / exe_name
     if not built.exists():
         raise SystemExit(f"cargo produced no binary at {built}")
     return built

--- a/tests/e2e/ci_setup/spawn_mock_llm.py
+++ b/tests/e2e/ci_setup/spawn_mock_llm.py
@@ -5,14 +5,23 @@ e2e cases have a stub Anthropic endpoint to talk to in CI.
 Two phases:
 
   1. Ensure the mock binary exists. If --binary is passed, use it directly.
-     Otherwise `git clone --depth 1` sudocode into --sudocode-src (default
-     $RUNNER_TEMP/sudocode-src or scratchpad) and `cargo build --release
-     -p mock-anthropic-service`, then use the produced binary.
+     Otherwise `git clone --depth 1` sudocode at a PINNED tag into
+     --sudocode-src (default $RUNNER_TEMP/sudocode-src) and `cargo build
+     --release -p mock-anthropic-service`.
 
   2. Spawn the binary with `--bind 127.0.0.1:0` and parse
      `MOCK_ANTHROPIC_BASE_URL=…` from its stdout. Optionally write the URL
      to $GITHUB_ENV (as MOCK_ANTHROPIC_BASE_URL) so downstream workflow
      steps can pick it up; also print the URL to stdout for local use.
+
+Which sudocode revision? By default, the tag matching the scode engine
+version sudowork pins in src/shared/runtime-versions.json — i.e. scode
+"0.1.13" resolves to sudocode tag "v0.1.13". So the mock LLM and the scode
+binary it serves come from the SAME sudocode commit, and a scode version
+bump carries the mock along with it for free. Tracking sudocode's `main`
+instead (the previous behaviour) made this job depend on a moving target:
+an unrelated break on sudocode main would redden sudowork CI, and the build
+was not reproducible across reruns.
 
 By default the script blocks until SIGTERM (Ctrl-C) so a workflow step of
 form `python spawn_mock_llm.py --github-env "$GITHUB_ENV" &` keeps the
@@ -23,6 +32,7 @@ after the URL is captured (writes the child PID to --pidfile).
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import signal
@@ -35,6 +45,21 @@ from typing import Optional
 
 SUDOCODE_REPO = "https://github.com/sudoprivacy/sudocode.git"
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNTIME_VERSIONS = REPO_ROOT / "src" / "shared" / "runtime-versions.json"
+
+
+def default_sudocode_ref() -> str:
+    """Sudocode tag matching the pinned scode engine version (the SSOT).
+
+    Exposed (not private) because the workflow keys its cargo cache on this
+    value — the cache must invalidate exactly when the pinned revision moves,
+    and on nothing else.
+    """
+    with RUNTIME_VERSIONS.open() as fh:
+        version = json.load(fh)["scode"]
+    return f"v{version}"
+
 
 def _default_src_dir() -> Path:
     runner_temp = os.environ.get("RUNNER_TEMP")
@@ -43,20 +68,19 @@ def _default_src_dir() -> Path:
     return Path.home() / ".cache" / "sudowork-e2e" / "sudocode-src"
 
 
-def _clone_or_update(src: Path, ref: Optional[str]) -> None:
+def _clone_or_update(src: Path, ref: str) -> None:
+    """Check out sudocode at exactly `ref` (a tag). Idempotent across reruns."""
     if (src / ".git").exists():
-        subprocess.check_call(["git", "fetch", "--depth", "1", "origin", ref or "HEAD"], cwd=src)
-        subprocess.check_call(["git", "reset", "--hard", "FETCH_HEAD"], cwd=src)
+        subprocess.check_call(["git", "fetch", "--depth", "1", "origin", "tag", ref, "--no-tags"], cwd=src)
+        subprocess.check_call(["git", "checkout", "--force", ref], cwd=src)
         return
     src.parent.mkdir(parents=True, exist_ok=True)
     if src.exists():
         # Non-git dir sitting at the target — wipe and reclone.
         shutil.rmtree(src)
-    args = ["git", "clone", "--depth", "1"]
-    if ref:
-        args += ["--branch", ref]
-    args += [SUDOCODE_REPO, str(src)]
-    subprocess.check_call(args)
+    subprocess.check_call(
+        ["git", "clone", "--depth", "1", "--branch", ref, SUDOCODE_REPO, str(src)]
+    )
 
 
 def _cargo_build(src: Path) -> Path:
@@ -105,7 +129,18 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build + spawn sudocode's mock-anthropic-service.")
     parser.add_argument("--binary", type=Path, help="Path to a pre-built mock-anthropic-service binary.")
     parser.add_argument("--sudocode-src", type=Path, default=_default_src_dir(), help="Where to clone sudocode (cache-friendly).")
-    parser.add_argument("--sudocode-ref", default=None, help="Sudocode branch/tag to clone (default: main).")
+    parser.add_argument(
+        "--sudocode-ref",
+        default=None,
+        help="Sudocode tag to build the mock from. Default: the tag matching the scode "
+        "engine version pinned in src/shared/runtime-versions.json (e.g. v0.1.13).",
+    )
+    parser.add_argument(
+        "--print-ref",
+        action="store_true",
+        help="Print the resolved sudocode ref and exit. The workflow keys its cargo cache "
+        "on this so the derivation stays in ONE place.",
+    )
     parser.add_argument("--github-env", help="Path to $GITHUB_ENV; MOCK_ANTHROPIC_BASE_URL is appended.")
     parser.add_argument("--pidfile", type=Path, help="Write the mock service PID here (for teardown).")
     parser.add_argument("--url-file", type=Path, help="Write just the mock URL to this file.")
@@ -115,10 +150,16 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 
 def main(argv: Optional[list[str]] = None) -> int:
     args = _parse_args(argv)
+    ref = args.sudocode_ref or default_sudocode_ref()
+
+    if args.print_ref:
+        print(ref)
+        return 0
 
     binary = args.binary
     if binary is None:
-        _clone_or_update(args.sudocode_src, args.sudocode_ref)
+        print(f"[spawn_mock_llm] building mock-anthropic-service from sudocode {ref}", flush=True)
+        _clone_or_update(args.sudocode_src, ref)
         binary = _cargo_build(args.sudocode_src)
 
     proc, url = _spawn_and_capture(binary)

--- a/tests/e2e/ops/mouse_click.py
+++ b/tests/e2e/ops/mouse_click.py
@@ -1,82 +1,48 @@
-"""Click at coordinates or on an element using CDP mouse events.
+"""Click an element by its visible text.
 
-This is a true human-like click — dispatches mousePressed + mouseReleased
-through CDP, which triggers React synthetic events correctly.
+Thin delegation to ai-dev-browser's `click_by_text`. We used to hand-roll the
+matcher here, and it was the wrong kind of clever: it required an element's
+*direct* child text node to equal the target, with a `children.length < 3`
+fallback on `textContent`. React nests labels — `<button><Icon/><span>Sudo
+Code</span></button>` has no direct text node — so the primary match skipped
+every icon+label button in the app, and the fallback's arbitrary child-count
+cap dropped more. Cases hit `Element not found` on buttons that were plainly
+on screen.
+
+Upstream (>= 0.13.0) locates by *accessible name*, which is what a human
+reads off the button. Split labels, icon+span, nested spans, `<div onclick>`
+and same-origin iframes all resolve, and `find_by_text` / `click_by_text`
+are guaranteed to return the same element. Ambiguous text is scored, so
+"Search" prefers the button over a "Search products..." input. A DOM search
+is kept upstream as a tier-2 fallback, so attribute-located elements that
+the old matcher happened to catch are not lost.
+
+Coordinates are deliberately NOT handled here: the `click` op owns
+coordinate clicks (WebDriver §12.5.1). Two ops taking x/y at the same layer
+would be the duplicate-API-at-one-level problem, so this op does one thing.
 """
 
-import asyncio
-import json
-
-from ai_dev_browser.cdp import input_ as cdp_input
-from ai_dev_browser.core.page import js_evaluate
+from ai_dev_browser.core.elements import click_by_text
 
 
-async def mouse_click(tab, x: int = None, y: int = None,
-                      text: str = None, selector: str = None,
-                      wait: float = 1) -> dict:
-    """Click using CDP mouse events at coordinates or element center.
+async def mouse_click(tab, text: str = "", wait: float = 1) -> dict:
+    """Click the element whose accessible name matches `text`.
 
     Args:
-        tab: Browser tab
-        x, y: Explicit coordinates (CSS pixels)
-        text: Find element by visible text, click its center
-        selector: Find element by CSS selector, click its center
-        wait: Seconds to wait after click
+        tab: Browser tab.
+        text: Visible text / accessible name of the target element.
+        wait: Seconds to settle after the click (kept for case compatibility;
+              upstream already waits for the click to commit).
 
     Returns:
-        {"clicked": True, "x": int, "y": int} or {"error": str}
+        {"clicked": True, "ref": ..., "navigated": ...} on success,
+        {"error": "Element not found: <text>"} when nothing matches.
     """
-    # Resolve coordinates from text or selector
-    if x is None or y is None:
-        if text:
-            r = await js_evaluate(tab, """JSON.stringify((() => {
-                const all = document.querySelectorAll('*');
-                for (const el of all) {
-                    const own = Array.from(el.childNodes)
-                        .filter(n => n.nodeType === 3)
-                        .map(n => n.textContent.trim()).join('');
-                    if (own === %s) {
-                        const rect = el.getBoundingClientRect();
-                        return {x: Math.round(rect.left + rect.width/2),
-                                y: Math.round(rect.top + rect.height/2)};
-                    }
-                }
-                // Fallback: match textContent
-                for (const el of all) {
-                    if (el.textContent?.trim() === %s && el.children.length < 3 && el.offsetHeight > 0) {
-                        const rect = el.getBoundingClientRect();
-                        return {x: Math.round(rect.left + rect.width/2),
-                                y: Math.round(rect.top + rect.height/2)};
-                    }
-                }
-                return null;
-            })())""" % (repr(text), repr(text)))
-        elif selector:
-            r = await js_evaluate(tab, """JSON.stringify((() => {
-                const el = document.querySelector(%s);
-                if (el) {
-                    const rect = el.getBoundingClientRect();
-                    return {x: Math.round(rect.left + rect.width/2),
-                            y: Math.round(rect.top + rect.height/2)};
-                }
-                return null;
-            })())""" % repr(selector))
-        else:
-            return {"error": "Must provide x/y, text, or selector"}
+    if not text:
+        return {"error": "mouse_click requires `text` (use the `click` op for coordinates)"}
 
-        coords = json.loads(r.get("result", "null"))
-        if not coords:
-            return {"error": f"Element not found: {text or selector}"}
-        x, y = coords["x"], coords["y"]
+    result = await click_by_text(tab, text, timeout=max(wait, 1))
 
-    # CDP mouse click
-    btn = cdp_input.MouseButton("left")
-    await tab.send(cdp_input.dispatch_mouse_event(
-        "mousePressed", x=x, y=y, button=btn, click_count=1,
-    ))
-    await tab.send(cdp_input.dispatch_mouse_event(
-        "mouseReleased", x=x, y=y, button=btn, click_count=1,
-    ))
-
-    await asyncio.sleep(wait)
-    return {"clicked": True, "x": x, "y": y}
+    if not result.get("clicked"):
+        return {"error": f"Element not found: {text}"}
+    return result


### PR DESCRIPTION
Two follow-ups from #991.

## 1. Mock LLM: pinned tag instead of sudocode `main`

The mock was built from sudocode's `main` — a moving target. An unrelated break on sudocode main would redden sudowork CI, and no two runs built the same binary. The cargo cache made it *worse*: its key was `hashFiles(pr-e2e-artifacts.yml)`, so every workflow edit evicted it. The last run on #991 rebuilt from scratch — 2m49s.

`spawn_mock_llm` now derives the sudocode tag from the scode engine version already pinned in `src/shared/runtime-versions.json`: **scode `0.1.13` → sudocode tag `v0.1.13`**. So the mock LLM and the scode binary it serves come from *one* sudocode commit, and a scode bump carries the mock along for free. The workflow asks the script for the ref (`--print-ref`) rather than re-deriving it in YAML, and keys the cargo cache on it — the cache now invalidates exactly when the pinned revision moves, and on nothing else.

I considered publishing the mock as a sudocode release artifact (my original plan). Rejected: it's a test crate, and a cross-repo release contract is heavier coupling than a pinned tag for the same benefit.

## 2. `mouse_click` delegates to upstream's accessible-name locator

`ops/mouse_click.py` hand-rolled its text matcher — it required an element's *direct* child text node to equal the target, with a `children.length < 3` fallback. React nests labels, so an icon+label button has no direct text node: it skipped **every** icon+label button in the app and reported `Element not found` on buttons plainly on screen. That cost the interrupt+queue case several CI rounds chasing a red herring.

(For the record: I originally reported this to ai-dev-browser as *their* bug. It was ours. They fixed a real adjacent limitation in `click_by_text` anyway.)

It now delegates to ai-dev-browser >= 0.13.0's accessible-name locator — split labels, icon+span, `<div onclick>`, same-origin iframes all resolve, with a DOM search kept as tier-2 fallback so attribute-located elements aren't lost. All 37 call sites pass `text` only, so **no case changes**. Coordinate/selector paths dropped: the `click` op already owns coordinate clicks, and two ops taking x/y at the same layer is duplicate API at one level.

## Verification

`sidebar-nav-by-text.yaml` is the standing proof for (2): it clicks the sidebar's icon+label entries — the exact DOM shape that defeated the old matcher — and asserts on the **resulting route**, so a click that "worked" but landed on the wrong element still fails.

- [ ] `pr-e2e-artifacts` green on `sidebar-nav-by-text` (proves the delegation)
- [ ] `pr-e2e-artifacts` green on `interrupt-queue` (proves the pinned mock still serves)