### PR TITLE
feat(scode): support configurable auto model

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -2721,6 +2721,7 @@ export const eeclaw = {
       sudorouter_key?: string;
       model_service_url?: string;
       models?: string[];
+      scode_auto_model?: string;
     }>,
     { serverUrl: string; body: { grant_type: string; username?: string; password?: string; api_key?: string; params?: Record<string, string> }; deviceId: string }
   >('eeclaw.login'),

--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -1,11 +1,12 @@
 import { modelInputForModelId } from './imageUtils';
 import type { ScodeConfig, ScodeModelEntry } from './ipcBridge';
-import { getSudorouterBaseUrl } from './systemConfig';
+import { FALLBACK_SCODE_AUTO_MODEL_ID, getSudorouterBaseUrl } from './systemConfig';
 
 export type LoginSudoclawPayload = {
   sudorouterKey?: string;
   modelServiceUrl?: string;
   models: string[];
+  scodeAutoModel?: string;
 };
 
 export type ScodeCustomModelProvider = {
@@ -28,7 +29,7 @@ const SUDOROUTER_PROVIDER_ID = 'sudorouter';
 const OPENAI_COMPAT_API = 'openai-completions';
 const OPENAI_RESPONSES_API = 'openai-responses';
 export const SCODE_AUTO_MODEL_ALIAS = 'auto';
-export const SCODE_AUTO_ROUTER_MODEL_ID = 'gpt-5.5';
+export const SCODE_AUTO_ROUTER_MODEL_ID = FALLBACK_SCODE_AUTO_MODEL_ID;
 
 export type SpecificPricingItem = {
   model_id: string;
@@ -41,7 +42,13 @@ export type SpecificImagePricingItem = {
   extra?: Record<string, unknown>;
 };
 
-export function resolveAutoRouterModelId(modelIds: string[], pricingItems?: SpecificPricingItem[]): string | null {
+function normalizeExplicitAutoModelId(modelId?: string): string | undefined {
+  return typeof modelId === 'string' && modelId.trim() ? modelId.trim() : undefined;
+}
+
+export function resolveAutoRouterModelId(modelIds: string[], pricingItems?: SpecificPricingItem[], explicitAutoModelId?: string): string | null {
+  const configuredAutoModelId = normalizeExplicitAutoModelId(explicitAutoModelId);
+  if (configuredAutoModelId) return configuredAutoModelId;
   if (modelIds.length === 0) return null;
   if (modelIds.length === 1) return modelIds[0];
   if (modelIds.includes(SCODE_AUTO_ROUTER_MODEL_ID)) return SCODE_AUTO_ROUTER_MODEL_ID;
@@ -112,8 +119,8 @@ function buildSudorouterModelEntry(modelId: string, alias = modelId): ScodeModel
   };
 }
 
-export function addScodeAutoModel(models: Record<string, ScodeModelEntry>, modelIds: string[], pricingItems?: SpecificPricingItem[]): string | null {
-  const id = resolveAutoRouterModelId(modelIds, pricingItems);
+export function addScodeAutoModel(models: Record<string, ScodeModelEntry>, modelIds: string[], pricingItems?: SpecificPricingItem[], explicitAutoModelId?: string): string | null {
+  const id = resolveAutoRouterModelId(modelIds, pricingItems, explicitAutoModelId);
   if (id) models[SCODE_AUTO_MODEL_ALIAS] = buildSudorouterModelEntry(id, SCODE_AUTO_MODEL_ALIAS);
   return id;
 }
@@ -246,7 +253,7 @@ export function mergeSudorouterIntoScodeConfig(existing: ScodeConfig | null | un
     }
   }
 
-  const autoModelId = addScodeAutoModel(nextModels, modelIds, pricingItems);
+  const autoModelId = addScodeAutoModel(nextModels, modelIds, pricingItems, payload.scodeAutoModel);
   for (const modelId of modelIds) {
     nextModels[normalizeModelAlias(modelId)] = buildSudorouterModelEntry(modelId);
   }

--- a/src/common/sudoworkAuthLogin.ts
+++ b/src/common/sudoworkAuthLogin.ts
@@ -10,6 +10,7 @@ type LoginResponseData = {
   models?: unknown;
   available_models?: unknown;
   model_list?: unknown;
+  scode_auto_model?: unknown;
   access_token?: unknown;
 };
 
@@ -36,12 +37,14 @@ export function mergeLoginUserData(payload: unknown): Record<string, unknown> {
   const availableModels = asStringArray(loginData.available_models);
   const fallbackModels = asStringArray(loginData.model_list);
   const models = directModels.length ? directModels : availableModels.length ? availableModels : fallbackModels;
+  const scodeAutoModel = asNonEmptyString(loginData.scode_auto_model);
 
   return {
     ...loginUser,
     ...(sudorouterKey ? { sudorouter_key: sudorouterKey } : {}),
     ...(modelServiceUrl ? { model_service_url: modelServiceUrl } : {}),
     ...(models.length ? { models } : {}),
+    ...(scodeAutoModel ? { scode_auto_model: scodeAutoModel } : {}),
   };
 }
 
@@ -50,6 +53,7 @@ export function extractLoginSudoclawPayload(payload: unknown): LoginSudoclawPayl
   const sudorouterKey = asNonEmptyString(mergedUser.sudorouter_key);
   const modelServiceUrl = asNonEmptyString(mergedUser.model_service_url);
   const models = asStringArray(mergedUser.models);
+  const scodeAutoModel = asNonEmptyString(mergedUser.scode_auto_model);
 
   if (!sudorouterKey || !modelServiceUrl || models.length === 0) {
     return null;
@@ -59,6 +63,7 @@ export function extractLoginSudoclawPayload(payload: unknown): LoginSudoclawPayl
     sudorouterKey,
     modelServiceUrl,
     models,
+    ...(scodeAutoModel ? { scodeAutoModel } : {}),
   };
 }
 

--- a/src/common/systemConfig.ts
+++ b/src/common/systemConfig.ts
@@ -36,6 +36,7 @@ declare const __COS_RELEASE_BASE__: string | undefined;
 export const FALLBACK_SUDOROUTER_BASE_URL = 'https://hk.sudorouter.ai';
 export const FALLBACK_SKILLHUB_BASE_URL = 'https://sudoworkhub.sudoprivacy.com';
 export const FALLBACK_LOG_REPORT_BASE_URL = 'https://sudolog.sudoprivacy.com';
+export const FALLBACK_SCODE_AUTO_MODEL_ID = 'gpt-5.5';
 
 /** Build-time injected value, or fallback when not injected (mirrors sudoworkServer.ts:33). */
 export const BUILD_SUDOROUTER_BASE_URL: string = (typeof __SUDOROUTER_BASE_URL__ !== 'undefined' && __SUDOROUTER_BASE_URL__) || FALLBACK_SUDOROUTER_BASE_URL;
@@ -52,6 +53,7 @@ export interface SystemConfig {
   product_improvement?: { enabled: number; encryption_required?: boolean };
   sudorouter_baseurl?: string;
   skillhub_baseurl?: string;
+  scode_auto_model?: string;
 }
 
 export interface ThirdPartyAuthProvider {
@@ -165,6 +167,11 @@ export function isSudorouterBaseUrl(url: string | null | undefined): boolean {
 
 export function getSkillHubBaseUrl(): string {
   return resolve(getSystemConfigCache()?.skillhub_baseurl, BUILD_SKILLHUB_BASE_URL);
+}
+
+export function getConfiguredScodeAutoModelId(): string | undefined {
+  const raw = getSystemConfigCache()?.scode_auto_model;
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : undefined;
 }
 
 export function getLogReportBaseUrl(): string {

--- a/src/process/bridge/eeclawBridge.ts
+++ b/src/process/bridge/eeclawBridge.ts
@@ -375,6 +375,7 @@ export function initEeclawBridge(): void {
           sudorouter_key: data.sudorouter_key,
           model_service_url: data.model_service_url,
           models: Array.isArray(data.models) ? data.models : undefined,
+          scode_auto_model: typeof data.scode_auto_model === 'string' ? data.scode_auto_model : undefined,
         },
       };
     } catch (error) {

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -20,11 +20,12 @@ import { getDatabase } from '@process/database';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { SUDOCLAW_DIR } from '@process/services/sudoclaw/SudoclawInstallService';
 import { writeSudoclawImageGenerationModel } from '@process/bridge/imageGenerationModelSync';
+import { getSudoworkServerBaseUrlSync } from '@process/initStorage';
 import { ipcBridge } from '@/common';
 import { modelInputForModelId } from '@/common/imageUtils';
 import type { ScodeModelEntry } from '@/common/ipcBridge';
 import { addScodeAutoModel, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, type ScodeCustomModelProvider, type SpecificPricingItem } from '@/common/scodeConfig';
-import { getSudorouterBaseUrl } from '@/common/systemConfig';
+import { fetchSystemConfig, getConfiguredScodeAutoModelId, getSudorouterBaseUrl } from '@/common/systemConfig';
 
 const TAG = 'ScodeBridge';
 const SUDOCODE_CONFIG_PATH = path.join(SCODE_DIR, 'sudocode.json');
@@ -126,6 +127,13 @@ export async function fetchSpecificPricingItems(): Promise<SpecificPricingItem[]
   return json.data.filter((it): it is SpecificPricingItem => typeof it?.model_id === 'string' && it.model_id.trim().length > 0);
 }
 
+async function refreshSystemConfigForScodeModelSync(): Promise<void> {
+  const data = await fetchSystemConfig(getSudoworkServerBaseUrlSync());
+  if (!data) {
+    mainWarn(TAG, 'system-config refresh failed before scode model sync, using cached auto model config');
+  }
+}
+
 /**
  * Fetch the live model list from sudorouter's specific_pricing endpoint and
  * rewrite ONLY the `models` dict of sudocode.json. Preserves auth_modes /
@@ -136,6 +144,7 @@ export async function fetchSpecificPricingItems(): Promise<SpecificPricingItem[]
  * degrades to the last-known list instead of going empty.
  */
 export async function syncScodeModelsFromPricing(): Promise<void> {
+  await refreshSystemConfigForScodeModelSync();
   const pricingItems = await fetchSpecificPricingItems();
 
   const modelIds = pricingItems.map((m) => m.model_id.trim()).filter(Boolean);
@@ -155,7 +164,7 @@ export async function syncScodeModelsFromPricing(): Promise<void> {
     }
   }
 
-  addScodeAutoModel(models, modelIds, pricingItems);
+  addScodeAutoModel(models, modelIds, pricingItems, getConfiguredScodeAutoModelId());
   for (const modelId of modelIds) {
     models[modelId] = {
       alias: modelId,

--- a/src/process/services/systemConfigBootstrap.ts
+++ b/src/process/services/systemConfigBootstrap.ts
@@ -44,6 +44,7 @@ export async function ensureMainSystemConfig(): Promise<void> {
       loginMethod: data?.login_method ?? null,
       skillhubBaseurl: data?.skillhub_baseurl ?? null,
       sudorouterBaseurl: data?.sudorouter_baseurl ?? null,
+      scodeAutoModel: data?.scode_auto_model ?? null,
       logReportBaseurl: data?.log_report?.baseurl ?? null,
       versionUpdateEnabled: data?.version_update?.enabled ?? null,
       productImprovementEnabled: data?.product_improvement?.enabled ?? null,

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -23,6 +23,7 @@ export interface AuthUser {
   sudorouter_key?: string;
   model_service_url?: string;
   models?: string[];
+  scode_auto_model?: string;
   phone?: string;
   localAuth?: boolean;
   localModeAvailable?: boolean;

--- a/tests/unit/scodeConfig.test.ts
+++ b/tests/unit/scodeConfig.test.ts
@@ -152,6 +152,30 @@ describe('scodeConfig', () => {
     expect(next.models?.[SCODE_AUTO_MODEL_ALIAS]?.providers?.proxy?.model).toBe(SCODE_AUTO_ROUTER_MODEL_ID);
   });
 
+  it('uses the server-configured auto model from the login payload', () => {
+    const next = buildScodeConfigFromLoginPayload({
+      sudorouterKey: 'router-key',
+      modelServiceUrl: 'https://hk.sudorouter.ai/v1',
+      models: ['gemini-3-flash-preview', SCODE_AUTO_ROUTER_MODEL_ID, 'gpt-5.6'],
+      scodeAutoModel: 'gpt-5.6',
+    });
+
+    expect(next.default_model).toBe(SCODE_AUTO_MODEL_ALIAS);
+    expect(next.models?.[SCODE_AUTO_MODEL_ALIAS]?.providers?.proxy?.model).toBe('gpt-5.6');
+  });
+
+  it('allows the server-configured auto model to target a model outside the advertised list', () => {
+    const next = buildScodeConfigFromLoginPayload({
+      sudorouterKey: 'router-key',
+      modelServiceUrl: 'https://hk.sudorouter.ai/v1',
+      models: ['gemini-3-flash-preview'],
+      scodeAutoModel: 'gpt-5.6',
+    });
+
+    expect(next.models?.[SCODE_AUTO_MODEL_ALIAS]?.providers?.proxy?.model).toBe('gpt-5.6');
+    expect(next.models?.['gpt-5.6']).toBeUndefined();
+  });
+
   it('resets existing user-selected sudorouter model to auto on login refresh', () => {
     const next = buildScodeConfigFromLoginPayload(
       {

--- a/tests/unit/sudoworkAuthLogin.test.ts
+++ b/tests/unit/sudoworkAuthLogin.test.ts
@@ -13,6 +13,7 @@ describe('sudoworkAuthLogin', () => {
           sudorouter_key: 'router-key',
           model_service_url: 'https://hk.sudorouter.ai/v1',
           models: ['gemini-3-flash-preview', 'claude-sonnet-4'],
+          scode_auto_model: 'gpt-5.6',
         },
       })
     ).toEqual({
@@ -21,6 +22,7 @@ describe('sudoworkAuthLogin', () => {
       sudorouter_key: 'router-key',
       model_service_url: 'https://hk.sudorouter.ai/v1',
       models: ['gemini-3-flash-preview', 'claude-sonnet-4'],
+      scode_auto_model: 'gpt-5.6',
     });
   });
 
@@ -40,6 +42,27 @@ describe('sudoworkAuthLogin', () => {
       sudorouterKey: 'user-key',
       modelServiceUrl: 'https://user.example.com/v1',
       models: ['gemini-3-flash-preview'],
+    });
+  });
+
+  it('extracts the server-configured scode auto model from login response data', () => {
+    expect(
+      extractLoginSudoclawPayload({
+        data: {
+          user: {
+            id: 'u1',
+            sudorouter_key: 'user-key',
+            model_service_url: 'https://user.example.com/v1',
+            models: ['gemini-3-flash-preview'],
+            scode_auto_model: 'gpt-5.6',
+          },
+        },
+      })
+    ).toEqual({
+      sudorouterKey: 'user-key',
+      modelServiceUrl: 'https://user.example.com/v1',
+      models: ['gemini-3-flash-preview'],
+      scodeAutoModel: 'gpt-5.6',
     });
   });
 


### PR DESCRIPTION
## Summary
- Read the server-provided Sudowork auto model setting from login and system config payloads
- Use the configured non-empty model for the Sudo Code auto alias
- Preserve the existing client fallback behavior when the setting is empty or unavailable

## Verification
- bunx eslint src/common/ipcBridge.ts src/common/scodeConfig.ts src/common/sudoworkAuthLogin.ts src/common/systemConfig.ts src/process/bridge/eeclawBridge.ts src/process/bridge/scodeBridge.ts src/process/services/systemConfigBootstrap.ts src/renderer/context/AuthContext.tsx tests/unit/scodeConfig.test.ts tests/unit/sudoworkAuthLogin.test.ts --fix
- bun run test tests/unit/scodeConfig.test.ts tests/unit/sudoworkAuthLogin.test.ts
- bunx tsc --noEmit