### PR TITLE
fix(auth): inject credentials after token refresh on restore

### DIFF
--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -877,9 +877,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         setUser({ ...authStorage.user, token: authStorage.access_token });
         setStatus('authenticated');
         setReady(true);
-        // §6.4 restart-restore path: also cache credentials so reporters/skillhub work after
-        // a restart without requiring a manual re-login (fire-and-forget, don't block restore).
-        void fetchAndCacheCredentials();
         await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
 
         const restoredUserId = resolveConsumerUserId(authStorage.user);
@@ -920,6 +917,9 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         if (authStorage.expires_at && Date.now() > authStorage.expires_at - 5 * 60 * 1000) {
           await refreshTokens();
         }
+        // §6.4 凭据注入必须在 token 刷新之后:冷启动时 access_token 可能已过期,
+        // 若在刷新前注入,/system-config/credentials 会用过期 JWT 返回 401,凭据无法注入。
+        void fetchAndCacheCredentials();
         return;
       } catch {
         localStorage.removeItem(AUTH_STORAGE_KEY);


### PR DESCRIPTION
Move fetchAndCacheCredentials() to after refreshTokens() in the localStorage restore path. Injecting before refresh uses an expired access_token, so /system-config/credentials returns 401 and credentials fail to inject on cold start.
