### PR TITLE
fix(auth): fallback to scode auto model on login

### DIFF
--- a/src/common/sudoworkAuthLogin.ts
+++ b/src/common/sudoworkAuthLogin.ts
@@ -54,15 +54,16 @@ export function extractLoginSudoclawPayload(payload: unknown): LoginSudoclawPayl
   const modelServiceUrl = asNonEmptyString(mergedUser.model_service_url);
   const models = asStringArray(mergedUser.models);
   const scodeAutoModel = asNonEmptyString(mergedUser.scode_auto_model);
+  const resolvedModels = models.length ? models : scodeAutoModel ? [scodeAutoModel] : [];
 
-  if (!sudorouterKey || !modelServiceUrl || models.length === 0) {
+  if (!sudorouterKey || !modelServiceUrl || resolvedModels.length === 0) {
     return null;
   }
 
   return {
     sudorouterKey,
     modelServiceUrl,
-    models,
+    models: resolvedModels,
     ...(scodeAutoModel ? { scodeAutoModel } : {}),
   };
 }

--- a/tests/unit/sudoworkAuthLogin.test.ts
+++ b/tests/unit/sudoworkAuthLogin.test.ts
@@ -66,6 +66,27 @@ describe('sudoworkAuthLogin', () => {
     });
   });
 
+  it('uses the server-configured scode auto model when the login model list is empty', () => {
+    expect(
+      extractLoginSudoclawPayload({
+        data: {
+          user: {
+            id: 'u1',
+            sudorouter_key: 'user-key',
+            model_service_url: 'https://user.example.com/v1',
+            models: [],
+            scode_auto_model: 'gpt-5.5',
+          },
+        },
+      })
+    ).toEqual({
+      sudorouterKey: 'user-key',
+      modelServiceUrl: 'https://user.example.com/v1',
+      models: ['gpt-5.5'],
+      scodeAutoModel: 'gpt-5.5',
+    });
+  });
+
   it('returns null when login response does not contain a usable sudoclaw payload', () => {
     expect(
       extractLoginSudoclawPayload({


### PR DESCRIPTION
## Summary
- Use scode_auto_model as a fallback model list when login returns an empty models array
- Add a regression test for login responses that include Sudorouter credentials and scode_auto_model but no models

## Tests
- bun run test tests/unit/sudoworkAuthLogin.test.ts
- bunx eslint src/common/sudoworkAuthLogin.ts --fix
- bunx eslint tests/unit/sudoworkAuthLogin.test.ts --fix
- bunx tsc --noEmit
- git diff --check

Note: full bun run test was also attempted and hit existing real scode/PTY integration failures unrelated to this change: acpCancelContract.integration.test.ts timeouts and scodeConfigHomeIsolation.integration.test.ts posix_spawnp failed.