### PR TITLE
fix(assistant-hub): propagate localized example prompts across install paths

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -1955,6 +1955,10 @@ export interface IAssistantHubSkill {
   updated_at: string;
   /** Default initial prompt to pre-fill input when selecting this assistant */
   defaultInitPrompt?: string | null;
+  /** Localized example prompts shown when selecting this assistant */
+  promptsI18n?: Record<string, string[]>;
+  /** API-compatible snake_case variant */
+  prompts_i18n?: Record<string, string[]>;
   /** Internal: download URL from API (mapped from sourceUrl) */
   _sourceUrl?: string;
   /** Enterprise mode: visibility configuration */

--- a/src/process/AssistantManager.ts
+++ b/src/process/AssistantManager.ts
@@ -43,8 +43,12 @@ export interface IAssistantInfo {
   enhancement?: IAssistantEnhancement;
 }
 
+type AssistantPromptsI18n = Record<string, string[]>;
+
 interface VisibleAssistantEntry {
   assistant_id: string;
+  promptsI18n?: AssistantPromptsI18n;
+  prompts_i18n?: AssistantPromptsI18n;
   enhancement?: {
     enabled?: boolean;
     mode?: 'agent-chat' | 'workflow' | 'rag-only';
@@ -52,10 +56,50 @@ interface VisibleAssistantEntry {
   };
 }
 
+interface VisibleAssistantOverlay {
+  enhancement: IAssistantEnhancement;
+  promptsI18n?: AssistantPromptsI18n;
+}
+
 interface VisibleResponse {
   success: boolean;
   data?: VisibleAssistantEntry[];
   msg?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function normalizePromptsI18n(value: unknown): AssistantPromptsI18n | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const zhCN = Array.from(new Set((stringArray(value['zh-CN']) || []).map((item) => item.trim()).filter(Boolean)));
+  if (zhCN.length === 0) return undefined;
+
+  return { 'zh-CN': zhCN };
+}
+
+function firstPromptsI18n(...values: unknown[]): AssistantPromptsI18n | undefined {
+  for (const value of values) {
+    const normalized = normalizePromptsI18n(value);
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
+function applyVisibleOverlay(item: IAssistantInfo, overlay: VisibleAssistantOverlay | undefined, fallbackEnhancement: IAssistantEnhancement): IAssistantInfo {
+  const promptsI18n = overlay?.promptsI18n;
+  return {
+    ...item,
+    meta: promptsI18n ? { ...item.meta, promptsI18n } : item.meta,
+    enhancement: overlay?.enhancement ?? fallbackEnhancement,
+  };
 }
 
 /**
@@ -232,7 +276,7 @@ export class AssistantManager {
     const installed = await this.getInstalledAssistants();
     if (!accessToken) return installed;
 
-    let visibleMap: Map<string, IAssistantEnhancement> | null = null;
+    let visibleMap: Map<string, VisibleAssistantOverlay> | null = null;
     try {
       const resp = await fetch(`${getSudoworkServerBaseUrlSync()}/api/v1/agents/visible`, {
         headers: { Authorization: `Bearer ${accessToken}` },
@@ -245,9 +289,12 @@ export class AssistantManager {
           if (!entry.assistant_id) continue;
           const enh = entry.enhancement;
           visibleMap.set(entry.assistant_id, {
-            enabled: !!enh?.enabled,
-            mode: enh?.mode,
-            difyAppId: enh?.dify_app_id,
+            enhancement: {
+              enabled: !!enh?.enabled,
+              mode: enh?.mode,
+              difyAppId: enh?.dify_app_id,
+            },
+            promptsI18n: firstPromptsI18n(entry.promptsI18n, entry.prompts_i18n),
           });
         }
       }
@@ -264,8 +311,9 @@ export class AssistantManager {
     for (const item of installed) {
       const needsAclGate = item.category === 'tenant';
       const assistantId = item.meta.id ?? item.id;
+      const visibleOverlay = assistantId ? visibleMap.get(assistantId) : undefined;
       if (!needsAclGate) {
-        out.push({ ...item, enhancement: { enabled: false } });
+        out.push(applyVisibleOverlay(item, visibleOverlay, { enabled: false }));
         continue;
       }
       if (!assistantId) {
@@ -273,13 +321,12 @@ export class AssistantManager {
         out.push({ ...item, enhancement: { enabled: false } });
         continue;
       }
-      const enh = visibleMap.get(assistantId);
-      if (!enh) {
+      if (!visibleOverlay) {
         // not in visible list → admin revoked or assistant was deleted server-side
         mainLog('AssistantManager', `hiding hub assistant ${assistantId}: not in visible set`);
         continue;
       }
-      out.push({ ...item, enhancement: enh });
+      out.push(applyVisibleOverlay(item, visibleOverlay, { enabled: false }));
     }
     return out;
   }

--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -32,6 +32,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 
 type AssistantHubMeta = import('@/process/constants/assistantStorage').IAssistantMeta;
 type AssistantHubPublishStatus = 'pending' | 'approved' | 'rejected';
+type AssistantPromptsI18n = Record<string, string[]>;
 
 interface AssistantHubUploadApiBody {
   status?: string;
@@ -339,6 +340,23 @@ function stringArray(value: unknown): string[] | undefined {
   return value.filter((item): item is string => typeof item === 'string');
 }
 
+function normalizePromptsI18n(value: unknown): AssistantPromptsI18n | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const zhCN = normalizeStringList(stringArray(value['zh-CN']));
+  if (zhCN.length === 0) return undefined;
+
+  return { 'zh-CN': zhCN };
+}
+
+function firstPromptsI18n(...values: unknown[]): AssistantPromptsI18n | undefined {
+  for (const value of values) {
+    const normalized = normalizePromptsI18n(value);
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
 async function fetchVisibleAssistantOverlayMap(accessToken?: string): Promise<Map<string, VisibleAssistantOverlay> | null> {
   if (!accessToken?.trim()) return null;
 
@@ -388,6 +406,12 @@ function applyVisibleAssistantOverlay(raw: Record<string, unknown>, overlay?: Vi
   if (defaultInitPrompt !== undefined) {
     merged.defaultInitPrompt = defaultInitPrompt;
     merged.default_init_prompt = defaultInitPrompt;
+  }
+
+  const promptsI18n = firstPromptsI18n(overlay.promptsI18n, overlay.prompts_i18n);
+  if (promptsI18n) {
+    merged.promptsI18n = promptsI18n;
+    merged.prompts_i18n = promptsI18n;
   }
 
   const updatedAt = firstString(overlay.updatedAt, overlay.updated_at);
@@ -762,6 +786,8 @@ export function initAssistantHubBridge(): void {
                 if (!assistantCategories.includes(category)) continue;
               }
 
+              const promptsI18n = normalizePromptsI18n(meta.promptsI18n);
+
               assistants.push({
                 id: meta.id || assistantName,
                 name: assistantName,
@@ -782,6 +808,8 @@ export function initAssistantHubBridge(): void {
                 created_at: meta.installed_at || new Date().toISOString(),
                 updated_at: meta.installed_at || new Date().toISOString(),
                 defaultInitPrompt: meta.defaultInitPrompt || null,
+                promptsI18n,
+                prompts_i18n: promptsI18n,
                 visible_to: meta.visible_to || null,
                 version: meta.installed_version || '1.0.0',
               });
@@ -831,6 +859,7 @@ export function initAssistantHubBridge(): void {
         const latestVersion = (a.latestVersion as IAssistantHubVersionLike | undefined) || versions?.[0] || null;
         const version = [a.version, a.latest_version, latestVersion?.version, versions?.[0]?.version].find((value): value is string => typeof value === 'string' && value.length > 0);
         const sourceUrl = [a.sourceUrl, a.source_url, latestVersion?.source_url, versions?.[0]?.source_url].find((value): value is string => typeof value === 'string' && value.length > 0);
+        const promptsI18n = firstPromptsI18n(a.promptsI18n, a.prompts_i18n);
 
         return {
           id: a.id as string,
@@ -854,6 +883,8 @@ export function initAssistantHubBridge(): void {
           updated_at: a.updatedAt as string,
           // Default init prompt from API
           defaultInitPrompt: (a.defaultInitPrompt as string) || null,
+          promptsI18n,
+          prompts_i18n: promptsI18n,
           version,
           latestVersion,
           // Store sourceUrl for download (not in original type but needed for install)
@@ -940,6 +971,7 @@ export function initAssistantHubBridge(): void {
         }
 
         const meta = JSON.parse(metaResult.content) as AssistantHubMeta;
+        const promptsI18n = normalizePromptsI18n(meta.promptsI18n);
 
         const assistant: IAssistantHubSkill = {
           id: meta.id || assistantId,
@@ -961,6 +993,8 @@ export function initAssistantHubBridge(): void {
           created_at: meta.installed_at || new Date().toISOString(),
           updated_at: meta.installed_at || new Date().toISOString(),
           defaultInitPrompt: meta.defaultInitPrompt || null,
+          promptsI18n,
+          prompts_i18n: promptsI18n,
           visible_to: meta.visible_to || null,
           version: meta.installed_version || '1.0.0',
         };
@@ -1076,6 +1110,17 @@ export function initAssistantHubBridge(): void {
 
       // Scan for .md files and select ruleFile
       const ruleFile = await selectRuleFileFromDirectory(assistantDir, assistantName);
+
+      let extractedMeta: AssistantHubMeta | null = null;
+      const extractedMetaResult = await readAssistantMetaFileWithFallback(assistantDir);
+      if (extractedMetaResult) {
+        try {
+          extractedMeta = JSON.parse(extractedMetaResult.content) as AssistantHubMeta;
+        } catch {
+          mainWarn('AssistantHub', `Failed to parse extracted assistant meta for "${assistantName}"`);
+        }
+      }
+      const promptsI18n = firstPromptsI18n(assistantMeta.promptsI18n, assistantMeta.prompts_i18n, extractedMeta?.promptsI18n);
 
       // Install selected associated skills FIRST, collect skill IDs for meta
       const installedSkillNames: string[] = [];
@@ -1246,6 +1291,7 @@ export function initAssistantHubBridge(): void {
         is_builtin: assistantMeta.tag === 'system',
         enabled: true,
         defaultInitPrompt: assistantMeta.defaultInitPrompt || null,
+        promptsI18n,
         installed_version: version,
         installed_at: new Date().toISOString(),
         // enabledSkills: skill IDs that will be enabled for this assistant

--- a/src/process/sync/remoteToLocalSync.ts
+++ b/src/process/sync/remoteToLocalSync.ts
@@ -17,25 +17,27 @@
  * 5. 写入 _sudowork_meta.json 元数据
  */
 
-import { ProcessConfig, getHubSkillsDir, getHubAssistantsDir } from '@process/initStorage';
-import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
-import { getValidToken } from '@process/bridge/eeclawBridge';
 import fs from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import https from 'node:https';
 import http from 'node:http';
 import JSZip from 'jszip';
+import { getValidToken } from '@process/bridge/eeclawBridge';
+import { mainLog, mainError, mainWarn } from '@process/utils/mainLogger';
+import { ProcessConfig, getHubSkillsDir, getHubAssistantsDir } from '@process/initStorage';
 import { skillManager } from '@process/SkillManager';
 import { assistantManager } from '@process/AssistantManager';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { initEnterpriseDirs, getEnterpriseHubSkillsDir, getEnterpriseHubAssistantsDir, getEnterpriseTenantSkillsDir, getEnterpriseTenantAssistantsDir, getSkillMetaFileName, getAssistantMetaFileName, getAssistantInstallDir, getSkillInstallDir } from '@/process/constants/enterpriseStorage';
 import { SKILL_HUB_META_FILE } from '@/process/constants/skillStorage';
 import type { IAssistantMeta } from '@/process/constants/assistantStorage';
-import { ASSISTANT_META_FILE } from '@/process/constants/assistantStorage';
+import { ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE } from '@/process/constants/assistantStorage';
 import type { ISkillHubMeta } from '@/common/ipcBridge';
 
 // ============ 类型定义 ============
+
+type AssistantPromptsI18n = Record<string, string[]>;
 
 export type SyncResult = {
   installed: string[];
@@ -69,7 +71,14 @@ export type RemoteAssistantInfo = {
   isBuiltin?: boolean;
   tag?: string;
   sourceType?: string | null;
-  meta?: { source_type?: string | null; tag?: string | null } | null;
+  promptsI18n?: AssistantPromptsI18n;
+  prompts_i18n?: AssistantPromptsI18n;
+  meta?: {
+    source_type?: string | null;
+    tag?: string | null;
+    promptsI18n?: AssistantPromptsI18n;
+    prompts_i18n?: AssistantPromptsI18n;
+  } | null;
   visibleTo: { department_ids: string[] | null } | null;
   enabledSkills: string[];
 };
@@ -93,6 +102,52 @@ export type AssistantInstallDetail = {
 // ============ Mock 开关 ============
 
 const USE_MOCK = process.env.MOSS_SYNC_MOCK === 'true';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function normalizeStringList(values: string[] | undefined): string[] {
+  const normalized = (values || []).map((value) => value.trim()).filter(Boolean);
+  return Array.from(new Set(normalized));
+}
+
+function normalizePromptsI18n(value: unknown): AssistantPromptsI18n | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const zhCN = normalizeStringList(stringArray(value['zh-CN']));
+  if (zhCN.length === 0) return undefined;
+
+  return { 'zh-CN': zhCN };
+}
+
+function firstPromptsI18n(...values: unknown[]): AssistantPromptsI18n | undefined {
+  for (const value of values) {
+    const normalized = normalizePromptsI18n(value);
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
+async function readAssistantMetaWithFallback(assistantDir: string, primaryMetaFileName: string): Promise<IAssistantMeta | null> {
+  const metaFileNames = Array.from(new Set([primaryMetaFileName, ASSISTANT_META_FILE, MOSS_ASSISTANT_META_FILE]));
+
+  for (const fileName of metaFileNames) {
+    try {
+      const content = await fs.readFile(path.join(assistantDir, fileName), 'utf-8');
+      return JSON.parse(content) as IAssistantMeta;
+    } catch {
+      // Try next metadata file variant
+    }
+  }
+
+  return null;
+}
 
 // ============ API 调用 ============
 
@@ -618,6 +673,8 @@ async function installAssistantToLocal(detail: AssistantInstallDetail): Promise<
   // Use mode-aware metadata file name
   const metaFileName = getAssistantMetaFileName();
   const metaFilePath = path.join(assistantDir, metaFileName);
+  const existingMeta = await readAssistantMetaWithFallback(assistantDir, metaFileName);
+  const promptsI18n = firstPromptsI18n(detail.meta.promptsI18n, detail.meta.prompts_i18n, existingMeta?.promptsI18n);
   const meta = {
     id: detail.meta.id || assistantName,
     name: assistantName,
@@ -638,6 +695,7 @@ async function installAssistantToLocal(detail: AssistantInstallDetail): Promise<
     is_builtin: false,
     enabled: true,
     defaultInitPrompt: detail.meta.defaultInitPrompt || null,
+    promptsI18n,
     installed_version: detail.version,
     installed_at: new Date().toISOString(),
     enabledSkills: detail.meta.enabledSkills || [],
@@ -785,13 +843,8 @@ async function installAssistantById(assistant: RemoteAssistantInfo, serverUrl: s
   const metaFileName = getAssistantMetaFileName();
   const metaFilePath = path.join(assistantDir, metaFileName);
 
-  let existingMeta: IAssistantMeta | null = null;
-  try {
-    const metaContent = await fs.readFile(metaFilePath, 'utf-8');
-    existingMeta = JSON.parse(metaContent) as IAssistantMeta;
-  } catch {
-    // Meta file doesn't exist in zip, will create new one
-  }
+  const existingMeta = await readAssistantMetaWithFallback(assistantDir, metaFileName);
+  const promptsI18n = firstPromptsI18n(assistant.promptsI18n, assistant.prompts_i18n, assistant.meta?.promptsI18n, assistant.meta?.prompts_i18n, existingMeta?.promptsI18n);
 
   // Merge existing meta with remote info
   const meta: IAssistantMeta = {
@@ -815,6 +868,7 @@ async function installAssistantById(assistant: RemoteAssistantInfo, serverUrl: s
     is_builtin: false,
     enabled: true,
     defaultInitPrompt: existingMeta?.defaultInitPrompt || null,
+    promptsI18n,
     installed_version: assistant.version || existingMeta?.installed_version || '1.0.0',
     installed_at: new Date().toISOString(),
     enabledSkills: existingMeta?.enabledSkills || assistant.enabledSkills || [],

--- a/src/renderer/pages/agents/index.tsx
+++ b/src/renderer/pages/agents/index.tsx
@@ -621,6 +621,8 @@ const AgentSettings: React.FC = () => {
         created_at: meta.installed_at || '',
         updated_at: meta.installed_at || '',
         defaultInitPrompt: meta.defaultInitPrompt || null,
+        promptsI18n: meta.promptsI18n,
+        prompts_i18n: meta.promptsI18n,
         visible_to: meta.visible_to || null,
         version: normalizeAssistantVersion(meta.installed_version),
       };
@@ -1316,6 +1318,9 @@ const AgentSettings: React.FC = () => {
       core_features: assistant._hubMeta?.core_features || null,
       created_at: assistant._hubMeta?.created_at || '',
       updated_at: assistant._hubMeta?.updated_at || '',
+      defaultInitPrompt: assistant._hubMeta?.defaultInitPrompt || assistant.defaultInitPrompt || null,
+      promptsI18n: assistant._hubMeta?.promptsI18n || assistant.promptsI18n,
+      prompts_i18n: assistant._hubMeta?.prompts_i18n || assistant._hubMeta?.promptsI18n || assistant.promptsI18n,
       version: assistant._installedVersion,
     }),
     [localeKey]


### PR DESCRIPTION
## Summary
- Thread `promptsI18n` through the visible-overlay, hub bridge, remote-to-local sync, install, and renderer meta mappings so assistants published with zh-CN example prompts keep them after install.
- Normalize the field (trim, dedupe, accept both camelCase and snake_case) at every ingress so upstream API shapes stay flexible.
- Fall back to legacy meta filenames when reading existing assistant meta during sync, so previously installed assistants also pick up prompts on next sync.

## Test plan
- [ ] Install a hub assistant that ships `promptsI18n['zh-CN']` and verify the prompts appear in the assistant selector.
- [ ] Sync a remote assistant that has `promptsI18n` on the server and confirm `_sudowork_meta.json` includes it locally.
- [ ] Reinstall an assistant that had no `promptsI18n` and confirm the field is left untouched (no regressions).
- [ ] `bunx tsc --noEmit` passes.