### PR TITLE
fix(acp): harden scode model switching

### DIFF
--- a/src/process/bridge/acpConversationBridge.ts
+++ b/src/process/bridge/acpConversationBridge.ts
@@ -21,6 +21,7 @@ import { isEnterpriseMode, getCachedSessionMode } from '@/common/enterpriseDebug
 import { getConversationProvider } from '@/process/providers';
 import type RemoteConversationProvider from '@/process/providers/RemoteConversationProvider';
 import { ipcBridge } from '../../common';
+import { setAcpModelWithScodePersistence } from './acpModelSwitch';
 
 function getScodeConversationModelInfo(conversationId: string) {
   const result = getDatabase().getConversation(conversationId);
@@ -367,18 +368,21 @@ export function initAcpConversationBridge(): void {
       if (task instanceof AcpAgent) {
         mainLog('AcpConversationBridge', `setModel: Task is AcpAgent`);
 
-        // Persist default model to sudocode.json and settings.json when switching scode models
         const conv = getDatabase().getConversation(conversationId);
-        if (conv?.data?.extra?.backend === 'scode') {
-          try {
-            const { writeScodeDefaultModel } = await import('./scodeBridge');
-            writeScodeDefaultModel(modelId);
-          } catch {
-            /* best-effort */
-          }
-        }
-
-        const modelInfo = await task.setModel(modelId);
+        const backend = conv?.data?.extra?.backend;
+        const modelInfo = await setAcpModelWithScodePersistence({
+          backend,
+          modelId,
+          onSetModel: (nextModelId) => task.setModel(nextModelId),
+          onPersistScodeDefaultModel: async (nextModelId) => {
+            try {
+              const { writeScodeDefaultModel } = await import('./scodeBridge');
+              writeScodeDefaultModel(nextModelId);
+            } catch {
+              /* best-effort */
+            }
+          },
+        });
 
         return { success: true, data: { modelInfo } };
       }

--- a/src/process/bridge/acpModelSwitch.ts
+++ b/src/process/bridge/acpModelSwitch.ts
@@ -1,0 +1,16 @@
+import type { AcpModelInfo } from '@/types/acpTypes';
+
+export async function setAcpModelWithScodePersistence({ backend, modelId, onSetModel, onPersistScodeDefaultModel }: ISetAcpModelWithScodePersistenceParams): Promise<AcpModelInfo | null> {
+  const modelInfo = await onSetModel(modelId);
+  if (backend === 'scode') {
+    await onPersistScodeDefaultModel(modelId);
+  }
+  return modelInfo;
+}
+
+interface ISetAcpModelWithScodePersistenceParams {
+  backend?: string;
+  modelId: string;
+  onSetModel: (modelId: string) => Promise<AcpModelInfo | null>;
+  onPersistScodeDefaultModel: (modelId: string) => void | Promise<void>;
+}

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -6,5 +6,5 @@
   "nexus-fuse-plugin": "0.5.0",
   "fuse-t": "1.2.7",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
-  "scode": "0.1.15"
+  "scode": "0.1.17"
 }

--- a/tests/unit/acpModelSwitch.test.ts
+++ b/tests/unit/acpModelSwitch.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { setAcpModelWithScodePersistence } from '@/process/bridge/acpModelSwitch';
+
+describe('setAcpModelWithScodePersistence', () => {
+  it('persists scode default model only after live model switch succeeds', async () => {
+    const onSetModel = vi.fn(async () => ({
+      source: 'models' as const,
+      currentModelId: 'deepseek-v4-flash',
+      currentModelLabel: 'deepseek-v4-flash',
+      canSwitch: true,
+      availableModels: [{ id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' }],
+    }));
+    const onPersistScodeDefaultModel = vi.fn();
+
+    const modelInfo = await setAcpModelWithScodePersistence({
+      backend: 'scode',
+      modelId: 'deepseek-v4-flash',
+      onSetModel,
+      onPersistScodeDefaultModel,
+    });
+
+    expect(modelInfo?.currentModelId).toBe('deepseek-v4-flash');
+    expect(onSetModel).toHaveBeenCalledWith('deepseek-v4-flash');
+    expect(onPersistScodeDefaultModel).toHaveBeenCalledWith('deepseek-v4-flash');
+    expect(onSetModel.mock.invocationCallOrder[0]).toBeLessThan(onPersistScodeDefaultModel.mock.invocationCallOrder[0]);
+  });
+
+  it('does not persist scode default model when live model switch fails', async () => {
+    const onSetModel = vi.fn(async () => {
+      throw new Error('api returned 400 Bad Request');
+    });
+    const onPersistScodeDefaultModel = vi.fn();
+
+    await expect(
+      setAcpModelWithScodePersistence({
+        backend: 'scode',
+        modelId: 'deepseek-anthropic/deepseek-v4-flash',
+        onSetModel,
+        onPersistScodeDefaultModel,
+      })
+    ).rejects.toThrow('api returned 400 Bad Request');
+
+    expect(onPersistScodeDefaultModel).not.toHaveBeenCalled();
+  });
+
+  it('does not persist defaults for non-scode backends', async () => {
+    const onSetModel = vi.fn(async () => null);
+    const onPersistScodeDefaultModel = vi.fn();
+
+    await setAcpModelWithScodePersistence({
+      backend: 'codex',
+      modelId: 'gpt-5.4',
+      onSetModel,
+      onPersistScodeDefaultModel,
+    });
+
+    expect(onPersistScodeDefaultModel).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
         'src/process/telemetry/SudoLogTelemetryReporter.ts',
         'src/process/bridge/updateBridge.ts',
         'src/process/bridge/applicationBridge.ts',
+        'src/process/bridge/acpModelSwitch.ts',
         'src/process/bridge/documentBridge.ts',
         'src/process/bridge/pwdLoginBridge.ts',
         'src/process/utils/enabledSkillFilter.ts',


### PR DESCRIPTION
## Summary
- preserve ACP connection context when switching scode models
- pin bundled scode runtime to v0.1.17
- add regression coverage for model switch behavior

## Tests
- Confirmed by local testing before PR creation