### PR TITLE
fix(e2e): settle the Nexus init gate in the runner before driving the UI

### DIFF
--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -60,6 +60,19 @@ async def run_case(tab, case_path: Path) -> dict:
     print(f"  {name}")
     print(f"{'='*60}")
 
+    # Settle the startup gate before driving the UI. In CI the Nexus runtime
+    # install fails (no napi toolchain) and raises the "Starting Core Services"
+    # dialog; Skip enters the app — the documented product behaviour. On a
+    # healthy box the dialog never renders and this is a no-op. Done here so
+    # every UI case is robust to the gate without repeating the step; cases that
+    # settle it explicitly (dismiss_init_dialog in their steps) opt out.
+    if "dismiss_init_dialog" in OPS and "dismiss_init_dialog" not in step_ops:
+        settle = await invoke_op(tab, "dismiss_init_dialog", OPS)
+        if isinstance(settle, dict) and settle.get("pass") is False:
+            print(f"  [0] FAIL: dismiss_init_dialog — {settle.get('reason', '')}")
+            return {"name": name, "passed": 0, "failed": 1,
+                    "results": [{"step": 0, "op": "dismiss_init_dialog", **settle}]}
+
     for i, step in enumerate(steps):
         op_name = step.get("op")
         if op_name not in OPS:


### PR DESCRIPTION
## Problem
The scode/acp e2e cases have been red on `dev` since ~2026-07-13 (latent — the workflow is opt-in). In CI the Nexus runtime install fails (no napi toolchain), so the app raises the **"Starting Core Services / Initialization Failed"** dialog that covers the send-box. `wait_for_app_ready` then times out at 300s. Only 2 of 31 cases dismissed the gate explicitly; the other 29 (all scode/acp) didn't.

## Fix
`run_case` settles the gate once via the existing `dismiss_init_dialog` op (Skip = the documented "enter now, runtime continues in background"), for cases that don't settle it explicitly. Kept separate from `wait_for_app_ready` (honoring the op author's design) and real boot failures still surface (`pass:False` → clear reason). One change fixes all 29 + future cases.

## Verified
`scode-basic-conversation` on this branch: **`wait_for_app_ready` now PASSES**, the app boots, scode spawns and drives a real conversation (mock LLM) — 3 passed / 1 failed, vs 1 passed / 8 failed before. (The 1 remaining failure is a pre-existing brittle assertion unrelated to the gate — the agent chip truncates to "S...", tracked separately.)