### PR TITLE
feat(guest): allow using sudowork without login

### DIFF
--- a/src/process/services/scode/scodeProxyModels.ts
+++ b/src/process/services/scode/scodeProxyModels.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import fs from 'fs';
 import { getDefaultAcpModelId } from '@/common/acp/defaultModels';
 import { isVisionModel } from '@/common/imageUtils';
 import type { AcpModelInfo } from '@/types/acpTypes';
-import fs from 'fs';
 import { SCODE_CONFIG_PATH } from './scodePaths';
 
 const SUDOCODE_CONFIG_PATH = SCODE_CONFIG_PATH;
@@ -113,8 +113,11 @@ export function getScodeProxyModelInfoSync(currentModelId?: string | null, confi
   const explicitModelId = typeof currentModelId === 'string' && currentModelId.trim() ? currentModelId.trim() : null;
   // Prefer default_model from sudocode.json (persisted user choice), fallback to hardcoded default
   const defaultModelId = readScodeDefaultModelFromConfig(configPath) ?? getDefaultAcpModelId('scode');
+  const explicitInList = explicitModelId ? availableModels.some((model) => model.id === explicitModelId) : false;
   const defaultInList = defaultModelId ? availableModels.some((model) => model.id === defaultModelId) : false;
-  const effectiveCurrentModelId = explicitModelId || (defaultInList ? defaultModelId : availableModels[0].id);
+  // Only honor explicitModelId when it is actually in the available list; otherwise it is a stale/ghost id
+  // (e.g. a deleted model still referenced by a conversation) and we fall back to default / first available.
+  const effectiveCurrentModelId = (explicitInList ? explicitModelId : null) || (defaultInList ? defaultModelId : availableModels[0].id);
   const effectiveCurrentModelLabel = availableModels.find((model) => model.id === effectiveCurrentModelId)?.label || effectiveCurrentModelId;
 
   return {
@@ -201,7 +204,10 @@ export function mergeScodeProxyModelInfo(modelInfo: AcpModelInfo | null, current
     return modelInfo;
   }
 
-  const effectiveCurrentModelId = modelInfo?.currentModelId || proxyModelInfo.currentModelId;
+  // candidate = live modelInfo value (if any) else the proxy-resolved value; reject stale/ghost ids not in the list
+  const candidateCurrentModelId = modelInfo?.currentModelId || proxyModelInfo.currentModelId;
+  const candidateInList = candidateCurrentModelId ? proxyModelInfo.availableModels.some((model) => model.id === candidateCurrentModelId) : false;
+  const effectiveCurrentModelId = candidateInList ? candidateCurrentModelId : proxyModelInfo.currentModelId;
   const effectiveCurrentModelLabel = proxyModelInfo.availableModels.find((model) => model.id === effectiveCurrentModelId)?.label || modelInfo?.currentModelLabel || effectiveCurrentModelId;
 
   return {

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -95,6 +95,7 @@ import { detectChannelQueryIntent, executeChannelInfoCommand, type ChannelQueryC
 import { extractTextFromMessage, processCronInMessage } from './MessageMiddleware';
 import { processAtFileReferences } from './acp/AcpAtFileProcessor';
 import { StreamTextBuffer, CronTextAccumulator, preprocessContentMessage } from './acp/AcpMessagePipeline';
+import { StreamingThinkFilter } from './acp/StreamingThinkFilter';
 import { clearAcpSessionId, saveAcpSessionId, saveSessionMode, saveModelId, saveContextUsage } from './acp/AcpPersistence';
 import { extractLatestScodeAssistantUsageFromJsonl, findScodeSessionFile, normalizePromptUsageForMessage, SCODE_LATE_RECONCILIATION_DEFAULTS } from './acpUsageReconciliation';
 
@@ -230,6 +231,8 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
 
   // Message pipeline
   private readonly streamTextBuffer = new StreamTextBuffer();
+  // Per-msg_id streaming think-tag filters (see getOrCreateThinkFilter / flushThinkFilters).
+  private readonly thinkFilters = new Map<string, StreamingThinkFilter>();
   private readonly cronAccumulator = new CronTextAccumulator();
 
   // Workspace file tracking for channel file_send messages
@@ -1140,6 +1143,7 @@ This identity statement takes priority over the default identity in USER.md.
       }
       return result;
     } catch (e) {
+      this.flushThinkFilters();
       this.streamTextBuffer.flushAll();
       cronBusyGuard.setProcessing(this.conversation_id, false);
       this.status = 'finished';
@@ -1510,6 +1514,7 @@ This identity statement takes priority over the default identity in USER.md.
 
   private patchAssistantTokenUsage(msgId: string, tokenUsage: TurnTokenUsage, options: { flush?: boolean } = {}): void {
     if (options.flush) {
+      this.flushThinkFilters();
       this.streamTextBuffer.flushAll();
     }
 
@@ -1667,6 +1672,7 @@ This identity statement takes priority over the default identity in USER.md.
     this.userCancelled = true;
 
     // 1. Flush buffered streaming text
+    this.flushThinkFilters();
     this.streamTextBuffer.flushAll();
 
     // 2. Respond to pending permission requests with Cancelled
@@ -2248,6 +2254,7 @@ This identity statement takes priority over the default identity in USER.md.
   }
 
   kill(): Promise<void> {
+    this.flushThinkFilters();
     this.streamTextBuffer.flushAll();
     this.toolCallMeta.clear();
     this.workspaceFileSnapshot.clear();
@@ -3387,7 +3394,14 @@ This identity statement takes priority over the default identity in USER.md.
       saveContextUsage(this.conversation_id, usageData);
     }
 
-    const filteredMessage = preprocessContentMessage(message as IResponseMessage);
+    let filteredMessage = preprocessContentMessage(message as IResponseMessage);
+
+    // Streaming think-tag filter (per-msg_id state machine). Applied on the common upstream
+    // of queue() (DB) and responseStream.emit() (IPC display) so both paths stay clean.
+    if (filteredMessage.type === 'content' && typeof filteredMessage.data === 'string' && filteredMessage.msg_id) {
+      const filter = this.getOrCreateThinkFilter(filteredMessage.msg_id);
+      filteredMessage = { ...filteredMessage, data: filter.feed(filteredMessage.data) };
+    }
 
     if (message.type === 'content' && filteredMessage.type === 'content' && filteredMessage.data === '') {
       return;
@@ -3406,6 +3420,7 @@ This identity statement takes priority over the default identity in USER.md.
         if (isStreamTextChunk) {
           this.streamTextBuffer.queue(tMessage, this.options.backend);
         } else {
+          this.flushThinkFilters();
           this.streamTextBuffer.flushAll();
           addOrUpdateMessage(message.conversation_id, tMessage);
         }
@@ -3430,6 +3445,42 @@ This identity statement takes priority over the default identity in USER.md.
     }
   }
 
+  /**
+   * Flush all streaming think filters: release any pending tail as ordinary
+   * content (so a trailing char like '<' is not lost) via the same emit + queue
+   * path as a normal chunk, then clear all filters. MUST be called before
+   * streamTextBuffer.flushAll() so the queued tail is flushed to DB immediately
+   * rather than relying on the 120ms timer.
+   */
+  private flushThinkFilters(): void {
+    for (const [msgId, filter] of this.thinkFilters) {
+      const tail = filter.flush();
+      if (!tail) continue;
+      const flushedMessage = {
+        type: 'content',
+        msg_id: msgId,
+        conversation_id: this.conversation_id,
+        data: tail,
+      } as IResponseMessage;
+      const tMessage = transformMessage(flushedMessage);
+      if (tMessage && tMessage.type === 'text') {
+        this.streamTextBuffer.queue(tMessage, this.options.backend);
+      }
+      ipcBridge.acpConversation.responseStream.emit(flushedMessage);
+      channelEventBus.emitAgentMessage(this.conversation_id, { ...flushedMessage, conversation_id: this.conversation_id });
+    }
+    this.thinkFilters.clear();
+  }
+
+  private getOrCreateThinkFilter(msgId: string): StreamingThinkFilter {
+    let filter = this.thinkFilters.get(msgId);
+    if (!filter) {
+      filter = new StreamingThinkFilter();
+      this.thinkFilters.set(msgId, filter);
+    }
+    return filter;
+  }
+
   private async handleSignalEvent(v: IResponseMessage): Promise<void> {
     // Ignore messages if user has cancelled
     if (this.userCancelled && v.type !== 'finish') {
@@ -3437,6 +3488,7 @@ This identity statement takes priority over the default identity in USER.md.
       return;
     }
 
+    this.flushThinkFilters();
     this.streamTextBuffer.flushAll();
 
     if (v.type === 'acp_permission') {

--- a/src/process/task/acp/AcpMessagePipeline.ts
+++ b/src/process/task/acp/AcpMessagePipeline.ts
@@ -147,7 +147,8 @@ export function isRawToolCallText(content: string): boolean {
 }
 
 /**
- * Apply all content message preprocessing: think tag filtering + Windows path normalization.
+ * Apply content message preprocessing: Windows image path normalization.
+ * (Think-tag filtering is handled by StreamingThinkFilter at the AcpAgent stream level.)
  * This is the main entry point for message preprocessing before emission to the frontend.
  */
 export function preprocessContentMessage(message: IResponseMessage): IResponseMessage {
@@ -161,12 +162,8 @@ export function preprocessContentMessage(message: IResponseMessage): IResponseMe
     return { ...message, data: '' };
   }
 
-  // 1. Filter think tags
-  if (/<\s*\/?\s*think(?:ing)?\s*>/i.test(data)) {
-    data = stripThinkTags(data);
-  }
-
-  // 2. Normalize Windows image paths
+  // Normalize Windows image paths. Think-tag filtering is handled by StreamingThinkFilter
+  // at the AcpAgent stream level (so tags can reach the renderer as a fallback).
   data = normalizeWindowsImagePaths(data);
 
   if (data === message.data) {

--- a/src/process/task/acp/StreamingThinkFilter.ts
+++ b/src/process/task/acp/StreamingThinkFilter.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Streaming think-tag filter state machine.
+ *
+ * Filters `<think>...</think>` / `<thinking>...</thinking>` blocks out of a
+ * stream of text chunks where the tags may be split across chunk boundaries.
+ *
+ * Design constraints (must not affect models that never emit think tags, e.g.
+ * sudorouter):
+ * - In normal state, ONLY an opening `<think>`/`<thinking>` triggers content
+ *   consumption. A stray closing tag (e.g. MiniMax M2.5 emits only `</think>`
+ *   with no opening) is passed through verbatim, so the renderer's whole-text
+ *   fallback regex (thinkTagFilter.ts Step 3) can still clean it up.
+ * - Matching is strict (no `\s*` tolerance): MiniMax-M3 emits `<think>` with no
+ *   spaces, so this is sufficient and avoids swallowing literal `< think>` text
+ *   in normal prose / code.
+ * - Any exception resets the machine to a known normal state and returns the
+ *   original chunk unchanged — a filter anomaly must never break the stream.
+ */
+
+const OPEN_TAGS = ['<think>', '<thinking>'];
+const CLOSE_TAGS = ['</think>', '</thinking>'];
+const MAX_PENDING = 10; // len('</thinking') === 10
+
+function findEarliestTag(buffer: string, tags: string[]): { idx: number; tag: string } | null {
+  let best: { idx: number; tag: string } | null = null;
+  for (const tag of tags) {
+    const idx = buffer.indexOf(tag);
+    if (idx >= 0 && (best === null || idx < best.idx)) {
+      best = { idx, tag };
+    }
+  }
+  return best;
+}
+
+/**
+ * Length of the longest suffix of `buffer` that is a STRICT prefix of one of
+ * `tags` (shorter than the full tag). The tail is held until the next chunk
+ * resolves whether it is a real (possibly split) tag or ordinary text.
+ */
+function trailingPrefixLen(buffer: string, tags: string[]): number {
+  let maxLen = 0;
+  for (const tag of tags) {
+    const limit = Math.min(buffer.length, tag.length - 1, MAX_PENDING);
+    for (let len = limit; len > maxLen; len--) {
+      if (buffer.endsWith(tag.slice(0, len))) {
+        maxLen = len;
+        break;
+      }
+    }
+  }
+  return maxLen;
+}
+
+export class StreamingThinkFilter {
+  private isInThink = false;
+  private pendingTail = '';
+
+  /** Feed one chunk; returns the non-think text that should be displayed now (may be ''). */
+  feed(chunk: string): string {
+    try {
+      let buffer = this.pendingTail + chunk;
+      this.pendingTail = '';
+      let output = '';
+      let guard = 0;
+      while (buffer.length > 0 && guard++ < 1000) {
+        if (this.isInThink) {
+          const found = findEarliestTag(buffer, CLOSE_TAGS);
+          if (found) {
+            buffer = buffer.slice(found.idx + found.tag.length);
+            this.isInThink = false;
+          } else {
+            const prefixLen = trailingPrefixLen(buffer, CLOSE_TAGS);
+            this.pendingTail = buffer.slice(buffer.length - prefixLen);
+            buffer = '';
+          }
+        } else {
+          const found = findEarliestTag(buffer, OPEN_TAGS);
+          if (found) {
+            output += buffer.slice(0, found.idx);
+            buffer = buffer.slice(found.idx + found.tag.length);
+            this.isInThink = true;
+          } else {
+            const prefixLen = trailingPrefixLen(buffer, OPEN_TAGS);
+            output += buffer.slice(0, buffer.length - prefixLen);
+            this.pendingTail = buffer.slice(buffer.length - prefixLen);
+            buffer = '';
+          }
+        }
+      }
+      return output;
+    } catch {
+      // Defensive: never let a filter anomaly break the stream. Reset to a
+      // known normal state and pass the original chunk through verbatim.
+      this.isInThink = false;
+      this.pendingTail = '';
+      return chunk;
+    }
+  }
+
+  /**
+   * Flush at stream end. Returns any pending tail that should be displayed:
+   * - normal state: the tail is ordinary text (e.g. a trailing `<`), return it.
+   * - think state (unclosed `<think>`): the tail is inside think, drop it and reset.
+   */
+  flush(): string {
+    try {
+      const tail = this.pendingTail;
+      this.pendingTail = '';
+      if (this.isInThink) {
+        this.isInThink = false;
+        return '';
+      }
+      return tail;
+    } catch {
+      this.isInThink = false;
+      this.pendingTail = '';
+      return '';
+    }
+  }
+}

--- a/src/renderer/components/AcpModelSelector.tsx
+++ b/src/renderer/components/AcpModelSelector.tsx
@@ -10,6 +10,7 @@ import type { IResponseMessage } from '@/common/ipcBridge';
 import { ConfigStorage } from '@/common/storage';
 import type { IProvider } from '@/common/storage';
 import type { AcpModelInfo } from '@/types/acpTypes';
+import { useAuth } from '@/renderer/context/AuthContext';
 import { usePreviewContext } from '@/renderer/pages/conversation/preview';
 import { getModelDisplayLabel } from '@/renderer/utils/agentUiDisplay';
 import { buildProviderModelGroups } from '@/renderer/utils/modelProviderGroups';
@@ -48,6 +49,7 @@ const AcpModelSelector: React.FC<{
 }> = ({ conversationId, backend, initialModelId, isCompact = false }) => {
   const { t } = useTranslation();
   const { isOpen: isPreviewOpen } = usePreviewContext();
+  const { isGuest } = useAuth();
   const fallbackModelId = resolvePreferredAcpModelId({
     backend,
     explicitModelId: initialModelId,
@@ -89,6 +91,10 @@ const AcpModelSelector: React.FC<{
     };
 
     async function fetchScodeLiveModelInfo() {
+      if (isGuest) {
+        runStandardModelInfoFetch();
+        return;
+      }
       try {
         const result = await ipcBridge.scode.refreshModels.invoke();
         if (cancelled) return;
@@ -235,7 +241,7 @@ const AcpModelSelector: React.FC<{
         }
       }
     }
-  }, [conversationId, backend, fallbackModelId, initialModelId]);
+  }, [conversationId, backend, fallbackModelId, initialModelId, isGuest]);
 
   // Track pending model switch for showing success message
   const pendingModelSwitchRef = useRef<string | null>(null);
@@ -447,7 +453,7 @@ const AcpModelSelector: React.FC<{
             <div key={group.key} className='flex flex-col gap-0.5'>
               <div className='flex items-center justify-between gap-2 pl-2.5 pr-0.5 pt-1 pb-0.5 min-h-6'>
                 <span className='text-12px leading-18px text-secondary truncate'>{group.name || t('common.other', { defaultValue: 'Other' })}</span>
-                {backend === 'scode' && groupIndex === 0 && (
+                {backend === 'scode' && !isGuest && groupIndex === 0 && (
                   <span onClick={(e) => e.stopPropagation()}>
                     <Tooltip content={t('common.refresh')} position='top'>
                       <Button size='mini' shape='circle' type='text' icon={<IconRefresh spin={refreshingModels} />} loading={refreshingModels} onClick={handleRefreshModels} />

--- a/src/renderer/components/HubEmptyState.tsx
+++ b/src/renderer/components/HubEmptyState.tsx
@@ -32,17 +32,35 @@ import { IconExclamationCircle, IconLock, IconRefresh } from '@arco-design/web-r
 import type { HubError } from '@common/nexus/hubErrors';
 
 interface IHubEmptyStateProps {
-  /** Typed error from the most recent hub fetch. When null, render
+  /** Typed error from the most recent hub fetch. When null (and no onLogin), render
    *  nothing (the caller decides what "actually empty" looks like). */
-  error: HubError | null;
+  error?: HubError | null;
   /** Invoked when the user clicks the retry button. Only shown for
    *  retriable error classes (i.e. FETCH_FAILED). */
   onRetry?: () => void;
+  /** 游客态登录引导回调。传入时优先渲染「登录后查看 + 去登录」，忽略 error。 */
+  onLogin?: () => void;
 }
 
-export default function HubEmptyState({ error, onRetry }: IHubEmptyStateProps) {
+export default function HubEmptyState({ error, onRetry, onLogin }: IHubEmptyStateProps) {
   const { t } = useTranslation();
 
+  if (!error && !onLogin) return null;
+
+  // 游客态登录引导：传入 onLogin 时优先渲染（须在下方 error.code 访问之前 early-return，避免 error=null 时崩溃）
+  if (onLogin) {
+    return (
+      <div className='flex flex-col items-center justify-center py-8 text-center' data-testid='hub-empty-state-login'>
+        <IconLock className='text-32px text-secondary mb-3' />
+        <div className='text-13px text-secondary mb-3'>{t('settings.hubEmpty.loginToView', { defaultValue: '登录后查看完整列表' })}</div>
+        <Button size='mini' onClick={onLogin}>
+          {t('settings.hubEmpty.login', { defaultValue: '去登录' })}
+        </Button>
+      </div>
+    );
+  }
+
+  // 到此处 onLogin 必假；结合上方守卫 error 必真，收窄类型供下方 error.code/message/retriable 安全访问
   if (!error) return null;
 
   const isTokenMissing = error.code === 'TOKEN_MISSING';

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -11,7 +11,7 @@ import { fetchSystemConfig } from '@/common/systemConfig';
 import { buildCasLogoutServiceUrl, buildCasLogoutUrl, resolveThirdPartyAuthConfig } from '@/common/thirdPartyAuthConfig';
 import type { AcpModelInfo } from '@/types/acpTypes';
 
-type AuthStatus = 'checking' | 'syncing' | 'authenticated' | 'unauthenticated';
+type AuthStatus = 'checking' | 'syncing' | 'authenticated' | 'unauthenticated' | 'guest';
 
 export interface AuthUser {
   id: string;
@@ -198,6 +198,7 @@ interface AuthContextValue {
   ready: boolean;
   user: AuthUser | null;
   status: AuthStatus;
+  isGuest: boolean;
   syncMessage: string | null;
   login: (params: LoginParams) => Promise<LoginResult>;
   register: (params: RegisterParams) => Promise<RegisterResult>;
@@ -212,6 +213,7 @@ interface AuthContextValue {
   loginWithThirdPartyAuth: (params: ThirdPartyAuthLoginParams) => Promise<PasswordAuthResult>;
   exchangeThirdPartyAuthCode: (params: ThirdPartyAuthExchangeParams) => Promise<PasswordAuthResult>;
   changePassword: (params: ChangePasswordParams) => Promise<PasswordAuthResult>;
+  enterGuest: () => void;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -219,6 +221,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 const AUTH_USER_ENDPOINT = '/api/auth/user';
 const AUTH_STORAGE_KEY = 'sudowork_auth_v2';
 export const EECLAW_AUTH_STORAGE_KEY = 'eeclaw_auth_v1';
+export const GUEST_FLAG_KEY = 'sudowork_guest';
 const DEVICE_ID_KEY = 'sudowork_device_id';
 
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
@@ -566,6 +569,7 @@ async function handleLoginSuccess(data: LoginSuccessResponse, setUser: SetAuthUs
   setUser(authData);
   setStatus('authenticated');
   setReady(true);
+  localStorage.removeItem(GUEST_FLAG_KEY);
 
   if (isDesktopRuntime) {
     // §6.4 active-login path: cache server-driven credentials BEFORE restarting the gateway
@@ -606,6 +610,12 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   // Cooldown to prevent rapid repeated refresh
   const lastRefreshAtRef = useRef<number>(0);
   const REFRESH_COOLDOWN_MS = 30_000;
+
+  // 进入游客态（未登录使用）：写标志 + setStatus('guest')，调用方负责 navigate('/guid')
+  const enterGuest = useCallback(() => {
+    localStorage.setItem(GUEST_FLAG_KEY, '1');
+    setStatus('guest');
+  }, []);
 
   // Token 刷新函数 — supports both C-side and enterprise mode
   const refreshTokens = useCallback(async (): Promise<boolean> => {
@@ -979,6 +989,14 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       } catch {
         localStorage.removeItem('sudowork_auth_v1');
       }
+    }
+
+    // 游客态恢复（桌面端、无任何登录态、有 guest 标志）—— 须在 unauthenticated 之前，保证有登录态时优先登录态
+    if (isDesktopRuntime && localStorage.getItem(GUEST_FLAG_KEY)) {
+      setStatus('guest');
+      setUser(null);
+      setReady(true);
+      return;
     }
 
     if (isDesktopRuntime) {
@@ -1572,6 +1590,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       ready,
       user,
       status,
+      isGuest: status === 'guest',
       syncMessage,
       login,
       register,
@@ -1586,8 +1605,9 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       loginWithThirdPartyAuth,
       exchangeThirdPartyAuthCode,
       changePassword,
+      enterGuest,
     }),
-    [login, register, logout, ready, refresh, status, syncMessage, user, ensureValidToken, forceRefreshToken, enterpriseLogin, enterpriseLoginWithOAuth2, loginByPassword, registerByPassword, loginWithThirdPartyAuth, exchangeThirdPartyAuthCode, changePassword]
+    [login, register, logout, ready, refresh, status, syncMessage, user, ensureValidToken, forceRefreshToken, enterpriseLogin, enterpriseLoginWithOAuth2, loginByPassword, registerByPassword, loginWithThirdPartyAuth, exchangeThirdPartyAuthCode, changePassword, enterGuest]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/renderer/context/AuthContext.tsx
+++ b/src/renderer/context/AuthContext.tsx
@@ -213,7 +213,7 @@ interface AuthContextValue {
   loginWithThirdPartyAuth: (params: ThirdPartyAuthLoginParams) => Promise<PasswordAuthResult>;
   exchangeThirdPartyAuthCode: (params: ThirdPartyAuthExchangeParams) => Promise<PasswordAuthResult>;
   changePassword: (params: ChangePasswordParams) => Promise<PasswordAuthResult>;
-  enterGuest: () => void;
+  enterGuest: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -222,7 +222,19 @@ const AUTH_USER_ENDPOINT = '/api/auth/user';
 const AUTH_STORAGE_KEY = 'sudowork_auth_v2';
 export const EECLAW_AUTH_STORAGE_KEY = 'eeclaw_auth_v1';
 export const GUEST_FLAG_KEY = 'sudowork_guest';
+// Virtual SQLite user_id for guest custom model providers (scode_custom_model_providers.user_id has no FK constraint)
+export const GUEST_USER_ID = 'sudowork_guest';
 const DEVICE_ID_KEY = 'sudowork_device_id';
+
+// Restore guest custom models from SQLite into sudocode.json with an empty base,
+// which drops sudorouter and other non-custom entries (clears residue).
+async function restoreGuestScodeModels(): Promise<void> {
+  try {
+    await ipcBridge.scode.restoreCustomModelProviders.invoke({ userId: GUEST_USER_ID, baseConfig: {} });
+  } catch (err) {
+    console.warn('[Auth] Guest scode restore failed:', err);
+  }
+}
 
 const isDesktopRuntime = typeof window !== 'undefined' && Boolean(window.electronAPI);
 
@@ -611,8 +623,10 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const lastRefreshAtRef = useRef<number>(0);
   const REFRESH_COOLDOWN_MS = 30_000;
 
-  // 进入游客态（未登录使用）：写标志 + setStatus('guest')，调用方负责 navigate('/guid')
-  const enterGuest = useCallback(() => {
+  // Enter guest mode (unauthenticated use): restore guest custom models, set flag + status.
+  // Caller is responsible for navigate('/guid').
+  const enterGuest = useCallback(async () => {
+    await restoreGuestScodeModels();
     localStorage.setItem(GUEST_FLAG_KEY, '1');
     setStatus('guest');
   }, []);
@@ -993,6 +1007,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
     // 游客态恢复（桌面端、无任何登录态、有 guest 标志）—— 须在 unauthenticated 之前，保证有登录态时优先登录态
     if (isDesktopRuntime && localStorage.getItem(GUEST_FLAG_KEY)) {
+      await restoreGuestScodeModels();
       setStatus('guest');
       setUser(null);
       setReady(true);

--- a/src/renderer/hooks/useAvailableModels.ts
+++ b/src/renderer/hooks/useAvailableModels.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { ipcBridge } from '@/common';
+import { uuid } from '@/common/utils';
+import type { IProvider } from '@/common/storage';
+import { useGeminiGoogleAuthModels } from '@/renderer/hooks/useGeminiGoogleAuthModels';
+import { hasAvailableModels } from '@/renderer/pages/guid/utils/modelUtils';
+
+/**
+ * 只读的「可用模型」判定单一来源。计算逻辑对齐 useGuidModelSelection 的 modelList
+ * （含 Google Auth 合成的 gemini-with-google-auth provider），但**不挂 setCurrentModel
+ * 副作用**，可安全用于非 guid 页（如 team/detail 经 useHasAvailableModel 间接调用）。
+ *
+ * ready = modelConfig 与 google.auth.status 双解析完成；用于发送前校验时避免在 SWR
+ * pending 期间误拦「仅配 Google Auth」的游客。
+ */
+export function useAvailableModels(): { modelList: IProvider[]; ready: boolean } {
+  const { geminiModeOptions, isGoogleAuth, isGoogleAuthResolved } = useGeminiGoogleAuthModels();
+  const geminiModelValues = useMemo(() => geminiModeOptions.map((option) => option.value), [geminiModeOptions]);
+
+  const { data: modelConfig, error } = useSWR('model.config.welcome', () => {
+    return ipcBridge.mode.getModelConfig.invoke().then((data) => (data || []).filter((platform) => !!platform.model.length));
+  });
+
+  const modelList = useMemo(() => {
+    let allProviders: IProvider[] = [];
+
+    if (isGoogleAuth) {
+      const geminiProvider: IProvider = {
+        id: uuid(),
+        name: 'Gemini Google Auth',
+        platform: 'gemini-with-google-auth',
+        baseUrl: '',
+        apiKey: '',
+        model: geminiModelValues,
+        capabilities: [{ type: 'text' }, { type: 'vision' }, { type: 'function_calling' }],
+      };
+      allProviders = [geminiProvider, ...(modelConfig || [])];
+    } else {
+      allProviders = modelConfig || [];
+    }
+
+    return allProviders.filter(hasAvailableModels);
+  }, [geminiModelValues, isGoogleAuth, modelConfig]);
+
+  const ready = !error && modelConfig !== undefined && isGoogleAuthResolved;
+  return { modelList, ready };
+}

--- a/src/renderer/hooks/useGeminiGoogleAuthModels.ts
+++ b/src/renderer/hooks/useGeminiGoogleAuthModels.ts
@@ -8,6 +8,8 @@ import { getGeminiModeList, type GeminiModeOption } from './useModeModeList';
 export interface GeminiGoogleAuthModelResult {
   geminiModeOptions: GeminiModeOption[];
   isGoogleAuth: boolean;
+  /** google.auth.status SWR 是否已解析（raw data !== undefined）。现有 isGoogleAuth 被 Boolean() 抹平无法反映 pending。 */
+  isGoogleAuthResolved: boolean;
   subscriptionStatus?: {
     isSubscriber: boolean;
     tier?: string;
@@ -49,6 +51,7 @@ export const useGeminiGoogleAuthModels = (): GeminiGoogleAuthModelResult => {
   return {
     geminiModeOptions,
     isGoogleAuth: Boolean(isGoogleAuth),
+    isGoogleAuthResolved: isGoogleAuth !== undefined,
     subscriptionStatus: subscriptionResponse?.data,
   };
 };

--- a/src/renderer/hooks/useHasAvailableModel.ts
+++ b/src/renderer/hooks/useHasAvailableModel.ts
@@ -1,0 +1,11 @@
+import { useAvailableModels } from '@/renderer/hooks/useAvailableModels';
+
+/**
+ * 是否存在可用模型（仅游客发送前校验用）。复用 useAvailableModels 的单一判定来源
+ * （含 Google Auth）。ready 为 false 时（SWR 加载中/失败）一律视为「未确认」→ 由调用方放行，
+ * 绝不误拦有模型的已登录用户。
+ */
+export function useHasAvailableModel(): { hasModel: boolean; ready: boolean } {
+  const { modelList, ready } = useAvailableModels();
+  return { hasModel: modelList.length > 0, ready };
+}

--- a/src/renderer/i18n/locales/en-US/guid.json
+++ b/src/renderer/i18n/locales/en-US/guid.json
@@ -64,6 +64,7 @@
   "agentTabAutoSwitch": "Model not compatible with Gemini, auto-switched to {{fallback}}",
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
+  "modelNotConfigured": "No available model configured. Please add a model in Settings.",
   "scanning": {
     "initialMessage": "Current Agent is unavailable, detecting other available agents...",
     "scanningMessage": "Scanning local available agents...",

--- a/src/renderer/i18n/locales/en-US/login.json
+++ b/src/renderer/i18n/locales/en-US/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "Authentication callback is missing ticket",
   "thirdPartyFailed": "Third-party sign-in failed",
   "backToModeSelect": "← Back to mode selection",
-  "skip": "Skip →"
+  "skip": "Skip for now →"
 }

--- a/src/renderer/i18n/locales/en-US/login.json
+++ b/src/renderer/i18n/locales/en-US/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "Authentication callback is missing ticket",
   "thirdPartyFailed": "Third-party sign-in failed",
   "backToModeSelect": "← Back to mode selection",
-  "skip": "Skip"
+  "skip": "Skip →"
 }

--- a/src/renderer/i18n/locales/en-US/login.json
+++ b/src/renderer/i18n/locales/en-US/login.json
@@ -64,5 +64,6 @@
   "thirdPartyStateInvalid": "Authentication callback verification failed, please try again",
   "thirdPartyMissingTicket": "Authentication callback is missing ticket",
   "thirdPartyFailed": "Third-party sign-in failed",
-  "backToModeSelect": "← Back to mode selection"
+  "backToModeSelect": "← Back to mode selection",
+  "skip": "Skip"
 }

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -1178,6 +1178,8 @@
   "hubEmpty.tokenMissing": "Skill Hub not configured — check your sudowork-server login",
   "hubEmpty.fetchFailed": "Fetch failed, please retry",
   "hubEmpty.retry": "Retry",
+  "hubEmpty.loginToView": "Sign in to view the full list",
+  "hubEmpty.login": "Sign in",
   "sudocodeModel": {
     "editModelTitle": "Edit Model",
     "openAIOnlyHint": "Only supports OpenAI-compatible API",

--- a/src/renderer/i18n/locales/ja-JP/guid.json
+++ b/src/renderer/i18n/locales/ja-JP/guid.json
@@ -63,6 +63,7 @@
   "agentTabAutoSwitch": "Model not compatible with Gemini, auto-switched to {{fallback}}",
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
+  "modelNotConfigured": "利用可能なモデルが未設定です。設定でモデルを追加してください。",
   "scanning": {
     "initialMessage": "Current Agent is unavailable, detecting other available agents...",
     "scanningMessage": "Scanning local available agents...",

--- a/src/renderer/i18n/locales/ja-JP/login.json
+++ b/src/renderer/i18n/locales/ja-JP/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "認証コールバックに ticket がありません",
   "thirdPartyFailed": "外部認証ログインに失敗しました",
   "backToModeSelect": "← モード選択に戻る",
-  "skip": "スキップ"
+  "skip": "スキップ →"
 }

--- a/src/renderer/i18n/locales/ja-JP/login.json
+++ b/src/renderer/i18n/locales/ja-JP/login.json
@@ -64,5 +64,6 @@
   "thirdPartyStateInvalid": "認証コールバックの検証に失敗しました。再試行してください",
   "thirdPartyMissingTicket": "認証コールバックに ticket がありません",
   "thirdPartyFailed": "外部認証ログインに失敗しました",
-  "backToModeSelect": "← モード選択に戻る"
+  "backToModeSelect": "← モード選択に戻る",
+  "skip": "スキップ"
 }

--- a/src/renderer/i18n/locales/ja-JP/login.json
+++ b/src/renderer/i18n/locales/ja-JP/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "認証コールバックに ticket がありません",
   "thirdPartyFailed": "外部認証ログインに失敗しました",
   "backToModeSelect": "← モード選択に戻る",
-  "skip": "スキップ →"
+  "skip": "今はスキップ →"
 }

--- a/src/renderer/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/i18n/locales/ja-JP/settings.json
@@ -1033,6 +1033,8 @@
   "hubEmpty.tokenMissing": "Skill Hub が未構成です — sudowork-server へのログイン状態を確認してください",
   "hubEmpty.fetchFailed": "取得に失敗しました。再試行してください",
   "hubEmpty.retry": "再試行",
+  "hubEmpty.loginToView": "ログインして完全なリストを表示",
+  "hubEmpty.login": "ログイン",
   "fetchModelList": "モデルリストを取得",
   "fetchModelListSuccess": "{{count}} 個のモデルを取得しました",
   "fetchModelListUnsupported": "このプロバイダーはモデルリストの取得をサポートしていません。モデル名を手動で入力してください。",

--- a/src/renderer/i18n/locales/ko-KR/guid.json
+++ b/src/renderer/i18n/locales/ko-KR/guid.json
@@ -63,6 +63,7 @@
   "agentTabAutoSwitch": "Model not compatible with Gemini, auto-switched to {{fallback}}",
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
+  "modelNotConfigured": "사용 가능한 모델이 없습니다. 설정에서 모델을 추가하세요.",
   "scanning": {
     "initialMessage": "Current Agent is unavailable, detecting other available agents...",
     "scanningMessage": "Scanning local available agents...",

--- a/src/renderer/i18n/locales/ko-KR/login.json
+++ b/src/renderer/i18n/locales/ko-KR/login.json
@@ -64,5 +64,6 @@
   "thirdPartyStateInvalid": "인증 콜백 검증에 실패했습니다. 다시 시도하세요",
   "thirdPartyMissingTicket": "인증 콜백에 ticket이 없습니다",
   "thirdPartyFailed": "타사 인증 로그인 실패",
-  "backToModeSelect": "← 모드 선택으로 돌아가기"
+  "backToModeSelect": "← 모드 선택으로 돌아가기",
+  "skip": "건너뛰기"
 }

--- a/src/renderer/i18n/locales/ko-KR/login.json
+++ b/src/renderer/i18n/locales/ko-KR/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "인증 콜백에 ticket이 없습니다",
   "thirdPartyFailed": "타사 인증 로그인 실패",
   "backToModeSelect": "← 모드 선택으로 돌아가기",
-  "skip": "건너뛰기 →"
+  "skip": "지금은 건너뛰기 →"
 }

--- a/src/renderer/i18n/locales/ko-KR/login.json
+++ b/src/renderer/i18n/locales/ko-KR/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "인증 콜백에 ticket이 없습니다",
   "thirdPartyFailed": "타사 인증 로그인 실패",
   "backToModeSelect": "← 모드 선택으로 돌아가기",
-  "skip": "건너뛰기"
+  "skip": "건너뛰기 →"
 }

--- a/src/renderer/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/i18n/locales/ko-KR/settings.json
@@ -1033,6 +1033,8 @@
   "hubEmpty.tokenMissing": "Skill Hub가 구성되지 않았습니다 — sudowork-server 로그인 상태를 확인하세요",
   "hubEmpty.fetchFailed": "가져오기 실패. 다시 시도하세요",
   "hubEmpty.retry": "다시 시도",
+  "hubEmpty.loginToView": "로그인 후 전체 목록 보기",
+  "hubEmpty.login": "로그인",
   "fetchModelList": "모델 목록 가져오기",
   "fetchModelListSuccess": "{{count}} 개의 모델을 가져왔습니다",
   "fetchModelListUnsupported": "이 제공자는 모델 목록 가져오기를 지원하지 않습니다. 모델 이름을 직접 입력하세요.",

--- a/src/renderer/i18n/locales/tr-TR/guid.json
+++ b/src/renderer/i18n/locales/tr-TR/guid.json
@@ -63,6 +63,7 @@
   "agentTabAutoSwitch": "Model not compatible with Gemini, auto-switched to {{fallback}}",
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
+  "modelNotConfigured": "Uygun model yapılandırılmadı. Lütfen Ayarlar'dan bir model ekleyin.",
   "scanning": {
     "initialMessage": "Current Agent is unavailable, detecting other available agents...",
     "scanningMessage": "Scanning local available agents...",

--- a/src/renderer/i18n/locales/tr-TR/login.json
+++ b/src/renderer/i18n/locales/tr-TR/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "Kimlik doğrulama geri çağrısında ticket eksik",
   "thirdPartyFailed": "Üçüncü taraf giriş başarısız",
   "backToModeSelect": "← Mod seçimine dön",
-  "skip": "Atla →"
+  "skip": "Şimdilik atla →"
 }

--- a/src/renderer/i18n/locales/tr-TR/login.json
+++ b/src/renderer/i18n/locales/tr-TR/login.json
@@ -64,5 +64,6 @@
   "thirdPartyStateInvalid": "Kimlik doğrulama geri çağrısı doğrulanamadı, lütfen tekrar deneyin",
   "thirdPartyMissingTicket": "Kimlik doğrulama geri çağrısında ticket eksik",
   "thirdPartyFailed": "Üçüncü taraf giriş başarısız",
-  "backToModeSelect": "← Mod seçimine dön"
+  "backToModeSelect": "← Mod seçimine dön",
+  "skip": "Atla"
 }

--- a/src/renderer/i18n/locales/tr-TR/login.json
+++ b/src/renderer/i18n/locales/tr-TR/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "Kimlik doğrulama geri çağrısında ticket eksik",
   "thirdPartyFailed": "Üçüncü taraf giriş başarısız",
   "backToModeSelect": "← Mod seçimine dön",
-  "skip": "Atla"
+  "skip": "Atla →"
 }

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -1029,6 +1029,8 @@
   "hubEmpty.tokenMissing": "Skill Hub yapılandırılmamış — sudowork-server oturum durumunuzu kontrol edin",
   "hubEmpty.fetchFailed": "Getirme başarısız, lütfen tekrar deneyin",
   "hubEmpty.retry": "Tekrar dene",
+  "hubEmpty.loginToView": "Listeyi görmek için giriş yapın",
+  "hubEmpty.login": "Giriş yap",
   "fetchModelList": "Model listesini getir",
   "fetchModelListSuccess": "{{count}} model getirildi",
   "fetchModelListUnsupported": "Bu sağlayıcı model listesi getirmeyi desteklemiyor. Lütfen model adını manuel olarak girin.",

--- a/src/renderer/i18n/locales/zh-CN/guid.json
+++ b/src/renderer/i18n/locales/zh-CN/guid.json
@@ -64,6 +64,7 @@
   "agentTabAutoSwitch": "模型不兼容 Gemini，已自动切换到 {{fallback}}",
   "autoSwitchToAgent": "Gemini 未配置，正在自动切换到 {{agent}}",
   "autoSwitchedAgent": "{{from}} 不可用，已自动切换到 {{to}}",
+  "modelNotConfigured": "未配置可用模型，请在设置页添加模型",
   "scanning": {
     "initialMessage": "当前Agent不可用, 正在检测其他可用agent...",
     "scanningMessage": "正在扫描本地可用agent...",

--- a/src/renderer/i18n/locales/zh-CN/login.json
+++ b/src/renderer/i18n/locales/zh-CN/login.json
@@ -69,5 +69,5 @@
   "thirdPartyMissingTicket": "认证回调缺少 ticket",
   "thirdPartyFailed": "三方认证登录失败",
   "backToModeSelect": "← 返回模式选择",
-  "skip": "跳过"
+  "skip": "跳过 →"
 }

--- a/src/renderer/i18n/locales/zh-CN/login.json
+++ b/src/renderer/i18n/locales/zh-CN/login.json
@@ -68,5 +68,6 @@
   "thirdPartyStateInvalid": "认证回调验证失败，请重试",
   "thirdPartyMissingTicket": "认证回调缺少 ticket",
   "thirdPartyFailed": "三方认证登录失败",
-  "backToModeSelect": "← 返回模式选择"
+  "backToModeSelect": "← 返回模式选择",
+  "skip": "跳过"
 }

--- a/src/renderer/i18n/locales/zh-CN/login.json
+++ b/src/renderer/i18n/locales/zh-CN/login.json
@@ -69,5 +69,5 @@
   "thirdPartyMissingTicket": "认证回调缺少 ticket",
   "thirdPartyFailed": "三方认证登录失败",
   "backToModeSelect": "← 返回模式选择",
-  "skip": "跳过 →"
+  "skip": "暂时跳过 →"
 }

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -1181,6 +1181,8 @@
   "hubEmpty.tokenMissing": "未配置 Skill Hub — 请检查 sudowork-server 登录状态",
   "hubEmpty.fetchFailed": "拉取失败，请重试",
   "hubEmpty.retry": "重试",
+  "hubEmpty.loginToView": "登录后查看完整列表",
+  "hubEmpty.login": "去登录",
   "sudocodeModel": {
     "editModelTitle": "编辑模型",
     "openAIOnlyHint": "仅支持 OpenAI 兼容协议 API",

--- a/src/renderer/i18n/locales/zh-TW/guid.json
+++ b/src/renderer/i18n/locales/zh-TW/guid.json
@@ -63,6 +63,7 @@
   "agentTabAutoSwitch": "Model not compatible with Gemini, auto-switched to {{fallback}}",
   "autoSwitchToAgent": "Gemini is not configured, auto-switching to {{agent}}",
   "autoSwitchedAgent": "{{from}} is not available, switched to {{to}}",
+  "modelNotConfigured": "未設定可用模型，請在設定頁新增模型。",
   "scanning": {
     "initialMessage": "Current Agent is unavailable, detecting other available agents...",
     "scanningMessage": "Scanning local available agents...",

--- a/src/renderer/i18n/locales/zh-TW/login.json
+++ b/src/renderer/i18n/locales/zh-TW/login.json
@@ -64,5 +64,6 @@
   "thirdPartyStateInvalid": "認證回調驗證失敗，請重試",
   "thirdPartyMissingTicket": "認證回調缺少 ticket",
   "thirdPartyFailed": "第三方認證登入失敗",
-  "backToModeSelect": "← 返回模式選擇"
+  "backToModeSelect": "← 返回模式選擇",
+  "skip": "跳過"
 }

--- a/src/renderer/i18n/locales/zh-TW/login.json
+++ b/src/renderer/i18n/locales/zh-TW/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "認證回調缺少 ticket",
   "thirdPartyFailed": "第三方認證登入失敗",
   "backToModeSelect": "← 返回模式選擇",
-  "skip": "跳過 →"
+  "skip": "暫時跳過 →"
 }

--- a/src/renderer/i18n/locales/zh-TW/login.json
+++ b/src/renderer/i18n/locales/zh-TW/login.json
@@ -65,5 +65,5 @@
   "thirdPartyMissingTicket": "認證回調缺少 ticket",
   "thirdPartyFailed": "第三方認證登入失敗",
   "backToModeSelect": "← 返回模式選擇",
-  "skip": "跳過"
+  "skip": "跳過 →"
 }

--- a/src/renderer/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/i18n/locales/zh-TW/settings.json
@@ -1033,6 +1033,8 @@
   "hubEmpty.tokenMissing": "未配置 Skill Hub — 請檢查 sudowork-server 登入狀態",
   "hubEmpty.fetchFailed": "拉取失敗，請重試",
   "hubEmpty.retry": "重試",
+  "hubEmpty.loginToView": "登入後查看完整列表",
+  "hubEmpty.login": "登入",
   "fetchModelList": "取得模型清單",
   "fetchModelListSuccess": "已取得 {{count}} 個模型",
   "fetchModelListUnsupported": "該提供商不支援取得模型清單，請手動輸入模型名稱",

--- a/src/renderer/layouts/components/SettingsSider.tsx
+++ b/src/renderer/layouts/components/SettingsSider.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Tooltip } from '@arco-design/web-react';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
+import { useAuth } from '@/renderer/context/AuthContext';
 import { useExtI18n } from '@/renderer/hooks/useExtI18n';
 import { extensions as extensionsIpc, type IExtensionSettingsTab } from '@/common/ipcBridge';
 import { isElectronDesktop, resolveExtensionAssetUrl } from '@/renderer/utils/platform';
@@ -32,6 +33,7 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
   const { pathname } = useLocation();
   const isDesktop = isElectronDesktop();
   const { isEnterprise } = useAppMode();
+  const { isGuest } = useAuth();
 
   const [extensionTabs, setExtensionTabs] = useState<IExtensionSettingsTab[]>([]);
   const { resolveExtTabName } = useExtI18n();
@@ -120,7 +122,7 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
 
     // Start with ordered builtin IDs (enterprise mode uses restricted set)
     const activeBuiltinTabIds = isEnterprise ? ENTERPRISE_BUILTIN_TAB_IDS : BUILTIN_TAB_IDS;
-    const result: SiderItem[] = activeBuiltinTabIds.map((id) => builtinMap[id]).filter((item) => !item.hidden);
+    const result: SiderItem[] = activeBuiltinTabIds.map((id) => builtinMap[id]).filter((item) => !item.hidden && !(isGuest && (item.id === 'profile' || item.id === 'recharge')));
 
     // Extension tabs with position anchoring
     const beforeMap = new Map<string, IExtensionSettingsTab[]>();
@@ -195,7 +197,7 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
     }
 
     return result;
-  }, [t, isDesktop, extensionTabs, resolveExtTabName, isEnterprise]);
+  }, [t, isDesktop, extensionTabs, resolveExtTabName, isEnterprise, isGuest]);
 
   const siderTooltipProps = getSiderTooltipProps(tooltipEnabled);
   return (

--- a/src/renderer/layouts/components/Sider.tsx
+++ b/src/renderer/layouts/components/Sider.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { AlarmClock, ArrowLeft, BookOpen, Bot, ChevronDown, Globe, ListChecks, LogOut, Plus, Settings, ShieldCheck, Sparkles } from 'lucide-react';
+import { AlarmClock, ArrowLeft, BookOpen, Bot, ChevronDown, Globe, ListChecks, LogIn, LogOut, Plus, Settings, ShieldCheck, Sparkles } from 'lucide-react';
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -31,7 +31,7 @@ const Sider: React.FC = () => {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { logout, user: currentUser } = useAuth();
+  const { logout, user: currentUser, isGuest } = useAuth();
   const { isEnterprise, mode } = useAppMode();
   const { isCronVisible } = useCronAccess();
   const [isBatchMode, setIsBatchMode] = useState(false);
@@ -147,7 +147,7 @@ const Sider: React.FC = () => {
       const target = lastNonSettingsPathRef.current || '/guid';
       void navigate(target);
     } else {
-      void navigate('/settings/profile');
+      void navigate(isGuest ? '/settings/model' : '/settings/profile');
     }
     onSessionClick();
   };
@@ -157,6 +157,9 @@ const Sider: React.FC = () => {
       handleSettingsClick();
       setUserMenuOpen(false);
       return;
+    } else if (key === 'login') {
+      setUserMenuOpen(false);
+      void navigate('/login', { replace: true });
     } else if (key === 'logout') {
       setUserMenuOpen(false);
       await logout();
@@ -290,12 +293,21 @@ const Sider: React.FC = () => {
                     <span>{t('common.settings')}</span>
                   </div>
                 </Menu.Item>
-                <Menu.Item key='logout'>
-                  <div className='flex items-center gap-2.5 text-danger'>
-                    <LogOut size={17} strokeWidth={1.8} className='text-danger' />
-                    <span>{t('login.logout', { defaultValue: '退出登录' })}</span>
-                  </div>
-                </Menu.Item>
+                {isGuest ? (
+                  <Menu.Item key='login'>
+                    <div className='flex items-center gap-2.5'>
+                      <LogIn size={17} strokeWidth={1.8} className='text-secondary' />
+                      <span>{t('login.submit')}</span>
+                    </div>
+                  </Menu.Item>
+                ) : (
+                  <Menu.Item key='logout'>
+                    <div className='flex items-center gap-2.5 text-danger'>
+                      <LogOut size={17} strokeWidth={1.8} className='text-danger' />
+                      <span>{t('login.logout', { defaultValue: '退出登录' })}</span>
+                    </div>
+                  </Menu.Item>
+                )}
               </Menu>
             }
             trigger='click'
@@ -308,10 +320,12 @@ const Sider: React.FC = () => {
           >
             <div className='flex flex-col gap-0.5'>
               <div ref={userTriggerRef} className='flex items-center gap-2.5 px-3 py-2.5 cursor-pointer transition-colors rd-3 border hover:bg-hover active:bg-fill-2 ml-0.5'>
-                <div className='size-8 rd-50% bg-fill-3 f-center text-foreground text-14px font-bold shrink-0'>{userInfo.avatar ? <img src={userInfo.avatar} alt={userInfo.name} className='w-full h-full rd-50% object-cover' /> : <span>{userInfo.name.charAt(0).toUpperCase()}</span>}</div>
+                <div className='size-8 rd-50% bg-fill-3 f-center text-foreground text-14px font-bold shrink-0'>
+                  {isGuest ? <LogIn size={16} strokeWidth={1.8} /> : userInfo.avatar ? <img src={userInfo.avatar} alt={userInfo.name} className='w-full h-full rd-50% object-cover' /> : <span>{userInfo.name.charAt(0).toUpperCase()}</span>}
+                </div>
                 <div className='flex-1 min-w-0'>
-                  <div className='text-14px font-medium text-foreground truncate'>{userInfo.name}</div>
-                  <div className='text-12px text-secondary truncate'>{userInfo.email}</div>
+                  <div className='text-14px font-medium text-foreground truncate'>{isGuest ? t('login.submit') : userInfo.name}</div>
+                  {!isGuest && <div className='text-12px text-secondary truncate'>{userInfo.email}</div>}
                 </div>
                 <ChevronDown size={16} strokeWidth={1.8} className='shrink-0 text-secondary' />
               </div>

--- a/src/renderer/pages/agents/index.tsx
+++ b/src/renderer/pages/agents/index.tsx
@@ -64,7 +64,7 @@ const AgentSettings: React.FC = () => {
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
 
   // Hub state (for store/exclusive tabs)
-  const { user, ensureValidToken } = useAuth();
+  const { user, ensureValidToken, isGuest } = useAuth();
   const enterpriseCode = user?.enterprise_code?.trim();
   const navigate = useNavigate();
   const [hubAssistantList, setHubAssistantList] = useState<IAssistantHubSkill[]>([]);
@@ -1709,19 +1709,27 @@ const AgentSettings: React.FC = () => {
                   </div>
                 )
               ) : activeTab === 'exclusive' && !enterpriseCode ? (
-                <div className='flex flex-col items-center justify-center py-12 text-secondary gap-2'>
-                  <Shield size={32} className='text-tertiary' />
-                  <span className='text-13px'>{t('settings.assistant.noEnterpriseCode', '当前账号没有企业编码，无法加载专属智能体。')}</span>
-                </div>
+                isGuest ? (
+                  <HubEmptyState onLogin={() => navigate('/login')} />
+                ) : (
+                  <div className='flex flex-col items-center justify-center py-12 text-secondary gap-2'>
+                    <Shield size={32} className='text-tertiary' />
+                    <span className='text-13px'>{t('settings.assistant.noEnterpriseCode', '当前账号没有企业编码，无法加载专属智能体。')}</span>
+                  </div>
+                )
               ) : hubLoading || !hubInstalledSkillsReady ? (
                 <div className='flex justify-center items-center py-12'>
                   <Spin size={28} />
                 </div>
               ) : hubAssistantList.length === 0 ? (
-                <div className='flex flex-col items-center justify-center py-12 text-secondary gap-2'>
-                  <Bot size={32} className='text-tertiary' />
-                  <span className='text-13px'>{t('settings.assistant.noResults', '暂无智能体')}</span>
-                </div>
+                isGuest ? (
+                  <HubEmptyState onLogin={() => navigate('/login')} />
+                ) : (
+                  <div className='flex flex-col items-center justify-center py-12 text-secondary gap-2'>
+                    <Bot size={32} className='text-tertiary' />
+                    <span className='text-13px'>{t('settings.assistant.noResults', '暂无智能体')}</span>
+                  </div>
+                )
               ) : (
                 <div className='grid gap-4 pb-4' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
                   {hubAssistantList.map((assistant) => {

--- a/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
@@ -1,11 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import useSWR from 'swr';
-import { ipcBridge } from '@/common';
 import type { IProvider, TProviderWithModel } from '@/common/storage';
 import { ConfigStorage } from '@/common/storage';
-import { uuid } from '@/common/utils';
 import { useGeminiGoogleAuthModels } from '@/renderer/hooks/useGeminiGoogleAuthModels';
-import { hasAvailableModels } from '../utils/modelUtils';
+import { useAvailableModels } from '@/renderer/hooks/useAvailableModels';
 
 /**
  * Build a unique key for a provider/model pair.
@@ -41,34 +38,7 @@ export type GuidModelSelectionResult = {
  */
 export const useGuidModelSelection = (): GuidModelSelectionResult => {
   const { geminiModeOptions, isGoogleAuth } = useGeminiGoogleAuthModels();
-  const { data: modelConfig } = useSWR('model.config.welcome', () => {
-    return ipcBridge.mode.getModelConfig.invoke().then((data) => {
-      return (data || []).filter((platform) => !!platform.model.length);
-    });
-  });
-
-  const geminiModelValues = useMemo(() => geminiModeOptions.map((option) => option.value), [geminiModeOptions]);
-
-  const modelList = useMemo(() => {
-    let allProviders: IProvider[] = [];
-
-    if (isGoogleAuth) {
-      const geminiProvider: IProvider = {
-        id: uuid(),
-        name: 'Gemini Google Auth',
-        platform: 'gemini-with-google-auth',
-        baseUrl: '',
-        apiKey: '',
-        model: geminiModelValues,
-        capabilities: [{ type: 'text' }, { type: 'vision' }, { type: 'function_calling' }],
-      };
-      allProviders = [geminiProvider, ...(modelConfig || [])];
-    } else {
-      allProviders = modelConfig || [];
-    }
-
-    return allProviders.filter(hasAvailableModels);
-  }, [geminiModelValues, isGoogleAuth, modelConfig]);
+  const { modelList } = useAvailableModels();
 
   const geminiModeLookup = useMemo(() => {
     const lookup = new Map<string, (typeof geminiModeOptions)[number]>();

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -27,6 +27,8 @@ export type GuidSendDeps = {
   // Agent state
   selectedAgent: AcpBackend | 'custom';
   selectedAgentKey: string;
+  /** Resolved backend key (builtin/preset) for the selected agent; used to skip the guest model guard for claude. */
+  modelBackendKey: AcpBackend;
   selectedAgentInfo: AvailableAgent | undefined;
   isPresetAgent: boolean;
   selectedMode: string;
@@ -86,6 +88,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     selectedSkills,
     selectedAgent,
     selectedAgentKey,
+    modelBackendKey,
     selectedAgentInfo,
     isPresetAgent,
     selectedMode,
@@ -117,7 +120,9 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
 
   const handleSend = useCallback(async () => {
     // Guest pre-send check: prompt if no usable model. Login users (isGuest=false) always skip.
-    if (isGuest && ready) {
+    // claude code carries its own config (~/.claude/settings.json) and does not consume
+    // model.config; skip this guard for claude to avoid a false "no model configured".
+    if (isGuest && ready && modelBackendKey !== 'claude') {
       let isScodeAvailable = false;
       try {
         const scodeRes = await ipcBridge.acpConversation.probeModelInfo.invoke({ backend: 'scode' });
@@ -332,6 +337,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     dir,
     selectedAgent,
     selectedAgentKey,
+    modelBackendKey,
     selectedAgentInfo,
     isPresetAgent,
     selectedMode,

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -28,7 +28,7 @@ export type GuidSendDeps = {
   selectedAgent: AcpBackend | 'custom';
   selectedAgentKey: string;
   /** Resolved backend key (builtin/preset) for the selected agent; used to skip the guest model guard for claude. */
-  modelBackendKey: AcpBackend;
+  modelBackendKey: string;
   selectedAgentInfo: AvailableAgent | undefined;
   isPresetAgent: boolean;
   selectedMode: string;

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -113,10 +113,19 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
   const { hasModel, ready } = useHasAvailableModel();
 
   const handleSend = useCallback(async () => {
-    // 游客态发送前校验：无可用模型则提示（仅游客；已登录 isGuest=false 完全不拦截）
-    if (isGuest && ready && !hasModel) {
-      Message.error(t('guid.modelNotConfigured', { defaultValue: '未配置可用模型，请在设置页添加模型' }));
-      return;
+    // Guest pre-send check: prompt if no usable model. Login users (isGuest=false) always skip.
+    if (isGuest && ready) {
+      let isScodeAvailable = false;
+      try {
+        const scodeRes = await ipcBridge.acpConversation.probeModelInfo.invoke({ backend: 'scode' });
+        isScodeAvailable = (scodeRes?.data?.modelInfo?.availableModels?.length ?? 0) > 0;
+      } catch {
+        // Treat probe failure as "no scode model available"
+      }
+      if (!hasModel && !isScodeAvailable) {
+        Message.error(t('guid.modelNotConfigured', { defaultValue: '未配置可用模型，请在设置页添加模型' }));
+        return;
+      }
     }
 
     const isCustomWorkspace = !!dir;

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -9,6 +9,8 @@ import { updateWorkspaceTime } from '@/renderer/utils/workspaceHistory';
 import { isAcpRoutedPresetType, type PresetAgentType } from '@/types/acpTypes';
 import { getPresetByAgentId, resolveSessionMode } from '@/common/presets/presetResolver';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
+import { useHasAvailableModel } from '@/renderer/hooks/useHasAvailableModel';
+import { useAuth } from '@/renderer/context/AuthContext';
 import type { AcpBackend, AvailableAgent, EffectiveAgentInfo } from '../types';
 
 export type GuidSendDeps = {
@@ -107,8 +109,16 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
   } = deps;
 
   const { isEnterprise } = useAppMode();
+  const { isGuest } = useAuth();
+  const { hasModel, ready } = useHasAvailableModel();
 
   const handleSend = useCallback(async () => {
+    // 游客态发送前校验：无可用模型则提示（仅游客；已登录 isGuest=false 完全不拦截）
+    if (isGuest && ready && !hasModel) {
+      Message.error(t('guid.modelNotConfigured', { defaultValue: '未配置可用模型，请在设置页添加模型' }));
+      return;
+    }
+
     const isCustomWorkspace = !!dir;
     const finalWorkspace = dir || '';
 
@@ -322,6 +332,9 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     closeAllTabs,
     openTab,
     t,
+    isGuest,
+    hasModel,
+    ready,
   ]);
 
   const sendMessageHandler = useCallback(() => {

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -6,7 +6,7 @@ import { ipcBridge } from '@/common';
 import type { TProviderWithModel } from '@/common/storage';
 import { emitter } from '@/renderer/utils/emitter';
 import { updateWorkspaceTime } from '@/renderer/utils/workspaceHistory';
-import { isAcpRoutedPresetType, type PresetAgentType } from '@/types/acpTypes';
+import { isAcpRoutedPresetType, type AcpModelInfo, type PresetAgentType } from '@/types/acpTypes';
 import { getPresetByAgentId, resolveSessionMode } from '@/common/presets/presetResolver';
 import { useAppMode } from '@/renderer/hooks/useAppMode';
 import { useHasAvailableModel } from '@/renderer/hooks/useHasAvailableModel';
@@ -32,6 +32,8 @@ export type GuidSendDeps = {
   selectedMode: string;
   selectedAcpModel: string | null;
   currentModel: TProviderWithModel | undefined;
+  /** Probe-resolved model info for the current backend; validates selectedAcpModel and provides a fallback when it is stale/ghost. */
+  currentAcpCachedModelInfo: AcpModelInfo | null;
 
   /** Current session mode (remote/local) for enterprise mode */
   sessionMode: 'remote' | 'local';
@@ -89,6 +91,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     selectedMode,
     selectedAcpModel,
     currentModel,
+    currentAcpCachedModelInfo,
     sessionMode,
     findAgentByKey,
     getEffectiveAgentType,
@@ -257,6 +260,10 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
         // For presets with a non-gemini backend (e.g. claude), don't pass the
         // UI's Gemini model — let the backend resolve the model itself.
         const isGeminiBackend = acpBackend === 'gemini';
+        // Reject stale/ghost selectedAcpModel (not in available list); fall back to probe's current model.
+        const acpAvailableModels = currentAcpCachedModelInfo?.availableModels;
+        const selectedAcpModelInList = acpAvailableModels && selectedAcpModel ? acpAvailableModels.some((m) => m.id === selectedAcpModel) : false;
+        const effectiveAcpModelId = (selectedAcpModelInList ? selectedAcpModel : currentAcpCachedModelInfo?.currentModelId) ?? selectedAcpModel ?? undefined;
         const conversation = await ipcBridge.conversation.create.invoke({
           type: 'acp',
           name: input,
@@ -273,7 +280,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
             enabledSkills: isPreset ? enabledSkills : undefined,
             presetAssistantId: isPreset ? agentInfo?.customAgentId || acpAgentInfo?.customAgentId : undefined,
             sessionMode: isPreset ? resolveSessionMode(getPresetByAgentId(agentInfo?.customAgentId)?.defaultMode, acpBackend, selectedMode) : selectedMode,
-            currentModelId: selectedAcpModel || undefined,
+            currentModelId: effectiveAcpModelId,
             sessionModeParam: 'local',
           },
         });
@@ -330,6 +337,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     selectedMode,
     selectedAcpModel,
     currentModel,
+    currentAcpCachedModelInfo,
     sessionMode,
     findAgentByKey,
     getEffectiveAgentType,

--- a/src/renderer/pages/guid/index.tsx
+++ b/src/renderer/pages/guid/index.tsx
@@ -121,6 +121,7 @@ const GuidPage: React.FC = () => {
     // Agent state
     selectedAgent: agentSelection.selectedAgent,
     selectedAgentKey: agentSelection.selectedAgentKey,
+    modelBackendKey: agentSelection.modelBackendKey,
     selectedAgentInfo: agentSelection.selectedAgentInfo,
     isPresetAgent: agentSelection.isPresetAgent,
     selectedMode: agentSelection.selectedMode,

--- a/src/renderer/pages/guid/index.tsx
+++ b/src/renderer/pages/guid/index.tsx
@@ -126,6 +126,7 @@ const GuidPage: React.FC = () => {
     selectedMode: agentSelection.selectedMode,
     selectedAcpModel: agentSelection.selectedAcpModel,
     currentModel: modelSelection.currentModel,
+    currentAcpCachedModelInfo: agentSelection.currentAcpCachedModelInfo,
     sessionMode: agentSelection.sessionMode,
 
     // Agent helpers

--- a/src/renderer/pages/login/PasswordAuthPanel.tsx
+++ b/src/renderer/pages/login/PasswordAuthPanel.tsx
@@ -154,8 +154,8 @@ const PasswordAuthPanel: React.FC<PasswordAuthPanelProps> = ({ appName, logo, de
             </span>
             <span
               className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors'
-              onClick={() => {
-                enterGuest();
+              onClick={async () => {
+                await enterGuest();
                 void navigate('/guid');
               }}
             >

--- a/src/renderer/pages/login/PasswordAuthPanel.tsx
+++ b/src/renderer/pages/login/PasswordAuthPanel.tsx
@@ -21,7 +21,7 @@ interface PasswordAuthPanelProps {
 const PasswordAuthPanel: React.FC<PasswordAuthPanelProps> = ({ appName, logo, defaultLogo, onBackToModeSelect }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { loginByPassword, registerByPassword } = useAuth();
+  const { enterGuest, loginByPassword, registerByPassword } = useAuth();
 
   const [mode, setMode] = useState<'login' | 'register'>('login');
   const [account, setAccount] = useState('');
@@ -148,9 +148,18 @@ const PasswordAuthPanel: React.FC<PasswordAuthPanelProps> = ({ appName, logo, de
         {mode === 'login' && <div className='text-center text-12px text-tertiary mt-12px'>{t('login.pwdFootNote')}</div>}
 
         {onBackToModeSelect && (
-          <div className='text-center mt-12px'>
+          <div className='flex items-center justify-center gap-16px mt-12px'>
             <span className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors' onClick={onBackToModeSelect}>
               ← 返回模式选择
+            </span>
+            <span
+              className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors'
+              onClick={() => {
+                enterGuest();
+                void navigate('/guid');
+              }}
+            >
+              {t('login.skip')}
             </span>
           </div>
         )}

--- a/src/renderer/pages/login/ThirdPartyAuthPanel.tsx
+++ b/src/renderer/pages/login/ThirdPartyAuthPanel.tsx
@@ -161,8 +161,8 @@ export default function ThirdPartyAuthPanel({ appName, logo, defaultLogo, system
             </span>
             <span
               className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors'
-              onClick={() => {
-                enterGuest();
+              onClick={async () => {
+                await enterGuest();
                 void navigate('/guid');
               }}
             >

--- a/src/renderer/pages/login/ThirdPartyAuthPanel.tsx
+++ b/src/renderer/pages/login/ThirdPartyAuthPanel.tsx
@@ -12,7 +12,7 @@ import './LoginPage.css';
 export default function ThirdPartyAuthPanel({ appName, logo, defaultLogo, systemConfig, onBackToModeSelect }: IThirdPartyAuthPanelProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { exchangeThirdPartyAuthCode, loginWithThirdPartyAuth } = useAuth();
+  const { enterGuest, exchangeThirdPartyAuthCode, loginWithThirdPartyAuth } = useAuth();
   const resolvedConfig = useMemo(() => resolveThirdPartyAuthConfig(systemConfig), [systemConfig]);
   const [selectedProviderId, setSelectedProviderId] = useState(() => resolvedConfig?.defaultProvider || '');
   const [isWaiting, setIsWaiting] = useState(false);
@@ -155,9 +155,18 @@ export default function ThirdPartyAuthPanel({ appName, logo, defaultLogo, system
         <div className='text-center text-12px text-tertiary mt-2px'>{t('login.thirdPartyBrowserHint')}</div>
 
         {onBackToModeSelect && (
-          <div className='text-center mt-12px'>
+          <div className='flex items-center justify-center gap-16px mt-12px'>
             <span className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors' onClick={onBackToModeSelect}>
               {t('login.backToModeSelect')}
+            </span>
+            <span
+              className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors'
+              onClick={() => {
+                enterGuest();
+                void navigate('/guid');
+              }}
+            >
+              {t('login.skip')}
             </span>
           </div>
         )}

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -694,8 +694,8 @@ const LoginPage: React.FC = () => {
             </span>
             <span
               className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors'
-              onClick={() => {
-                enterGuest();
+              onClick={async () => {
+                await enterGuest();
                 void navigate('/guid');
               }}
             >

--- a/src/renderer/pages/login/index.tsx
+++ b/src/renderer/pages/login/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Button, Input, Message, Space } from '@arco-design/web-react';
 import { Phone, Protect, Key, User, Lock } from '@icon-park/react';
 import { getSudoworkServerBaseUrl } from '@/common/sudoworkServer';
@@ -11,7 +12,7 @@ import { useSystemLoginMethod } from '@/renderer/hooks/useSystemLoginMethod';
 import { ConfigStorage } from '@/common/storage';
 import { ipcBridge } from '@/common';
 import WindowControls from '../../components/WindowControls';
-import { useAuth } from '../../context/AuthContext';
+import { useAuth, GUEST_FLAG_KEY } from '../../context/AuthContext';
 import AppLoader from '../../components/AppLoader';
 import PasswordAuthPanel from './PasswordAuthPanel';
 import ThirdPartyAuthPanel from './ThirdPartyAuthPanel';
@@ -56,7 +57,8 @@ function getCachedTenantConfig(): Required<typeof DEFAULT_TENANT_CONFIG> {
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
-  const { status, login, register, enterpriseLogin, enterpriseLoginWithOAuth2 } = useAuth();
+  const { t } = useTranslation();
+  const { status, enterGuest, login, register, enterpriseLogin, enterpriseLoginWithOAuth2 } = useAuth();
   const { isEnterprise } = useAppMode();
   const { loginMethod, systemConfig } = useSystemLoginMethod();
 
@@ -478,6 +480,7 @@ const LoginPage: React.FC = () => {
       // Clear C-side auth to avoid falling into authenticated state
       localStorage.removeItem('sudowork_auth_v2');
       localStorage.removeItem('sudowork_auth_v1');
+      localStorage.removeItem(GUEST_FLAG_KEY);
       // Reload page instead of restarting app
       window.location.reload();
     } catch (error) {
@@ -685,9 +688,18 @@ const LoginPage: React.FC = () => {
             {mode === 'login' ? '登录' : '注册'}
           </Button>
 
-          <div className='text-center mt-12px'>
+          <div className='flex items-center justify-center gap-16px mt-12px'>
             <span className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors' onClick={handleBackToModeSelect}>
               ← 返回模式选择
+            </span>
+            <span
+              className='text-12px text-tertiary cursor-pointer hover:text-secondary transition-colors'
+              onClick={() => {
+                enterGuest();
+                void navigate('/guid');
+              }}
+            >
+              {t('login.skip')}
             </span>
           </div>
         </div>

--- a/src/renderer/pages/settings/models/index.tsx
+++ b/src/renderer/pages/settings/models/index.tsx
@@ -6,7 +6,7 @@ import { ipcBridge } from '@/common';
 import type { ScodeConfig } from '@/common/ipcBridge';
 import { extractCustomProvidersFromScodeConfig, mergeCustomProviderIntoScodeConfig, removeCustomProviderFromScodeConfig, type ScodeCustomModelProvider } from '@/common/scodeConfig';
 import AionScrollArea from '@/renderer/components/base/AionScrollArea';
-import { useAuth } from '@/renderer/context/AuthContext';
+import { GUEST_USER_ID, useAuth } from '@/renderer/context/AuthContext';
 import PageWrapper from '@renderer/components/base/PageWrapper';
 import type { EditingModelTarget, ProviderRow } from './types';
 import { buildProviderRows, contextLabel, findModelEntry, getConfiguredModelIds, maskSecret, normalizeDefaultModel } from './utils';
@@ -53,12 +53,11 @@ const SudocodeModelSettings: React.FC = () => {
           Message.error(res?.msg || t('settings.sudocodeModel.saveConfigFailed', '保存模型配置失败'));
           return;
         }
-        if (user?.id) {
-          const persistRes = await ipcBridge.scode.saveCustomModelProviders.invoke({ userId: user.id, providers: extractCustomProvidersFromScodeConfig(nextConfig) });
-          if (!persistRes?.success) {
-            Message.error(persistRes?.msg || t('settings.sudocodeModel.saveCustomProvidersFailed', '保存第三方模型配置失败'));
-            return;
-          }
+        const userId = user?.id ?? GUEST_USER_ID;
+        const persistRes = await ipcBridge.scode.saveCustomModelProviders.invoke({ userId, providers: extractCustomProvidersFromScodeConfig(nextConfig) });
+        if (!persistRes?.success) {
+          Message.error(persistRes?.msg || t('settings.sudocodeModel.saveCustomProvidersFailed', '保存第三方模型配置失败'));
+          return;
         }
         setConfig(nextConfig);
         Message.success(t('settings.sudocodeModel.saveConfigSuccess', '模型配置已保存'));

--- a/src/renderer/pages/skills/index.tsx
+++ b/src/renderer/pages/skills/index.tsx
@@ -30,7 +30,7 @@ import type { IBridgeResponse, SkillLatestVersion, SkillDetailResponse, SkillSto
 
 const SkillSettings: React.FC = () => {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, isGuest } = useAuth();
   const navigate = useNavigate();
 
   // Tab state
@@ -1245,16 +1245,22 @@ const SkillSettings: React.FC = () => {
                   </div>
                 )
               ) : activeTab === 'exclusive' && !enterpriseCode ? (
-                <div className='flex flex-col items-center justify-center py-12 text-secondary gap-2'>
-                  <Shield size={32} className='text-tertiary' />
-                  <span className='text-13px'>{t('settings.skill.noEnterpriseCode', '当前账号没有企业编码，无法加载专属技能。')}</span>
-                </div>
+                isGuest ? (
+                  <HubEmptyState onLogin={() => navigate('/login')} />
+                ) : (
+                  <div className='flex flex-col items-center justify-center py-12 text-secondary gap-2'>
+                    <Shield size={32} className='text-tertiary' />
+                    <span className='text-13px'>{t('settings.skill.noEnterpriseCode', '当前账号没有企业编码，无法加载专属技能。')}</span>
+                  </div>
+                )
               ) : loading || !installedSkillsReady ? (
                 <div className='flex justify-center items-center py-12'>
                   <Spin size={28} />
                 </div>
               ) : skills.length === 0 ? (
-                hubError ? (
+                isGuest ? (
+                  <HubEmptyState onLogin={() => navigate('/login')} />
+                ) : hubError ? (
                   <HubEmptyState error={hubError} onRetry={() => void fetchSkills()} />
                 ) : (
                   <div className='flex flex-col items-center justify-center py-12 text-secondary gap-2'>

--- a/src/renderer/pages/team/detail.tsx
+++ b/src/renderer/pages/team/detail.tsx
@@ -67,13 +67,15 @@ function TeamDetailPage() {
   const leaderTeamSendMessage = useMemo(
     () =>
       async ({ input, files, msg_id }: { input: string; files?: string[]; msg_id?: string }) => {
-        if (isGuest && ready && !hasModel) {
+        // claude/scode leaders carry their own config and must not be blocked by model.config.
+        // Probing on every team message is too costly, so skip the guard for these two backends only.
+        if (isGuest && ready && !hasModel && leader.assistant_backend !== 'claude' && leader.assistant_backend !== 'scode') {
           Message.error(t('guid.modelNotConfigured', { defaultValue: '未配置可用模型，请在设置页添加模型' }));
           return;
         }
         await ipcBridge.team.sendMessage.invoke({ teamId, input, files, msgId: msg_id });
       },
-    [teamId, t, isGuest, hasModel, ready]
+    [teamId, t, isGuest, hasModel, ready, leader?.assistant_backend]
   );
 
   const onLeaderTeamAnswerQuestion = useMemo(

--- a/src/renderer/pages/team/detail.tsx
+++ b/src/renderer/pages/team/detail.tsx
@@ -1,4 +1,4 @@
-import { Spin } from '@arco-design/web-react';
+import { Message, Spin } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -6,6 +6,8 @@ import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/storage';
 import { shouldSyncWorkspaceSkills } from '@/common/utils/workspaceSkillSync';
 import { emitter } from '@/renderer/utils/emitter';
+import { useAuth } from '@/renderer/context/AuthContext';
+import { useHasAvailableModel } from '@/renderer/hooks/useHasAvailableModel';
 import type { AcpBackend } from '@/types/acpTypes';
 import AcpChat from '@renderer/pages/conversation/acp/AcpChat';
 import ChatLayout from '@renderer/pages/conversation/ChatLayout';
@@ -60,12 +62,18 @@ function TeamDetailPage() {
     };
   }, [leader?.conversation_id]);
 
+  const { isGuest } = useAuth();
+  const { hasModel, ready } = useHasAvailableModel();
   const leaderTeamSendMessage = useMemo(
     () =>
       async ({ input, files, msg_id }: { input: string; files?: string[]; msg_id?: string }) => {
+        if (isGuest && ready && !hasModel) {
+          Message.error(t('guid.modelNotConfigured', { defaultValue: '未配置可用模型，请在设置页添加模型' }));
+          return;
+        }
         await ipcBridge.team.sendMessage.invoke({ teamId, input, files, msgId: msg_id });
       },
-    [teamId]
+    [teamId, t, isGuest, hasModel, ready]
   );
 
   const onLeaderTeamAnswerQuestion = useMemo(

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -45,7 +45,8 @@ const ENTERPRISE_ALLOWED_PATHS = ['/settings/profile', '/settings/enterprise', '
 // Mode-aware default settings route
 const SettingsDefaultRoute: React.FC = () => {
   const { isEnterprise } = useAppMode();
-  return <Navigate to={isEnterprise ? '/settings/enterprise' : '/settings/profile'} replace />;
+  const { isGuest } = useAuth();
+  return <Navigate to={isGuest ? '/settings/model' : isEnterprise ? '/settings/enterprise' : '/settings/profile'} replace />;
 };
 
 const PROTECTED_ROUTE_CONFIGS = [
@@ -92,8 +93,13 @@ const ProtectedLayout: React.FC<{ layout: React.ReactElement }> = ({ layout }) =
     return <AppLoader />;
   }
 
-  if (status !== 'authenticated') {
+  if (status !== 'authenticated' && status !== 'guest') {
     return <Navigate to='/login' replace />;
+  }
+
+  // 游客态隐藏「用户中心」「充值中心」（需求 4）：直达这两个 URL 重定向到 /settings/model
+  if (status === 'guest' && (location.pathname === '/settings/profile' || location.pathname === '/settings/recharge')) {
+    return <Navigate to='/settings/model' replace />;
   }
 
   // Wait for useAppMode async initialization to prevent route guard bypass on page refresh

--- a/tests/unit/StreamingThinkFilter.test.ts
+++ b/tests/unit/StreamingThinkFilter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { StreamingThinkFilter } from '@/process/task/acp/StreamingThinkFilter';
+
+function feedAll(filter: StreamingThinkFilter, chunks: string[]): string {
+  return chunks.map((c) => filter.feed(c)).join('');
+}
+
+describe('StreamingThinkFilter', () => {
+  describe('think blocks', () => {
+    it('strips a complete <think>...</think> block within one chunk', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['<think>secret</think>visible'])).toBe('visible');
+    });
+
+    it('strips a <thinking>...</thinking> block', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['<thinking>secret</thinking>visible'])).toBe('visible');
+    });
+
+    it('handles an opening tag split across chunks', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['<thi', 'nk>secret</think>visible'])).toBe('visible');
+    });
+
+    it('handles a closing tag split across chunks', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['<think>secret</thi', 'nk>visible'])).toBe('visible');
+    });
+
+    it('drops an unclosed <think> at flush (still inside think)', () => {
+      const f = new StreamingThinkFilter();
+      expect(f.feed('<think>secret')).toBe('');
+      expect(f.flush()).toBe('');
+    });
+  });
+
+  describe('normal text (constraint: do not affect sudorouter-style output)', () => {
+    it('passes plain text through unchanged', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['hello world'])).toBe('hello world');
+    });
+
+    it('does not swallow HTML / code-like angle brackets', () => {
+      const f1 = new StreamingThinkFilter();
+      expect(feedAll(f1, ['<div>hi</div>'])).toBe('<div>hi</div>');
+      const f2 = new StreamingThinkFilter();
+      expect(feedAll(f2, ['<table>x</table>'])).toBe('<table>x</table>');
+    });
+
+    it('uses strict matching: "< think>" (with space) is not a tag', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['a < think> b'])).toBe('a < think> b');
+    });
+
+    it('passes a stray </think> (no opening tag) through for renderer fallback', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['thinking</think>rest'])).toBe('thinking</think>rest');
+    });
+
+    it('reunites a lone "<" across chunks without losing it', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['a <', ' b'])).toBe('a < b');
+    });
+
+    it('reunites a "<thi" + non-think across chunks without losing text', () => {
+      const f = new StreamingThinkFilter();
+      expect(feedAll(f, ['<thi', 'ng>'])).toBe('<thing>');
+    });
+  });
+
+  describe('flush (no trailing char loss)', () => {
+    it('flush releases a trailing "<" as normal text', () => {
+      const f = new StreamingThinkFilter();
+      expect(f.feed('a <')).toBe('a ');
+      expect(f.flush()).toBe('<');
+    });
+
+    it('flush releases a trailing "<thi" prefix as normal text', () => {
+      const f = new StreamingThinkFilter();
+      expect(f.feed('x<thi')).toBe('x');
+      expect(f.flush()).toBe('<thi');
+    });
+  });
+});

--- a/tests/unit/scodeConfig.test.ts
+++ b/tests/unit/scodeConfig.test.ts
@@ -332,4 +332,35 @@ describe('scodeConfig', () => {
     expect(config.models?.auto?.providers?.proxy?.api).toBe('openai-responses');
     expect(config.models?.['gpt-5.5']?.providers?.proxy?.api).toBe('openai-responses');
   });
+
+  it('drops sudorouter models when rebuilding from an empty base with custom providers only (guest restore)', () => {
+    const withBoth = mergeCustomProviderIntoScodeConfig(
+      buildScodeConfigFromLoginPayload({
+        sudorouterKey: 'router-key',
+        modelServiceUrl: 'https://hk.sudorouter.ai/v1',
+        models: ['gemini-3-flash-preview', SCODE_AUTO_ROUTER_MODEL_ID],
+      }),
+      {
+        providerId: 'custom-openai',
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'custom-key',
+        models: [{ id: 'gpt-4o' }],
+      }
+    );
+
+    const restored = mergeCustomProvidersIntoScodeConfig({}, extractCustomProvidersFromScodeConfig(withBoth));
+
+    // Custom provider retained
+    expect(restored.models?.['custom-openai/gpt-4o']?.providers?.['api-key']?.provider).toBe('custom-openai');
+    expect(restored.auth_modes?.['api-key']?.['custom-openai']).toEqual({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'custom-key',
+    });
+    // Sudorouter models and credentials cleared (guest has no sudorouter key)
+    expect(restored.auth_modes?.proxy?.sudorouter).toBeUndefined();
+    const sudorouterAliases = Object.entries(restored.models || {})
+      .filter(([, model]) => model.providers?.proxy?.provider === 'sudorouter')
+      .map(([alias]) => alias);
+    expect(sudorouterAliases).toEqual([]);
+  });
 });

--- a/tests/unit/scodeProxyModels.test.ts
+++ b/tests/unit/scodeProxyModels.test.ts
@@ -81,4 +81,25 @@ describe('scodeProxyModels', () => {
       { id: 'custom-openai/gpt-4o', label: 'gpt-4o', provider: 'custom-openai', providerLabel: 'custom-openai' },
     ]);
   });
+
+  it('falls back to availableModels[0] when currentModelId is a stale/ghost id not in the list', () => {
+    // Fixture intentionally has no default_model (so defaultInList=false) to prove
+    // that a ghost explicit id falls back to availableModels[0], not to default.
+    const configPath = writeConfig({
+      models: {
+        'custom-openai/MiniMax-M3': {
+          alias: 'custom-openai/MiniMax-M3',
+          name: 'MiniMax-M3',
+          providers: {
+            'api-key': { provider: 'custom-openai', model: 'MiniMax-M3', api: 'openai-completions' },
+          },
+        },
+      },
+    });
+
+    const info = getScodeProxyModelInfoSync('sudorouter/gpt-5.5', configPath);
+
+    expect(info?.currentModelId).toBe('custom-openai/MiniMax-M3');
+    expect(info?.currentModelLabel).toBe('MiniMax-M3');
+  });
 });

--- a/tests/unit/windowsImagePaths.test.ts
+++ b/tests/unit/windowsImagePaths.test.ts
@@ -10,8 +10,8 @@ vi.mock('@process/message', () => ({
   addOrUpdateMessage: vi.fn(),
 }));
 
-import { normalizeWindowsImagePaths, preprocessContentMessage } from '@process/task/acp/AcpMessagePipeline';
 import { defaultUrlTransform } from 'react-markdown';
+import { normalizeWindowsImagePaths, preprocessContentMessage } from '@process/task/acp/AcpMessagePipeline';
 
 describe('normalizeWindowsImagePaths', () => {
   it('should normalize Windows backslash paths in markdown image syntax', () => {
@@ -154,7 +154,7 @@ describe('preprocessContentMessage', () => {
     expect(result).toBe(message);
   });
 
-  it('should handle both think tags and Windows paths', () => {
+  it('preserves think tags (filtering moved to StreamingThinkFilter) and normalizes Windows paths', () => {
     const message = {
       type: 'content' as const,
       conversation_id: 'test-conv',
@@ -162,7 +162,9 @@ describe('preprocessContentMessage', () => {
       data: '<think>thinking...</think>![](C:\\Users\\test\\image.png)',
     };
     const result = preprocessContentMessage(message);
-    expect(result.data).toBe('![](C:/Users/test/image.png)');
+    // think tags are intentionally preserved here; streaming think filtering is
+    // handled by StreamingThinkFilter at the AcpAgent stream level.
+    expect(result.data).toBe('<think>thinking...</think>![](C:/Users/test/image.png)');
   });
 
   it('should return same message if no changes needed', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -126,6 +126,8 @@ export default defineConfig({
         'src/common/types/conversion.ts',
         // Renderer utils
         'src/renderer/components/HubEmptyState.tsx',
+        'src/renderer/hooks/useAvailableModels.ts',
+        'src/renderer/hooks/useHasAvailableModel.ts',
         'src/renderer/components/sendboxKeyGuards.ts',
         'src/renderer/messages/RuntimeErrorBanner.tsx',
         'src/renderer/messages/useAutoScroll.ts',


### PR DESCRIPTION
## Summary
Introduces guest mode so Sudowork can be used without logging in, plus related fixes surfaced when rebasing onto `dev`.

## Changes
- feat(guest): allow using sudowork without login (login page gains a "skip for now" link)
- fix(guest): use sudocode.json for model checks and skip the sudorouter list fetch
- fix(guest): correct model display and hide scode thinking leakage
- fix(guest): skip the model.config pre-send guard for claude/scode backends
- chore(i18n): reword the login "skip" link copy to "skip for now" across all locales
- fix(guest): type `modelBackendKey` as string to match `useGuidAgentSelection`