### PR TITLE
fix(scode): update auto router model

### DIFF
--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -28,7 +28,7 @@ const SUDOROUTER_PROVIDER_ID = 'sudorouter';
 const OPENAI_COMPAT_API = 'openai-completions';
 const OPENAI_RESPONSES_API = 'openai-responses';
 export const SCODE_AUTO_MODEL_ALIAS = 'auto';
-export const SCODE_AUTO_ROUTER_MODEL_ID = 'claude-opus-4-8';
+export const SCODE_AUTO_ROUTER_MODEL_ID = 'gpt-5.5';
 
 export type SpecificPricingItem = {
   model_id: string;

--- a/tests/unit/scodeConfig.test.ts
+++ b/tests/unit/scodeConfig.test.ts
@@ -41,7 +41,7 @@ describe('scodeConfig', () => {
       {
         sudorouterKey: 'router-key',
         modelServiceUrl: 'https://hk.sudorouter.ai/v1',
-        models: ['gemini-3-flash-preview'],
+        models: ['gemini-3-flash-preview', SCODE_AUTO_ROUTER_MODEL_ID],
       },
       existing
     );
@@ -66,7 +66,7 @@ describe('scodeConfig', () => {
     const sudorouterModelAliases = Object.entries(next.models || {})
       .filter(([, model]) => model.providers?.proxy?.provider === 'sudorouter')
       .map(([alias]) => alias);
-    expect(sudorouterModelAliases).toEqual([SCODE_AUTO_MODEL_ALIAS, 'gemini-3-flash-preview']);
+    expect(sudorouterModelAliases).toEqual([SCODE_AUTO_MODEL_ALIAS, 'gemini-3-flash-preview', SCODE_AUTO_ROUTER_MODEL_ID]);
     expect(next.models?.['custom-openai/gpt-4o']?.providers?.['api-key']).toEqual({
       provider: 'custom-openai',
       model: 'gpt-4o',
@@ -145,7 +145,7 @@ describe('scodeConfig', () => {
     const next = buildScodeConfigFromLoginPayload({
       sudorouterKey: 'router-key',
       modelServiceUrl: 'https://hk.sudorouter.ai/v1',
-      models: ['gemini-3-flash-preview'],
+      models: ['gemini-3-flash-preview', SCODE_AUTO_ROUTER_MODEL_ID],
     });
 
     expect(next.default_model).toBe(SCODE_AUTO_MODEL_ALIAS);


### PR DESCRIPTION
## Summary
- update the scode auto router model id to gpt-5.5
- keep login payload model handling aligned with the auto router model id in unit tests

## Tests
- bunx eslint src/common/scodeConfig.ts tests/unit/scodeConfig.test.ts --fix
- bunx tsc --noEmit
- bun test tests/unit/scodeConfig.test.ts
- bun run test (fails: existing unrelated repo-wide failures; changed scodeConfig unit test passes within the run)