### PR TITLE
fix(team): resolve message duplication and turn busy-wait in team sessions

### DIFF
--- a/src/process/services/team/EventLoop.ts
+++ b/src/process/services/team/EventLoop.ts
@@ -165,7 +165,7 @@ export class EventLoop {
       const text = messages.map((m) => m.content).join('\n\n');
       const latestUserLanguage = this.deps.getLatestUserLanguage?.() ?? null;
       const hiddenPromptPrefix = latestUserLanguage ? buildTeamUserLanguageContract(latestUserLanguage) : undefined;
-      await agent.sendMessage({ content: text, msg_id: turnId, hiddenPromptPrefix });
+      await agent.sendMessage({ content: text, msg_id: turnId, hiddenPromptPrefix, suppressUserBubble: true });
       if (!this.alive) return null;
       // Stage 2 → 3: starting_reservations → active_child_turns (turn has run).
       this.deps.teamRun.recordChildStarted(reservation, turnId, this.deps.member.conversation_id ?? '');

--- a/src/process/services/team/GovernancePrompt.ts
+++ b/src/process/services/team/GovernancePrompt.ts
@@ -41,6 +41,7 @@ export function buildGovernancePrompt(role: TeamRole, teamName: string, memberNa
       `10. For dependent work, do not tell one teammate to wait for another. Assign the prerequisite first; when it reports back, assign the dependent task.\n` +
       `11. For rename or shutdown requests, use team_rename_agent or team_shutdown_agent.\n` +
       `12. When teammates report back, review results, avoid duplicating work already assigned, decide next steps, and synthesize a final answer for the user.\n\n` +
+      `Turn discipline: After assigning work via team_send_message, END your turn. Teammate replies arrive automatically as new turns (via idle_notification) — do NOT use Sleep or repeatedly poll team_members to wait. Sleep is blocked in team sessions and will be interrupted.\n\n` +
       `Coordinate only through the team_* tools.`
     );
   }
@@ -50,6 +51,7 @@ export function buildGovernancePrompt(role: TeamRole, teamName: string, memberNa
     `${PRIORITY_BLOCK}\n\n` +
     `- Execute the task the leader assigned to you.\n` +
     `- When you finish, get blocked, or have nothing to do, notify the leader via team_send_message (an idle notification).\n` +
+    `- Do NOT use Sleep to wait — Sleep is blocked in team sessions and will be interrupted.\n` +
     `- Coordinate only through the team_* tools.`
   );
 }

--- a/src/process/services/team/MessageProjection.ts
+++ b/src/process/services/team/MessageProjection.ts
@@ -38,7 +38,7 @@ export function projectMessage(teamId: string, mail: TeamMail, targetConversatio
   if (mail.type !== 'message') return;
   const isFromUser = mail.from_member_id === 'user';
   const key = dedupeKey(teamId, mail.id, targetConversationId);
-  if (!isFromUser && messageExistsByMsgId(key)) return;
+  if (messageExistsByMsgId(key)) return;
 
   const position = isFromUser ? 'right' : 'left';
   const content: { content: string } | TeammateMessageContent = isFromUser
@@ -63,7 +63,14 @@ export function projectMessage(teamId: string, mail: TeamMail, targetConversatio
   };
   addMessage(targetConversationId, message as TMessage);
 
-  if (!isFromUser) {
+  if (isFromUser) {
+    ipcBridge.acpConversation.responseStream.emit({
+      type: 'user_content',
+      conversation_id: targetConversationId,
+      msg_id: key,
+      data: stripSystemNotes(mail.content),
+    });
+  } else {
     ipcBridge.team.onTeammateMessage.emit({
       conversation_id: targetConversationId,
       content: mail.content,
@@ -79,7 +86,6 @@ export function projectMessage(teamId: string, mail: TeamMail, targetConversatio
  */
 export function mirrorUnreadToConversation(teamId: string, member: TeamMember, messages: TeamMail[], senderLookup: (slotId: string) => TeamMember | null): void {
   for (const mail of messages) {
-    if (mail.from_member_id === 'user') continue;
     if (mail.type === 'idle_notification') continue;
     if (!member.conversation_id) continue;
     projectMessage(teamId, mail, member.conversation_id, senderLookup(mail.from_member_id));

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -1914,7 +1914,9 @@ This identity statement takes priority over the default identity in USER.md.
 
   private emitFallbackCompletionMessage(finalFiles: Array<{ path: string; reason: string }>): void {
     const hasVisibleContentAfterLastTool = this.turnHadVisibleAssistantContent && this.lastVisibleAssistantContentSequence > this.lastToolCompletionSequence;
-    if (this.userCancelled || hasVisibleContentAfterLastTool) {
+    // Team 场景豁免：leader/member 的正常 turn 以工具调用结尾（GovernancePrompt 要求工具协调后 END turn），
+    // 工具之后无可见总结文本是常态，不应误报为"模型没有返回总结"。
+    if (this.userCancelled || hasVisibleContentAfterLastTool || this.options.teamMcpConfig) {
       return;
     }
 

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -1742,6 +1742,48 @@ This identity statement takes priority over the default identity in USER.md.
   }
 
   /**
+   * Interrupt a team member's turn that attempted Sleep (busy-wait).
+   *
+   * Deliberately does NOT call this.stop() / handleSignalEvent(finish):
+   *  - stop()->performStop() sets userCancelled=true, after which
+   *    handleStreamEvent / handleSignalEvent ignore the leader's subsequent
+   *    teammate replies (see :3273 / :3372).
+   *  - handleSignalEvent(finish) resets turnActive / cronBusyGuard and archives
+   *    turn files (:3403 / :3404 / :3414); because this method is
+   *    fire-and-forget and the pending sendPrompt resolves sendToConnection's
+   *    await (registered earlier) BEFORE this method's await, the EventLoop
+   *    starts the next turn (sendMessage re-asserts turnActive / cronBusyGuard
+   *    at :726 / :723) BEFORE handleSignalEvent(finish) runs — finish would
+   *    wrongly clobber the new turn's state. (stop() avoids this only because
+   *    user-stop has no following turn.)
+   *
+   * So: only the race-free low-level primitives. turnActive / cronBusyGuard
+   * are intentionally left untouched — the next turn's sendMessage re-asserts
+   * them; if no next turn (leader idle), they stay set until the next message,
+   * which is harmless (the only turnActive reader — the stop() guard at :1634
+   * — treats true as "can stop"; cronBusyGuard only gates cron tasks for this
+   * conversation, never team coordination).
+   */
+  private async cancelTeamSleepTurn(): Promise<void> {
+    let result: 'cancelled' | 'abandoned' | 'disconnected';
+    try {
+      result = await this.connection.cancel(5000);
+    } catch {
+      result = 'disconnected';
+    }
+    if (result !== 'cancelled') {
+      await this.connection.disconnect();
+    }
+    this.emitClearIncompleteTools();
+    ipcBridge.acpConversation.responseStream.emit({
+      type: 'finish',
+      conversation_id: this.conversation_id,
+      msg_id: uuid(),
+      data: null,
+    });
+  }
+
+  /**
    * Clean up current-turn draft files on cancel. Final files are preserved.
    * 取消时只清理当前 Turn 的草稿文件，保留最终交付文件。
    */
@@ -2523,6 +2565,13 @@ This identity statement takes priority over the default identity in USER.md.
         const toolName = toolCallUpdate.update?.title || '';
         const toolCallId = toolCallUpdate.update?.toolCallId;
         console.log(`[AcpAgent] tool_call event: toolName=${toolName}, toolCallId=${toolCallId}`);
+
+        // Team 场景禁止 Sleep：leader/member 用 Sleep 会在 turn 内 busy-wait，
+        // 导致 EventLoop 串行阻塞、member 回复堆积（根因）。检测到即中断 turn 释放阻塞。
+        if (this.options.teamMcpConfig && toolName === 'Sleep') {
+          mainLog('[AcpAgent]', `[TEAM] Sleep blocked in team session (conv=${this.conversation_id}), interrupting turn`);
+          void this.cancelTeamSleepTurn().catch((err) => mainWarn('[AcpAgent]', `[TEAM] cancelTeamSleepTurn failed:`, err));
+        }
 
         // Breadcrumb: MCP/tool call started
         mcpBreadcrumbs.toolCall(toolName, 'acp', this.conversation_id);

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -714,7 +714,7 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
 
   // ========== Public API (BaseAgent contract) ==========
 
-  async sendMessage(data: { content: string; files?: string[]; msg_id?: string; cronMeta?: CronMessageMeta; skills?: string[]; hiddenPromptPrefix?: string }): Promise<{
+  async sendMessage(data: { content: string; files?: string[]; msg_id?: string; cronMeta?: CronMessageMeta; skills?: string[]; hiddenPromptPrefix?: string; suppressUserBubble?: boolean }): Promise<{
     success: boolean;
     msg?: string;
     message?: string;
@@ -772,42 +772,44 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
 
       // Emit/persist user message immediately
       if (data.msg_id && data.content) {
-        const displayContent = appendNexusFilesMarker(data.content, data.files || [], this.workspace);
-        const userMessage: TMessage = {
-          id: data.msg_id,
-          msg_id: data.msg_id,
-          type: 'text',
-          position: 'right',
-          conversation_id: this.conversation_id,
-          content: {
-            content: displayContent,
-            ...(data.skills && data.skills.length > 0 && { skills: data.skills }),
-            ...(data.cronMeta && { cronMeta: data.cronMeta }),
-          },
-          createdAt: Date.now(),
-        };
-        addMessage(this.conversation_id, userMessage);
         try {
           getDatabase().updateConversation(this.conversation_id, {});
         } catch {
           // Conversation might not exist in DB yet
         }
-        let responseData: any = displayContent;
-        if (data.cronMeta || (data.skills && data.skills.length > 0)) {
-          responseData = {
-            content: displayContent,
-            ...(data.cronMeta && { cronMeta: data.cronMeta }),
-            ...(data.skills && data.skills.length > 0 && { skills: data.skills }),
+        if (!data.suppressUserBubble) {
+          const displayContent = appendNexusFilesMarker(data.content, data.files || [], this.workspace);
+          const userMessage: TMessage = {
+            id: data.msg_id,
+            msg_id: data.msg_id,
+            type: 'text',
+            position: 'right',
+            conversation_id: this.conversation_id,
+            content: {
+              content: displayContent,
+              ...(data.skills && data.skills.length > 0 && { skills: data.skills }),
+              ...(data.cronMeta && { cronMeta: data.cronMeta }),
+            },
+            createdAt: Date.now(),
           };
-        }
+          addMessage(this.conversation_id, userMessage);
+          let responseData: any = displayContent;
+          if (data.cronMeta || (data.skills && data.skills.length > 0)) {
+            responseData = {
+              content: displayContent,
+              ...(data.cronMeta && { cronMeta: data.cronMeta }),
+              ...(data.skills && data.skills.length > 0 && { skills: data.skills }),
+            };
+          }
 
-        const userResponseMessage: IResponseMessage = {
-          type: 'user_content',
-          conversation_id: this.conversation_id,
-          msg_id: data.msg_id,
-          data: responseData,
-        };
-        ipcBridge.acpConversation.responseStream.emit(userResponseMessage);
+          const userResponseMessage: IResponseMessage = {
+            type: 'user_content',
+            conversation_id: this.conversation_id,
+            msg_id: data.msg_id,
+            data: responseData,
+          };
+          ipcBridge.acpConversation.responseStream.emit(userResponseMessage);
+        }
       }
 
       // Emit start event before async initAgent so frontend loading state

--- a/tests/unit/teamEventLoop.test.ts
+++ b/tests/unit/teamEventLoop.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
   addMessage: vi.fn(),
   emitStatus: vi.fn(),
   emitTeammate: vi.fn(),
+  emitUserContent: vi.fn(),
   agentSend: vi.fn(),
   onWakeSlot: vi.fn(),
 }));
@@ -36,6 +37,9 @@ vi.mock('@/common', () => ({
       onChildTurnStarted: { emit: vi.fn() },
       onChildTurnCompleted: { emit: vi.fn() },
       onChildTurnCancelled: { emit: vi.fn() },
+    },
+    acpConversation: {
+      responseStream: { emit: h.emitUserContent },
     },
   },
 }));
@@ -159,6 +163,7 @@ beforeEach(() => {
   h.addMessage.mockReset();
   h.emitStatus.mockReset();
   h.emitTeammate.mockReset();
+  h.emitUserContent.mockReset();
   h.agentSend.mockReset();
   h.onWakeSlot.mockReset();
 
@@ -228,7 +233,7 @@ describe('EventLoop turn driving (附录 I.5)', () => {
     expect(h.agentSend).not.toHaveBeenCalled();
   });
 
-  it('teammate mirrors incoming teammate messages as left bubbles (deduped) and skips user/idle', async () => {
+  it('teammate mirrors incoming teammate messages as left bubbles (deduped) and skips idle', async () => {
     const agent: AgentLike = { sendMessage: h.agentSend };
     const { loop, teamRun } = buildLoop(makeMember({ id: 's1', role: 'teammate' }), agent);
     seedWake(teamRun, 's1', 'teammate', 'mcp_send_message');
@@ -243,6 +248,24 @@ describe('EventLoop turn driving (附录 I.5)', () => {
     expect(projected.position).toBe('left');
     expect(projected.content.teammateMessage).toBe(true);
     expect(projected.content.content).toBe('please review');
+  });
+
+  it('mirrors user messages as right bubbles with real-time emit', async () => {
+    const agent: AgentLike = { sendMessage: h.agentSend };
+    const { loop, teamRun } = buildLoop(makeMember({ id: 's1', role: 'teammate' }), agent);
+    seedWake(teamRun, 's1', 'teammate', 'mcp_send_message');
+    queue.push(row({ id: 'm-user', from_member_id: 'user', content: 'hello team' }));
+
+    loop.start();
+    loop.notifyWake();
+    await flush();
+
+    expect(h.addMessage).toHaveBeenCalledTimes(1);
+    const [, projected] = h.addMessage.mock.calls[0] as [string, { position: string; msg_id: string; content: { content: string } }];
+    expect(projected.position).toBe('right');
+    expect(projected.msg_id).toBe('team:t1:mailbox:m-user:conversation:c1');
+    expect(projected.content.content).toBe('hello team');
+    expect(h.emitUserContent).toHaveBeenCalledWith(expect.objectContaining({ type: 'user_content', conversation_id: 'c1', msg_id: 'team:t1:mailbox:m-user:conversation:c1' }));
   });
 
   it('teammate writes an idle_notification to the leader and wakes it after a turn', async () => {


### PR DESCRIPTION
修复 Claude Code team 会话中的三类消息 / turn 处理问题。

- **阻止 team 会话使用 Sleep 工具导致 turn 忙等**

  leader / member agent 用 Sleep 等待队友时会在 turn 内忙等，串行阻塞 EventLoop 并堆积 member 回复。通过 team prompt 约束双方在 `team_send_message` 后结束 turn 且永不 Sleep，并在 `AcpAgent` 增加代码级守卫，检测到 Sleep 工具调用时经 `cancelTeamSleepTurn` 中断 turn（避免 stop() / handleSignalEvent(finish) 破坏下一 turn 状态）。

- **消除 team 成员消息气泡重复**

  EventLoop 此前把每封 team mail 投影两次 —— 一次经 mirror（左气泡），一次经 agent.sendMessage（右气泡），且 msg_id 不同导致去重失效，UI 渲染出两个相同气泡。现由 mirror 统一负责所有气泡投影：接管 user mail（此前被跳过）、对所有发送方按 msg_id 去重、并 emit user_content 实时显示；sendMessage 新增可选 `suppressUserBubble` 标志，team turn 设置该标志以跳过重复的 addMessage / emit，同时保留 updateConversation。

- **跳过 team 会话的 fallback 完成消息**

  team 会话中跳过 fallback completion message。