### PR TITLE
fix(assistant): correct visible ACL gate and guid input navigation

### DIFF
--- a/src/process/AssistantManager.ts
+++ b/src/process/AssistantManager.ts
@@ -9,13 +9,12 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { existsSync, mkdirSync } from 'fs';
-import { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir } from './initStorage';
+import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
+import { getAssistantsDir, getHubAssistantsDir, getSystemAssistantsDir, getCustomAssistantsDir, getSudoworkServerBaseUrlSync } from './initStorage';
 import { ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE } from './constants/assistantStorage';
 import { mainLog, mainWarn, mainError } from './utils/mainLogger';
 import type { IAssistantMeta } from './constants/assistantStorage';
 import { getEnterpriseTenantAssistantsDir } from './constants/enterpriseStorage';
-import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
-import { getSudoworkServerBaseUrlSync } from './initStorage';
 
 export type AssistantCategory = 'custom' | 'hub' | 'system' | 'tenant';
 
@@ -263,7 +262,7 @@ export class AssistantManager {
 
     const out: IAssistantInfo[] = [];
     for (const item of installed) {
-      const needsAclGate = item.category === 'hub' || item.category === 'tenant';
+      const needsAclGate = item.category === 'tenant';
       const assistantId = item.meta.id ?? item.id;
       if (!needsAclGate) {
         out.push({ ...item, enhancement: { enabled: false } });

--- a/src/renderer/i18n/i18n-keys.d.ts
+++ b/src/renderer/i18n/i18n-keys.d.ts
@@ -2576,24 +2576,4 @@ export type I18nKey =
   | 'update.showInFolder'
   | 'update.upToDateTitle';
 
-export type I18nModule =
-  | 'common'
-  | 'agentMode'
-  | 'update'
-  | 'login'
-  | 'fileSelection'
-  | 'preview'
-  | 'conversation'
-  | 'settings'
-  | 'messages'
-  | 'mcp'
-  | 'acp'
-  | 'codex'
-  | 'tools'
-  | 'gemini'
-  | 'cron'
-  | 'team'
-  | 'starOffice'
-  | 'guid'
-  | 'agent'
-  | 'setup';
+export type I18nModule = 'common' | 'agentMode' | 'update' | 'login' | 'fileSelection' | 'preview' | 'conversation' | 'settings' | 'messages' | 'mcp' | 'acp' | 'codex' | 'tools' | 'gemini' | 'cron' | 'team' | 'starOffice' | 'guid' | 'agent' | 'setup';

--- a/src/renderer/pages/guid/index.tsx
+++ b/src/renderer/pages/guid/index.tsx
@@ -64,7 +64,8 @@ const GuidPage: React.FC = () => {
   const [installedSkillsLoaded, setInstalledSkillsLoaded] = useState(false);
 
   const textareaRef = useRef<RefTextAreaType>(null);
-  const prefilledAssistantRef = useRef<string | null>(null);
+  // Last assistantParam prefilled for; each "去使用" navigation changes it.
+  const prevAssistantParamRef = useRef<string | null>(null);
 
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -307,30 +308,17 @@ const GuidPage: React.FC = () => {
     setGuidDraft({ selectedSkills });
   }, [selectedSkills]);
 
+  // Pre-fill the URL-selected assistant's defaultInitPrompt on each "去使用".
+  // 跨路由重挂载时 guidInput 经 guidDraftStore 持久化会恢复上次输入，故须按
+  // assistantParam 变化无条件覆盖（无 defaultInitPrompt 则清空），不依赖输入框是否为空。
   useEffect(() => {
     if (!assistantParam || !agentSelection.customAgents || agentSelection.customAgents.length === 0) return;
-    if (!agentSelection.selectedAgentKey.startsWith('custom:')) return;
-
-    const assistantId = agentSelection.selectedAgentKey.slice(7);
-
-    // Skip if we've already pre-filled for this assistant
-    if (prefilledAssistantRef.current === assistantId) return;
-
-    const assistantConfig = agentSelection.customAgents.find((a) => a.id === assistantId);
-
-    // Only pre-fill if input is empty and assistant has defaultInitPrompt
-    if (assistantConfig?.defaultInitPrompt && !guidInput.input.trim()) {
-      guidInput.setInput(assistantConfig.defaultInitPrompt);
-      prefilledAssistantRef.current = assistantId;
-    }
-  }, [assistantParam, agentSelection.customAgents, agentSelection.selectedAgentKey, guidInput]);
-
-  // Reset prefilledAssistantRef when assistantParam changes or becomes empty
-  useEffect(() => {
-    if (!assistantParam) {
-      prefilledAssistantRef.current = null;
-    }
-  }, [assistantParam]);
+    if (prevAssistantParamRef.current === assistantParam) return;
+    const target = agentSelection.customAgents.find((a) => a.name === assistantParam || a.id === assistantParam);
+    if (!target) return; // customAgents 尚未加载到目标，不更新 ref，等加载后重跑
+    prevAssistantParamRef.current = assistantParam;
+    guidInput.setInput(target.defaultInitPrompt || '');
+  }, [assistantParam, agentSelection.customAgents, guidInput]);
 
   // Listen for guid.reset event to reset agent/mention state only
   const handleGuidReset = useCallback(() => {
@@ -342,7 +330,6 @@ const GuidPage: React.FC = () => {
     mention.setMentionSelectorVisible(false);
     mention.setMentionSelectorOpen(false);
     mention.setMentionActiveIndex(0);
-    prefilledAssistantRef.current = null;
   }, [agentSelection, mention]);
 
   useAddEventListener('guid.reset', handleGuidReset, [handleGuidReset]);
@@ -445,7 +432,6 @@ const GuidPage: React.FC = () => {
         }
         agentSelection.resetSelection();
         guidInput.setInput('');
-        prefilledAssistantRef.current = null;
       } else {
         agentSelection.setSelectedAgentKey(key);
       }
@@ -480,7 +466,6 @@ const GuidPage: React.FC = () => {
   const handleBackFromAssistant = useCallback(() => {
     agentSelection.resetSelection();
     guidInput.setInput('');
-    prefilledAssistantRef.current = null;
   }, [agentSelection, guidInput]);
 
   // Handle changing the assistant's main agent type
@@ -604,7 +589,6 @@ const GuidPage: React.FC = () => {
       onClosePresetTag={() => {
         agentSelection.setSelectedAgentKey('gemini');
         guidInput.setInput('');
-        prefilledAssistantRef.current = null;
       }}
       skillTriggerNode={skillTriggerNode}
       loading={guidInput.loading}


### PR DESCRIPTION
修复两个与 assistant 选择/使用流程相关的问题：

## 1. 可见 ACL 门控限制到租户助手 (AssistantManager.ts)
公共 store (hub) 助手 `tenant_id=NULL`，从不被 `/agents/visible` 返回（skill-hub `list_all_cursor` 按 `tenant_id` 过滤）。此前对它们施加门控会将其从 picker 隐藏，导致 `customAgents` 为空并在发送时留下悬空的 custom agent key，从而触发 `Custom agent CLI path/command is required` 错误。只有租户助手属于 visible/assistant_acl 体系，故门控现仅应用于租户助手。

## 2. 导航切换助手时覆盖陈旧输入 (guid/index.tsx)
guid 输入通过 `guidDraftStore` 跨挂载持久化，导致上一个助手的 `defaultInitPrompt` 泄漏到下一次「去使用」导航中。改为从 URL `assistantParam` 解析目标（而非异步设置的 `selectedAgentKey`），并在每次导航时覆盖输入（助手无 `defaultInitPrompt` 时清空）；移除不再使用的 `prefilledAssistantRef`。