### PR TITLE
fix(ci): per-platform build timeout (75 min Windows, 30 min macOS)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -137,7 +137,7 @@ jobs:
     name: Build Test (${{ matrix.platform }})
     if: github.event.action != 'edited'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
@@ -148,24 +148,28 @@ jobs:
             target: '--mac'
             build_args: '--mac --arm64'
             unpacked_dir: 'mac-arm64'
+            timeout: 30
           - platform: 'macos-x64'
             os: 'macos-14'
             arch: 'x64'
             target: '--mac'
             build_args: '--mac --x64'
             unpacked_dir: 'mac'
+            timeout: 30
           - platform: 'windows-x64'
             os: 'windows-2022'
             arch: 'x64'
             target: '--win'
             build_args: '--win --x64'
             unpacked_dir: 'win-unpacked'
+            timeout: 75
           - platform: 'windows-arm64'
             os: 'windows-2022'
             arch: 'arm64'
             target: '--win'
             build_args: '--win --arm64'
             unpacked_dir: 'win-arm64-unpacked'
+            timeout: 75
           # Linux build disabled — no .deb target configured, snap requires snapcraft login
           # - platform: 'linux'
           #   os: 'ubuntu-latest'


### PR DESCRIPTION
## Summary

- Windows Electron builds on GHA runners consistently take 40-55 min, exceeding the flat 45 min timeout
- 3 consecutive timeouts on sudoprivacy/sudowork#1037 (all at exactly 45m)
- macOS builds finish in 3-5 min — no reason to give them the same budget

## Change

Use per-matrix `timeout` field instead of a single `timeout-minutes: 45`:
- Windows (x64/arm64): **75 min** (observed range: 41-54 min, headroom for slow runners)
- macOS (x64/arm64): **30 min** (observed range: 3-5 min)

## Evidence

| PR | Platform | Duration | Result |
|---|---|---|---|
| #1037 | windows-x64 | 45m05s | timeout |
| #1037 | windows-x64 | 45m15s | timeout |
| #1037 | windows-x64 | 45m04s | timeout |
| #1037 | windows-arm64 | 41m35s | pass |
| #1036 | windows-x64 | 36m04s | pass |
| #1036 | windows-arm64 | 42m45s | pass |