### PR TITLE
fix(fs): stop _nexus_<ts> suffixes accumulating on repeated collisions

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,6 +9,32 @@ export const NEXUS_TIMESTAMP_SEPARATOR = '_nexus_';
 
 /** 用于匹配和清理时间戳后缀的正则表达式 */
 export const NEXUS_TIMESTAMP_REGEX = /_nexus_\d{13}(\.\w+)?$/;
+
+/**
+ * 去掉文件名（不含扩展名）末尾所有的 `_nexus_<13位时间戳>` 后缀。
+ * Strip every trailing `_nexus_<13-digit timestamp>` suffix from a file's
+ * base name (extension already removed).
+ *
+ * 追加时间戳前必须先调用本函数，否则同名文件反复冲突时后缀会不断累积，
+ * 变成 `a_nexus_<t1>_nexus_<t2>.xlsx`。循环去除是因为历史文件可能已经
+ * 带有多个后缀 —— NEXUS_TIMESTAMP_REGEX 以 `$` 锚定，单次只能去掉一个。
+ *
+ * Must be called before appending a new timestamp, otherwise repeated
+ * collisions accumulate suffixes. Loops because existing files may already
+ * carry several: NEXUS_TIMESTAMP_REGEX is `$`-anchored and strips only one
+ * per pass.
+ */
+export function stripNexusTimestampSuffixes(baseName: string): string {
+  let out = baseName;
+  // 有界循环，避免正则意外不收敛时死循环 / Bounded so a non-converging
+  // replace can never spin forever.
+  for (let i = 0; i < 16; i++) {
+    const next = out.replace(NEXUS_TIMESTAMP_REGEX, '$1');
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
 export const NEXUS_FILES_MARKER = '[[NEXUS_FILES]]';
 
 // ===== 媒体类型相关常量 =====

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -10,7 +10,7 @@ import https from 'node:https';
 import http from 'node:http';
 import { app } from 'electron';
 import JSZip from 'jszip';
-import { NEXUS_TIMESTAMP_SEPARATOR } from '@/common/constants';
+import { NEXUS_TIMESTAMP_SEPARATOR, stripNexusTimestampSuffixes } from '@/common/constants';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 import { ipcBridge } from '../../common';
@@ -436,7 +436,10 @@ export function initFsBridge(): void {
       if (fileExists) {
         const timestamp = Date.now();
         const ext = path.extname(safeFileName);
-        const name = path.basename(safeFileName, ext);
+        // 先去掉已有的时间戳后缀，否则重复冲突会累积成
+        // a_nexus_<t1>_nexus_<t2>.xlsx / Strip existing suffixes first,
+        // otherwise repeated collisions accumulate them.
+        const name = stripNexusTimestampSuffixes(path.basename(safeFileName, ext));
         const tempFileName = `${name}${NEXUS_TIMESTAMP_SEPARATOR}${timestamp}${ext}`;
         tempFilePath = path.join(tempDir, tempFileName);
       }
@@ -781,7 +784,10 @@ export function initFsBridge(): void {
             // 如果文件已存在，添加时间戳后缀 / Append timestamp when target file already exists
             const timestamp = Date.now();
             const ext = path.extname(targetPath);
-            const name = path.basename(targetPath, ext);
+            // 先去掉已有的时间戳后缀，否则重复冲突会累积成
+            // a_nexus_<t1>_nexus_<t2>.xlsx / Strip existing suffixes first,
+            // otherwise repeated collisions accumulate them.
+            const name = stripNexusTimestampSuffixes(path.basename(targetPath, ext));
             // Construct new path in the same directory / 在同一目录下构建新路径
             const dir = path.dirname(targetPath);
             const newFileName = `${name}${NEXUS_TIMESTAMP_SEPARATOR}${timestamp}${ext}`;

--- a/src/renderer/services/FileService.ts
+++ b/src/renderer/services/FileService.ts
@@ -55,9 +55,19 @@ export function getFileExtension(fileName: string): string {
 
 import { NEXUS_TIMESTAMP_REGEX } from '@/common/constants';
 
-// 清理Nexus时间戳后缀，返回原始文件名
+// 清理Nexus时间戳后缀，返回原始文件名。
+// 循环去除：历史文件可能带有多个累积的后缀（修复前会产生
+// a_nexus_<t1>_nexus_<t2>.xlsx），单次 replace 只能去掉一个。
+// Loops so that legacy names carrying several accumulated suffixes are
+// fully cleaned — a single replace only strips the last one.
 export function cleanNexusTimestamp(fileName: string): string {
-  return fileName.replace(NEXUS_TIMESTAMP_REGEX, '$1');
+  let out = fileName;
+  for (let i = 0; i < 16; i++) {
+    const next = out.replace(NEXUS_TIMESTAMP_REGEX, '$1');
+    if (next === out) break;
+    out = next;
+  }
+  return out;
 }
 
 // 从文件路径获取清理后的文件名（用于UI显示）


### PR DESCRIPTION
> Replaces #1043, which was branched from a stale base (186 commits behind dev). Same change, rebased onto current dev. Please close #1043.

## The bug

Both collision-rename sites in `fsBridge.ts` built the new name from `path.basename(name, ext)`, which strips only the **extension**. Any existing `_nexus_<timestamp>` suffix was carried through and a second one appended:

```
report.xlsx
  → report_nexus_1785400000000.xlsx                     (1st collision)
  → report_nexus_1785400000000_nexus_1785400123000.xlsx (2nd collision)
```

The name grew on every round-trip and was never shortened again — the separator was write-only in the main process, so nothing ever undid the accumulation.

## Scope

| Path | Affected |
| --- | --- |
| `createTempFile` (`:440`) — paste / drop / preview | **Yes** |
| `copyFilesToWorkspace` (`:787`) | **Yes** |
| Enterprise remote upload (`conversationBridge`) | No — never renamed at all |

Neither site is gated on `isEnterpriseMode()`, so **consumer/personal mode hits this too** — it is not enterprise-only.

## The fix

Adds `stripNexusTimestampSuffixes()` to `common/constants.ts`, called before appending a new timestamp.

`NEXUS_TIMESTAMP_REGEX` already existed for exactly this purpose (commented *"用于匹配和清理时间戳后缀"*) but was only used by the renderer for display. It is `$`-anchored so it strips **one** suffix per pass — the helper therefore loops (bounded at 16) so names that already accumulated several before this fix are also fully cleaned.

`cleanNexusTimestamp()` in `FileService` gains the same loop, so legacy multi-suffix names render fully cleaned in the UI instead of partially stripped.

The helper lives in `common/` because `fsBridge` is main-process and `FileService` is renderer — importing across that boundary would be wrong.

## Verification

Ran the real rename logic over edge cases:

| input | result |
| --- | --- |
| `report.xlsx` | `report_nexus_<new>.xlsx` |
| `report_nexus_<t1>.xlsx` | `report_nexus_<new>.xlsx` |
| `report_nexus_<t1>_nexus_<t2>.xlsx` | `report_nexus_<new>.xlsx` ← **the bug** |
| `my_nexus_file.xlsx` | `my_nexus_file_nexus_<new>.xlsx` |
| `report_nexus_123.xlsx` | `report_nexus_123_nexus_<new>.xlsx` |

The last two matter: the **13-digit** requirement means legitimate filenames containing `_nexus_` are never mangled.

`npx tsc --noEmit` reports **0 errors** across the project, re-run on this rebased base.

## Note

`archive.tar.gz` → `archive.tar_nexus_<ts>.gz` is pre-existing `path.extname` behaviour for multi-part extensions. Left unchanged — flagging it as a separate known wart rather than silently altering it inside a bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)