### PR TITLE
refactor(bridge): remove syncScodeModelsFromPricing, use ACP SSOT

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -966,7 +966,7 @@ export const scode = {
   restoreCustomModelProviders: bridge.buildProvider<IBridgeResponse<ScodeConfig>, { userId: string; baseConfig?: ScodeConfig }>('scode.restore-custom-model-providers'),
   /** Update only the default_model field in sudocode.json */
   setDefaultModel: bridge.buildProvider<IBridgeResponse<void>, { modelId: string }>('scode.set-default-model'),
-  /** Fetch live model list from sudorouter specific_pricing, rewrite sudocode.json models, return resolved model info */
+  /** Read the pre-connection model list from sudocode.json (fallback before ACP is connected) */
   refreshModels: bridge.buildProvider<IBridgeResponse<AcpModelInfo>, void>('scode.refresh-models'),
   /** Read-only fetch of sudorouter specific_pricing items (no write to sudocode.json) */
   fetchSpecificPricing: bridge.buildProvider<IBridgeResponse<SpecificPricingItem[]>, void>('scode.fetch-specific-pricing'),

--- a/src/process/bridge/scodeBridge.ts
+++ b/src/process/bridge/scodeBridge.ts
@@ -20,12 +20,10 @@ import { getDatabase } from '@process/database';
 import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { SUDOCLAW_DIR } from '@process/services/sudoclaw/SudoclawInstallService';
 import { writeSudoclawImageGenerationModel } from '@process/bridge/imageGenerationModelSync';
-import { getSudoworkServerBaseUrlSync } from '@process/initStorage';
 import { ipcBridge } from '@/common';
 import { modelInputForModelId } from '@/common/imageUtils';
-import type { ScodeModelEntry } from '@/common/ipcBridge';
-import { addScodeAutoModel, buildSudorouterModelEntry, mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, normalizeScodeModelApiTypesInScodeConfig, type ScodeCustomModelProvider, type SpecificPricingItem } from '@/common/scodeConfig';
-import { fetchSystemConfig, getConfiguredScodeAutoModelId, getSudorouterBaseUrl } from '@/common/systemConfig';
+import { mergeCustomProvidersIntoScodeConfig, normalizeCustomApiKeyModelsInScodeConfig, normalizeScodeModelApiTypesInScodeConfig, type ScodeCustomModelProvider, type SpecificPricingItem } from '@/common/scodeConfig';
+import { getSudorouterBaseUrl } from '@/common/systemConfig';
 
 const TAG = 'ScodeBridge';
 const SUDOCODE_CONFIG_PATH = path.join(SCODE_DIR, 'sudocode.json');
@@ -127,60 +125,10 @@ export async function fetchSpecificPricingItems(): Promise<SpecificPricingItem[]
   return json.data.filter((it): it is SpecificPricingItem => typeof it?.model_id === 'string' && it.model_id.trim().length > 0);
 }
 
-async function refreshSystemConfigForScodeModelSync(): Promise<void> {
-  const data = await fetchSystemConfig(getSudoworkServerBaseUrlSync());
-  if (!data) {
-    mainWarn(TAG, 'system-config refresh failed before scode model sync, using cached auto model config');
-  }
-}
-
-/**
- * Fetch the live model list from sudorouter's specific_pricing endpoint and
- * rewrite ONLY the `models` dict of sudocode.json. Preserves auth_modes /
- * default_model / web_search / tools.
- *
- * Best-effort: on any fetch/parse failure (offline, timeout, success=false)
- * this is a no-op — sudocode.json keeps its existing models so the dropdown
- * degrades to the last-known list instead of going empty.
- */
-export async function syncScodeModelsFromPricing(): Promise<void> {
-  await refreshSystemConfigForScodeModelSync();
-  const pricingItems = await fetchSpecificPricingItems();
-
-  const modelIds = pricingItems.map((m) => m.model_id.trim()).filter(Boolean);
-  if (modelIds.length === 0) {
-    mainWarn(TAG, 'specific_pricing returned empty model list, keeping existing models');
-    return;
-  }
-
-  const existing = readExistingConfig();
-  const normalizedExisting = normalizeCustomApiKeyModelsInScodeConfig(existing);
-  const normalizedExistingModels = normalizedExisting.models || {};
-  const existingModels = (normalizedExistingModels && typeof normalizedExistingModels === 'object' ? normalizedExistingModels : {}) as Record<string, ScodeModelEntry>;
-  const models: Record<string, ScodeModelEntry> = {};
-  for (const [alias, entry] of Object.entries(existingModels)) {
-    if (entry?.providers?.proxy?.provider !== 'sudorouter') {
-      models[alias] = entry;
-    }
-  }
-
-  addScodeAutoModel(models, modelIds, pricingItems, getConfiguredScodeAutoModelId());
-  for (const modelId of modelIds) {
-    models[modelId] = buildSudorouterModelEntry(modelId);
-  }
-
-  normalizedExisting.models = models; // only replace `models`; other keys preserved
-  if (typeof normalizedExisting.default_model === 'string' && !models[normalizedExisting.default_model]) {
-    const fallbackModel = modelIds[0];
-    if (fallbackModel) {
-      normalizedExisting.default_model = fallbackModel;
-    } else {
-      delete normalizedExisting.default_model;
-    }
-  }
-  writeConfig(normalizedExisting as unknown as Record<string, unknown>);
-  mainLog(TAG, `Synced ${modelIds.length} sudorouter models from specific_pricing into sudocode.json`);
-}
+// NOTE: syncScodeModelsFromPricing() was removed. Model discovery is now
+// handled by scode's capabilities SSOT (model-capabilities.json), which is
+// refreshed from sudorouter's /v1/models endpoint every 24h and exposed via
+// ACP get_model_info(). See sudoprivacy/sudocode#344.
 
 /**
  * Resolve the image generation model id for a main-process sync point (startup /
@@ -380,7 +328,9 @@ export function registerScodeBridge(): void {
 
   ipcBridge.scode.refreshModels.provider(async () => {
     try {
-      await syncScodeModelsFromPricing();
+      // Model discovery is now handled by scode's capabilities SSOT
+      // (model-capabilities.json, refreshed from sudorouter /v1/models).
+      // This handler reads the pre-connection fallback from sudocode.json.
       const { getScodeProxyModelInfoSync } = await import('@process/services/scode/scodeProxyModels');
       const info = getScodeProxyModelInfoSync();
       if (!info) {

--- a/src/renderer/components/AcpModelSelector.tsx
+++ b/src/renderer/components/AcpModelSelector.tsx
@@ -75,48 +75,15 @@ const AcpModelSelector: React.FC<{
     }
 
     // For scode, pull the live model list from sudorouter specific_pricing
-    // (rewrites sudocode.json models). Falls back to the standard path on
-    // failure so the dropdown still works offline.
-    if (backend === 'scode') {
-      void fetchScodeLiveModelInfo();
-      return () => {
-        cancelled = true;
-      };
-    }
-
+    // Model discovery for scode is now handled by the capabilities SSOT
+    // inside scode itself (refreshed from sudorouter /v1/models every 24h).
+    // ACP get_model_info() returns config aliases + capabilities models.
+    // The standard fetch path works for all backends including scode.
     runStandardModelInfoFetch();
 
     return () => {
       cancelled = true;
     };
-
-    async function fetchScodeLiveModelInfo() {
-      if (isGuest) {
-        runStandardModelInfoFetch();
-        return;
-      }
-      try {
-        const result = await ipcBridge.scode.refreshModels.invoke();
-        if (cancelled) return;
-        if (result.success && result.data && (result.data.availableModels?.length ?? 0) > 0) {
-          const info = result.data;
-          // Honor a Guid-page pre-selected model on first load.
-          if (!hasUserChangedModel.current && initialModelId) {
-            const match = info.availableModels.find((m) => m.id === initialModelId);
-            if (match) {
-              setModelInfo({ ...info, currentModelId: match.id, currentModelLabel: match.label });
-              return;
-            }
-          }
-          setModelInfo(info);
-          return;
-        }
-      } catch (error) {
-        console.error('[AcpModelSelector][scode] refreshModels failed:', error);
-      }
-      if (cancelled) return;
-      runStandardModelInfoFetch();
-    }
 
     function runStandardModelInfoFetch() {
       ipcBridge.acpConversation.getModelInfo
@@ -241,7 +208,7 @@ const AcpModelSelector: React.FC<{
         }
       }
     }
-  }, [conversationId, backend, fallbackModelId, initialModelId, isGuest]);
+  }, [conversationId, backend, fallbackModelId, initialModelId]);
 
   // Track pending model switch for showing success message
   const pendingModelSwitchRef = useRef<string | null>(null);

--- a/tests/e2e/cases/scode-model-discovery-ssot.yaml
+++ b/tests/e2e/cases/scode-model-discovery-ssot.yaml
@@ -1,0 +1,35 @@
+name: "scode model discovery shows capabilities SSOT models"
+description: >
+  Verify that the model selector dropdown for scode shows models from the
+  capabilities SSOT (not just config aliases). After sudocode#344, ACP
+  get_model_info() returns config aliases + capabilities models (~30+).
+  The dropdown should include non-config models like deepseek or grok.
+tags: [scode, model-discovery]
+
+steps:
+  - op: wait_for_app_ready
+    timeout: 300
+
+  # Navigate to Sudo Code agent
+  - op: click
+    x: 530
+    y: 27
+  - op: pause
+    duration: 3000
+  - op: mouse_click
+    text: "Sudo Code"
+  - op: pause
+    duration: 3000
+
+  # Type /model and send to show model list
+  - op: type_text
+    text: "/model"
+  - op: press_key
+    key: "Enter"
+    wait: 5
+
+  # Screenshot and verify the model list includes capabilities SSOT models
+  - op: screenshot
+    path: "screenshots/scode-model-discovery-ssot.png"
+  - op: judge
+    expect: "model list with multiple models including claude"


### PR DESCRIPTION
## Summary

- Remove `syncScodeModelsFromPricing()` which fetched from sudorouter's `specific_pricing` API and rewrote `sudocode.json` models. This was a second writer to the config file that scode owns.
- AcpModelSelector no longer has a scode-specific `fetchScodeLiveModelInfo` path. Scode uses the standard ACP `getModelInfo` path like all other agents.
- `refreshModels` IPC handler simplified to just read `sudocode.json` (pre-connection fallback).

## Why

sudocode#344 made `model-capabilities.json` the SSOT for model discovery. ACP `get_model_info()` now returns config aliases + capabilities models (~178 models). sudowork no longer needs its own fetch-and-rewrite path.

## What does NOT change

- `scodeProxyModels.ts` — still serves as pre-connection fallback (reads `sudocode.json` before ACP agent is up)
- Model switching via ACP `setModel` — unchanged
- Refresh button in model dropdown — still works (re-reads `sudocode.json`)
- All other agent backends (codex, remote-agent, etc.) — unchanged

## Test plan

- [x] vitest: `scodeProxyModels.test.ts` — 2/2 pass
- [x] eslint: no new errors (1 pre-existing on unrelated line)
- [x] Phase 1 live PTY tests: `model_report_shows_capabilities_models` — mock + live pass (sudocode#344)
- [x] Phase 1 30-model compat sweep — 4P/26S/0F