### PR TITLE
feat(acp): surface inline <think> reasoning in a collapsible thought panel

### DIFF
--- a/src/process/message.ts
+++ b/src/process/message.ts
@@ -61,7 +61,15 @@ export class ConversationManageWithDB {
               this.stack.push(updateMessage);
             }
           } else {
-            messageList = composeMessage(updateMessage[1], messageList, (type, message) => {
+            const msg = updateMessage[1];
+            // thought 按 msg_id 合并，但 messageList 只含最近 50 条；若已被挤出
+            // 窗口，composeMessage 会当新消息 insert 导致重载历史时出现重复思考块。
+            // 先把 DB 里的既有记录拉进 list，使 composeMessage 走 update 复用既有 id。
+            if (msg.type === 'thought' && msg.msg_id && !messageList.some((m) => m.type === 'thought' && m.msg_id === msg.msg_id)) {
+              const existing = this.db.getMessageByMsgId(this.conversation_id, msg.msg_id, 'thought');
+              if (existing.success && existing.data) messageList.push(existing.data);
+            }
+            messageList = composeMessage(msg, messageList, (type, message) => {
               if (type === 'insert') this.db.insertMessage(message);
               if (type === 'update') {
                 this.db.updateMessage(message.id, message);

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -3400,13 +3400,13 @@ This identity statement takes priority over the default identity in USER.md.
     // of queue() (DB) and responseStream.emit() (IPC display) so both paths stay clean.
     if (filteredMessage.type === 'content' && typeof filteredMessage.data === 'string' && filteredMessage.msg_id) {
       const filter = this.getOrCreateThinkFilter(filteredMessage.msg_id);
-      const { content, thinkText } = filter.feed(filteredMessage.data);
+      const { content, thinkDelta, thinkFull } = filter.feed(filteredMessage.data);
       filteredMessage = { ...filteredMessage, data: content };
       // Emit extracted think content as a thought message BEFORE the content
       // empty check below: a pure-think chunk (e.g. "<think>The") has empty
       // content and would otherwise return early, dropping the thought.
-      if (thinkText) {
-        this.emitThoughtMessage(`${filteredMessage.msg_id}-think`, thinkText);
+      if (thinkDelta && thinkFull) {
+        this.emitThoughtMessage(`${filteredMessage.msg_id}-think`, thinkDelta, thinkFull);
       }
     }
 
@@ -3493,23 +3493,38 @@ This identity statement takes priority over the default identity in USER.md.
    * tags) as a `thought` message so it renders in the "思考过程" area
    * (MessageThought). Bypasses handleStreamEvent because that path triggers
    * flushThinkFilters() for non text/content messages, which would clear the
-   * filter mid-stream and lose accumulated think state. Reuses the same
-   * transformMessage → addOrUpdateMessage → emit path the thought case uses.
+   * filter mid-stream and lose accumulated think state.
+   *
+   * DB receives the FULL accumulated text (replace-merge via composeMessage,
+   * unchanged — shared with RemoteAgent). IPC receives only the per-call DELTA
+   * (append-merge in the renderer) so long reasoning is O(n) over IPC instead
+   * of re-sending the full text every chunk. subject is derived from `full` and
+   * shared by both paths. Also marks the turn as having visible assistant output
+   * so a pure-think reply no longer trips the "no summary" fallback.
    */
-  private emitThoughtMessage(thoughtMsgId: string, description: string): void {
-    if (!description.trim()) return;
-    const thoughtMessage = {
+  private emitThoughtMessage(thoughtMsgId: string, delta: string, full: string): void {
+    if (!delta.trim()) return;
+    this.turnHadVisibleAssistantContent = true;
+    this.lastVisibleAssistantContentSequence = ++this.turnEventSequence;
+    const subject = this.extractThoughtSubject(full);
+    const dbMessage = {
       type: 'thought',
       msg_id: thoughtMsgId,
       conversation_id: this.conversation_id,
-      data: { subject: this.extractThoughtSubject(description), description },
+      data: { subject, description: full },
     } as IResponseMessage;
-    const tMessage = transformMessage(thoughtMessage);
+    const tMessage = transformMessage(dbMessage);
     if (tMessage) {
       addOrUpdateMessage(this.conversation_id, tMessage);
     }
-    ipcBridge.acpConversation.responseStream.emit(thoughtMessage);
-    channelEventBus.emitAgentMessage(this.conversation_id, { ...thoughtMessage, conversation_id: this.conversation_id });
+    const ipcMessage = {
+      type: 'thought',
+      msg_id: thoughtMsgId,
+      conversation_id: this.conversation_id,
+      data: { subject, description: delta },
+    } as IResponseMessage;
+    ipcBridge.acpConversation.responseStream.emit(ipcMessage);
+    channelEventBus.emitAgentMessage(this.conversation_id, { ...ipcMessage, conversation_id: this.conversation_id });
   }
 
   private async handleSignalEvent(v: IResponseMessage): Promise<void> {

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -3400,7 +3400,14 @@ This identity statement takes priority over the default identity in USER.md.
     // of queue() (DB) and responseStream.emit() (IPC display) so both paths stay clean.
     if (filteredMessage.type === 'content' && typeof filteredMessage.data === 'string' && filteredMessage.msg_id) {
       const filter = this.getOrCreateThinkFilter(filteredMessage.msg_id);
-      filteredMessage = { ...filteredMessage, data: filter.feed(filteredMessage.data) };
+      const { content, thinkText } = filter.feed(filteredMessage.data);
+      filteredMessage = { ...filteredMessage, data: content };
+      // Emit extracted think content as a thought message BEFORE the content
+      // empty check below: a pure-think chunk (e.g. "<think>The") has empty
+      // content and would otherwise return early, dropping the thought.
+      if (thinkText) {
+        this.emitThoughtMessage(`${filteredMessage.msg_id}-think`, thinkText);
+      }
     }
 
     if (message.type === 'content' && filteredMessage.type === 'content' && filteredMessage.data === '') {
@@ -3479,6 +3486,30 @@ This identity statement takes priority over the default identity in USER.md.
       this.thinkFilters.set(msgId, filter);
     }
     return filter;
+  }
+
+  /**
+   * Emit think content (extracted by StreamingThinkFilter from inline `<think>`
+   * tags) as a `thought` message so it renders in the "思考过程" area
+   * (MessageThought). Bypasses handleStreamEvent because that path triggers
+   * flushThinkFilters() for non text/content messages, which would clear the
+   * filter mid-stream and lose accumulated think state. Reuses the same
+   * transformMessage → addOrUpdateMessage → emit path the thought case uses.
+   */
+  private emitThoughtMessage(thoughtMsgId: string, description: string): void {
+    if (!description.trim()) return;
+    const thoughtMessage = {
+      type: 'thought',
+      msg_id: thoughtMsgId,
+      conversation_id: this.conversation_id,
+      data: { subject: this.extractThoughtSubject(description), description },
+    } as IResponseMessage;
+    const tMessage = transformMessage(thoughtMessage);
+    if (tMessage) {
+      addOrUpdateMessage(this.conversation_id, tMessage);
+    }
+    ipcBridge.acpConversation.responseStream.emit(thoughtMessage);
+    channelEventBus.emitAgentMessage(this.conversation_id, { ...thoughtMessage, conversation_id: this.conversation_id });
   }
 
   private async handleSignalEvent(v: IResponseMessage): Promise<void> {

--- a/src/process/task/acp/StreamingThinkFilter.ts
+++ b/src/process/task/acp/StreamingThinkFilter.ts
@@ -9,9 +9,10 @@
  *
  * Filters `<think>...</think>` / `<thinking>...</thinking>` blocks out of a
  * stream of text chunks where the tags may be split across chunk boundaries.
- * The text inside the tags is accumulated and surfaced as `thinkText` (the FULL
- * accumulated text so far, for replace-style merging) instead of being dropped,
- * so callers can route it to the dedicated reasoning surface (MessageThought).
+ * The text inside the tags is accumulated and surfaced as `thinkFull` (the
+ * FULL accumulated text so far, for DB replace-merge) and `thinkDelta` (the
+ * this-call increment, for IPC append-merge) instead of being dropped, so
+ * callers can route it to the dedicated reasoning surface (MessageThought).
  *
  * Design constraints (must not affect models that never emit think tags, e.g.
  * sudorouter):
@@ -67,20 +68,33 @@ export class StreamingThinkFilter {
   // Accumulated text inside <think>/<thinking> blocks for this filter (one
   // filter per content msg_id). Persists across feed() calls so multi-chunk and
   // multi-block think content merges into one reasoning block; reset on flush().
-  // Emitted incrementally via thinkText (replace semantics).
+  // Returned as thinkFull (complete value, for DB replace) and thinkDelta
+  // (this-call increment, for IPC append).
   private accumulatedThink = '';
+  // True once any <think> block has been entered; gates the inter-block
+  // separator so the FIRST block has no leading separator.
+  private hadAnyThink = false;
+  // Set when a new <think> block opens after a prior block; flushed as a "\n\n"
+  // prefix on the next think-text accumulation so the separator always travels
+  // with content (never emitted as a standalone whitespace-only delta).
+  private pendingThinkSeparator = false;
 
   /**
-   * Feed one chunk. Returns `{ content, thinkText }`:
+   * Feed one chunk. Returns `{ content, thinkDelta, thinkFull }`:
    * - `content`: the non-think text to display now (may be '').
-   * - `thinkText`: when new think text accumulated this call, the FULL
-   *   accumulated think text so far (for replace-style merge); otherwise null.
+   * - `thinkDelta`: when new think text accumulated this call, the increment
+   *   added this call (for IPC append-style merge); otherwise null.
+   * - `thinkFull`: when new think text accumulated this call, the FULL
+   *   accumulated think text so far (for DB replace-style merge); otherwise null.
+   * Multiple <think> blocks in one filter merge with a `\n\n` separator that
+   * always rides along with content (never a standalone whitespace delta).
    */
-  feed(chunk: string): { content: string; thinkText: string | null } {
+  feed(chunk: string): { content: string; thinkDelta: string | null; thinkFull: string | null } {
     try {
       let buffer = this.pendingTail + chunk;
       this.pendingTail = '';
       let output = '';
+      const prevLen = this.accumulatedThink.length;
       let hadNewThink = false;
       let guard = 0;
       while (buffer.length > 0 && guard++ < 1000) {
@@ -89,7 +103,7 @@ export class StreamingThinkFilter {
           if (found) {
             // Text before the close tag is think content; accumulate it.
             if (found.idx > 0) {
-              this.accumulatedThink += buffer.slice(0, found.idx);
+              this.appendThink(buffer.slice(0, found.idx));
               hadNewThink = true;
             }
             buffer = buffer.slice(found.idx + found.tag.length);
@@ -99,7 +113,7 @@ export class StreamingThinkFilter {
             // Everything except a possible split close-tag suffix is think content.
             const thinkPart = buffer.slice(0, buffer.length - prefixLen);
             if (thinkPart) {
-              this.accumulatedThink += thinkPart;
+              this.appendThink(thinkPart);
               hadNewThink = true;
             }
             this.pendingTail = buffer.slice(buffer.length - prefixLen);
@@ -109,6 +123,10 @@ export class StreamingThinkFilter {
           const found = findEarliestTag(buffer, OPEN_TAGS);
           if (found) {
             output += buffer.slice(0, found.idx);
+            // Entering a new think block: if we already had one, queue a
+            // separator to be emitted ahead of this block's first content.
+            if (this.hadAnyThink) this.pendingThinkSeparator = true;
+            this.hadAnyThink = true;
             buffer = buffer.slice(found.idx + found.tag.length);
             this.isInThink = true;
           } else {
@@ -119,14 +137,31 @@ export class StreamingThinkFilter {
           }
         }
       }
-      return { content: output, thinkText: hadNewThink ? this.accumulatedThink : null };
+      return {
+        content: output,
+        thinkDelta: hadNewThink ? this.accumulatedThink.slice(prevLen) : null,
+        thinkFull: hadNewThink ? this.accumulatedThink : null,
+      };
     } catch {
       // Defensive: never let a filter anomaly break the stream. Reset to a
       // known normal state and pass the original chunk through verbatim.
       this.isInThink = false;
       this.pendingTail = '';
-      return { content: chunk, thinkText: null };
+      return { content: chunk, thinkDelta: null, thinkFull: null };
     }
+  }
+
+  /**
+   * Accumulate think text, prepending the queued inter-block separator (if any)
+   * so it always travels with real content rather than emitting a
+   * whitespace-only delta.
+   */
+  private appendThink(text: string): void {
+    if (this.pendingThinkSeparator) {
+      this.accumulatedThink += '\n\n';
+      this.pendingThinkSeparator = false;
+    }
+    this.accumulatedThink += text;
   }
 
   /**
@@ -141,6 +176,8 @@ export class StreamingThinkFilter {
       const tail = this.pendingTail;
       this.pendingTail = '';
       this.accumulatedThink = '';
+      this.hadAnyThink = false;
+      this.pendingThinkSeparator = false;
       if (this.isInThink) {
         this.isInThink = false;
         return '';
@@ -150,6 +187,8 @@ export class StreamingThinkFilter {
       this.isInThink = false;
       this.pendingTail = '';
       this.accumulatedThink = '';
+      this.hadAnyThink = false;
+      this.pendingThinkSeparator = false;
       return '';
     }
   }

--- a/src/process/task/acp/StreamingThinkFilter.ts
+++ b/src/process/task/acp/StreamingThinkFilter.ts
@@ -9,6 +9,9 @@
  *
  * Filters `<think>...</think>` / `<thinking>...</thinking>` blocks out of a
  * stream of text chunks where the tags may be split across chunk boundaries.
+ * The text inside the tags is accumulated and surfaced as `thinkText` (the FULL
+ * accumulated text so far, for replace-style merging) instead of being dropped,
+ * so callers can route it to the dedicated reasoning surface (MessageThought).
  *
  * Design constraints (must not affect models that never emit think tags, e.g.
  * sudorouter):
@@ -20,7 +23,8 @@
  *   spaces, so this is sufficient and avoids swallowing literal `< think>` text
  *   in normal prose / code.
  * - Any exception resets the machine to a known normal state and returns the
- *   original chunk unchanged — a filter anomaly must never break the stream.
+ *   original chunk unchanged (thinkText=null) — a filter anomaly must never
+ *   break the stream.
  */
 
 const OPEN_TAGS = ['<think>', '<thinking>'];
@@ -60,22 +64,44 @@ function trailingPrefixLen(buffer: string, tags: string[]): number {
 export class StreamingThinkFilter {
   private isInThink = false;
   private pendingTail = '';
+  // Accumulated text inside <think>/<thinking> blocks for this filter (one
+  // filter per content msg_id). Persists across feed() calls so multi-chunk and
+  // multi-block think content merges into one reasoning block; reset on flush().
+  // Emitted incrementally via thinkText (replace semantics).
+  private accumulatedThink = '';
 
-  /** Feed one chunk; returns the non-think text that should be displayed now (may be ''). */
-  feed(chunk: string): string {
+  /**
+   * Feed one chunk. Returns `{ content, thinkText }`:
+   * - `content`: the non-think text to display now (may be '').
+   * - `thinkText`: when new think text accumulated this call, the FULL
+   *   accumulated think text so far (for replace-style merge); otherwise null.
+   */
+  feed(chunk: string): { content: string; thinkText: string | null } {
     try {
       let buffer = this.pendingTail + chunk;
       this.pendingTail = '';
       let output = '';
+      let hadNewThink = false;
       let guard = 0;
       while (buffer.length > 0 && guard++ < 1000) {
         if (this.isInThink) {
           const found = findEarliestTag(buffer, CLOSE_TAGS);
           if (found) {
+            // Text before the close tag is think content; accumulate it.
+            if (found.idx > 0) {
+              this.accumulatedThink += buffer.slice(0, found.idx);
+              hadNewThink = true;
+            }
             buffer = buffer.slice(found.idx + found.tag.length);
             this.isInThink = false;
           } else {
             const prefixLen = trailingPrefixLen(buffer, CLOSE_TAGS);
+            // Everything except a possible split close-tag suffix is think content.
+            const thinkPart = buffer.slice(0, buffer.length - prefixLen);
+            if (thinkPart) {
+              this.accumulatedThink += thinkPart;
+              hadNewThink = true;
+            }
             this.pendingTail = buffer.slice(buffer.length - prefixLen);
             buffer = '';
           }
@@ -93,13 +119,13 @@ export class StreamingThinkFilter {
           }
         }
       }
-      return output;
+      return { content: output, thinkText: hadNewThink ? this.accumulatedThink : null };
     } catch {
       // Defensive: never let a filter anomaly break the stream. Reset to a
       // known normal state and pass the original chunk through verbatim.
       this.isInThink = false;
       this.pendingTail = '';
-      return chunk;
+      return { content: chunk, thinkText: null };
     }
   }
 
@@ -107,11 +133,14 @@ export class StreamingThinkFilter {
    * Flush at stream end. Returns any pending tail that should be displayed:
    * - normal state: the tail is ordinary text (e.g. a trailing `<`), return it.
    * - think state (unclosed `<think>`): the tail is inside think, drop it and reset.
+   * Think content accumulated so far was already emitted incrementally via
+   * feed() thinkText, so flush only resets accumulatedThink without re-emitting.
    */
   flush(): string {
     try {
       const tail = this.pendingTail;
       this.pendingTail = '';
+      this.accumulatedThink = '';
       if (this.isInThink) {
         this.isInThink = false;
         return '';
@@ -120,6 +149,7 @@ export class StreamingThinkFilter {
     } catch {
       this.isInThink = false;
       this.pendingTail = '';
+      this.accumulatedThink = '';
       return '';
     }
   }

--- a/src/process/task/acp/StreamingThinkFilter.ts
+++ b/src/process/task/acp/StreamingThinkFilter.ts
@@ -147,6 +147,9 @@ export class StreamingThinkFilter {
       // known normal state and pass the original chunk through verbatim.
       this.isInThink = false;
       this.pendingTail = '';
+      this.accumulatedThink = '';
+      this.hadAnyThink = false;
+      this.pendingThinkSeparator = false;
       return { content: chunk, thinkDelta: null, thinkFull: null };
     }
   }

--- a/src/renderer/messages/hooks.ts
+++ b/src/renderer/messages/hooks.ts
@@ -24,7 +24,7 @@ const indexCache = new WeakMap<TMessage[], MessageIndex>();
 
 // 构建消息索引
 // Build message index
-function buildMessageIndex(list: TMessage[]): MessageIndex {
+export function buildMessageIndex(list: TMessage[]): MessageIndex {
   const msgIdIndex = new Map<string, number>();
   const callIdIndex = new Map<string, number>();
   const toolCallIdIndex = new Map<string, number>();
@@ -59,7 +59,7 @@ function getOrBuildIndex(list: TMessage[]): MessageIndex {
 
 // 使用索引优化的消息合并函数
 // Index-optimized message compose function
-function composeMessageWithIndex(message: TMessage, list: TMessage[], index: MessageIndex): TMessage[] {
+export function composeMessageWithIndex(message: TMessage, list: TMessage[], index: MessageIndex): TMessage[] {
   if (!message) return list || [];
   if (!list?.length) {
     // Update index when adding first message
@@ -202,6 +202,27 @@ function composeMessageWithIndex(message: TMessage, list: TMessage[], index: Mes
     const newIdx = list.length;
     index.msgIdIndex.set(message.msg_id, newIdx);
     return list.concat(message);
+  }
+
+  // thought: streaming think deltas arrive incrementally — append description,
+  // subject follows the latest full-text first line from the emitter.
+  if (message.type === 'thought' && message.msg_id) {
+    const existingIdx = index.msgIdIndex.get(message.msg_id);
+    if (existingIdx !== undefined && existingIdx < list.length) {
+      const existingMsg = list[existingIdx];
+      if (existingMsg.type === 'thought') {
+        const newList = list.slice();
+        newList[existingIdx] = {
+          ...existingMsg,
+          content: {
+            subject: message.content.subject,
+            description: (existingMsg.content.description || '') + (message.content.description || ''),
+          },
+        } as TMessage;
+        return newList;
+      }
+    }
+    // Not found / type mismatch: fall through to the generic insert below.
   }
 
   // agent_status / tips / plan and other msg_id-based messages:

--- a/src/renderer/pages/conversation/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/acp/AcpSendBox.tsx
@@ -79,7 +79,9 @@ const useAcpMessage = (conversation_id: string) => {
   } | null>(null);
 
   // Think 消息节流：限制更新频率，减少渲染次数
-  // Throttle thought updates to reduce render frequency
+  // Throttle thought updates to reduce render frequency. Think deltas arrive
+  // incrementally, so pending accumulates description (subject follows the
+  // latest delta) and each flush appends to the current thought state.
   const thoughtThrottleRef = useRef<{
     lastUpdate: number;
     pending: ThoughtData | null;
@@ -88,32 +90,27 @@ const useAcpMessage = (conversation_id: string) => {
 
   const throttledSetThought = useMemo(() => {
     const THROTTLE_MS = 50;
+    const flush = () => {
+      const ref = thoughtThrottleRef.current;
+      const pending = ref.pending;
+      ref.pending = null;
+      ref.lastUpdate = Date.now();
+      if (pending) {
+        setThought((prev) => ({ subject: pending.subject, description: (prev.description || '') + pending.description }));
+      }
+    };
     return (data: ThoughtData) => {
       const now = Date.now();
       const ref = thoughtThrottleRef.current;
+      ref.pending = ref.pending ? { subject: data.subject, description: ref.pending.description + data.description } : { subject: data.subject, description: data.description };
       if (now - ref.lastUpdate >= THROTTLE_MS) {
-        ref.lastUpdate = now;
-        ref.pending = null;
         if (ref.timer) {
           clearTimeout(ref.timer);
           ref.timer = null;
         }
-        setThought(data);
-      } else {
-        ref.pending = data;
-        if (!ref.timer) {
-          ref.timer = setTimeout(
-            () => {
-              ref.lastUpdate = Date.now();
-              ref.timer = null;
-              if (ref.pending) {
-                setThought(ref.pending);
-                ref.pending = null;
-              }
-            },
-            THROTTLE_MS - (now - ref.lastUpdate)
-          );
-        }
+        flush();
+      } else if (!ref.timer) {
+        ref.timer = setTimeout(flush, THROTTLE_MS - (now - ref.lastUpdate));
       }
     };
   }, []);

--- a/tests/unit/StreamingThinkFilter.test.ts
+++ b/tests/unit/StreamingThinkFilter.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { StreamingThinkFilter } from '@/process/task/acp/StreamingThinkFilter';
 
 function feedAll(filter: StreamingThinkFilter, chunks: string[]): string {
-  return chunks.map((c) => filter.feed(c)).join('');
+  return chunks.map((c) => filter.feed(c).content).join('');
 }
 
 describe('StreamingThinkFilter', () => {
-  describe('think blocks', () => {
+  describe('think blocks (content stripping)', () => {
     it('strips a complete <think>...</think> block within one chunk', () => {
       const f = new StreamingThinkFilter();
       expect(feedAll(f, ['<think>secret</think>visible'])).toBe('visible');
@@ -27,10 +27,59 @@ describe('StreamingThinkFilter', () => {
       expect(feedAll(f, ['<think>secret</thi', 'nk>visible'])).toBe('visible');
     });
 
-    it('drops an unclosed <think> at flush (still inside think)', () => {
+    it('keeps content empty for an unclosed <think> and does not leak at flush', () => {
       const f = new StreamingThinkFilter();
-      expect(f.feed('<think>secret')).toBe('');
+      expect(f.feed('<think>secret').content).toBe('');
       expect(f.flush()).toBe('');
+    });
+  });
+
+  describe('think extraction (thinkText)', () => {
+    it('returns the think content as thinkText (full accumulated value)', () => {
+      const f = new StreamingThinkFilter();
+      const r = f.feed('<think>secret</think>visible');
+      expect(r.content).toBe('visible');
+      expect(r.thinkText).toBe('secret');
+    });
+
+    it('accumulates think across chunks and returns the full value each time', () => {
+      const f = new StreamingThinkFilter();
+      const r1 = f.feed('<think>hel');
+      expect(r1.content).toBe('');
+      expect(r1.thinkText).toBe('hel');
+      const r2 = f.feed('lo');
+      expect(r2.content).toBe('');
+      expect(r2.thinkText).toBe('hello');
+      const r3 = f.feed('</think>world');
+      expect(r3.content).toBe('world');
+      expect(r3.thinkText).toBeNull();
+    });
+
+    it('returns thinkText=null when no new think text arrived (close-only chunk)', () => {
+      const f = new StreamingThinkFilter();
+      f.feed('<think>secret');
+      const r = f.feed('</think>visible');
+      expect(r.content).toBe('visible');
+      expect(r.thinkText).toBeNull();
+    });
+
+    it('merges multiple think blocks in one filter into one thinkText', () => {
+      const f = new StreamingThinkFilter();
+      f.feed('<think>a</think>');
+      const r = f.feed('x<think>b</think>y');
+      expect(r.content).toBe('xy');
+      expect(r.thinkText).toBe('ab');
+    });
+
+    it('emits think incrementally even when unclosed at flush', () => {
+      const f = new StreamingThinkFilter();
+      expect(f.feed('<think>secret').thinkText).toBe('secret');
+      expect(f.flush()).toBe('');
+    });
+
+    it('does not report thinkText for normal text', () => {
+      const f = new StreamingThinkFilter();
+      expect(f.feed('hello world').thinkText).toBeNull();
     });
   });
 
@@ -71,13 +120,13 @@ describe('StreamingThinkFilter', () => {
   describe('flush (no trailing char loss)', () => {
     it('flush releases a trailing "<" as normal text', () => {
       const f = new StreamingThinkFilter();
-      expect(f.feed('a <')).toBe('a ');
+      expect(f.feed('a <').content).toBe('a ');
       expect(f.flush()).toBe('<');
     });
 
     it('flush releases a trailing "<thi" prefix as normal text', () => {
       const f = new StreamingThinkFilter();
-      expect(f.feed('x<thi')).toBe('x');
+      expect(f.feed('x<thi').content).toBe('x');
       expect(f.flush()).toBe('<thi');
     });
   });

--- a/tests/unit/StreamingThinkFilter.test.ts
+++ b/tests/unit/StreamingThinkFilter.test.ts
@@ -141,4 +141,32 @@ describe('StreamingThinkFilter', () => {
       expect(f.flush()).toBe('<thi');
     });
   });
+
+  describe('defensive error recovery (feed catch resets state)', () => {
+    it('resets accumulated think state when feed() catches an internal anomaly', () => {
+      const f = new StreamingThinkFilter();
+      // Precondition: a prior think block leaves accumulatedThink non-empty
+      // and hadAnyThink=true.
+      f.feed('<think>old</think>');
+
+      // Drive feed() into its defensive catch. A Symbol cannot be implicitly
+      // coerced to string, so `pendingTail + chunk` (StreamingThinkFilter.ts:94)
+      // throws TypeError inside the try block. This couples only to feed()'s
+      // public input contract (it concatenates the chunk) — no private-method
+      // name, no vi.spyOn / mock.
+      const sym = Symbol('boom');
+      const r = f.feed(sym as unknown as string);
+      expect(r.content).toBe(sym);
+      expect(r.thinkDelta).toBeNull();
+      expect(r.thinkFull).toBeNull();
+
+      // After the catch the filter must be clean: a subsequent think block must
+      // NOT merge with pre-anomaly 'old' nor prepend a stray '\n\n'.
+      // (Pre-fix: thinkFull would be 'old\n\nfresh', thinkDelta '\n\nfresh'.)
+      const after = f.feed('<think>fresh</think>');
+      expect(after.content).toBe('');
+      expect(after.thinkDelta).toBe('fresh');
+      expect(after.thinkFull).toBe('fresh');
+    });
+  });
 });

--- a/tests/unit/StreamingThinkFilter.test.ts
+++ b/tests/unit/StreamingThinkFilter.test.ts
@@ -34,52 +34,63 @@ describe('StreamingThinkFilter', () => {
     });
   });
 
-  describe('think extraction (thinkText)', () => {
-    it('returns the think content as thinkText (full accumulated value)', () => {
+  describe('think extraction (thinkDelta / thinkFull)', () => {
+    it('returns the think content as thinkDelta (increment) and thinkFull (complete)', () => {
       const f = new StreamingThinkFilter();
       const r = f.feed('<think>secret</think>visible');
       expect(r.content).toBe('visible');
-      expect(r.thinkText).toBe('secret');
+      expect(r.thinkDelta).toBe('secret');
+      expect(r.thinkFull).toBe('secret');
     });
 
-    it('accumulates think across chunks and returns the full value each time', () => {
+    it('accumulates think across chunks: delta is the increment, full is complete', () => {
       const f = new StreamingThinkFilter();
       const r1 = f.feed('<think>hel');
       expect(r1.content).toBe('');
-      expect(r1.thinkText).toBe('hel');
+      expect(r1.thinkDelta).toBe('hel');
+      expect(r1.thinkFull).toBe('hel');
       const r2 = f.feed('lo');
       expect(r2.content).toBe('');
-      expect(r2.thinkText).toBe('hello');
+      expect(r2.thinkDelta).toBe('lo');
+      expect(r2.thinkFull).toBe('hello');
       const r3 = f.feed('</think>world');
       expect(r3.content).toBe('world');
-      expect(r3.thinkText).toBeNull();
+      expect(r3.thinkDelta).toBeNull();
+      expect(r3.thinkFull).toBeNull();
     });
 
-    it('returns thinkText=null when no new think text arrived (close-only chunk)', () => {
+    it('returns thinkDelta/thinkFull=null when no new think text arrived (close-only chunk)', () => {
       const f = new StreamingThinkFilter();
       f.feed('<think>secret');
       const r = f.feed('</think>visible');
       expect(r.content).toBe('visible');
-      expect(r.thinkText).toBeNull();
+      expect(r.thinkDelta).toBeNull();
+      expect(r.thinkFull).toBeNull();
     });
 
-    it('merges multiple think blocks in one filter into one thinkText', () => {
+    it('merges multiple think blocks with a \\n\\n separator (delta carries it with content)', () => {
       const f = new StreamingThinkFilter();
-      f.feed('<think>a</think>');
+      const first = f.feed('<think>a</think>');
+      expect(first.thinkDelta).toBe('a');
+      expect(first.thinkFull).toBe('a');
       const r = f.feed('x<think>b</think>y');
       expect(r.content).toBe('xy');
-      expect(r.thinkText).toBe('ab');
+      expect(r.thinkDelta).toBe('\n\nb');
+      expect(r.thinkFull).toBe('a\n\nb');
     });
 
     it('emits think incrementally even when unclosed at flush', () => {
       const f = new StreamingThinkFilter();
-      expect(f.feed('<think>secret').thinkText).toBe('secret');
+      const r = f.feed('<think>secret');
+      expect(r.thinkDelta).toBe('secret');
+      expect(r.thinkFull).toBe('secret');
       expect(f.flush()).toBe('');
     });
 
-    it('does not report thinkText for normal text', () => {
+    it('does not report think for normal text', () => {
       const f = new StreamingThinkFilter();
-      expect(f.feed('hello world').thinkText).toBeNull();
+      expect(f.feed('hello world').thinkDelta).toBeNull();
+      expect(f.feed('hello world').thinkFull).toBeNull();
     });
   });
 

--- a/tests/unit/composeMessageWithIndex.dom.test.ts
+++ b/tests/unit/composeMessageWithIndex.dom.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { TMessage } from '@/common/chatLib';
+import { buildMessageIndex, composeMessageWithIndex } from '@/renderer/messages/hooks';
+
+type ThoughtMessage = Extract<TMessage, { type: 'thought' }>;
+
+function thought(msgId: string, subject: string, description: string, suffix = description): ThoughtMessage {
+  return {
+    id: `${msgId}-${suffix}`,
+    type: 'thought',
+    msg_id: msgId,
+    position: 'left',
+    conversation_id: 'c',
+    content: { subject, description },
+  } as ThoughtMessage;
+}
+
+describe('composeMessageWithIndex — thought append', () => {
+  it('concatenates description across same-msg_id thought deltas and takes latest subject', () => {
+    let list: TMessage[] = [];
+    const index = buildMessageIndex(list);
+
+    list = composeMessageWithIndex(thought('t1', 's1', 'a'), list, index);
+    expect(list).toHaveLength(1);
+    expect((list[0] as ThoughtMessage).content.description).toBe('a');
+    expect((list[0] as ThoughtMessage).content.subject).toBe('s1');
+
+    list = composeMessageWithIndex(thought('t1', 's2', 'b'), list, index);
+    expect(list).toHaveLength(1);
+    expect((list[0] as ThoughtMessage).content.description).toBe('ab');
+    expect((list[0] as ThoughtMessage).content.subject).toBe('s2');
+
+    list = composeMessageWithIndex(thought('t1', 's3', 'c'), list, index);
+    expect(list).toHaveLength(1);
+    expect((list[0] as ThoughtMessage).content.description).toBe('abc');
+    expect((list[0] as ThoughtMessage).content.subject).toBe('s3');
+  });
+
+  it('keeps distinct thought msg_ids as separate messages', () => {
+    let list: TMessage[] = [];
+    const index = buildMessageIndex(list);
+    list = composeMessageWithIndex(thought('t1', 's1', 'a'), list, index);
+    list = composeMessageWithIndex(thought('t2', 's2', 'b'), list, index);
+    expect(list).toHaveLength(2);
+  });
+
+  it('does not affect tips (still replace by msg_id)', () => {
+    const tips = (msgId: string, content: string): TMessage =>
+      ({
+        id: msgId,
+        type: 'tips',
+        msg_id: msgId,
+        position: 'left',
+        conversation_id: 'c',
+        content: { content, type: 'info' },
+      }) as TMessage;
+
+    let list: TMessage[] = [];
+    const index = buildMessageIndex(list);
+    list = composeMessageWithIndex(tips('k1', 'old'), list, index);
+    list = composeMessageWithIndex(tips('k1', 'new'), list, index);
+    expect(list).toHaveLength(1);
+    expect((list[0].content as { content: string }).content).toBe('new');
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the inline `<think>`/`<thinking>` reasoning that ACP-channel models (e.g. scode) emit, rendering it in the collapsible "思考过程" panel (`MessageThought`) instead of discarding it.

## Changes

- **extract inline think as `thought` messages** — `StreamingThinkFilter` now returns the captured think text instead of dropping it. `AcpAgent.emitThoughtMessage` routes it as a `thought` message so it renders in `MessageThought`. Emitting it before the empty-content early return means a pure-think chunk is no longer dropped. The turn is marked as having visible assistant output, so a think-only reply no longer trips the "no summary" fallback.
- **streaming delta/full split** — DB receives the FULL accumulated text (replace-merge); IPC carries only the per-call DELTA (append-merge in the renderer), so long reasoning is O(n) over IPC instead of re-sending the full text every chunk. Multiple think blocks in one stream merge with a `\n\n` separator that always rides with content. DB thought merge also pulls the existing record by `msg_id` when it falls out of the recent-50 window, preventing duplicate thinking blocks in reloaded history.
- **defensive catch parity** — `feed()`'s catch now resets `accumulatedThink` / `hadAnyThink` / `pendingThinkSeparator` to match `flush()`, so an internal anomaly can't leak stale think state into later blocks.

## Notes

- Reasoning is desktop/WebUI-only: `ChannelMessageService` skips `thought` events, so nothing is forwarded to IM channels (Telegram / Lark / DingTalk).
- Models that never emit think tags (e.g. sudorouter) are unaffected — the filter only consumes content after an opening `<think>`.