### PR TITLE
fix: respect tenant assistant visibility and surface update badge

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -2036,7 +2036,7 @@ export const assistantHub = {
 
   // === Hub API methods (parallel to skillHub) ===
   /** Fetch assistants list from Assistant Hub API with cursor-based pagination */
-  fetchAssistants: bridge.buildProvider<IBridgeResponse<IAssistantHubListResponse>, { cursor?: string; limit?: number; query?: string; category?: string; tenantId?: string; sourceType?: 'hub' | 'tenant' }>('assistant-hub.fetch-assistants'),
+  fetchAssistants: bridge.buildProvider<IBridgeResponse<IAssistantHubListResponse>, { cursor?: string; limit?: number; query?: string; category?: string; tenantId?: string; sourceType?: 'hub' | 'tenant'; accessToken?: string }>('assistant-hub.fetch-assistants'),
   /** Fetch assistant categories from Assistant Hub API (type=1 for assistants) */
   fetchCategories: bridge.buildProvider<IBridgeResponse<string[]>, void>('assistant-hub.fetch-categories'),
   /** Fetch assistant detail from Assistant Hub API */

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -13,7 +13,7 @@ import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { ipcBridge } from '@/common';
 import type { IAssistantHubSkill, IAssistantHubDetail, ISkillHubSkill, IAssistantHubVersionLike } from '@/common/ipcBridge';
 import { assistantManager } from '@/process/AssistantManager';
-import { getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir } from '@/process/initStorage';
+import { getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir, getSudoworkServerBaseUrlSync } from '@/process/initStorage';
 import { skillManager } from '@/process/SkillManager';
 import { getDatabase } from '@/process/database';
 import { DEFAULT_PRESET_AGENT_TYPE, normalizePresetAgentType } from '@/types/acpTypes';
@@ -60,6 +60,101 @@ async function writeAssistantMetaFile(assistantDir: string, meta: AssistantHubMe
   const fileName = isEnterprise ? MOSS_ASSISTANT_META_FILE : ASSISTANT_META_FILE;
   const filePath = path.join(assistantDir, fileName);
   await fs.writeFile(filePath, JSON.stringify(meta, null, 2), 'utf-8');
+}
+
+interface VisibleAssistantOverlay extends Record<string, unknown> {
+  assistant_id?: string;
+  id?: string;
+}
+
+interface VisibleAssistantsResponse {
+  success?: boolean;
+  data?: VisibleAssistantOverlay[];
+  msg?: string;
+}
+
+function bearerHeader(token: string): string {
+  const trimmed = token.trim();
+  return /^Bearer\s+/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string') return value;
+  }
+  return undefined;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+async function fetchVisibleAssistantOverlayMap(accessToken?: string): Promise<Map<string, VisibleAssistantOverlay> | null> {
+  if (!accessToken?.trim()) return null;
+
+  try {
+    const response = await fetch(`${getSudoworkServerBaseUrlSync()}/api/v1/agents/visible`, {
+      headers: { Authorization: bearerHeader(accessToken) },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const body = (await response.json()) as VisibleAssistantsResponse;
+    if (!body.success || !Array.isArray(body.data)) return null;
+
+    const map = new Map<string, VisibleAssistantOverlay>();
+    for (const item of body.data) {
+      const id = firstNonEmptyString(item.assistant_id, item.id);
+      if (id) map.set(id, item);
+    }
+    return map;
+  } catch (error) {
+    mainWarn('AssistantHub', 'Failed to fetch visible assistant overlays:', error);
+    return null;
+  }
+}
+
+function applyVisibleAssistantOverlay(raw: Record<string, unknown>, overlay?: VisibleAssistantOverlay): Record<string, unknown> {
+  if (!overlay) return raw;
+
+  const merged: Record<string, unknown> = { ...raw };
+  const displayName = firstNonEmptyString(overlay.display_name, overlay.profession, overlay.name);
+  if (displayName) merged.display_name = displayName;
+
+  const profession = firstString(overlay.profession, overlay.display_name, overlay.name);
+  if (profession !== undefined) merged.profession = profession;
+
+  const description = firstString(overlay.description);
+  if (description !== undefined) merged.description = description;
+
+  const avatar = firstString(overlay.avatar);
+  if (avatar !== undefined) merged.avatar = avatar;
+
+  const categories = stringArray(overlay.categories);
+  if (categories) merged.categories = categories;
+
+  const skills = stringArray(overlay.skills);
+  if (skills) merged.skills = skills;
+
+  const defaultInitPrompt = firstString(overlay.defaultInitPrompt, overlay.default_init_prompt);
+  if (defaultInitPrompt !== undefined) {
+    merged.defaultInitPrompt = defaultInitPrompt;
+    merged.default_init_prompt = defaultInitPrompt;
+  }
+
+  const updatedAt = firstString(overlay.updatedAt, overlay.updated_at);
+  if (updatedAt !== undefined) {
+    merged.updatedAt = updatedAt;
+    merged.updated_at = updatedAt;
+  }
+
+  return merged;
 }
 
 // ==================== Helper Functions ====================
@@ -351,7 +446,7 @@ export function initAssistantHubBridge(): void {
   // === Hub API operations ===
 
   // Fetch assistants list from Hub API with cursor-based pagination
-  ipcBridge.assistantHub.fetchAssistants.provider(async ({ cursor, limit = 20, query = '', category = '', tenantId, sourceType }) => {
+  ipcBridge.assistantHub.fetchAssistants.provider(async ({ cursor, limit = 20, query = '', category = '', tenantId, sourceType, accessToken }) => {
     try {
       mainLog('AssistantHub', `fetchAssistants called with tenantId: ${tenantId}, sourceType: ${sourceType}, isEnterpriseMode: ${isEnterpriseMode()}`);
 
@@ -464,8 +559,14 @@ export function initAssistantHubBridge(): void {
       // Map API response to our type structure
       // API returns: { data: { assistants: [{ id, name, profession, description, avatar, categories, sourceUrl, ... }] } }
       const rawAssistants = result.data?.assistants || [];
+      const visibleOverlayMap = typeof tenantId === 'string' && tenantId.trim() ? await fetchVisibleAssistantOverlayMap(accessToken) : null;
+      const visibleAssistants = visibleOverlayMap
+        ? rawAssistants.filter((a: Record<string, unknown>) => typeof a.id === 'string' && visibleOverlayMap.has(a.id))
+        : rawAssistants;
 
-      const mappedAssistants = rawAssistants.map((a: Record<string, unknown>): IAssistantHubSkill => {
+      const mappedAssistants = visibleAssistants.map((raw: Record<string, unknown>): IAssistantHubSkill => {
+        const overlay = typeof raw.id === 'string' ? visibleOverlayMap?.get(raw.id) : undefined;
+        const a = applyVisibleAssistantOverlay(raw, overlay);
         const versions = a.versions as IAssistantHubVersionLike[] | undefined;
         const latestVersion = (a.latestVersion as IAssistantHubVersionLike | undefined) || versions?.[0] || null;
         const version = [a.version, a.latest_version, latestVersion?.version, versions?.[0]?.version].find((value): value is string => typeof value === 'string' && value.length > 0);

--- a/src/renderer/pages/agents/components/HubAssistantCard.tsx
+++ b/src/renderer/pages/agents/components/HubAssistantCard.tsx
@@ -38,7 +38,7 @@ const HubAssistantCard: React.FC<HubAssistantCardProps> = ({ assistant, isInstal
 
       {/* Content */}
       <div className='flex-1 min-w-0'>
-        <div className='flex items-center gap-1.5 pr-25 min-w-0'>
+        <div className='flex items-center gap-1.5 pr-32 min-w-0'>
           <span className='min-w-0 font-medium text-13px text-foreground truncate'>{displayName}</span>
           {latestVersion && <span className='px-5px py-0 bg-control text-secondary text-10px rd-3px whitespace-nowrap flex-shrink-0 leading-18px'>v{latestVersion}</span>}
         </div>
@@ -59,6 +59,11 @@ const HubAssistantCard: React.FC<HubAssistantCardProps> = ({ assistant, isInstal
             {!hasUpdate && !updating && (
               <span className='store-action-badge' style={{ backgroundColor: 'rgba(var(--ui-accent-orange-rgb), 0.10)', color: 'var(--ui-accent-orange)' }}>
                 {t('settings.assistant.installed', '已安装')}
+              </span>
+            )}
+            {hasUpdate && !updating && (
+              <span className='store-action-badge' style={{ backgroundColor: 'rgba(var(--ui-accent-orange-rgb), 0.10)', color: 'var(--ui-accent-orange)' }}>
+                {t('settings.assistant.updateAvailable', '可更新')}
               </span>
             )}
             <Tooltip content={t('settings.assistant.duplicate', '复制')}>

--- a/src/renderer/pages/agents/index.tsx
+++ b/src/renderer/pages/agents/index.tsx
@@ -64,7 +64,7 @@ const AgentSettings: React.FC = () => {
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
 
   // Hub state (for store/exclusive tabs)
-  const { user } = useAuth();
+  const { user, ensureValidToken } = useAuth();
   const enterpriseCode = user?.enterprise_code?.trim();
   const navigate = useNavigate();
   const [hubAssistantList, setHubAssistantList] = useState<IAssistantHubSkill[]>([]);
@@ -355,7 +355,16 @@ const AgentSettings: React.FC = () => {
         const tenantId = isEnterprise ? undefined : currentAssistantTenantIdRef.current;
 
         if (isElectronDesktop()) {
-          const res = await assistantHub.fetchAssistants.invoke({ cursor, limit: 40, query, category, tenantId, sourceType });
+          const accessToken = !isEnterprise && tenantId ? await ensureValidToken().catch((): null => null) : null;
+          const res = await assistantHub.fetchAssistants.invoke({
+            cursor,
+            limit: 40,
+            query,
+            category,
+            tenantId,
+            sourceType,
+            accessToken: accessToken || undefined,
+          });
           if (res.success && res.data) {
             // Successful fetch — clear any prior typed error so the
             // empty-state UI falls back to the generic "暂无智能体"
@@ -407,7 +416,7 @@ const AgentSettings: React.FC = () => {
         setHubLoadingMore(false);
       }
     },
-    [fetchLatestAssistantVersions, isEnterprise, t]
+    [ensureValidToken, fetchLatestAssistantVersions, isEnterprise, t]
   );
 
   // Load more Hub assistants (infinite scroll)
@@ -1250,6 +1259,14 @@ const AgentSettings: React.FC = () => {
     [getAssistantLookupKeys, hubInstalledAssistants]
   );
 
+  const getResolvedAssistantLatestVersion = useCallback(
+    (assistant: IAssistantHubSkill | null | undefined): AssistantLatestVersion | undefined => {
+      if (isEnterprise || !assistant) return undefined;
+      return latestAssistantVersions.get(assistant.id) || resolveAssistantVersionLike(assistant, assistant.latestVersion) || undefined;
+    },
+    [isEnterprise, latestAssistantVersions]
+  );
+
   const installedAssistantToHubAssistant = useCallback(
     (assistant: AssistantListItem): IAssistantHubSkill => ({
       ...(assistant._hubMeta || {}),
@@ -1503,7 +1520,8 @@ const AgentSettings: React.FC = () => {
     <div className='grid gap-4' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
       {list.map((assistant) => {
         const hubId = !isEnterprise ? assistant._hubId : undefined;
-        const latestVersion = hubId ? latestAssistantVersions.get(hubId) : undefined;
+        const hubAssistantForUpdate = !isEnterprise && assistant._isHubInstalled && hubId ? installedAssistantToHubAssistant(assistant) : undefined;
+        const latestVersion = hubAssistantForUpdate ? getResolvedAssistantLatestVersion(hubAssistantForUpdate) : undefined;
         const installedVersion = !isEnterprise ? normalizeAssistantVersion(assistant._installedVersion) : '';
         const hasUpdate = Boolean(!isEnterprise && assistant._isHubInstalled && hubId && latestVersion && (!installedVersion || latestVersion.version !== installedVersion));
 
@@ -1710,7 +1728,7 @@ const AgentSettings: React.FC = () => {
                     const isInstalled = isEnterprise ? hubInstalledAssistants.has(assistant.name) : isHubAssistantInstalled(assistant);
                     const isInstalling = installingAssistantId === assistant.id;
                     const isUpdating = !isEnterprise && updatingAssistantId === assistant.id;
-                    const latestVersion = !isEnterprise ? latestAssistantVersions.get(assistant.id) : undefined;
+                    const latestVersion = getResolvedAssistantLatestVersion(assistant);
                     const installedVersion = !isEnterprise ? getHubAssistantInstalledVersion(assistant) : '';
                     const hasUpdate = !isEnterprise && isInstalled && !!latestVersion && (!installedVersion || latestVersion.version !== installedVersion);
                     return (
@@ -1900,7 +1918,7 @@ const AgentSettings: React.FC = () => {
               void handleInstallHubAssistant(hubDetailAssistant.id, selectedSkillIds);
             }
           }}
-          latestVersionInfo={!isEnterprise && hubDetailAssistant ? latestAssistantVersions.get(hubDetailAssistant.id) : undefined}
+          latestVersionInfo={!isEnterprise && hubDetailAssistant ? getResolvedAssistantLatestVersion(hubDetailAssistant) : undefined}
           installedVersion={!isEnterprise && hubDetailAssistant ? getHubAssistantInstalledVersion(hubDetailAssistant) : undefined}
           onUpdate={
             !isEnterprise


### PR DESCRIPTION
## Summary
- Filter tenant-scoped Assistant Hub list by the visible-agents endpoint and overlay tenant-specific metadata (display name, description, avatar, categories, skills, prompt) onto each entry.
- Pass the current access token from the renderer via a new `accessToken` param on `assistantHub.fetchAssistants` so the main-process bridge can authenticate the visibility request.
- Resolve the latest hub version from installed assistants' hub metadata so the "update available" badge and detail-drawer update action appear correctly.
- Show the new "可更新 / updateAvailable" badge in `HubAssistantCard` and reserve extra right padding so long names truncate cleanly.

## Test plan
- [ ] In a non-enterprise tenant, open the Assistant Hub tab and confirm only assistants marked visible for the tenant show up, with tenant-specific display name / description / avatar applied.
- [ ] Install a hub assistant, then bump its version on the hub; confirm the card and detail drawer show the "可更新" badge and offer the update action.
- [ ] Enterprise mode still lists assistants unchanged (no visibility filter, no overlay).