### PR TITLE
feat(cron): let owners/co-owners manage existing tasks while client cron is disabled

### DIFF
--- a/src/process/providers/cron/index.ts
+++ b/src/process/providers/cron/index.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { mainLog } from '@process/utils/mainLogger';
 import type { ICronProvider } from './types';
 import { LocalCronProvider } from './LocalCronProvider';
 import { RemoteCronProvider } from './RemoteCronProvider';
-import { getCachedLocalModeAvailable, getCachedSessionMode, isEnterpriseMode } from '@/common/enterpriseDebugConfig';
-import { mainLog } from '@process/utils/mainLogger';
 
 /**
  * Get Cron Provider
@@ -16,20 +16,18 @@ import { mainLog } from '@process/utils/mainLogger';
  *
  * Returns the appropriate provider based on:
  * - Non-enterprise mode: always local
- * - Enterprise mode: based on sessionMode setting
+ * - Enterprise mode: always remote — scheduled tasks are moss-hosted. The
+ *   deprecated enterprise "local" session mode no longer routes cron to the
+ *   local store, so ownership/policy enforcement stays server-side.
  *
  * 每次调用都创建新实例，避免 token 过期/用户切换串状态
  */
 export function getCronProvider(): ICronProvider {
   const isEnterprise = isEnterpriseMode();
-  let mode = isEnterprise ? getCachedSessionMode() : 'local';
-  if (isEnterprise && mode === 'local' && getCachedLocalModeAvailable() === false) {
-    mode = 'remote';
-  }
 
-  mainLog('CronProvider', `Provider selected: ${mode} (enterprise: ${isEnterprise})`);
+  mainLog('CronProvider', `Provider selected: ${isEnterprise ? 'remote' : 'local'} (enterprise: ${isEnterprise})`);
 
-  if (mode === 'remote') {
+  if (isEnterprise) {
     return new RemoteCronProvider();
   }
   return new LocalCronProvider();

--- a/src/process/remote/MossCronApi.ts
+++ b/src/process/remote/MossCronApi.ts
@@ -14,7 +14,16 @@ import { ProcessConfig } from '@process/initStorage';
 export interface MossCronJob {
   id: string;
   orgId: string;
+  /** Owner (creator) of the job. The list endpoint only returns jobs the caller owns or co-owns. */
   userId: string;
+  /** Owner display name, resolved server-side */
+  userName?: string;
+  /** Co-owners have flat management parity with the owner (view/edit/delete/trigger) */
+  coOwnerIds?: string[];
+  coOwnerNames?: string[];
+  /** Identity scheduled runs execute as; defaults to the owner */
+  executorUserId?: string | null;
+  executorName?: string;
   name: string;
   enabled: boolean;
   schedule: {

--- a/src/process/services/cron/cronPolicy.ts
+++ b/src/process/services/cron/cronPolicy.ts
@@ -32,6 +32,23 @@ export class CronDisabledError extends Error {
   }
 }
 
+/**
+ * Agent instruction injected instead of the cron skill when the org has
+ * client cron disabled. Creation is banned, but existing jobs remain
+ * manageable by their owner/co-owners (moss enforces per-job ownership), so
+ * the agent keeps the list/delete command syntax. The ban must be explicit —
+ * merely omitting the skill lets the agent hallucinate "task created" from
+ * prior transcript knowledge.
+ */
+export const CRON_RESTRICTED_INSTRUCTION =
+  '[Scheduled Tasks — CREATION DISABLED BY ORGANIZATION]\n' +
+  'Creating scheduled tasks is disabled by this organization. [CRON_CREATE] is unavailable: NEVER output it, NEVER claim a scheduled task was created, and NEVER invent a task ID. ' +
+  'If the user asks to create or schedule a recurring/timed task, tell them an administrator must enable the feature.\n' +
+  "The user's EXISTING scheduled tasks can still be managed:\n" +
+  "- Output [CRON_LIST] alone to list the user's scheduled tasks (only tasks the user owns or co-owns are returned).\n" +
+  "- Output [CRON_DELETE: task-id] to delete one of the user's own tasks. Tasks owned by other users cannot be deleted.\n" +
+  'These commands are asynchronous system commands: output ONE command by itself (not in a code block), then WAIT for the system response before continuing. Never combine commands in a single message.';
+
 /** Test hook: drop the in-memory cache. */
 export function resetCronPolicyCache(): void {
   cache = null;
@@ -94,15 +111,35 @@ export async function getClientCronEnabled(forceFresh = false): Promise<boolean>
 }
 
 /**
- * Whether the cron skill may be advertised to an agent. Same decision as the
- * execution gate, used at skill-injection time so the skill is never offered
- * when the org has cron disabled (the agent then never attempts it).
+ * Whether the logged-in enterprise user is admin-capable for cron. Mirrors
+ * moss's isCronAdminCapable (roles are the lowercase moss values): admins keep
+ * full cron (including creation) while client_cron_enabled=false, matching the
+ * server's cron_disabled_by_org bypass. Fail closed when the role is unknown.
+ */
+export function isCronAdminUser(): boolean {
+  try {
+    const userInfo = ProcessConfig.getSync('eeclaw.userInfo') as { role?: string } | undefined;
+    const role = userInfo?.role?.toLowerCase();
+    return role === 'admin' || role === 'super_admin';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether the full cron skill may be advertised to an agent. Enabled orgs and
+ * admin-capable users get the full skill; a disabled org's non-admin users get
+ * the restricted instruction instead (list/delete own tasks, no creation), so
+ * the agent's advertised capability matches what the moss server will accept.
  */
 export async function isCronSkillAllowed(): Promise<boolean> {
   // Force-fresh: skill injection happens at the start of a session, and an admin
   // may have flipped the flag since app launch. Read the current value so the
   // agent's cron capability matches policy without an app restart.
-  return getClientCronEnabled(true);
+  if (await getClientCronEnabled(true)) {
+    return true;
+  }
+  return isEnterpriseMode() && isCronAdminUser();
 }
 
 /**

--- a/src/process/task/MessageMiddleware.ts
+++ b/src/process/task/MessageMiddleware.ts
@@ -8,7 +8,7 @@ import type { TMessage } from '@/common/chatLib';
 import { ipcBridge } from '@/common';
 import type { AcpBackendAll } from '@/types/acpTypes';
 import { getCronProvider } from '@process/providers/cron';
-import { getClientCronEnabled } from '@process/services/cron/cronPolicy';
+import { getClientCronEnabled, isCronAdminUser } from '@process/services/cron/cronPolicy';
 import { detectCronCommands, stripCronCommands, type CronCommand } from './CronCommandDetector';
 import { hasThinkTags, stripThinkTags } from './ThinkTagDetector';
 
@@ -181,26 +181,37 @@ export async function processCronInMessage(conversationId: string, agentType: Ac
  * Handle detected cron commands
  */
 async function handleCronCommands(conversationId: string, agentType: AcpBackendAll, commands: CronCommand[]): Promise<string[]> {
-  // Org policy gate (issue #854): conversations whose transcripts already
-  // teach the cron commands will keep emitting them after an admin disables
-  // the feature — refuse here with an explicit response so the agent relays
-  // an honest answer instead of hallucinating success.
-  if (!(await getClientCronEnabled())) {
-    return ['⛔ Scheduled tasks are disabled by your organization. Tell the user that an administrator must enable them, and do not retry the command.'];
-  }
-
-  const responses: string[] = [];
-
   // Route through the active provider, not the local cronService singleton, so
   // a remote-mode agent's jobs land on moss (RemoteCronProvider → gated moss
   // API) — the same backend the cron UI reads/writes. Local mode's provider
   // delegates to cronService, so that path is unchanged. (#854/#835)
   const provider = getCronProvider();
 
+  // Org policy gate (issue #854): the client_cron_enabled flag blocks CREATING
+  // jobs, not managing existing ones. With the remote (moss) provider, owners
+  // and co-owners may still list and delete their jobs — the list endpoint is
+  // scoped to the caller's own/co-owned jobs and deletes are rejected
+  // server-side (canManageJob) for jobs the caller does not own. Non-remote
+  // providers have no server-side ownership model, so they keep the blanket
+  // refusal (agents whose transcripts teach the commands get an honest answer
+  // instead of hallucinating success).
+  const cronEnabled = await getClientCronEnabled();
+  if (!cronEnabled && provider.type !== 'remote') {
+    return ['⛔ Scheduled tasks are disabled by your organization. Tell the user that an administrator must enable them, and do not retry the command.'];
+  }
+
+  const responses: string[] = [];
+
   for (const cmd of commands) {
     try {
       switch (cmd.kind) {
         case 'create': {
+          // Admin-capable users bypass the creation gate, mirroring the moss
+          // server's cron_disabled_by_org check (which it enforces anyway).
+          if (!cronEnabled && !isCronAdminUser()) {
+            responses.push('⛔ Creating scheduled tasks is disabled by your organization. Tell the user that an administrator must enable the feature, and do not retry the command. Existing tasks can still be listed with [CRON_LIST] and deleted with [CRON_DELETE: task-id].');
+            break;
+          }
           const job = await provider.addJob({
             name: cmd.name,
             schedule: { kind: 'cron', expr: cmd.schedule, description: cmd.scheduleDescription },

--- a/src/process/task/RemoteAgent.ts
+++ b/src/process/task/RemoteAgent.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import BaseAgent from './BaseAgent';
+import * as nodePath from 'node:path';
+import * as fs from 'node:fs';
 import { MossWsConnection, type MossWsConnectionConfig, type MossWsCallbacks } from '@/agent/remote/MossWsConnection';
 import { ipcBridge } from '@/common';
 import type { IResponseMessage } from '@/common/ipcBridge';
@@ -12,18 +13,17 @@ import type { AcpQuestionAnswerItem, TMessage } from '@/common/chatLib';
 import type { AcpQuestionResponseAnswer } from '@/types/acpTypes';
 import type { TChatConversation } from '@/common/storage';
 import { uuid } from '@/common/utils';
+import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
 import { mainLog, mainError, mainWarn } from '../utils/mainLogger';
 import { getDatabase } from '../database/export';
 import { addOrUpdateMessage } from '../message';
-import { detectFileIntent, matchesDraftPattern } from './draftsCleanup';
-import * as nodePath from 'node:path';
-import * as fs from 'node:fs';
 import { initMossApi } from '../remote/MossSessionApi';
-import { isRemoteContainerPath } from '@/common/utils/workspaceSkillSync';
 import { filterEnabledSkillNames } from '../utils/enabledSkillFilter';
 import { ProcessConfig, getBundledBuiltinSkillDir } from '../initStorage';
+import { CRON_RESTRICTED_INSTRUCTION, isCronSkillAllowed } from '../services/cron/cronPolicy';
 import { hasCronCommands } from './CronCommandDetector';
-import { isCronSkillAllowed } from '../services/cron/cronPolicy';
+import { detectFileIntent, matchesDraftPattern } from './draftsCleanup';
+import BaseAgent from './BaseAgent';
 
 /**
  * Cron instruction inlined into a remote session's first message. The moss
@@ -31,13 +31,15 @@ import { isCronSkillAllowed } from '../services/cron/cronPolicy';
  * - When cron is ALLOWED: the full skill (single source of truth for the
  *   [CRON_CREATE]/[CRON_LIST]/[CRON_DELETE] contract the local AcpAgent points
  *   at by path).
- * - When cron is DISABLED: an explicit ban, so the agent does NOT silently
- *   hallucinate "task created". Banning must be active, not just omission.
+ * - When cron is DISABLED: an explicit creation ban that keeps the
+ *   list/delete contract — owners/co-owners may still manage their existing
+ *   jobs (moss enforces per-job ownership). Banning creation must be active,
+ *   not just omission, or the agent hallucinates "task created".
  */
 async function buildRemoteCronInstruction(): Promise<string> {
   if (!(await isCronSkillAllowed())) {
-    mainLog('RemoteAgent', 'cron disabled by org — injecting explicit ban instruction');
-    return CRON_DISABLED_INSTRUCTION;
+    mainLog('RemoteAgent', 'cron disabled by org — injecting restricted (list/delete-only) instruction');
+    return CRON_RESTRICTED_INSTRUCTION;
   }
   try {
     // Read from the bundled SOURCE, not getBuiltinSkillsDir() — the latter
@@ -50,16 +52,9 @@ async function buildRemoteCronInstruction(): Promise<string> {
     return `[Scheduled Task Skill — you MUST follow this to manage scheduled tasks; output the [CRON_*] commands directly in your reply]\n${skillContent}`;
   } catch (err) {
     mainError('RemoteAgent', `Failed to read cron SKILL.md: ${err}`);
-    return CRON_DISABLED_INSTRUCTION;
+    return CRON_RESTRICTED_INSTRUCTION;
   }
 }
-
-const CRON_DISABLED_INSTRUCTION =
-  '[Scheduled Tasks — DISABLED]\n' +
-  'Scheduled task / cron functionality is disabled by your organization. ' +
-  'You CANNOT create, list, modify, or delete scheduled tasks. ' +
-  'If the user asks you to schedule, create, or manage a recurring/timed task, you MUST tell them that scheduled tasks are disabled by their organization and that an administrator must enable the feature. ' +
-  'NEVER claim that a scheduled task was created, and NEVER invent a task ID.';
 
 /**
  * Default idle detach timeout for finished remote sessions.

--- a/src/process/task/agentUtils.ts
+++ b/src/process/task/agentUtils.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DRAFTS_DIR_NAME } from '@/common/constants';
-import { getBuiltinSkillsDir, loadSkillsContent } from '@process/initStorage';
-import { isCronSkillAllowed } from '@process/services/cron/cronPolicy';
-import { AcpSkillManager, buildSkillsIndexText, type SkillIndex } from './AcpSkillManager';
-import type { PresetAgentType } from '@/types/acpTypes';
-import { getNodeBinaryPath, isNodeInstalled } from '@process/services/claudeCli/NodeRuntimeService';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
+import { DRAFTS_DIR_NAME } from '@/common/constants';
+import { getBuiltinSkillsDir, loadSkillsContent } from '@process/initStorage';
+import { CRON_RESTRICTED_INSTRUCTION, isCronSkillAllowed } from '@process/services/cron/cronPolicy';
+import type { PresetAgentType } from '@/types/acpTypes';
+import { getNodeBinaryPath, isNodeInstalled } from '@process/services/claudeCli/NodeRuntimeService';
+import { AcpSkillManager, buildSkillsIndexText, type SkillIndex } from './AcpSkillManager';
 
 /** mcporter CLI 路径（解压后的 JS 文件，跨平台相同） */
 const MCPORTER_CLI_PATH = path.join(os.homedir(), '.nexus', 'mcporter', 'package', 'node_modules', 'mcporter', 'dist', 'cli.js');
@@ -409,17 +409,13 @@ Skill capabilities are subject to organization policy: if the system refuses a s
     instructions.push(skillsInstruction);
   }
 
-  // Explicit ban: when cron is disabled, omitting the skill is not enough — the
-  // agent may still hallucinate a created task from prior knowledge. Tell it
-  // directly that scheduled tasks are unavailable. (Omitted in personal mode and
-  // when cron is enabled.)
+  // Explicit creation ban: when cron is disabled, omitting the skill is not
+  // enough — the agent may still hallucinate a created task from prior
+  // knowledge. The instruction keeps the list/delete contract, since owners and
+  // co-owners may still manage their existing jobs. (Omitted in personal mode
+  // and when cron is enabled.)
   if (!cronAllowed) {
-    instructions.push(
-      '[Scheduled Tasks — DISABLED]\n' +
-        'Scheduled task / cron functionality is disabled by your organization. You CANNOT create, list, modify, or delete scheduled tasks. ' +
-        'If asked to schedule or manage a recurring/timed task, tell the user it is disabled by their organization and an administrator must enable it. ' +
-        'NEVER claim a scheduled task was created, and NEVER invent a task ID.'
-    );
+    instructions.push(CRON_RESTRICTED_INSTRUCTION);
   }
 
   if (instructions.length === 0) {

--- a/src/renderer/hooks/useCronAccess.ts
+++ b/src/renderer/hooks/useCronAccess.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import { ipcBridge } from '@/common';
+import { useAuth } from '@/renderer/context/AuthContext';
+import { useCronEnabled } from '@/renderer/hooks/useCronEnabled';
+
+/**
+ * Cron feature access for the current user.
+ *
+ * - `isCronEnabled` — the org-level `client_cron_enabled` flag (consumer mode:
+ *   always true).
+ * - `isCronCreateEnabled` — whether NEW scheduled tasks may be created: the
+ *   flag, or an admin/super_admin (the moss server lets admin-capable actors
+ *   bypass the cron_disabled_by_org creation gate).
+ * - `isCronVisible` — whether the cron UI (sidebar menu entry, scheduled tab,
+ *   /app/cron routes) is shown. When the org disables client cron the UI stays
+ *   visible for admins and for users who own/co-own at least one existing job
+ *   (moss scopes the job list to the caller), so they can still view, edit,
+ *   run and delete their existing tasks — only creation is hidden.
+ */
+export function useCronAccess(): ICronAccess {
+  const isCronEnabled = useCronEnabled();
+  const { user } = useAuth();
+  // Enterprise (moss) roles are lowercase ('admin' | 'super_admin' | ...);
+  // consumer roles are uppercase but never reach the disabled branch, since
+  // consumer mode is always cron-enabled.
+  const role = user?.role?.toLowerCase();
+  const isAdminRole = role === 'admin' || role === 'super_admin' || role === 'enterprise_admin';
+  const [isOwningJobs, setIsOwningJobs] = useState(false);
+
+  // Probe for owned/co-owned jobs only when the flag alone would hide the UI
+  // (enterprise + disabled + non-admin). The remote provider's listJobs is
+  // already scoped server-side to the caller's own/co-owned jobs; a fetch
+  // failure fails closed (hidden).
+  const shouldProbe = !isCronEnabled && !isAdminRole;
+
+  useEffect(() => {
+    if (!shouldProbe) {
+      return;
+    }
+    let isMounted = true;
+    const probe = () => {
+      ipcBridge.cron.listJobs
+        .invoke()
+        .then((jobs) => {
+          // The bridge returns an { __error } envelope (not an array) on failure.
+          if (isMounted) setIsOwningJobs(Array.isArray(jobs) && jobs.length > 0);
+        })
+        .catch(() => {
+          if (isMounted) setIsOwningJobs(false);
+        });
+    };
+    probe();
+    const unsubCreated = ipcBridge.cron.onJobCreated.on(probe);
+    const unsubRemoved = ipcBridge.cron.onJobRemoved.on(probe);
+    return () => {
+      isMounted = false;
+      unsubCreated();
+      unsubRemoved();
+    };
+  }, [shouldProbe]);
+
+  return {
+    isCronEnabled,
+    isCronCreateEnabled: isCronEnabled || isAdminRole,
+    isCronVisible: isCronEnabled || isAdminRole || isOwningJobs,
+  };
+}
+
+interface ICronAccess {
+  /** Org-level client_cron_enabled flag */
+  isCronEnabled: boolean;
+  /** Whether new scheduled tasks may be created (flag enabled, or admin bypass) */
+  isCronCreateEnabled: boolean;
+  /** Whether cron menu/tab/routes are shown (enabled, admin, or owns/co-owns ≥1 job) */
+  isCronVisible: boolean;
+}

--- a/src/renderer/layouts/components/Sider.tsx
+++ b/src/renderer/layouts/components/Sider.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '@renderer/context/AuthContext';
 import { addEventListener, emitter } from '@renderer/utils/emitter';
 import { ConfigStorage } from '@common/storage';
 import { useAppMode } from '@renderer/hooks/useAppMode';
-import { useCronEnabled } from '@renderer/hooks/useCronEnabled';
+import { useCronAccess } from '@renderer/hooks/useCronAccess';
 
 import WorkspaceGroupedHistory from '@renderer/pages/conversation/WorkspaceGroupedHistory';
 import { maskPhone } from '@renderer/utils';
@@ -32,7 +32,7 @@ const Sider: React.FC = () => {
   const navigate = useNavigate();
   const { logout, user: currentUser } = useAuth();
   const { isEnterprise } = useAppMode();
-  const cronEnabled = useCronEnabled();
+  const { isCronVisible } = useCronAccess();
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   // 账户菜单触发区，用于让弹层宽度与之对齐
@@ -59,7 +59,7 @@ const Sider: React.FC = () => {
     { id: 'skill-store', label: t('common.siderMenu.skillStore'), icon: Sparkles, path: '/app/skills' },
     { id: 'security', label: t('common.siderMenu.security'), icon: ShieldCheck, path: '/app/security' },
     ...(!isEnterprise ? [{ id: 'channels' as const, label: t('common.siderMenu.webui'), icon: Globe, path: '/app/channels' }] : []),
-    ...(cronEnabled ? [{ id: 'cron' as const, label: t('common.siderMenu.cron'), icon: AlarmClock, path: '/app/cron' }] : []),
+    ...(isCronVisible ? [{ id: 'cron' as const, label: t('common.siderMenu.cron'), icon: AlarmClock, path: '/app/cron' }] : []),
   ];
 
   const isSettings = pathname.startsWith('/settings');
@@ -72,9 +72,9 @@ const Sider: React.FC = () => {
     avatar: null as string | null,
   };
 
-  // With client cron disabled the scheduled tab is hidden, so fall back to the
-  // timeline even if 'scheduled' was previously persisted.
-  const effectiveTab: 'timeline' | 'scheduled' = cronEnabled ? activeTab : 'timeline';
+  // With the cron UI hidden the scheduled tab is hidden too, so fall back to
+  // the timeline even if 'scheduled' was previously persisted.
+  const effectiveTab: 'timeline' | 'scheduled' = isCronVisible ? activeTab : 'timeline';
 
   // Batch management only applies to conversations (timeline tab); leaving the
   // timeline tab exits batch mode so the popover can't be opened under 定时任务.
@@ -214,7 +214,7 @@ const Sider: React.FC = () => {
 
             {/* Session history tabs + batch mode button */}
             <div className={classNames('mb-2 px-2 flex items-center justify-between')}>
-              {cronEnabled && (
+              {isCronVisible && (
                 <Tabs
                   className='sidebar-tabs flex-1 shrink-0'
                   type='line'

--- a/src/renderer/pages/cron/detail.tsx
+++ b/src/renderer/pages/cron/detail.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppMode } from '@renderer/hooks/useAppMode';
-import { useEnterpriseSessionMode } from '@renderer/hooks/useEnterpriseSessionMode';
 import { emitter } from '@renderer/utils/emitter';
 import { ipcBridge } from '@/common';
 import type { ICronJob } from '@/common/ipcBridge';
@@ -13,7 +12,6 @@ import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import CronJobFormDrawer from '@/renderer/pages/cron/components/CronJobFormDrawer';
 import { useAssistantsForCron } from '@/renderer/pages/cron/hooks/useAssistantsForCron';
 import { formatNextRunRelative, getJobStatusFlags, unwrapCronResult } from '@/renderer/pages/cron/utils';
-import { useAuth } from '@/renderer/context/AuthContext';
 import { useConversationTabs } from '@/renderer/pages/conversation/context/ConversationTabsContext';
 import PageWrapper from '@renderer/components/base/PageWrapper';
 
@@ -28,10 +26,9 @@ export default function CronJobDetailPage() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { isEnterprise } = useAppMode();
-  const { user } = useAuth();
   const { openTab } = useConversationTabs();
-  const canUseLocalCronMode = !isEnterprise || user?.localModeAvailable === true;
-  const { sessionMode } = useEnterpriseSessionMode({ localModeAvailable: canUseLocalCronMode, remoteModeAvailable: isEnterprise });
+  // Enterprise scheduled tasks are always moss-hosted; consumer mode is local.
+  const sessionMode: 'remote' | 'local' = isEnterprise ? 'remote' : 'local';
   const [job, setJob] = useState<ICronJob | null>(null);
   const [drawerVisible, setDrawerVisible] = useState(false);
   const assistants = useAssistantsForCron();

--- a/src/renderer/pages/cron/index.tsx
+++ b/src/renderer/pages/cron/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useAppMode } from '@renderer/hooks/useAppMode';
-import { useEnterpriseSessionMode } from '@renderer/hooks/useEnterpriseSessionMode';
+import { useCronAccess } from '@renderer/hooks/useCronAccess';
 import { useAddEventListener } from '@renderer/utils/emitter';
 import { ipcBridge } from '@/common';
 import type { ICronJob } from '@/common/ipcBridge';
@@ -14,7 +14,6 @@ import CronJobFormDrawer from '@/renderer/pages/cron/components/CronJobFormDrawe
 import Item from '@/renderer/pages/cron/components/Item';
 import { useAllCronJobs } from '@/renderer/pages/cron/hooks/useCronJobs';
 import { getJobStatusFlags } from '@/renderer/pages/cron/utils';
-import { useAuth } from '@/renderer/context/AuthContext';
 import PageWrapper from '@renderer/components/base/PageWrapper';
 
 function CronJobCardGrid({ jobs, onSelectJob }: ICronJobCardGridProps) {
@@ -44,12 +43,12 @@ export default function CronPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { isEnterprise } = useAppMode();
-  const { user } = useAuth();
-  const canUseLocalCronMode = !isEnterprise || user?.localModeAvailable === true;
-  const { sessionMode, setSessionMode } = useEnterpriseSessionMode({
-    localModeAvailable: canUseLocalCronMode,
-    remoteModeAvailable: isEnterprise,
-  });
+  // Creation is gated by the org flag (admins bypass); owners/co-owners keep
+  // view/edit/run/delete on their existing jobs even while creation is disabled.
+  const { isCronCreateEnabled } = useCronAccess();
+  // Enterprise scheduled tasks are always moss-hosted (the legacy enterprise
+  // "local" cron mode is deprecated); consumer mode is always local.
+  const sessionMode: 'remote' | 'local' = isEnterprise ? 'remote' : 'local';
   const { jobs, loading, error, refetch } = useAllCronJobs();
 
   const [keepAwake, setKeepAwake] = useState(false);
@@ -79,7 +78,8 @@ export default function CronPage() {
       title={t('cron.scheduledTasks', '定时任务')}
       subtitle={t('cron.create.listSubtitle', '设定定时任务，让 Agent 按计划自动执行')}
       actions={
-        jobs.length > 0 && (
+        jobs.length > 0 &&
+        isCronCreateEnabled && (
           <Button type='primary' shape='round' icon={<IconPlus />} onClick={() => setDrawerVisible(true)}>
             {t('cron.create.button', '新建任务')}
           </Button>
@@ -87,26 +87,6 @@ export default function CronPage() {
       }
     >
       <div className='space-y-4'>
-        {/* Enterprise mode: Remote/Local switcher */}
-        {isEnterprise && (
-          <div className='bg-2 rd-12px px-4 py-3 flex items-center justify-between'>
-            <div className='flex items-center gap-2 text-13px text-secondary'>
-              <Info size={16} />
-              <span>{t('cron.mode.select', '数据存储位置')}</span>
-            </div>
-            <div className='flex items-center gap-1'>
-              {canUseLocalCronMode && (
-                <Button size='small' shape='round' type={sessionMode === 'local' ? 'primary' : 'text'} onClick={() => setSessionMode('local')}>
-                  {t('cron.mode.local', '本地')}
-                </Button>
-              )}
-              <Button size='small' shape='round' type={sessionMode === 'remote' ? 'primary' : 'text'} onClick={() => setSessionMode('remote')}>
-                {t('cron.mode.remote', '云端')}
-              </Button>
-            </div>
-          </div>
-        )}
-
         {/* Error state (remote mode) */}
         {error && sessionMode === 'remote' && (
           <div className='bg-red-1 rd-12px px-4 py-3 flex items-center justify-between'>
@@ -133,7 +113,13 @@ export default function CronPage() {
 
         {/* Job cards or empty state */}
         {!loading && jobs.length === 0 ? (
-          <EmptyState simple icon={<AlarmClock size={56} className='text-secondary' />} title={t('cron.noTasks', '暂无定时任务')} description={t('cron.create.emptyHint', '创建自动执行的 Agent 任务')} actions={[{ label: t('cron.create.button', '新建任务'), onClick: () => setDrawerVisible(true) }]} />
+          <EmptyState
+            simple
+            icon={<AlarmClock size={56} className='text-secondary' />}
+            title={t('cron.noTasks', '暂无定时任务')}
+            description={t('cron.create.emptyHint', '创建自动执行的 Agent 任务')}
+            actions={isCronCreateEnabled ? [{ label: t('cron.create.button', '新建任务'), onClick: () => setDrawerVisible(true) }] : undefined}
+          />
         ) : (
           <CronJobCardGrid jobs={jobs} onSelectJob={(job) => void navigate(`/app/cron/${job.id}`)} />
         )}

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -3,7 +3,7 @@ import { HashRouter, Navigate, Route, Routes, useLocation } from 'react-router-d
 import AppLoader from './components/AppLoader';
 import { useAuth } from './context/AuthContext';
 import { useAppMode, isModeResolved } from './hooks/useAppMode';
-import { useCronEnabled } from './hooks/useCronEnabled';
+import { useCronAccess } from './hooks/useCronAccess';
 
 const Conversation = React.lazy(() => import('./pages/conversation'));
 const Guid = React.lazy(() => import('./pages/guid'));
@@ -81,7 +81,7 @@ export const REGISTERED_ROUTE_PATHS = ['/login', '/register', '/', ...PROTECTED_
 const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
   const { status } = useAuth();
   const { isEnterprise } = useAppMode();
-  const cronEnabled = useCronEnabled();
+  const { isCronVisible } = useCronAccess();
   const location = useLocation();
 
   if (status === 'checking') {
@@ -102,8 +102,9 @@ const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) =
     return <Navigate to='/settings/enterprise' replace />;
   }
 
-  // Client cron disabled: the cron settings page is not reachable.
-  if (!cronEnabled && location.pathname.startsWith('/app/cron')) {
+  // Cron UI hidden (org disabled it and the user is neither an admin nor an
+  // owner/co-owner of any job): the cron pages are not reachable.
+  if (!isCronVisible && location.pathname.startsWith('/app/cron')) {
     return <Navigate to='/settings/agent' replace />;
   }
 

--- a/tests/unit/agentUtils.test.ts
+++ b/tests/unit/agentUtils.test.ts
@@ -26,9 +26,13 @@ vi.mock('electron', () => ({
 }));
 
 const isCronSkillAllowed = vi.fn(async () => true);
-vi.mock('@process/services/cron/cronPolicy', () => ({
-  isCronSkillAllowed: () => isCronSkillAllowed(),
-}));
+vi.mock('@process/services/cron/cronPolicy', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@process/services/cron/cronPolicy')>();
+  return {
+    ...actual,
+    isCronSkillAllowed: () => isCronSkillAllowed(),
+  };
+});
 
 describe('prepareFirstMessageWithSkillsIndex', () => {
   beforeEach(() => {
@@ -88,9 +92,11 @@ describe('prepareFirstMessageWithSkillsIndex', () => {
     // The cron skill index entry / file path is omitted...
     expect(result).not.toContain('cron/SKILL.md');
     expect(result).not.toContain('- cron:');
-    // ...but an explicit ban is injected so the agent can't hallucinate success.
-    expect(result).toContain('[Scheduled Tasks — DISABLED]');
+    // ...but an explicit creation ban is injected so the agent can't
+    // hallucinate success; listing/deleting existing tasks stays allowed.
+    expect(result).toContain('[Scheduled Tasks — CREATION DISABLED BY ORGANIZATION]');
     expect(result).toContain('NEVER claim a scheduled task was created');
+    expect(result).toContain('[CRON_LIST]');
     expect(result).toContain('browser');
   });
 
@@ -110,7 +116,7 @@ describe('prepareFirstMessageWithSkillsIndex', () => {
 
     expect(result).toContain('cron/SKILL.md');
     expect(result).toContain('browser');
-    expect(result).not.toContain('[Scheduled Tasks — DISABLED]');
+    expect(result).not.toContain('[Scheduled Tasks — CREATION DISABLED BY ORGANIZATION]');
   });
 
   it('injects workspace skills directory hint before user request', async () => {

--- a/tests/unit/cronPolicyGate.test.ts
+++ b/tests/unit/cronPolicyGate.test.ts
@@ -144,6 +144,64 @@ describe('cronPolicy.getClientCronEnabled (issue #854)', () => {
   });
 });
 
+describe('cronPolicy admin capability (isCronAdminUser / isCronSkillAllowed)', () => {
+  beforeEach(async () => {
+    const { resetCronPolicyCache } = await import('@/process/services/cron/cronPolicy');
+    resetCronPolicyCache();
+    isEnterpriseModeMock.mockReturnValue(true);
+    getSyncMock.mockImplementation((key: string) => (key === 'eeclaw.serverUrl' ? 'http://moss.example' : undefined));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubUserRole(role: string | undefined) {
+    getSyncMock.mockImplementation((key: string) => {
+      if (key === 'eeclaw.serverUrl') return 'http://moss.example';
+      if (key === 'eeclaw.userInfo') return role ? { id: 'u1', username: 'u', role } : undefined;
+      return undefined;
+    });
+  }
+
+  it('isCronAdminUser: true for the moss admin/super_admin roles, false otherwise (fail closed)', async () => {
+    const { isCronAdminUser } = await import('@/process/services/cron/cronPolicy');
+
+    stubUserRole('admin');
+    expect(isCronAdminUser()).toBe(true);
+    stubUserRole('super_admin');
+    expect(isCronAdminUser()).toBe(true);
+    stubUserRole('dept_admin');
+    expect(isCronAdminUser()).toBe(false);
+    stubUserRole('user');
+    expect(isCronAdminUser()).toBe(false);
+    stubUserRole(undefined);
+    expect(isCronAdminUser()).toBe(false);
+  });
+
+  it('isCronSkillAllowed: admin keeps the full cron skill while the org flag is off', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => tenantResponse(false))
+    );
+    stubUserRole('admin');
+
+    const { isCronSkillAllowed } = await import('@/process/services/cron/cronPolicy');
+    expect(await isCronSkillAllowed()).toBe(true);
+  });
+
+  it('isCronSkillAllowed: non-admin loses the full skill while the org flag is off', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => tenantResponse(false))
+    );
+    stubUserRole('user');
+
+    const { isCronSkillAllowed } = await import('@/process/services/cron/cronPolicy');
+    expect(await isCronSkillAllowed()).toBe(false);
+  });
+});
+
 describe('handleCronCommands org-policy refusal + provider routing (issues #854/#835)', () => {
   const createMessage = () =>
     ({
@@ -160,15 +218,20 @@ describe('handleCronCommands org-policy refusal + provider routing (issues #854/
     }));
   }
 
-  it('refuses all cron commands with an explicit message when disabled, without touching the provider', async () => {
+  function mockCronPolicy({ enabled, admin = false }: { enabled: boolean; admin?: boolean }) {
+    vi.doMock('@process/services/cron/cronPolicy', () => ({
+      getClientCronEnabled: vi.fn(async () => enabled),
+      isCronAdminUser: vi.fn(() => admin),
+    }));
+  }
+
+  it('refuses all cron commands with an explicit message when disabled on a non-remote provider', async () => {
     vi.resetModules();
     const addJobMock = vi.fn();
     vi.doMock('@process/providers/cron', () => ({
-      getCronProvider: () => ({ addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
+      getCronProvider: () => ({ type: 'local', addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
     }));
-    vi.doMock('@process/services/cron/cronPolicy', () => ({
-      getClientCronEnabled: vi.fn(async () => false),
-    }));
+    mockCronPolicy({ enabled: false });
     mockCommon();
 
     const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
@@ -184,9 +247,7 @@ describe('handleCronCommands org-policy refusal + provider routing (issues #854/
     vi.doMock('@process/providers/cron', () => ({
       getCronProvider: () => ({ addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
     }));
-    vi.doMock('@process/services/cron/cronPolicy', () => ({
-      getClientCronEnabled: vi.fn(async () => true),
-    }));
+    mockCronPolicy({ enabled: true });
     mockCommon();
 
     const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
@@ -194,6 +255,105 @@ describe('handleCronCommands org-policy refusal + provider routing (issues #854/
 
     expect(addJobMock).toHaveBeenCalledTimes(1);
     expect(result.systemResponses.join('\n')).toContain('Scheduled task created');
+  });
+
+  it('with the remote provider and cron disabled: refuses CREATE only, without touching the provider', async () => {
+    vi.resetModules();
+    const addJobMock = vi.fn();
+    vi.doMock('@process/providers/cron', () => ({
+      getCronProvider: () => ({ type: 'remote', addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
+    }));
+    mockCronPolicy({ enabled: false });
+    mockCommon();
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-1', 'scode', createMessage());
+
+    const text = result.systemResponses.join('\n');
+    expect(text).toContain('Creating scheduled tasks is disabled by your organization');
+    expect(addJobMock).not.toHaveBeenCalled();
+  });
+
+  it('with the remote provider and cron disabled: an admin-capable user may still CREATE (moss allows it)', async () => {
+    vi.resetModules();
+    const addJobMock = vi.fn(async () => ({ id: 'cron_admin', name: 'T' }));
+    vi.doMock('@process/providers/cron', () => ({
+      getCronProvider: () => ({ type: 'remote', addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
+    }));
+    mockCronPolicy({ enabled: false, admin: true });
+    mockCommon();
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-1', 'scode', createMessage());
+
+    expect(addJobMock).toHaveBeenCalledTimes(1);
+    expect(result.systemResponses.join('\n')).toContain('Scheduled task created');
+  });
+
+  it('with the remote provider and cron disabled: CRON_LIST still lists the user-scoped jobs', async () => {
+    vi.resetModules();
+    const listJobsMock = vi.fn(async () => [
+      {
+        id: 'cron_own',
+        name: 'My report',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 9 * * *', description: 'daily' },
+        target: { payload: { kind: 'message', text: 'go' } },
+        metadata: { conversationId: 'conv-9', agentType: 'remote-agent', createdBy: 'user', createdAt: 0, updatedAt: 0 },
+        state: { runCount: 0 },
+      },
+    ]);
+    vi.doMock('@process/providers/cron', () => ({
+      getCronProvider: () => ({ type: 'remote', addJob: vi.fn(), listJobs: listJobsMock, removeJob: vi.fn() }),
+    }));
+    mockCronPolicy({ enabled: false });
+    mockCommon();
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const result = await processAgentResponse('conv-1', 'scode', {
+      id: 'msg-1',
+      conversation_id: 'conv-1',
+      type: 'content',
+      status: 'finish',
+      content: { content: '[CRON_LIST]' },
+    } as never);
+
+    expect(listJobsMock).toHaveBeenCalledTimes(1);
+    const text = result.systemResponses.join('\n');
+    expect(text).toContain('My report');
+    expect(text).toContain('cron_own');
+  });
+
+  it('with the remote provider and cron disabled: CRON_DELETE reaches the server, which enforces ownership', async () => {
+    vi.resetModules();
+    const removeJobMock = vi.fn(async (jobId: string) => {
+      if (jobId !== 'cron_own') {
+        throw new Error('Failed to delete cron job: 403 Access denied');
+      }
+    });
+    vi.doMock('@process/providers/cron', () => ({
+      getCronProvider: () => ({ type: 'remote', addJob: vi.fn(), listJobs: vi.fn(async () => []), removeJob: removeJobMock }),
+    }));
+    mockCronPolicy({ enabled: false });
+    mockCommon();
+
+    const { processAgentResponse } = await import('@/process/task/MessageMiddleware');
+    const deleteMessage = (jobId: string) =>
+      ({
+        id: 'msg-1',
+        conversation_id: 'conv-1',
+        type: 'content',
+        status: 'finish',
+        content: { content: `[CRON_DELETE: ${jobId}]` },
+      }) as never;
+
+    const owned = await processAgentResponse('conv-1', 'scode', deleteMessage('cron_own'));
+    expect(owned.systemResponses.join('\n')).toContain('Task deleted: cron_own');
+
+    const foreign = await processAgentResponse('conv-1', 'scode', deleteMessage('cron_other'));
+    const text = foreign.systemResponses.join('\n');
+    expect(text).toContain('Access denied');
+    expect(text).not.toContain('Task deleted: cron_other');
   });
 
   it('surfaces a provider failure (e.g. moss 403) as an error, not a false success', async () => {
@@ -205,9 +365,7 @@ describe('handleCronCommands org-policy refusal + provider routing (issues #854/
       getCronProvider: () => ({ addJob: addJobMock, listJobs: vi.fn(async () => []), removeJob: vi.fn() }),
     }));
     // Gate enabled (e.g. stale-true locally) so we exercise the provider path.
-    vi.doMock('@process/services/cron/cronPolicy', () => ({
-      getClientCronEnabled: vi.fn(async () => true),
-    }));
+    mockCronPolicy({ enabled: true });
     mockCommon();
 
     const { processAgentResponse } = await import('@/process/task/MessageMiddleware');


### PR DESCRIPTION
## Summary

When the enterprise `client_cron_enabled` flag is off, the client previously hid all cron UI and refused every agent cron command. The moss server, however, only gates job **creation** (`cron_disabled_by_org`), scopes `GET /api/v1/cron/jobs` to the caller's owned/co-owned jobs (`listByUser` + `json_each(co_owner_ids)`), and lets owners, co-owners and admin-capable actors manage existing jobs (`canManageJob`). This PR aligns the client with that model.

## Behavior matrix

| Mode | Flag | Behavior |
| --- | --- | --- |
| Personal | n/a | Unchanged — policy always resolves enabled, local provider, all paths identical |
| Enterprise | on | Full CRUD + exec for everyone (unchanged) |
| Enterprise | off, admin/super_admin | Cron menu always visible; create allowed (UI button, chat `[CRON_CREATE]`, full cron skill injected) — mirrors moss `isCronAdminCapable` bypass |
| Enterprise | off, non-admin | Create hidden/refused (client + server); list/edit/run/delete only on owned/co-owned tasks (server-filtered list, server-enforced mutations); cron menu + scheduled-sessions tab shown only when the user owns/co-owns ≥1 task |

## Changes

- **Provider**: enterprise mode always uses `RemoteCronProvider` — the deprecated enterprise local cron mode no longer routes to the local SQLite store; the cron page's 本地/云端 switcher is removed.
- **Chat commands** (`MessageMiddleware`): with the remote provider and the flag off, `[CRON_LIST]`/`[CRON_DELETE]` pass through (moss enforces ownership; deleting a non-owned task surfaces `Access denied`); `[CRON_CREATE]` is refused unless `isCronAdminUser()` (reads the moss role from `eeclaw.userInfo`). Non-remote providers keep the blanket refusal.
- **Agent instruction**: shared `CRON_RESTRICTED_INSTRUCTION` replaces the full-ban text in `RemoteAgent` and `agentUtils` — bans creation but keeps the `[CRON_LIST]` / `[CRON_DELETE: task-id]` contract; admins keep the full skill via `isCronSkillAllowed()`.
- **Renderer**: new `useCronAccess` hook — `isCronVisible` (flag ∥ admin role ∥ owns/co-owns ≥1 job, fail-closed probe) drives the sidebar cron menu, scheduled-sessions tab and `/app/cron` route guard; `isCronCreateEnabled` (flag ∥ admin) gates the create button and empty-state action.
- **Types**: `MossCronJob` documents the server's `coOwnerIds` / `userName` / `executorUserId` fields.

Org-wide admin listing intentionally stays in the moss admin console (`/api/v1/admin/cron/jobs` is not wired into the client).

## Testing

- `bunx tsc --noEmit` clean; ESLint 0 errors on changed files; Prettier clean.
- `cronPolicyGate` suite extended to 17 tests: remote/disabled create-refusal, admin create bypass, user-scoped `CRON_LIST`, ownership-enforced `CRON_DELETE`, `isCronAdminUser` role matrix, `isCronSkillAllowed` admin bypass.
- Full vitest run matches the dev baseline (no new failures; pre-existing failures untouched).
