### PR TITLE
feat(settings): support provider-level model editing

### DIFF
--- a/src/renderer/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/i18n/locales/ja-JP/settings.json
@@ -1058,6 +1058,8 @@
     "modelIdPlaceholder": "例: gpt-4o または openai/gpt-4o",
     "modelIdsPlaceholder": "1 つ以上のモデルを選択または入力",
     "bulkModelSelectHint": "リストから複数のモデルを選択するか、手動で入力してください。",
+    "selectAllModels": "すべて選択",
+    "clearSelectedModels": "クリア",
     "selectedModelsCount": "{{count}} 個のモデルを選択済み",
     "advancedConfig": "詳細設定",
     "supportsTools": "ツール呼び出し",

--- a/src/renderer/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/i18n/locales/tr-TR/settings.json
@@ -1054,6 +1054,8 @@
     "modelIdPlaceholder": "örn. gpt-4o veya openai/gpt-4o",
     "modelIdsPlaceholder": "Bir veya daha fazla model seçin ya da girin",
     "bulkModelSelectHint": "Listeden birden fazla model seçin ya da manuel girmeye devam edin.",
+    "selectAllModels": "Tümünü Seç",
+    "clearSelectedModels": "Temizle",
     "selectedModelsCount": "{{count}} model seçildi",
     "advancedConfig": "Gelişmiş Ayarlar",
     "supportsTools": "Araç Çağrısı",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -1200,6 +1200,8 @@
     "modelIdPlaceholder": "例如 gpt-4o 或 openai/gpt-4o",
     "modelIdsPlaceholder": "选择或输入一个或多个模型",
     "bulkModelSelectHint": "可从列表多选模型，也可继续手动输入。",
+    "selectAllModels": "全选",
+    "clearSelectedModels": "清空",
     "selectedModelsCount": "已选择 {{count}} 个模型",
     "advancedConfig": "高级配置",
     "supportsTools": "工具调用",

--- a/src/renderer/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/i18n/locales/zh-TW/settings.json
@@ -1058,6 +1058,8 @@
     "modelIdPlaceholder": "例如 gpt-4o 或 openai/gpt-4o",
     "modelIdsPlaceholder": "選擇或輸入一個或多個模型",
     "bulkModelSelectHint": "可從清單多選模型，也可繼續手動輸入。",
+    "selectAllModels": "全選",
+    "clearSelectedModels": "清空",
     "selectedModelsCount": "已選擇 {{count}} 個模型",
     "advancedConfig": "進階設定",
     "supportsTools": "工具呼叫",

--- a/src/renderer/pages/settings/models/components/AddModelDialog.tsx
+++ b/src/renderer/pages/settings/models/components/AddModelDialog.tsx
@@ -5,19 +5,14 @@
  */
 
 import { Button, Checkbox, Form, Input, InputNumber, Message, Modal, Select, Spin, Tag } from '@arco-design/web-react';
-import { IconDownload, IconEye } from '@arco-design/web-react/icon';
+import { IconDownload, IconEraser, IconEye, IconSelectAll } from '@arco-design/web-react/icon';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import type { ScodeConfig } from '@/common/ipcBridge';
 import { buildCustomModelAlias, type ScodeCustomModelProvider } from '@/common/scodeConfig';
-import { editableModelFromEntry, findModelEntry, presetValueForProvider, sanitizeProviderId, PROVIDER_PRESETS } from '../utils';
-import type { EditableModel, EditingModelTarget } from '../types';
-
-function normalizeModelIds(value: unknown): string[] {
-  const values = Array.isArray(value) ? value : [value];
-  return Array.from(new Set(values.map((item) => String(item || '').trim()).filter(Boolean)));
-}
+import { buildEditableModelFromFormValues, buildProviderEditModels, editableModelFromEntry, findModelEntry, normalizeModelIds, presetValueForProvider, sanitizeProviderId, PROVIDER_PRESETS } from '../utils';
+import type { EditingModelTarget } from '../types';
 
 const DEFAULT_MODEL_API = 'openai-completions';
 
@@ -26,23 +21,6 @@ const MODEL_API_OPTIONS = [
   { value: 'openai-responses', i18nKey: 'settings.sudocodeModel.protocolOpenAIResponses', fallback: 'OpenAI Responses' },
   { value: 'anthropic-messages', i18nKey: 'settings.sudocodeModel.protocolAnthropicMessages', fallback: 'Anthropic Messages' },
 ];
-
-function buildEditableModel(modelId: string, values: IAddModelFormValues): EditableModel {
-  const input = ['text'];
-  if (values.supportsVision) {
-    input.push('image');
-  }
-  return {
-    id: modelId,
-    name: modelId,
-    api: values.api,
-    input,
-    supportsTools: values.supportsTools,
-    supportsReasoning: values.supportsReasoning,
-    inputContext: values.inputContext,
-    outputContext: values.outputContext,
-  };
-}
 
 export default function AddModelDialog({ visible, onClose, onSubmit, existingProviderIds, existingModelIds, config, editingTarget }: IAddModelDialogProps) {
   const { t } = useTranslation();
@@ -55,14 +33,18 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
   const selectedApi = String(Form.useWatch('api', form) || DEFAULT_MODEL_API);
   const selectedModelIds = normalizeModelIds(Form.useWatch('modelIds', form));
   const selectedPreset = useMemo(() => PROVIDER_PRESETS.find((item) => item.value === providerPreset), [providerPreset]);
+  const isModelEditing = editingTarget?.mode === 'model';
+  const isProviderEditing = editingTarget?.mode === 'provider';
   const isEditing = Boolean(editingTarget);
+  const isBulkModelPicker = !isModelEditing;
   const modelOptions = useMemo(() => providerModels.map((model) => ({ label: model, value: model })), [providerModels]);
   const modelApiOptions = useMemo(() => MODEL_API_OPTIONS.map((item) => ({ label: t(item.i18nKey, item.fallback), value: item.value })), [t]);
+  const dialogTitle = isProviderEditing ? t('common.edit', '编辑') : isModelEditing ? t('settings.sudocodeModel.editModelTitle', '编辑模型') : t('settings.addModel', '添加模型');
 
   useEffect(() => {
     if (!visible) return;
     form.resetFields();
-    if (editingTarget) {
+    if (isModelEditing) {
       const entry = findModelEntry(config, editingTarget.modelId);
       const editableModel = editableModelFromEntry(config, editingTarget.modelId);
       const input = entry?.input || [];
@@ -85,6 +67,30 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
       return;
     }
 
+    if (isProviderEditing) {
+      const editableModels = editingTarget.provider.modelIds.map((modelId) => editableModelFromEntry(config, modelId));
+      const firstModel = editableModels[0];
+      const firstInput = firstModel?.input || [];
+      const modelIds = editableModels.map((model) => model.id);
+      form.setFieldsValue({
+        providerPreset: presetValueForProvider(editingTarget.provider),
+        providerId: editingTarget.provider.id,
+        baseUrl: editingTarget.provider.baseUrl,
+        apiKey: editingTarget.provider.apiKey,
+        api: firstModel?.api || DEFAULT_MODEL_API,
+        modelId: '',
+        modelIds,
+        supportsTools: firstModel?.supportsTools ?? true,
+        supportsVision: firstInput.includes('image'),
+        supportsReasoning: Boolean(firstModel?.supportsReasoning),
+        inputContext: firstModel?.inputContext,
+        outputContext: firstModel?.outputContext,
+      });
+      setIsApiKeyVisible(false);
+      setProviderModels(modelIds);
+      return;
+    }
+
     form.setFieldsValue({
       providerPreset: 'custom',
       providerId: 'custom-openai',
@@ -99,8 +105,7 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
     });
     setIsApiKeyVisible(false);
     setProviderModels([]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form, visible]);
+  }, [config, editingTarget, form, isModelEditing, isProviderEditing, visible]);
 
   useEffect(() => {
     if (isEditing) return;
@@ -115,7 +120,7 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
     setProviderModels([]);
   }, [form, isEditing, providerPreset]);
 
-  const handleFetchProviderModels = async () => {
+  const onFetchProviderModels = async () => {
     const baseUrl = String(form.getFieldValue('baseUrl') || '').trim();
     const apiKey = String(form.getFieldValue('apiKey') || '').trim();
     if (!baseUrl) {
@@ -156,11 +161,20 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
     }
   };
 
-  const handleSubmit = async () => {
+  const onSelectAllProviderModels = () => {
+    form.setFieldValue('modelIds', normalizeModelIds([...selectedModelIds, ...providerModels]));
+  };
+
+  const onClearSelectedModels = () => {
+    form.setFieldValue('modelIds', []);
+  };
+
+  const onSubmitDialog = async () => {
     const values = (await form.validate()) as IAddModelFormValues;
     const providerId = sanitizeProviderId(values.providerId);
-    const modelIds = isEditing ? normalizeModelIds(values.modelId) : normalizeModelIds(values.modelIds);
-    const modelAlias = isEditing && modelIds[0] ? buildCustomModelAlias(providerId, modelIds[0]) : undefined;
+    const modelIds = isModelEditing ? normalizeModelIds(values.modelId) : normalizeModelIds(values.modelIds);
+    let previousModelId = isModelEditing ? editingTarget.modelId : undefined;
+    let nextModelId = isModelEditing && modelIds[0] ? buildCustomModelAlias(providerId, modelIds[0]) : undefined;
     if (!providerId) {
       Message.error(t('settings.sudocodeModel.providerIdInvalid', 'Provider ID 无效'));
       return;
@@ -176,14 +190,23 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
 
     for (const modelId of modelIds) {
       const alias = buildCustomModelAlias(providerId, modelId);
-      if (existingModelIds.some((item) => item === alias && item !== editingTarget?.modelId)) {
+      const isCurrentProviderModel = isProviderEditing && providerId === editingTarget.provider.id && editingTarget.provider.modelIds.includes(alias);
+      if (existingModelIds.some((item) => item === alias && item !== previousModelId && !isCurrentProviderModel)) {
         Message.error(t('settings.sudocodeModel.modelIdExists', '模型名称已存在，请换一个名称'));
         return;
       }
     }
 
-    const nextModels = modelIds.map((modelId) => buildEditableModel(modelId, values));
-    const models = editingTarget ? editingTarget.provider.modelIds.map((item) => (item === editingTarget.modelId ? nextModels[0] : editableModelFromEntry(config, item))) : nextModels;
+    if (isProviderEditing && providerId !== editingTarget.provider.id && config?.default_model && editingTarget.provider.modelIds.includes(config.default_model)) {
+      const defaultModel = editableModelFromEntry(config, config.default_model);
+      if (modelIds.includes(defaultModel.id)) {
+        previousModelId = config.default_model;
+        nextModelId = buildCustomModelAlias(providerId, defaultModel.id);
+      }
+    }
+
+    const nextModels = modelIds.map((modelId) => buildEditableModelFromFormValues(modelId, values));
+    const models = isModelEditing ? editingTarget.provider.modelIds.map((item) => (item === editingTarget.modelId ? nextModels[0] : editableModelFromEntry(config, item))) : isProviderEditing ? buildProviderEditModels(config, editingTarget.provider, modelIds, values) : nextModels;
 
     setIsSaving(true);
     try {
@@ -195,8 +218,8 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
           models,
         },
         editingTarget?.provider.id,
-        editingTarget?.modelId,
-        modelAlias
+        previousModelId,
+        nextModelId
       );
       onClose();
     } finally {
@@ -207,10 +230,13 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
   return (
     <Modal
       visible={visible}
-      title={isEditing ? t('settings.sudocodeModel.editModelTitle', '编辑模型') : t('settings.addModel', '添加模型')}
-      style={{ width: 760 }}
+      title={dialogTitle}
+      className='sudocode-model-dialog'
+      style={{ width: 'min(760px, calc(100vw - 32px))' }}
+      alignCenter={false}
+      focusLock={false}
       onCancel={onClose}
-      onOk={handleSubmit}
+      onOk={onSubmitDialog}
       okText={t('common.save', '保存')}
       cancelText={t('common.cancel', '取消')}
       confirmLoading={isSaving}
@@ -243,12 +269,12 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
             suffix={<Button type='text' size='mini' icon={<IconEye />} onClick={() => setIsApiKeyVisible((prev) => !prev)} />}
           />
         </Form.Item>
-        {isEditing ? (
+        {isModelEditing ? (
           <Form.Item
             label={
               <div className='flex items-center justify-between gap-3 w-full'>
                 <span>{t('settings.sudocodeModel.modelIdLabel', '模型名称')}</span>
-                <Button size='mini' icon={<IconDownload />} loading={isFetchingModels} onClick={() => void handleFetchProviderModels()}>
+                <Button size='mini' icon={<IconDownload />} loading={isFetchingModels} onClick={() => void onFetchProviderModels()}>
                   {t('settings.fetchModelList')}
                 </Button>
               </div>
@@ -273,11 +299,19 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
         ) : (
           <Form.Item
             label={
-              <div className='flex items-center justify-between gap-3 w-full'>
+              <div className='flex items-center justify-between gap-3 w-full flex-wrap'>
                 <span>{t('settings.sudocodeModel.modelIdLabel', '模型名称')}</span>
-                <Button size='mini' icon={<IconDownload />} loading={isFetchingModels} onClick={() => void handleFetchProviderModels()}>
-                  {t('settings.fetchModelList')}
-                </Button>
+                <div className='flex items-center gap-2 flex-wrap justify-end'>
+                  <Button size='mini' icon={<IconDownload />} loading={isFetchingModels} onClick={() => void onFetchProviderModels()}>
+                    {t('settings.fetchModelList')}
+                  </Button>
+                  <Button size='mini' icon={<IconSelectAll />} disabled={providerModels.length === 0} onClick={onSelectAllProviderModels}>
+                    {t('settings.sudocodeModel.selectAllModels', '全选')}
+                  </Button>
+                  <Button size='mini' icon={<IconEraser />} disabled={selectedModelIds.length === 0} onClick={onClearSelectedModels}>
+                    {t('settings.sudocodeModel.clearSelectedModels', '清空')}
+                  </Button>
+                </div>
               </div>
             }
             field='modelIds'
@@ -301,7 +335,7 @@ export default function AddModelDialog({ visible, onClose, onSubmit, existingPro
             />
           </Form.Item>
         )}
-        {!isEditing && selectedModelIds.length > 0 && (
+        {isBulkModelPicker && selectedModelIds.length > 0 && (
           <div className='mb-4 border border-light rd-2 bg-muted p-3'>
             <div className='mb-2 text-12px text-secondary'>{t('settings.sudocodeModel.selectedModelsCount', '已选择 {{count}} 个模型', { count: selectedModelIds.length })}</div>
             <div className='flex flex-wrap gap-1.5'>

--- a/src/renderer/pages/settings/models/index.tsx
+++ b/src/renderer/pages/settings/models/index.tsx
@@ -86,22 +86,27 @@ const SudocodeModelSettings: React.FC = () => {
     [user?.id, t]
   );
 
-  const openAddDialog = useCallback(() => {
+  const onOpenAddDialog = useCallback(() => {
     setEditingTarget(null);
     setDialogVisible(true);
   }, []);
 
-  const openEditDialog = useCallback((provider: ProviderRow, modelId: string) => {
-    setEditingTarget({ provider, modelId });
+  const onOpenEditModelDialog = useCallback((provider: ProviderRow, modelId: string) => {
+    setEditingTarget({ mode: 'model', provider, modelId });
     setDialogVisible(true);
   }, []);
 
-  const closeDialog = useCallback(() => {
+  const onOpenEditProviderDialog = useCallback((provider: ProviderRow) => {
+    setEditingTarget({ mode: 'provider', provider });
+    setDialogVisible(true);
+  }, []);
+
+  const onCloseDialog = useCallback(() => {
     setDialogVisible(false);
     setEditingTarget(null);
   }, []);
 
-  const handleSubmitProvider = useCallback(
+  const onSubmitProvider = useCallback(
     async (provider: ScodeCustomModelProvider, previousProviderId?: string, previousModelId?: string, nextModelId?: string) => {
       const sourceConfig = previousProviderId && previousProviderId !== provider.providerId ? removeCustomProviderFromScodeConfig(config || {}, previousProviderId) : config || {};
       const nextConfig = normalizeDefaultModel(mergeCustomProviderIntoScodeConfig(sourceConfig, provider), previousModelId, nextModelId);
@@ -110,7 +115,7 @@ const SudocodeModelSettings: React.FC = () => {
     [config, saveConfig]
   );
 
-  const handleRemoveProvider = useCallback(
+  const onRemoveProvider = useCallback(
     async (providerId: string) => {
       await saveConfig(removeCustomProviderFromScodeConfig(config || {}, providerId));
     },
@@ -134,7 +139,7 @@ const SudocodeModelSettings: React.FC = () => {
           <Button icon={<IconRefresh />} onClick={loadConfig}>
             {t('common.refresh', '刷新')}
           </Button>
-          <Button type='primary' icon={<IconPlus />} onClick={openAddDialog} className='!bg-primary !border-[var(--ui-accent-orange)] !text-white hover:!bg-[var(--ui-accent-orange-hover)] hover:!border-[var(--ui-accent-orange-hover)] hover:!text-white'>
+          <Button type='primary' icon={<IconPlus />} onClick={onOpenAddDialog} className='!bg-primary !border-[var(--ui-accent-orange)] !text-white hover:!bg-[var(--ui-accent-orange-hover)] hover:!border-[var(--ui-accent-orange-hover)] hover:!text-white'>
             {t('settings.addModel', '添加模型')}
           </Button>
         </Space>
@@ -197,7 +202,10 @@ const SudocodeModelSettings: React.FC = () => {
                     </div>
                     <Space>
                       <Tag bordered>{maskSecret(provider.apiKey) || t('common.notSet', '未设置')}</Tag>
-                      <Popconfirm title={t('settings.sudocodeModel.deleteProviderConfirm', '删除该第三方提供商及其模型？')} onOk={() => void handleRemoveProvider(provider.id)}>
+                      <Button icon={<IconEdit />} loading={saving} onClick={() => onOpenEditProviderDialog(provider)}>
+                        {t('common.edit', '编辑')}
+                      </Button>
+                      <Popconfirm title={t('settings.sudocodeModel.deleteProviderConfirm', '删除该第三方提供商及其模型？')} onOk={() => void onRemoveProvider(provider.id)}>
                         <Button status='danger' icon={<IconDelete style={{ fontSize: 16 }} />} loading={saving}>
                           {t('common.delete', '删除')}
                         </Button>
@@ -230,7 +238,7 @@ const SudocodeModelSettings: React.FC = () => {
                               </Tag>
                             </div>
                           </div>
-                          <Button icon={<IconEdit />} loading={saving} onClick={() => openEditDialog(provider, modelId)}>
+                          <Button icon={<IconEdit />} loading={saving} onClick={() => onOpenEditModelDialog(provider, modelId)}>
                             {t('common.edit', '编辑')}
                           </Button>
                         </div>
@@ -243,7 +251,7 @@ const SudocodeModelSettings: React.FC = () => {
           </div>
         </AionScrollArea>
       )}
-      <AddModelDialog visible={dialogVisible} onClose={closeDialog} onSubmit={handleSubmitProvider} existingProviderIds={customProviders.map((provider) => provider.id)} existingModelIds={configuredModelIds} config={config} editingTarget={editingTarget} />
+      <AddModelDialog visible={dialogVisible} onClose={onCloseDialog} onSubmit={onSubmitProvider} existingProviderIds={customProviders.map((provider) => provider.id)} existingModelIds={configuredModelIds} config={config} editingTarget={editingTarget} />
     </PageWrapper>
   );
 };

--- a/src/renderer/pages/settings/models/types/index.ts
+++ b/src/renderer/pages/settings/models/types/index.ts
@@ -15,7 +15,13 @@ export type ProviderRow = {
 
 export type EditableModel = ScodeCustomModelProvider['models'][number];
 
-export type EditingModelTarget = {
-  provider: ProviderRow;
-  modelId: string;
-};
+export type EditingModelTarget =
+  | {
+      mode: 'model';
+      provider: ProviderRow;
+      modelId: string;
+    }
+  | {
+      mode: 'provider';
+      provider: ProviderRow;
+    };

--- a/src/renderer/pages/settings/models/utils/index.ts
+++ b/src/renderer/pages/settings/models/utils/index.ts
@@ -101,6 +101,37 @@ export function sanitizeProviderId(value: string): string {
 }
 
 /**
+ * Normalize a single value, array value, or empty value into unique model IDs.
+ * @param value - Select form field value.
+ */
+export function normalizeModelIds(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return Array.from(new Set(values.map((item) => String(item || '').trim()).filter(Boolean)));
+}
+
+/**
+ * Build a saveable custom model from form defaults.
+ * @param modelId - Upstream model ID.
+ * @param values - Protocol and capability defaults from the form.
+ */
+export function buildEditableModelFromFormValues(modelId: string, values: IModelFormDefaults): EditableModel {
+  const input = ['text'];
+  if (values.supportsVision) {
+    input.push('image');
+  }
+  return {
+    id: modelId,
+    name: modelId,
+    api: values.api,
+    input,
+    supportsTools: values.supportsTools,
+    supportsReasoning: values.supportsReasoning,
+    inputContext: values.inputContext,
+    outputContext: values.outputContext,
+  };
+}
+
+/**
  * 将输入/输出上下文窗口大小格式化为可读的标签文本。
  * @param input - 输入上下文大小（K tokens）
  * @param output - 输出上下文大小（K tokens）
@@ -149,13 +180,31 @@ export function editableModelFromEntry(config: ScodeConfig | null, modelId: stri
   const providerModelId = entry?.providers?.['api-key']?.model || modelId;
   return {
     id: providerModelId,
-    name: entry?.name || providerModelId,
+    name: providerModelId,
+    api: entry?.providers?.['api-key']?.api,
     input: entry?.input,
     supportsTools: entry?.supports_tools,
     supportsReasoning: entry?.supports_reasoning,
     inputContext: entry?.context?.input,
     outputContext: entry?.context?.output,
   };
+}
+
+/**
+ * Build provider-level edit models, preserving existing model settings while applying defaults to new models.
+ * @param config - Current sudocode config.
+ * @param provider - Provider being edited.
+ * @param modelIds - Upstream model IDs selected or entered by the user.
+ * @param values - Protocol and capability defaults for newly added models.
+ */
+export function buildProviderEditModels(config: ScodeConfig | null, provider: ProviderRow, modelIds: string[], values: IModelFormDefaults): EditableModel[] {
+  const existingModels = new Map<string, EditableModel>();
+  for (const modelId of provider.modelIds) {
+    const editableModel = editableModelFromEntry(config, modelId);
+    existingModels.set(editableModel.id, editableModel);
+  }
+
+  return normalizeModelIds(modelIds).map((modelId) => existingModels.get(modelId) || buildEditableModelFromFormValues(modelId, values));
 }
 
 /**
@@ -176,4 +225,13 @@ export function normalizeDefaultModel(config: ScodeConfig, previousModelId?: str
     return nextConfig;
   }
   return config;
+}
+
+export interface IModelFormDefaults {
+  api: string;
+  supportsTools?: boolean;
+  supportsVision?: boolean;
+  supportsReasoning?: boolean;
+  inputContext?: number;
+  outputContext?: number;
 }

--- a/src/renderer/styles/arco-override.scss
+++ b/src/renderer/styles/arco-override.scss
@@ -112,11 +112,39 @@ body[arco-theme='dark'] {
 
 .arco-modal {
   border-radius: 16px;
+
+  &,
+  &-mask,
+  &-wrapper,
+  &-close-icon {
+    -webkit-app-region: no-drag;
+  }
+
   &-header {
     border-bottom-color: var(--border-tiny);
   }
   &-footer {
     border-top-color: var(--border-tiny);
+  }
+}
+
+.arco-modal.sudocode-model-dialog {
+  top: 56px;
+  max-height: calc(100vh - 72px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .arco-modal-header,
+  .arco-modal-footer {
+    flex: 0 0 auto;
+  }
+
+  .arco-modal-content {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 }
 

--- a/tests/unit/sudocodeModelSettingsUtils.test.ts
+++ b/tests/unit/sudocodeModelSettingsUtils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { mergeCustomProviderIntoScodeConfig } from '@/common/scodeConfig';
+import { buildProviderEditModels } from '@/renderer/pages/settings/models/utils';
+
+describe('sudocode model settings utils', () => {
+  it('preserves existing model settings and applies defaults only to newly selected provider models', () => {
+    const config = mergeCustomProviderIntoScodeConfig(null, {
+      providerId: 'model-sudorouter',
+      baseUrl: 'https://model.sudorouter.ai/v1',
+      apiKey: 'key',
+      models: [
+        {
+          id: 'gpt-4o',
+          api: 'openai-completions',
+          input: ['text', 'image'],
+          supportsTools: true,
+          supportsReasoning: false,
+          inputContext: 128,
+          outputContext: 32,
+        },
+        {
+          id: 'legacy-model',
+          api: 'anthropic-messages',
+          supportsTools: false,
+          supportsReasoning: true,
+        },
+      ],
+    });
+
+    const models = buildProviderEditModels(
+      config,
+      {
+        id: 'model-sudorouter',
+        baseUrl: 'https://model.sudorouter.ai/v1',
+        apiKey: 'key',
+        modelIds: ['model-sudorouter/gpt-4o', 'model-sudorouter/legacy-model'],
+      },
+      ['gpt-4o', 'gpt-5.5'],
+      {
+        api: 'openai-responses',
+        supportsTools: false,
+        supportsVision: false,
+        supportsReasoning: true,
+        inputContext: 256,
+        outputContext: 64,
+      }
+    );
+
+    expect(models).toEqual([
+      {
+        id: 'gpt-4o',
+        name: 'gpt-4o',
+        api: 'openai-completions',
+        input: ['text', 'image'],
+        supportsTools: true,
+        supportsReasoning: false,
+        inputContext: 128,
+        outputContext: 32,
+      },
+      {
+        id: 'gpt-5.5',
+        name: 'gpt-5.5',
+        api: 'openai-responses',
+        input: ['text'],
+        supportsTools: false,
+        supportsReasoning: true,
+        inputContext: 256,
+        outputContext: 64,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add provider-level editing for custom Sudo Code model providers while preserving existing per-model settings.
- Add bulk select and clear controls after fetching provider model lists.
- Fix Add/Edit Model modal sizing, scrolling, and Electron no-drag interaction on small screens.

## Verification
- Targeted lint/type/unit checks were run during implementation.
- Full test suite was not used as a blocker per request.