### PR TITLE
feat(workspace): add Download to file right-click menu

### DIFF
--- a/src/renderer/i18n/locales/en-US/conversation.json
+++ b/src/renderer/i18n/locales/en-US/conversation.json
@@ -211,7 +211,11 @@
       "openFailed": "Failed to open",
       "revealFailed": "Failed to open containing folder",
       "uploadToBdpan": "Upload to Baidu Netdisk",
-      "newFolder": "New Folder"
+      "newFolder": "New Folder",
+      "download": "Download",
+      "downloadSuccess": "Downloaded",
+      "downloadFailed": "Download failed",
+      "downloadTooLarge": "File exceeds the server download limit (2MB for text, 20MB otherwise)"
     },
     "newFolder": {
       "title": "New Folder",

--- a/src/renderer/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/i18n/locales/ja-JP/conversation.json
@@ -156,7 +156,11 @@
       "openFailed": "開けませんでした",
       "revealFailed": "フォルダーを開けませんでした",
       "uploadToBdpan": "百度ネットディスクにアップロード",
-      "newFolder": "新しいフォルダー"
+      "newFolder": "新しいフォルダー",
+      "download": "ダウンロード",
+      "downloadSuccess": "ダウンロードしました",
+      "downloadFailed": "ダウンロードに失敗しました",
+      "downloadTooLarge": "ファイルがサーバーのダウンロード上限を超えています（テキスト 2MB / その他 20MB）"
     },
     "newFolder": {
       "title": "新しいフォルダー",

--- a/src/renderer/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/i18n/locales/ko-KR/conversation.json
@@ -156,7 +156,11 @@
       "openFailed": "열기 실패",
       "revealFailed": "포함 폴더 열기 실패",
       "uploadToBdpan": "바이두 넷디스크에 업로드",
-      "newFolder": "새 폴더"
+      "newFolder": "새 폴더",
+      "download": "다운로드",
+      "downloadSuccess": "다운로드 완료",
+      "downloadFailed": "다운로드 실패",
+      "downloadTooLarge": "파일이 서버 다운로드 한도를 초과했습니다(텍스트 2MB / 기타 20MB)"
     },
     "newFolder": {
       "title": "새 폴더",

--- a/src/renderer/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/i18n/locales/tr-TR/conversation.json
@@ -148,7 +148,11 @@
       "openFailed": "Açılamadı",
       "revealFailed": "İçeren klasör açılamadı",
       "uploadToBdpan": "Baidu Netdisk'e Yükle",
-      "newFolder": "Yeni Klasör"
+      "newFolder": "Yeni Klasör",
+      "download": "İndir",
+      "downloadSuccess": "İndirildi",
+      "downloadFailed": "İndirme başarısız",
+      "downloadTooLarge": "Dosya sunucu indirme sınırını aşıyor (metin için 2MB, diğerleri için 20MB)"
     },
     "newFolder": {
       "title": "Yeni Klasör",

--- a/src/renderer/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/i18n/locales/zh-CN/conversation.json
@@ -211,7 +211,11 @@
       "openFailed": "打开失败",
       "revealFailed": "无法打开所在目录",
       "uploadToBdpan": "上传至百度网盘",
-      "newFolder": "新建文件夹"
+      "newFolder": "新建文件夹",
+      "download": "下载",
+      "downloadSuccess": "下载成功",
+      "downloadFailed": "下载失败",
+      "downloadTooLarge": "文件超过服务端下载上限（文本 2MB / 其他 20MB）"
     },
     "newFolder": {
       "title": "新建文件夹",

--- a/src/renderer/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/i18n/locales/zh-TW/conversation.json
@@ -155,7 +155,11 @@
       "openFailed": "開啟失敗",
       "revealFailed": "無法開啟所在資料夾",
       "uploadToBdpan": "上傳至百度網盤",
-      "newFolder": "新增資料夾"
+      "newFolder": "新增資料夾",
+      "download": "下載",
+      "downloadSuccess": "下載成功",
+      "downloadFailed": "下載失敗",
+      "downloadTooLarge": "檔案超過伺服器下載上限（文字 2MB / 其他 20MB）"
     },
     "newFolder": {
       "title": "新增資料夾",

--- a/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
+++ b/src/renderer/pages/conversation/workspace/hooks/useWorkspaceFileOps.ts
@@ -615,6 +615,60 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
   );
 
   /**
+   * 下载文件（本地会话直接读盘，远程会话走 Moss 接口）
+   * Download a file (local sessions read from disk, remote sessions go through the Moss API)
+   */
+  const handleDownloadNode = useCallback(
+    async (nodeData: IDirOrFile | null) => {
+      if (!nodeData || !nodeData.fullPath || !nodeData.isFile) return;
+
+      ensureNodeSelected(nodeData);
+      closeContextMenu();
+
+      try {
+        let bytes: Uint8Array;
+
+        if (dataSource === 'moss-session') {
+          if (!conversation_id) {
+            throw new Error('conversation_id is required for remote download');
+          }
+          const res = await ipcBridge.conversation.previewRemoteWorkspaceFile.invoke({
+            conversation_id,
+            path: nodeData.relativePath || nodeData.fullPath,
+          });
+          if (!res?.success || !res.data) {
+            // 服务端对超过预览上限的文件返回 413 / The server returns 413 for files over the preview limit
+            if (res?.msg?.includes('413') || /exceeds preview limit/i.test(res?.msg || '')) {
+              Message.error(t('conversation.workspace.contextMenu.downloadTooLarge'));
+              return;
+            }
+            throw new Error(res?.msg || 'Failed to download remote workspace file');
+          }
+          bytes = res.data.kind === 'base64' ? base64ToBytes(res.data.contentBase64) : new TextEncoder().encode(res.data.content);
+        } else {
+          bytes = base64ToBytes(await ipcBridge.fs.readFileBase64.invoke({ path: nodeData.fullPath }));
+        }
+
+        const blob = new Blob([bytes as unknown as BlobPart], { type: 'application/octet-stream' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = nodeData.name;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+
+        Message.success(t('conversation.workspace.contextMenu.downloadSuccess'));
+      } catch (error) {
+        console.error('[useWorkspaceFileOps] Failed to download:', error);
+        Message.error(t('conversation.workspace.contextMenu.downloadFailed'));
+      }
+    },
+    [closeContextMenu, conversation_id, dataSource, ensureNodeSelected, t]
+  );
+
+  /**
    * 打开重命名弹窗
    * Open rename modal
    */
@@ -636,6 +690,7 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
     handleRenameConfirm,
     handleAddToChat,
     handlePreviewFile,
+    handleDownloadNode,
     openRenameModal,
   };
 }

--- a/src/renderer/pages/conversation/workspace/index.tsx
+++ b/src/renderer/pages/conversation/workspace/index.tsx
@@ -1435,7 +1435,7 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
       {modalsHook.contextMenu.visible &&
         contextMenuNode &&
         contextMenuStyle &&
-        (!readonly || (isContextMenuNodeFile && isPreviewSupported)) &&
+        (!readonly || isContextMenuNodeFile) &&
         typeof document !== 'undefined' &&
         createPortal(
           <div
@@ -1449,15 +1449,28 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
           >
             <div className='flex flex-col gap-4px'>
               {readonly ? (
-                <button
-                  type='button'
-                  className={menuButtonBase}
-                  onClick={() => {
-                    void fileOpsHook.handlePreviewFile(contextMenuNode);
-                  }}
-                >
-                  {t('conversation.workspace.contextMenu.preview')}
-                </button>
+                <>
+                  {isPreviewSupported && (
+                    <button
+                      type='button'
+                      className={menuButtonBase}
+                      onClick={() => {
+                        void fileOpsHook.handlePreviewFile(contextMenuNode);
+                      }}
+                    >
+                      {t('conversation.workspace.contextMenu.preview')}
+                    </button>
+                  )}
+                  <button
+                    type='button'
+                    className={menuButtonBase}
+                    onClick={() => {
+                      void fileOpsHook.handleDownloadNode(contextMenuNode);
+                    }}
+                  >
+                    {t('conversation.workspace.contextMenu.download')}
+                  </button>
+                </>
               ) : isContextMenuNodeRoot ? (
                 <>
                   <button
@@ -1543,6 +1556,17 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({ conversation_id, workspace, e
                       }}
                     >
                       {t('conversation.workspace.contextMenu.openLocation')}
+                    </button>
+                  )}
+                  {isContextMenuNodeFile && (
+                    <button
+                      type='button'
+                      className={menuButtonBase}
+                      onClick={() => {
+                        void fileOpsHook.handleDownloadNode(contextMenuNode);
+                      }}
+                    >
+                      {t('conversation.workspace.contextMenu.download')}
                     </button>
                   )}
                   {isContextMenuNodeFile && isPreviewSupported && (


### PR DESCRIPTION
## Why

Downloading a workspace file previously required opening the preview panel and clicking its toolbar download button. That path breaks in two common cases:

- **Preview does not support the file type** — `.log`, `.txt`, `.sh`, `.toml`, `.sql` and friends are missing from the preview extension whitelist, so no Preview entry appears and there is no route to the toolbar.
- **Preview fails** — for large files preview can fail outright, and the only download affordance fails with it.

In both cases there was previously no way to get the file out of the workspace.

## What

Adds a **Download / 下载** entry to the workspace file context menu, for both personal (local) and enterprise (remote) sessions.

- **Local**: reads the file via `fs.readFileBase64` and saves it directly. No preview step, no size limit.
- **Remote (`moss-session`)**: fetches bytes via `previewRemoteWorkspaceFile`, handling both the `base64` and `text` response shapes.

Download is offered for **any file type** — it deliberately does not inherit the preview extension whitelist, since that whitelist is what makes the current flow unusable for `.log` and similar.

Also relaxes the readonly-branch menu condition from `isContextMenuNodeFile && isPreviewSupported` to `isContextMenuNodeFile`. Previously a file the whitelist did not cover showed **no context menu at all** in remote sessions; it now shows Download, with Preview still gated on actual support.

## Notes

**Folders are intentionally not downloadable.** `createZip` packs from local `sourcePath`s, so zipping a remote folder would need one capped request per file, assembled client-side. That needs a server-side archive endpoint, not a client workaround.

**Remote downloads are capped by the Moss server.** `GET /api/v1/sessions/:id/workspace/file` is the only route serving bytes and it returns `413` above its size limits. This PR surfaces that as a dedicated "file too large" message rather than a generic failure. Companion PR on the moss side raises those limits from 2MB/20MB to 10MB/100MB. Local downloads are unaffected and have no cap.

## Testing

- `bunx tsc --noEmit` — clean
- `bunx eslint <changed files> --fix` — 0 errors (remaining warnings are pre-existing `exhaustive-deps` on untouched hooks)
- `bunx prettier --check` — passes
- All 4 new i18n keys resolve in all 6 locales; no stale keys left behind
- Test suite unchanged vs. baseline: 120 failures before and after, all pre-existing jsdom `localStorage` issues in unrelated files

Not yet exercised against a live Moss session — the remote contract was verified by reading both sides. Worth a manual pass on a large `.log`, a binary file, and a remote file over the cap.