### PR TITLE
chore(ci): block AI authorship signatures via commit-msg hook + CI

### DIFF
--- a/.github/workflows/no-ai-signature.yml
+++ b/.github/workflows/no-ai-signature.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Self-test the detector
+        run: sh scripts/ci/check-no-ai-signature.sh --selftest
+
       - name: Reject AI signatures in commit messages
         run: |
           HEAD_REF="${{ github.head_ref }}"

--- a/.github/workflows/no-ai-signature.yml
+++ b/.github/workflows/no-ai-signature.yml
@@ -1,0 +1,36 @@
+name: No AI Signatures
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  check:
+    name: Block AI Authorship Signatures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject AI signatures in commit messages
+        run: |
+          HEAD_REF="${{ github.head_ref }}"
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+          # dev→main promotions replay history already gated at feature→dev.
+          if [ "$HEAD_REF" = "dev" ] && [ "$BASE_REF" = "main" ] && [ "$HEAD_REPO" = "${{ github.repository }}" ]; then
+            echo "✅ dev → main promotion — skipping AI-signature scan"
+            exit 0
+          fi
+
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          BASE_SHA=$(git merge-base "origin/${BASE_REF}" "$HEAD_SHA" 2>/dev/null || echo "")
+          if [ -z "$BASE_SHA" ]; then
+            echo "⚠️ Could not compute merge-base for origin/${BASE_REF}..${HEAD_SHA}, skipping"
+            exit 0
+          fi
+
+          sh scripts/ci/check-no-ai-signature.sh --range "${BASE_SHA}..${HEAD_SHA}"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+sh scripts/ci/check-no-ai-signature.sh --message-file "$1"

--- a/scripts/ci/check-no-ai-signature.sh
+++ b/scripts/ci/check-no-ai-signature.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+# Reject AI-authorship signatures in commit messages.
+# Single source of truth shared by the local hook (.husky/commit-msg) and
+# CI (.github/workflows/no-ai-signature.yml). See AGENTS.md.
+set -eu
+
+# Vendor names are matched only inside co-author trailers / "Generated with"
+# footers, so ordinary subjects like "fix cursor position" stay allowed.
+PATTERN='co-authored-by:[[:space:]].*(claude|anthropic|openai|chatgpt|gpt-|copilot|codeium|cursor|gemini|llama)|noreply@anthropic\.com|generated with[[:space:]]+\[?(claude|chatgpt|copilot|cursor)|🤖[[:space:]]*generated'
+
+check_text() {
+  label="$1"
+  hits=$(grep -iEn "$PATTERN" || true)
+  if [ -n "$hits" ]; then
+    echo "❌ AI authorship signature in $label:"
+    echo "$hits" | sed 's/^/     /'
+    return 1
+  fi
+  return 0
+}
+
+rc=0
+case "${1:-}" in
+  --message-file)
+    file="${2:?usage: --message-file <path>}"
+    check_text "commit message" <"$file" || rc=1
+    ;;
+  --range)
+    range="${2:?usage: --range <base>..<head>}"
+    for sha in $(git rev-list "$range"); do
+      git log -1 --format='%B' "$sha" | check_text "$(git log -1 --format='%h %s' "$sha")" || rc=1
+    done
+    ;;
+  *)
+    echo "usage: $0 --message-file <path> | --range <base>..<head>" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$rc" -ne 0 ]; then
+  echo ""
+  echo "Per AGENTS.md: never add 'Co-Authored-By', 'Generated with', or any AI"
+  echo "attribution to commits. Remove the offending line(s) and commit again."
+  exit 1
+fi
+
+echo "✅ No AI signatures found"

--- a/scripts/ci/check-no-ai-signature.sh
+++ b/scripts/ci/check-no-ai-signature.sh
@@ -19,8 +19,34 @@ check_text() {
   return 0
 }
 
+matches() { printf '%s\n' "$1" | grep -iEq "$PATTERN"; }
+
+selftest() {
+  # Guards the detector itself against regression: known signatures must be
+  # caught, ordinary subjects and human co-authors must pass through.
+  fails=0
+  for bad in \
+    'Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>' \
+    '🤖 Generated with [Claude Code](https://claude.com/claude-code)' \
+    'Co-authored-by: Copilot <bot@github.com>'; do
+    matches "$bad" || { echo "selftest FAIL: missed -> $bad"; fails=1; }
+  done
+  for good in \
+    'fix(editor): restore cursor position after paste' \
+    'Co-authored-by: Ethan Song <elfenliedsp@gmail.com>' \
+    'feat(agent): add claude code adapter'; do
+    matches "$good" && { echo "selftest FAIL: flagged -> $good"; fails=1; }
+  done
+  [ "$fails" -eq 0 ] || return 1
+  echo "✅ detector selftest passed"
+}
+
 rc=0
 case "${1:-}" in
+  --selftest)
+    selftest || exit 1
+    exit 0
+    ;;
   --message-file)
     file="${2:?usage: --message-file <path>}"
     check_text "commit message" <"$file" || rc=1
@@ -32,7 +58,7 @@ case "${1:-}" in
     done
     ;;
   *)
-    echo "usage: $0 --message-file <path> | --range <base>..<head>" >&2
+    echo "usage: $0 --selftest | --message-file <path> | --range <base>..<head>" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Why

The `绝不添加 AI 署名` rule in AGENTS.md/CLAUDE.md had **no enforcement**. As a result a `Co-Authored-By: Claude …` trailer already slipped into merged history (commit `483670d3`, PR #867, now on `dev`). We chose **not** to rewrite that history (it sits under 996 commits on `dev`; force-pushing to strip one trailer isn't worth the blast radius). Instead this adds a guard so it can never happen again.

## What

- **`scripts/ci/check-no-ai-signature.sh`** — single source of truth. Detects `Co-Authored-By` trailers naming AI vendors, `Generated with [Claude …]`/`🤖 Generated` footers, and the `noreply@anthropic.com` bot email. Two modes: `--message-file` (one message) and `--range` (a commit range).
- **`.husky/commit-msg`** — fast local gate; rejects the commit before it's created.
- **`.github/workflows/no-ai-signature.yml`** — authoritative PR gate (modeled on `no-merge-commits.yml`). Scans the PR's commit range; skips `dev→main` promotions since new commits are already gated at feature→dev.

Vendor names are matched **only inside trailers/footers**, so ordinary subjects like `fix cursor position` and legitimate human co-authors are not flagged.

## Verification

Tested locally, all passing:
- blocks the exact legacy trailer + the Claude Code footer
- passes clean messages, `cursor position` subjects, and human `Co-authored-by`
- `--range` correctly flags `483670d3` and passes clean ranges
- live husky hook blocked a real bad commit (HEAD unchanged); a clean commit passed