### PR TITLE
fix(e2e): judge reads visible attribute text so truncated labels pass

### DIFF
--- a/tests/e2e/ops/judge.py
+++ b/tests/e2e/ops/judge.py
@@ -17,7 +17,14 @@ from .press_key import press_key
 
 
 async def _get_shadow_text(tab):
-    """Get text including Shadow DOM content."""
+    """Get on-screen text: text nodes, Shadow DOM, and user-visible attributes.
+
+    Some visible text lives in attributes, not text nodes — a truncated agent
+    chip renders "S..." while the full "Sudo Code" is only in the send-box
+    placeholder. The judge checks keyword presence, so including placeholder /
+    value / aria-label / title avoids false negatives without risking false
+    positives (the text is genuinely on screen).
+    """
     r = await js_evaluate(tab, """(() => {
         const texts = [];
         function collect(root) {
@@ -28,6 +35,11 @@ async def _get_shadow_text(tab):
                 if (t) texts.push(t);
             }
             root.querySelectorAll('*').forEach(el => {
+                ['placeholder', 'aria-label', 'title'].forEach(attr => {
+                    const v = el.getAttribute && el.getAttribute(attr);
+                    if (v && v.trim()) texts.push(v.trim());
+                });
+                if (el.value && String(el.value).trim()) texts.push(String(el.value).trim());
                 if (el.shadowRoot) collect(el.shadowRoot);
             });
         }


### PR DESCRIPTION
Follow-up to #1048. The keyword judge only walked text nodes, so an agent chip truncated to "S..." failed an `expect: "Sudo Code"` check even though the full name is in the send-box placeholder. `_get_shadow_text` now also collects placeholder/aria-label/title/value — genuinely on-screen text, presence-only check, so no false positives.

Verified: with #1048 + this, `scode-basic-conversation` runs **4 passed / 0 failed** (was 1/8 before the gate fix). Only 2 cases used the brittle `Sudo Code` selection judge.

Note: a separate launch-time flake surfaced in the full-suite sweep (mock-auth CDP seed timing out at 30s, correlated with the nexus-init retries in CI) — tracked separately, not addressed here.