### PR TITLE
fix(skill-hub): auto-update installed hub skills to latest

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -97,7 +97,7 @@ jobs:
         # — observability fix for the bug class where users (e.g. 进二
         # on v0.2.7) saw silent empty catalogs without any signal that
         # their skillhub token wasn't provisioned.
-        run: bunx vitest run tests/unit/hubErrors.test.ts tests/unit/HubEmptyState.dom.test.tsx
+        run: bunx vitest run tests/unit/hubErrors.test.ts tests/unit/HubEmptyState.dom.test.tsx tests/unit/skillUpdateVersion.test.ts
 
   # Job 2c: Conversation resource reaper regression tests
   unit-tests-conversation-reaper:

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -72,6 +72,9 @@ export interface IConfigStorageRefer {
   // ON (true): force-cap to 128 KB regardless of advertised value, trading image fidelity for
   // lower input-token cost on metered plans. See `image-handling-non-user-facing.html` Decision 3.
   'image.economyMode'?: boolean;
+  // 已安装 hub skill 自动更新到最新版 / Auto-update installed hub skills to latest.
+  // Default ON (unset = enabled); explicit `false` opts out (manual updates only).
+  'skill.autoUpdate'?: boolean;
   // guid 页面上次选择的 agent 类型 / Last selected agent type on guid page
   'guid.lastSelectedAgent'?: string;
   // guid 页面 session 模式（E端 Local/Remote 切换）/ Guid page session mode (Enterprise Local/Remote toggle)

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -36,6 +36,7 @@ const MISSING_ROOT_SKILL_MD_MESSAGE = 'The selected directory must contain a roo
 const SKILL_HUB_UPLOAD_EXCLUDED_FILE_NAMES = new Set([SKILL_HUB_META_FILE, MOSS_SKILL_META_FILE, '_sudowork_audit.json', '_sudowork_audit.md']);
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 type SkillHubMeta = import('@/common/ipcBridge').ISkillHubMeta;
+type SkillHubSkill = import('@/common/ipcBridge').ISkillHubSkill;
 type SkillHubPublishStatus = 'pending' | 'approved' | 'rejected';
 type SkillHubUploadStatus = Extract<SkillHubPublishStatus, 'pending' | 'approved'>;
 
@@ -917,6 +918,110 @@ async function verifyChecksum(buffer: Buffer, expectedChecksum: string): Promise
  * Initialize IPC bridge for Skill Hub API.
  * Fetches skills, categories, and skill details from the external Skill Hub service.
  */
+/**
+ * Download + install a hub skill package into the hub skills dir, writing its
+ * metadata (installed_version is the single source of truth) and reloading the
+ * skill runtime.
+ *
+ * Extracted from the download-and-install IPC provider so first-install AND
+ * SkillUpdateService (auto-update) share one install path — no duplicated logic,
+ * and install is reachable as a plain function rather than only via IPC.
+ */
+export async function installHubSkillPackage(params: {
+  skillName: string;
+  displayName: string;
+  sourceUrl: string;
+  version: string;
+  checksum?: string;
+  skillMeta?: SkillHubSkill;
+}): Promise<{ success: true; data: { skillName: string; installedVersion: string } } | { success: false; msg: string }> {
+  const { skillName, displayName, sourceUrl, version, checksum, skillMeta } = params;
+  try {
+    // Trim skillName to prevent directory names with leading/trailing spaces
+    const trimmedSkillName = skillName.trim();
+    mainLog('SkillHub', `Downloading skill: ${trimmedSkillName} version: ${version}`);
+
+    // Download zip file
+    const zipBuffer = await downloadFile(sourceUrl, (percent) => {
+      mainLog('SkillHub', `Download progress: ${percent}%`);
+    });
+
+    // Verify checksum if provided
+    if (checksum) {
+      const isValid = await verifyChecksum(zipBuffer, checksum);
+      if (!isValid) {
+        mainWarn('SkillHub', 'Checksum verification failed, but continuing anyway');
+      }
+    }
+
+    // Get hub skills subdirectory
+    const hubSkillsDir = getHubSkillsDir();
+    await fs.mkdir(hubSkillsDir, { recursive: true });
+
+    const skillDir = path.join(hubSkillsDir, trimmedSkillName);
+
+    await removeExistingInstalledSkillDirs({
+      userSkillsDir: hubSkillsDir,
+      requestedSkillName: trimmedSkillName,
+      finalSkillDirName: trimmedSkillName,
+    });
+    await fs.mkdir(skillDir, { recursive: true });
+
+    await extractSkillZipToDirectory(zipBuffer, skillDir);
+
+    // Write hub metadata file so installed skills can be displayed with full info.
+    // NOTE: Metadata file is the single source of truth for installed version.
+    const meta: SkillHubMeta = {
+      id: skillMeta?.id ?? '',
+      name: trimmedSkillName,
+      display_name: skillMeta?.display_name ?? displayName,
+      description: skillMeta?.description ?? '',
+      icon: skillMeta?.icon ?? '',
+      emoji: skillMeta?.emoji ?? null,
+      category: skillMeta?.category ?? '',
+      categories: skillMeta?.categories ?? [],
+      applicable_scenarios: skillMeta?.applicable_scenarios ?? null,
+      core_features: skillMeta?.core_features ?? null,
+      homepage: skillMeta?.homepage ?? null,
+      author_id: skillMeta?.author_id ?? '',
+      source_type: 'hub',
+      is_builtin: false,
+      enabled: true,
+      installed_version: version,
+      installed_at: new Date().toISOString(),
+    };
+    await writeSkillMetaFile(skillDir, meta);
+
+    mainLog('SkillHub', `Successfully installed skill "${trimmedSkillName}" v${version} to ${skillDir}`);
+
+    // Reload Sudoclaw gateway to pick up new skills.
+    // - On Unix: use SIGUSR1 for hot-reload (keeps sessions alive)
+    // - On Windows/In-process: full restart required (SIGUSR1 not supported)
+    void (async () => {
+      try {
+        await reloadSkillRuntime();
+      } catch (err) {
+        mainWarn('SkillHub', 'Reload failed:', err);
+        await serviceManager.restartSudoclaw();
+      }
+    })();
+
+    return {
+      success: true,
+      data: {
+        skillName: trimmedSkillName,
+        installedVersion: version,
+      },
+    };
+  } catch (error) {
+    mainError('SkillHub', 'Failed to install skill:', error);
+    return {
+      success: false,
+      msg: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export function initSkillHubBridge(): void {
   mainLog('SkillHub', 'Initializing SkillHub bridge...');
 
@@ -1156,93 +1261,7 @@ export function initSkillHubBridge(): void {
   });
 
   // Download and install skill
-  ipcBridge.skillHub.downloadAndInstallSkill.provider(async ({ skillName, displayName, sourceUrl, version, checksum, skillMeta }) => {
-    try {
-      // Trim skillName to prevent directory names with leading/trailing spaces
-      const trimmedSkillName = skillName.trim();
-      mainLog('SkillHub', `Downloading skill: ${trimmedSkillName} version: ${version}`);
-
-      // Download zip file
-      const zipBuffer = await downloadFile(sourceUrl, (percent) => {
-        mainLog('SkillHub', `Download progress: ${percent}%`);
-      });
-
-      // Verify checksum if provided
-      if (checksum) {
-        const isValid = await verifyChecksum(zipBuffer, checksum);
-        if (!isValid) {
-          mainWarn('SkillHub', 'Checksum verification failed, but continuing anyway');
-        }
-      }
-
-      // Get hub skills subdirectory
-      const hubSkillsDir = getHubSkillsDir();
-      await fs.mkdir(hubSkillsDir, { recursive: true });
-
-      const skillDir = path.join(hubSkillsDir, trimmedSkillName);
-
-      await removeExistingInstalledSkillDirs({
-        userSkillsDir: hubSkillsDir,
-        requestedSkillName: trimmedSkillName,
-        finalSkillDirName: trimmedSkillName,
-      });
-      await fs.mkdir(skillDir, { recursive: true });
-
-      await extractSkillZipToDirectory(zipBuffer, skillDir);
-
-      // Write hub metadata file so installed skills can be displayed with full info
-      // NOTE: Metadata file is the single source of truth for installed version.
-      // The standalone sudowork-version file is no longer written for new installs.
-      const meta: SkillHubMeta = {
-        id: skillMeta?.id ?? '',
-        name: trimmedSkillName,
-        display_name: skillMeta?.display_name ?? displayName,
-        description: skillMeta?.description ?? '',
-        icon: skillMeta?.icon ?? '',
-        emoji: skillMeta?.emoji ?? null,
-        category: skillMeta?.category ?? '',
-        categories: skillMeta?.categories ?? [],
-        applicable_scenarios: skillMeta?.applicable_scenarios ?? null,
-        core_features: skillMeta?.core_features ?? null,
-        homepage: skillMeta?.homepage ?? null,
-        author_id: skillMeta?.author_id ?? '',
-        source_type: 'hub',
-        is_builtin: false,
-        enabled: true,
-        installed_version: version,
-        installed_at: new Date().toISOString(),
-      };
-      await writeSkillMetaFile(skillDir, meta);
-
-      mainLog('SkillHub', `Successfully installed skill "${trimmedSkillName}" v${version} to ${skillDir}`);
-
-      // Reload Sudoclaw gateway to pick up new skills.
-      // - On Unix: use SIGUSR1 for hot-reload (keeps sessions alive)
-      // - On Windows/In-process: full restart required (SIGUSR1 not supported)
-      void (async () => {
-        try {
-          await reloadSkillRuntime();
-        } catch (err) {
-          mainWarn('SkillHub', 'Reload failed:', err);
-          await serviceManager.restartSudoclaw();
-        }
-      })();
-
-      return {
-        success: true,
-        data: {
-          skillName: trimmedSkillName,
-          installedVersion: version,
-        },
-      };
-    } catch (error) {
-      mainError('SkillHub', 'Failed to install skill:', error);
-      return {
-        success: false,
-        msg: error instanceof Error ? error.message : String(error),
-      };
-    }
-  });
+  ipcBridge.skillHub.downloadAndInstallSkill.provider(async (params) => installHubSkillPackage(params));
 
   ipcBridge.skillHub.downloadSkillZip.provider(async ({ skillName, version, sourceUrl, checksum }) => {
     try {

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -102,6 +102,12 @@ export const initializeProcess = async () => {
     void serviceManager.startup();
     perfLog('serviceManager.startup', Date.now() - serviceStart);
 
+    // Keep installed hub skills current on every launch (default ON, opt-out).
+    // Fire-and-forget + dynamic import so it never blocks or bloats startup.
+    void import('./services/skillUpdate/SkillUpdateService')
+      .then(({ checkAndUpdateInstalledHubSkills }) => checkAndUpdateInstalledHubSkills())
+      .catch((err) => mainError('Process', 'Skill auto-update failed', err));
+
     const channelStart = Date.now();
     try {
       await getChannelManager().initialize();

--- a/src/process/services/skillUpdate/SkillUpdateService.ts
+++ b/src/process/services/skillUpdate/SkillUpdateService.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * SkillUpdateService — keeps installed hub skills current.
+ *
+ * Installed hub skills are pinned at their install-time version and were never
+ * refreshed, so users kept a stale capability surface (e.g. a ShareOne skill
+ * missing "add collaborator" long after the hub shipped it). This service is the
+ * missing "update" half of the skill lifecycle:
+ *   enumerate installed hub skills → ask the hub for the latest version →
+ *   semver-compare against installed_version → reuse the shared install path.
+ *
+ * Orchestration only (SRP): version discovery reuses the hub client helpers, the
+ * actual download/extract/meta-write reuses installHubSkillPackage. Runs
+ * fire-and-forget off the startup critical path; throttled in-memory so repeated
+ * triggers (startup + hub-open) never hammer the hub.
+ */
+import { skillManager } from '@process/SkillManager';
+import { installHubSkillPackage } from '@process/bridge/skillHubBridge';
+import { ProcessConfig } from '@process/initStorage';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
+import { getSkillHubBaseUrl } from '@/common/systemConfig';
+import { getSkillhubToken } from '@/process/credentialsCache';
+import type { ISkillHubDetail } from '@/common/ipcBridge';
+import { isNewerVersion } from './version';
+
+/** Config key for the auto-update toggle. Default ON (VSCode-style: silent, opt-out). */
+export const SKILL_AUTO_UPDATE_SETTING_KEY = 'skill.autoUpdate';
+
+/** Minimum gap between hub checks. In-memory only — an ephemeral throttle, never persisted. */
+const CHECK_THROTTLE_MS = 10 * 60 * 1000;
+/** Cold-start token wait: the skillhub token provisions a few seconds after startup. */
+const TOKEN_WAIT_TIMEOUT_MS = 30_000;
+const TOKEN_WAIT_INTERVAL_MS = 2_000;
+let lastCheckAt = 0;
+let inFlight: Promise<SkillUpdateSummary> | null = null;
+
+export interface SkillUpdateSummary {
+  checked: number;
+  updated: string[];
+  skipped?: 'throttled' | 'disabled' | 'no-token';
+}
+
+async function isAutoUpdateEnabled(): Promise<boolean> {
+  // Default ON: only an explicit `false` disables it.
+  return (await ProcessConfig.get(SKILL_AUTO_UPDATE_SETTING_KEY).catch(() => true)) !== false;
+}
+
+/**
+ * The skillhub token is provisioned asynchronously during startup (nexus vault
+ * connect + secret decrypt), which finishes a few seconds AFTER this fire-and-
+ * forget trigger. Poll (bounded) for it so a cold start doesn't skip the check
+ * and leave skills stale until the next launch.
+ */
+async function waitForSkillhubToken(): Promise<string | null> {
+  const deadline = Date.now() + TOKEN_WAIT_TIMEOUT_MS;
+  let token = getSkillhubToken();
+  while (!token && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, TOKEN_WAIT_INTERVAL_MS));
+    token = getSkillhubToken();
+  }
+  return token;
+}
+
+/** Latest published detail for a hub skill; versions[0] is newest (hub API contract). */
+async function fetchLatestHubDetail(skillId: string, token: string): Promise<ISkillHubDetail | null> {
+  const res = await fetch(`${getSkillHubBaseUrl()}/api/skills/${encodeURIComponent(skillId)}`, {
+    headers: { Authorization: token },
+  });
+  if (!res.ok) return null;
+  const body = (await res.json()) as { data?: ISkillHubDetail };
+  return body?.data ?? null;
+}
+
+/**
+ * Check every installed hub skill against the hub and update the stale ones.
+ * Idempotent, throttled, and safe to call fire-and-forget from anywhere.
+ */
+export function checkAndUpdateInstalledHubSkills(opts?: { force?: boolean }): Promise<SkillUpdateSummary> {
+  // Coalesce concurrent triggers (startup + hub-open) onto one in-flight run.
+  if (inFlight) return inFlight;
+
+  const now = Date.now();
+  if (!opts?.force && now - lastCheckAt < CHECK_THROTTLE_MS) {
+    return Promise.resolve({ checked: 0, updated: [], skipped: 'throttled' });
+  }
+
+  inFlight = (async (): Promise<SkillUpdateSummary> => {
+    if (!(await isAutoUpdateEnabled())) {
+      mainLog('SkillUpdate', 'Skipped: auto-update disabled (skill.autoUpdate=false)');
+      return { checked: 0, updated: [], skipped: 'disabled' };
+    }
+    const token = await waitForSkillhubToken();
+    if (!token) {
+      mainLog('SkillUpdate', 'Skipped: skillhub token not provisioned (waited)');
+      return { checked: 0, updated: [], skipped: 'no-token' };
+    }
+
+    lastCheckAt = Date.now();
+
+    const installed = (await skillManager.getInstalledSkills()).filter((s) => s.isHubInstalled);
+    mainLog('SkillUpdate', `Checking ${installed.length} installed hub skill(s) for updates…`);
+    const updated: string[] = [];
+
+    for (const skill of installed) {
+      const installedVersion = skill.meta?.installed_version ?? skill.version;
+      const hubId = skill.meta?.id || skill.name;
+      if (!installedVersion || !hubId) continue;
+      try {
+        const detail = await fetchLatestHubDetail(hubId, token);
+        const latest = detail?.versions?.[0];
+        if (!latest?.version || !isNewerVersion(latest.version, installedVersion)) continue;
+
+        const result = await installHubSkillPackage({
+          skillName: skill.name,
+          displayName: skill.meta?.display_name || detail?.skill?.display_name || skill.name,
+          sourceUrl: latest.source_url,
+          version: latest.version,
+          checksum: latest.checksum,
+          skillMeta: detail?.skill,
+        });
+        if (result.success) {
+          updated.push(`${skill.name} ${installedVersion} → ${latest.version}`);
+          mainLog('SkillUpdate', `Updated hub skill "${skill.name}" ${installedVersion} → ${latest.version}`);
+        } else if ('msg' in result) {
+          mainWarn('SkillUpdate', `Failed to update "${skill.name}": ${result.msg}`);
+        }
+      } catch (err) {
+        mainWarn('SkillUpdate', `Error updating "${skill.name}"`, err);
+      }
+    }
+
+    mainLog(
+      'SkillUpdate',
+      `Done: checked ${installed.length} hub skill(s), updated ${updated.length}${updated.length ? ` (${updated.join('; ')})` : ''}`,
+    );
+    return { checked: installed.length, updated };
+  })();
+
+  try {
+    return inFlight;
+  } finally {
+    void inFlight.finally(() => {
+      inFlight = null;
+    });
+  }
+}

--- a/src/process/services/skillUpdate/version.ts
+++ b/src/process/services/skillUpdate/version.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import semver from 'semver';
+
+/**
+ * True when `latest` is a strictly newer semver than `installed`.
+ *
+ * Tolerates non-strict tags via `coerce` (e.g. "v1.2" → "1.2.0") and returns
+ * false on unparseable input (never updates on garbage, never downgrades).
+ *
+ * Kept in its own pure module — no I/O, no Electron imports — so the
+ * update-decision logic is unit-testable without the main-process graph.
+ */
+export function isNewerVersion(latest: string, installed: string): boolean {
+  const a = semver.valid(latest) || semver.coerce(latest)?.version;
+  const b = semver.valid(installed) || semver.coerce(installed)?.version;
+  if (!a || !b) return false;
+  return semver.gt(a, b);
+}

--- a/tests/unit/skillUpdateVersion.test.ts
+++ b/tests/unit/skillUpdateVersion.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+import { isNewerVersion } from '@process/services/skillUpdate/version';
+
+/**
+ * Regression guard for the auto-update decision. The live e2e proved the full
+ * flow (a stale shareone-skill v1.2.0 auto-updated to v1.2.7 on launch); this
+ * pins the version comparison that decides *whether* to update, including the
+ * traps that would silently break it (string-vs-semver ordering, downgrades,
+ * garbage input).
+ */
+describe('isNewerVersion (skill auto-update decision)', () => {
+  it('updates a stale skill — the real case this feature fixes', () => {
+    expect(isNewerVersion('1.2.7', '1.2.0')).toBe(true);
+  });
+
+  it('does not update when already at the latest version', () => {
+    expect(isNewerVersion('1.2.7', '1.2.7')).toBe(false);
+  });
+
+  it('never downgrades (hub older than installed)', () => {
+    expect(isNewerVersion('1.2.0', '1.2.7')).toBe(false);
+  });
+
+  it('orders by semver, not string — 1.10.0 is newer than 1.9.0', () => {
+    // A naive string compare would report 1.10.0 < 1.9.0 and miss the update.
+    expect(isNewerVersion('1.10.0', '1.9.0')).toBe(true);
+    expect(isNewerVersion('1.9.0', '1.10.0')).toBe(false);
+  });
+
+  it('bumps across minor/major boundaries', () => {
+    expect(isNewerVersion('2.0.0', '1.9.9')).toBe(true);
+    expect(isNewerVersion('1.3.0', '1.2.9')).toBe(true);
+  });
+
+  it('tolerates non-strict tags via coerce (v-prefix, missing patch)', () => {
+    expect(isNewerVersion('v1.3', '1.2.9')).toBe(true);
+    expect(isNewerVersion('1.2', '1.2.0')).toBe(false);
+  });
+
+  it('is safe on unparseable input — no update, no throw', () => {
+    expect(isNewerVersion('', '1.2.0')).toBe(false);
+    expect(isNewerVersion('not-a-version', '1.2.0')).toBe(false);
+    expect(isNewerVersion('1.2.7', '')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
Installed hub skills are pinned at their install-time version with **no update path** — users keep a stale capability surface. Concretely: SudoWork told a user "ShareOne has no collaborator API" because their installed `shareone-skill` was **v1.2.0** (missing `manage_collaborators.js`) while the hub had **v1.2.7**. Every feature shipped to any hub skill after a user installed it was invisible to them.

## Fix (architecture-level, not a patch)
- **Extract `installHubSkillPackage()`** out of the download-and-install IPC provider — business logic leaves the transport layer; one install path shared by first-install *and* auto-update.
- **New `SkillUpdateService`** (SRP orchestration): enumerate installed hub skills → hub latest → semver-compare vs `installed_version` → reuse the shared install path. In-memory throttle + single in-flight coalescing; **default-ON**, opt-out via `skill.autoUpdate` (registered in the typed config schema).
- **Bounded wait for the skillhub token** — it's provisioned asynchronously during startup (nexus vault connect + secret decrypt), a few seconds *after* the fire-and-forget trigger. Without this it skipped on **every cold launch**. **This bug was caught by the live e2e, not by types/units.**
- Pure `isNewerVersion` in `version.ts` (no Electron imports) so the decision logic is unit-testable.

## Validation
- **Live e2e on a real logged-in SudoWork:** a stale `shareone-skill` **1.2.0 → 1.2.7** auto-updated on launch and gained `manage_collaborators.js`. Log:
  `[SkillUpdate] Updated hub skill "shareone-skill" 1.2.0 → 1.2.7`
- `tests/unit/skillUpdateVersion.test.ts` — **vitest 7/7** (semver-vs-string trap, downgrade protection, garbage-safety).
- `tsc --noEmit`: 0 errors.

Once shipped, every user's installed skills self-heal on next launch — no more "feature doesn't exist" false negatives.