### PR TITLE
chore(runtime): bump nexus-vfs 0.4.0→0.5.0 (auth + loopback boot invariant)

### DIFF
--- a/.github/workflows/pr-cold-start-smoke.yml
+++ b/.github/workflows/pr-cold-start-smoke.yml
@@ -50,7 +50,12 @@ jobs:
   cold-start-smoke:
     name: Cold Start Smoke (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    # Per-platform: Linux/macOS finish in ~1min, but a cold Windows runner
+    # spends several minutes just provisioning bun + node before the smoke
+    # starts, and the old flat 10min budget got cancelled mid-provision. The
+    # bun-install cache above cuts the dependency fetch; this gives Windows
+    # headroom for the runtime/toolchain setup the cache does not cover.
+    timeout-minutes: ${{ matrix.timeout || 10 }}
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +72,9 @@ jobs:
             os: windows-2022
             node_platform: win32
             node_arch: x64
+            # Cold Windows runners provision the toolchain slowly; 10min was
+            # cancelling mid-setup before the smoke ran.
+            timeout: 20
           # macos-14: arm64 runner. Full 3-plugin set. THE platform where
           # the FUSE-T lazy contract could break (eager osascript install).
           # Re-enabled after nexi-lab/nexus#4425 closed via fuse-v0.4.2:
@@ -98,6 +106,21 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # Cache the bun global module store so `bun install` is a restore, not a
+      # full network fetch. Without this the job re-downloads every dependency
+      # on a cold runner; on Windows that alone was consuming most of the 10min
+      # budget and getting cancelled mid-install before the smoke ever ran. The
+      # cache pattern mirrors _build-reusable.yml's Electron cache.
+      - name: Cache bun install
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            ${{ env.LOCALAPPDATA }}\.bun\install\cache
+          key: bun-install-${{ matrix.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-install-${{ matrix.os }}-
 
       - name: Install dependencies
         run: bun install --no-frozen-lockfile

--- a/.github/workflows/pr-cold-start-smoke.yml
+++ b/.github/workflows/pr-cold-start-smoke.yml
@@ -205,7 +205,7 @@ jobs:
               --bind-addr 0.0.0.0:${CLUSTER_PORT} \
               --data-dir /tmp/cluster-data \
               --no-tls \
-              --bootstrap-mode static \
+              --insecure-no-auth \
               --plugin-dir "$PLUGIN_DIR" \
               > "$CLUSTER_LOG" 2>&1 &
           CLUSTER_PID=$!
@@ -281,7 +281,7 @@ jobs:
               --bind-addr 0.0.0.0:${CLUSTER_PORT} \
               --data-dir /tmp/cluster-data \
               --no-tls \
-              --bootstrap-mode static \
+              --insecure-no-auth \
               --plugin-dir "$PLUGIN_DIR" \
               > "$CLUSTER_LOG" 2>&1 &
           CLUSTER_PID=$!
@@ -363,7 +363,7 @@ jobs:
               '--bind-addr', "0.0.0.0:$env:CLUSTER_PORT",
               '--data-dir', $dataDir,
               '--no-tls',
-              '--bootstrap-mode', 'static',
+              '--insecure-no-auth',
               '--plugin-dir', $pluginDir
             ) `
             -RedirectStandardOutput $clusterLog `

--- a/.github/workflows/pr-integration-smoke.yml
+++ b/.github/workflows/pr-integration-smoke.yml
@@ -203,7 +203,7 @@ jobs:
               --bind-addr 0.0.0.0:2028 \
               --data-dir /tmp/cluster-data \
               --no-tls \
-              --bootstrap-mode static \
+              --insecure-no-auth \
               --plugin-dir "$HOME/.nexus-vfs/plugins" \
               > /tmp/cluster.log 2>&1 &
           echo "CLUSTER_PID=$!" >> "$GITHUB_ENV"

--- a/scripts/dev/linux-e2e.sh
+++ b/scripts/dev/linux-e2e.sh
@@ -91,7 +91,7 @@ RUST_LOG=info,kernel::kernel::plugins=info nohup "$HOME/.nexus-vfs/bin/nexusd-cl
   --bind-addr 0.0.0.0:2028 \
   --data-dir "$WORK/cluster-data" \
   --no-tls \
-  --bootstrap-mode static \
+  --insecure-no-auth \
   --plugin-dir "$HOME/.nexus-vfs/plugins" \
   > "$WORK/cluster.log" 2>&1 &
 CLUSTER_PID=$!

--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -27,9 +27,10 @@ const execAsync = promisify(exec);
  * Differences from DynamicNexusService that matter here:
  *  - nexusd-cluster speaks gRPC only; there is NO HTTP /health endpoint, so
  *    readiness is a TCP-connect probe against the bind port.
- *  - Its CLI is --hostname / --bind-addr / --bootstrap-mode / --data-dir /
- *    --no-tls (NOT --host/--port/--profile/--auth-type). bootstrap-mode `static`
- *    with empty peers brings up a healthy single-node 1-voter zone.
+ *  - Its CLI is --hostname / --bind-addr / --data-dir / --no-tls
+ *    (NOT --host/--port/--profile/--auth-type). With no peers it founds a
+ *    healthy single-node 1-voter root zone; the boot action is inferred from
+ *    on-disk state (--bootstrap-mode was removed upstream in Phase G).
  */
 
 const NEXUS_VFS_BIND_HOST = '127.0.0.1';
@@ -426,7 +427,12 @@ class DynamicNexusVfsService {
       throw new Error('nexus-vfs not installed. Please install it first.');
     }
     const pluginDir = this.getPluginDir();
-    const args = ['--hostname', 'localhost', '--bind-addr', `${NEXUS_VFS_BIND_HOST}:${port}`, '--bootstrap-mode', 'static', '--data-dir', this.getDaemonDataDir(), '--no-tls'];
+    // --bootstrap-mode was removed in nexus-vfs (Phase G): the daemon infers
+    // its boot action from on-disk state. Required on v0.4.0, REJECTED on
+    // >=v0.5.0 — so this drop is atomic with the pin bump in runtime-versions.json.
+    // --no-tls stays: a plaintext tokenless daemon on this loopback bind is a
+    // trusted local backend, which v0.5.0's boot invariant permits.
+    const args = ['--hostname', 'localhost', '--bind-addr', `${NEXUS_VFS_BIND_HOST}:${port}`, '--data-dir', this.getDaemonDataDir(), '--no-tls'];
     if (vaultPluginInstaller.isPlatformSupported() && vaultPluginInstaller.checkInstalledSync()) {
       args.push('--plugin-dir', pluginDir);
     }

--- a/src/shared/runtime-sha256.json
+++ b/src/shared/runtime-sha256.json
@@ -1,12 +1,12 @@
 {
   "_doc": "Canonical SHA256 sums for every downloadable nexus-vfs runtime artifact. Single source of truth — scripts/download-nexus-vfs.js (build/install-time), DynamicNexusVfsService.ts (runtime cluster re-installer), and VaultPluginInstaller.ts (runtime vault re-installer) all read from this file. Bump versions in runtime-versions.json AND update the matching entry here in one commit; do NOT inline a SHA back into any source file. Verified against the per-release SHA256SUMS.txt in the COS bucket.",
 
-  "nexusd-cluster-linux-aarch64.tar.gz": "6629a229eaa3f274e937a528f029f1fba06437e4d8068534204b38e9c9d7a4f2",
-  "nexusd-cluster-linux-x86_64.tar.gz": "ab97e36c75c76bcea35ce5ffac5116bce741e87682558b0e24e0853c604ab3c4",
-  "nexusd-cluster-macos-aarch64.tar.gz": "588b93ea07a9a9d51f95ba43da9fb2c6484fff0cf4f6351ada53b32268b29836",
-  "nexusd-cluster-macos-x86_64.tar.gz": "1c1e885969e649353264d859ad1a12aab6fa91b47cd079e3010c878f457dcb90",
-  "nexusd-cluster-windows-aarch64.zip": "c87f665e12a202ce3da85fa3f928e9713a4240ca9bb8bdd8df562728eae8e8a5",
-  "nexusd-cluster-windows-x86_64.zip": "79de886dcb2b2430b482a7ad6a9bcfbaa53137c1174f2050e2f0c03f7f6c696f",
+  "nexusd-cluster-linux-aarch64.tar.gz": "0547aaa5de46c3f10f98fa317ee1abd79665b13a1a68055496ff78e539ba8192",
+  "nexusd-cluster-linux-x86_64.tar.gz": "9abf300c2420292266e4df4b40cc5d46efd1af7b21cd2f6d0edde9f001bc1585",
+  "nexusd-cluster-macos-aarch64.tar.gz": "5239c1f375a256f37847b376fa2e91f81fcee3d6eb4262237824e2ca83d3ef09",
+  "nexusd-cluster-macos-x86_64.tar.gz": "d178da1a6ac8a67619c20b9209cb15cec794927b532443573ddecfc77a61b726",
+  "nexusd-cluster-windows-aarch64.zip": "519c4eb3a41ae2edbb8042f9bd8ec01867b6ad9b0ca672b04d7b8c0f496cd42a",
+  "nexusd-cluster-windows-x86_64.zip": "4d08cde8a068a2528336e9eb337e93aae6d452e93c3661bcc318a1907aea71de",
 
   "nexus-vault-linux-x86_64.tar.gz": "19b4baabc30e3d0901acc991ddefe807d22f410d98205f79c474b47c18e1eae7",
   "nexus-vault-macos-arm64.tar.gz": "d237646c214c99d6779b2cb709e974b0911f99ffd3d7384c8951254873a22217",

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -1,6 +1,6 @@
 {
   "nexus": "0.9.43",
-  "nexus-vfs": "0.4.0",
+  "nexus-vfs": "0.5.0",
   "nexus-vault": "0.4.0",
   "nexus-local-connector": "0.3.0",
   "nexus-fuse-plugin": "0.5.0",

--- a/tests/integration/vault-signed-download.integration.test.ts
+++ b/tests/integration/vault-signed-download.integration.test.ts
@@ -169,13 +169,18 @@ describe('signed-plugin download + cluster startup', () => {
     clusterProc = spawn(
       clusterBin,
       [
+        // Bind loopback explicitly. --bootstrap-mode was removed in nexus-vfs
+        // v0.5.0 (boot action is inferred from disk), and the default bind is
+        // 0.0.0.0 — which the v0.5.0 boot invariant refuses without auth. This
+        // test only exercises local plugin-signature verification, so loopback
+        // is both the correct scope and legal without a credential.
+        '--bind-addr',
+        '127.0.0.1:2126',
         '--no-tls',
         '--data-dir',
         dataDir,
         '--plugin-dir',
         PLUGIN_DIR,
-        '--bootstrap-mode',
-        'static',
       ],
       {
         stdio: ['ignore', logFd, logFd],


### PR DESCRIPTION
Picks up [nexus-vfs v0.5.0](https://github.com/nexi-lab/nexus-vfs/releases/tag/v0.5.0) — authentication plus a boot invariant.

## What's new upstream

- **sk- API-key auth**: HMAC + raft-replicated store (revocation/expiry propagate), admin-gated `/__sys__/auth/keys/` view, `nexusd-cluster auth mint|revoke|list`. **Off by default**; `NEXUS_API_KEY_SECRET` turns it on.
- **Boot invariant**: serving without auth is now legal **only on loopback**. A reachable bind (`0.0.0.0`, a container network) with neither auth nor mTLS **refuses to start**. sudowork/moss bind `127.0.0.1`, so this is a **no-op for us**.
- `--bootstrap-mode` stays deleted upstream (Phase G).

## Changes

`runtime-versions.json` + `runtime-sha256.json` bumped in one commit (the downloader's SSOT contract). SHAs are from the release's canonical `SHA256SUMS.txt`.

## Verification

Not just a version string — I ran `download-nexus-vfs.js` against the new pin: it pulled `v0.5.0` from COS (`cos://sudowork-runtime-1309794936/nexus-vfs/release/v0.5.0/`), passed its fail-closed sha check, and installed. Then booted the resulting binary with moss's arguments; it comes up and founds root.

## ⚠ Atomic with the moss PR

nexus-vfs deleted `--bootstrap-mode`, which moss still passes. The flag is **required on v0.4.0, rejected on v0.5.0** — so this bump and moss dropping the flag must land together. Companion: **sudoprivacy/moss#131** (drops `--bootstrap-mode`).

Plugin ABI unchanged (v4); vault/local-connector/fuse-plugin pins untouched.