### PR TITLE
fix(ci): align browser_start subprocess timeout with ai-dev-browser's 30s budget

### DIFF
--- a/tests/integration/browser_port_isolation.py
+++ b/tests/integration/browser_port_isolation.py
@@ -137,8 +137,14 @@ def run_test(sudowork_port: int = 9230) -> tuple[bool, str]:
     failures = []
 
     try:
-        # 1. browser_start
-        start = _run("browser_start", timeout=20)
+        # 1. browser_start — the subprocess timeout MUST exceed ai-dev-browser's
+        #    own startup_timeout (30s) for a cold Chrome launch. It used to be 20s,
+        #    tighter than the inner budget: on a slow CI cold-start (20–30s) this
+        #    outer timeout killed a launch that was still legitimately in progress,
+        #    reporting "browser_start failed: timeout" — a pure flake (passed when
+        #    Chrome came up fast, failed when it didn't). 60s gives the inner 30s
+        #    budget room to either succeed or report a real error, not be preempted.
+        start = _run("browser_start", timeout=60)
         if start["exit"] != 0:
             return False, f"browser_start failed: {start['stderr'] or start['stdout']}"
         chrome_port = (start["json"] or {}).get("port")


### PR DESCRIPTION
## Flake root cause

`tests/integration/browser_port_isolation.py` wrapped `browser_start` in a **20s** subprocess timeout — **tighter than ai-dev-browser's own 30s `startup_timeout`** for a cold Chrome launch. On a slow CI cold-start (20–30s under xvfb), the outer 20s fired first and killed a launch that was still legitimately in progress → `browser_start failed: timeout`.

Pure flake: passed when Chrome came up fast, failed when it didn't — green on #1003, red on #1005, **both docs-only, neither touching browser code**.

## Fix

Bump the cold-launch subprocess timeout to **60s** so browser_start's 30s budget can either succeed or surface a *real* error, instead of being preempted. This is the root cause (outer < inner), not a band-aid rerun.

The other `_run` calls (page_goto / click_by_text / find / screenshot) act on an already-launched Chrome, so their 10–15s timeouts are correct and untouched.

Not an ai-dev-browser bug — its 30s budget is reasonable; our test under-budgeted the wrapper. Benefits every PR that runs the integration smoke, not just the two that happened to flake.