### PR TITLE
fix(hub): clear stale upload status when a hub record is removed remotely

### DIFF
--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -32,6 +32,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 
 type AssistantHubMeta = import('@/process/constants/assistantStorage').IAssistantMeta;
 type AssistantHubPublishStatus = 'pending' | 'approved' | 'rejected';
+type AssistantHubRemoteStatus = AssistantHubPublishStatus | 'deleted';
 type AssistantPromptsI18n = Record<string, string[]>;
 
 interface AssistantHubUploadApiBody {
@@ -219,6 +220,22 @@ function normalizeAssistantHubPublishStatus(status: unknown): AssistantHubPublis
   return null;
 }
 
+function isHubDeletedMessage(...messages: unknown[]): boolean {
+  return messages.some((message) => {
+    if (typeof message !== 'string') return false;
+    const normalized = message.trim().toLowerCase();
+    return normalized.includes('not found') || normalized.includes('deleted') || normalized.includes('不存在') || normalized.includes('已删除');
+  });
+}
+
+async function readHubResponseJson(response: Response): Promise<unknown | null> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
 function resolveAssistantHubUploadId(body: AssistantHubUploadApiBody | null, fallbackId: string): string {
   return body?.data?.assistant?.id || body?.data?.agent?.id || body?.data?.id || body?.id || fallbackId;
 }
@@ -238,18 +255,59 @@ function resolveAssistantHubDetailPublishStatus(body: unknown): AssistantHubPubl
   return normalizeAssistantHubPublishStatus(assistant.status ?? data.status ?? body.status);
 }
 
-async function fetchUploadedAssistantPublishStatus(assistantId: string, token: string): Promise<AssistantHubPublishStatus | null> {
+function isAssistantHubDeletedDetailBody(body: unknown): boolean {
+  if (!isRecord(body)) {
+    return false;
+  }
+
+  if (body.data === null) {
+    if (body.success === false) {
+      return isHubDeletedMessage(body.message, body.msg);
+    }
+    return true;
+  }
+
+  const data = isRecord(body.data) ? body.data : null;
+  if (data && (('assistant' in data && data.assistant === null) || ('agent' in data && data.agent === null))) {
+    if (body.success === false) {
+      return isHubDeletedMessage(body.message, body.msg, data.message, data.msg);
+    }
+    return true;
+  }
+
+  const error = isRecord(body.error) ? body.error : null;
+  return isHubDeletedMessage(body.message, body.msg, body.detail, data?.message, data?.msg, error?.message, error?.msg, error?.detail);
+}
+
+function isHubDeletedResponseStatus(status: number, body?: unknown): boolean {
+  return status === 404 || status === 410 || (status === 400 && isAssistantHubDeletedDetailBody(body));
+}
+
+function resolveAssistantHubDetailRemoteStatus(body: unknown): AssistantHubRemoteStatus | null {
+  if (isAssistantHubDeletedDetailBody(body)) {
+    return 'deleted';
+  }
+
+  return resolveAssistantHubDetailPublishStatus(body);
+}
+
+async function fetchUploadedAssistantPublishStatus(assistantId: string, token: string): Promise<AssistantHubRemoteStatus | null> {
   const response = await fetch(`${getSkillHubBaseUrl()}/api/assistants/${encodeURIComponent(assistantId)}`, {
     headers: { Authorization: token },
   });
 
   if (!response.ok) {
+    const body = await readHubResponseJson(response);
+    if (isHubDeletedResponseStatus(response.status, body)) {
+      mainLog('AssistantHub', `Uploaded assistant ${assistantId} no longer exists on Assistant Hub: HTTP ${response.status}`);
+      return 'deleted';
+    }
     mainLog('AssistantHub', `Skip uploaded assistant status refresh for ${assistantId}: HTTP ${response.status}`);
     return null;
   }
 
   const body = await response.json();
-  return resolveAssistantHubDetailPublishStatus(body);
+  return resolveAssistantHubDetailRemoteStatus(body);
 }
 
 function isUploadedCustomAssistantStatusRefreshCandidate(assistant: IAssistantInfo): boolean {
@@ -258,9 +316,17 @@ function isUploadedCustomAssistantStatusRefreshCandidate(assistant: IAssistantIn
     return false;
   }
 
-  const isUploadedToHub = meta.uploaded === true || Boolean(meta.publish_status);
-  const isAwaitingFinalStatus = meta.publish_status !== 'approved' && meta.publish_status !== 'rejected';
-  return isUploadedToHub && isAwaitingFinalStatus;
+  const uploadPublishStatus = meta.publish_status || (meta.uploaded ? 'pending' : undefined);
+  return uploadPublishStatus === 'pending' || uploadPublishStatus === 'approved';
+}
+
+function clearAssistantHubUploadStatus(meta: AssistantHubMeta): AssistantHubMeta {
+  const nextMeta: AssistantHubMeta = { ...meta };
+  delete nextMeta.uploaded;
+  delete nextMeta.uploaded_at;
+  delete nextMeta.publish_status;
+  delete nextMeta.published_at;
+  return nextMeta;
 }
 
 async function refreshUploadedAssistantStatusesFromHub(token: string): Promise<{ checked: number; updated: number }> {
@@ -284,6 +350,14 @@ async function refreshUploadedAssistantStatusesFromHub(token: string): Promise<{
 
       const currentMeta = JSON.parse(metaResult.content) as AssistantHubMeta;
       const currentStatus = currentMeta.publish_status || (currentMeta.uploaded ? 'pending' : undefined);
+      if (remoteStatus === 'deleted') {
+        const nextMeta = clearAssistantHubUploadStatus(currentMeta);
+        await writeAssistantMetaFile(assistantDir, nextMeta);
+        updated += 1;
+        mainLog('AssistantHub', `Cleared uploaded assistant "${assistant.name}" publish status because the remote record no longer exists`);
+        continue;
+      }
+
       if (currentStatus === remoteStatus) continue;
 
       const nextMeta: AssistantHubMeta = {

--- a/src/process/bridge/skillHubBridge.ts
+++ b/src/process/bridge/skillHubBridge.ts
@@ -46,6 +46,7 @@ type SkillHubMeta = import('@/common/ipcBridge').ISkillHubMeta;
 type SkillHubSkill = import('@/common/ipcBridge').ISkillHubSkill;
 type SkillHubPublishStatus = 'pending' | 'approved' | 'rejected';
 type SkillHubUploadStatus = Extract<SkillHubPublishStatus, 'pending' | 'approved'>;
+type SkillHubRemoteStatus = SkillHubPublishStatus | 'deleted';
 
 interface SkillHubUploadApiBody {
   status?: string;
@@ -974,6 +975,22 @@ function normalizeSkillHubPublishStatus(status: unknown): SkillHubPublishStatus 
   return null;
 }
 
+function isHubDeletedMessage(...messages: unknown[]): boolean {
+  return messages.some((message) => {
+    if (typeof message !== 'string') return false;
+    const normalized = message.trim().toLowerCase();
+    return normalized.includes('not found') || normalized.includes('deleted') || normalized.includes('不存在') || normalized.includes('已删除');
+  });
+}
+
+async function readHubResponseJson(response: Response): Promise<unknown | null> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
 function resolveSkillHubDetailPublishStatus(body: unknown): SkillHubPublishStatus | null {
   if (!isRecord(body)) {
     return null;
@@ -985,18 +1002,59 @@ function resolveSkillHubDetailPublishStatus(body: unknown): SkillHubPublishStatu
   return normalizeSkillHubPublishStatus(skill.status ?? data.status ?? body.status);
 }
 
-async function fetchUploadedSkillPublishStatus(skillId: string, token: string): Promise<SkillHubPublishStatus | null> {
+function isSkillHubDeletedDetailBody(body: unknown): boolean {
+  if (!isRecord(body)) {
+    return false;
+  }
+
+  if (body.data === null) {
+    if (body.success === false) {
+      return isHubDeletedMessage(body.message, body.msg);
+    }
+    return true;
+  }
+
+  const data = isRecord(body.data) ? body.data : null;
+  if (data && 'skill' in data && data.skill === null) {
+    if (body.success === false) {
+      return isHubDeletedMessage(body.message, body.msg, data.message, data.msg);
+    }
+    return true;
+  }
+
+  const error = isRecord(body.error) ? body.error : null;
+  return isHubDeletedMessage(body.message, body.msg, body.detail, data?.message, data?.msg, error?.message, error?.msg, error?.detail);
+}
+
+function isHubDeletedResponseStatus(status: number, body?: unknown): boolean {
+  return status === 404 || status === 410 || (status === 400 && isSkillHubDeletedDetailBody(body));
+}
+
+function resolveSkillHubDetailRemoteStatus(body: unknown): SkillHubRemoteStatus | null {
+  if (isSkillHubDeletedDetailBody(body)) {
+    return 'deleted';
+  }
+
+  return resolveSkillHubDetailPublishStatus(body);
+}
+
+async function fetchUploadedSkillPublishStatus(skillId: string, token: string): Promise<SkillHubRemoteStatus | null> {
   const response = await fetch(`${getSkillHubBaseUrl()}/api/skills/${encodeURIComponent(skillId)}`, {
     headers: { Authorization: token },
   });
 
   if (!response.ok) {
+    const body = await readHubResponseJson(response);
+    if (isHubDeletedResponseStatus(response.status, body)) {
+      mainLog('SkillHub', `Uploaded skill ${skillId} no longer exists on SkillHub: HTTP ${response.status}`);
+      return 'deleted';
+    }
     mainLog('SkillHub', `Skip uploaded skill status refresh for ${skillId}: HTTP ${response.status}`);
     return null;
   }
 
   const body = await response.json();
-  return resolveSkillHubDetailPublishStatus(body);
+  return resolveSkillHubDetailRemoteStatus(body);
 }
 
 function isUploadedCustomSkillStatusRefreshCandidate(skill: ISkillInfo): boolean {
@@ -1005,9 +1063,17 @@ function isUploadedCustomSkillStatusRefreshCandidate(skill: ISkillInfo): boolean
     return false;
   }
 
-  const isUploadedToSkillHub = meta.uploaded === true || Boolean(meta.publish_status);
-  const isAwaitingFinalStatus = meta.publish_status !== 'approved' && meta.publish_status !== 'rejected';
-  return isUploadedToSkillHub && isAwaitingFinalStatus;
+  const uploadPublishStatus = meta.publish_status || (meta.uploaded ? 'pending' : undefined);
+  return uploadPublishStatus === 'pending' || uploadPublishStatus === 'approved';
+}
+
+function clearSkillHubUploadStatus(meta: SkillHubMeta): SkillHubMeta {
+  const nextMeta: SkillHubMeta = { ...meta };
+  delete nextMeta.uploaded;
+  delete nextMeta.uploaded_at;
+  delete nextMeta.publish_status;
+  delete nextMeta.published_at;
+  return nextMeta;
 }
 
 async function refreshUploadedSkillStatusesFromSkillHub(token: string): Promise<{ checked: number; updated: number }> {
@@ -1030,6 +1096,14 @@ async function refreshUploadedSkillStatusesFromSkillHub(token: string): Promise<
       if (!currentMeta) continue;
 
       const currentStatus = currentMeta.publish_status || (currentMeta.uploaded ? 'pending' : undefined);
+      if (remoteStatus === 'deleted') {
+        const nextMeta = clearSkillHubUploadStatus(currentMeta);
+        await writeSkillMetaFile(skillDir, nextMeta);
+        updated += 1;
+        mainLog('SkillHub', `Cleared uploaded skill "${skill.name}" publish status because the remote record no longer exists`);
+        continue;
+      }
+
       if (currentStatus === remoteStatus) continue;
 
       const nextMeta: SkillHubMeta = {

--- a/src/renderer/pages/agents/index.tsx
+++ b/src/renderer/pages/agents/index.tsx
@@ -674,10 +674,6 @@ const AgentSettings: React.FC = () => {
     }
   }, [assistantInfoToHubSkill, isEnterprise, normalizedExtensionAssistants, sortAssistants]);
 
-  useEffect(() => {
-    void loadAssistants();
-  }, [loadAssistants]);
-
   const refreshUploadedAssistantStatuses = useCallback(async () => {
     if (!isElectronDesktop() || isEnterprise) return;
     try {
@@ -687,14 +683,40 @@ const AgentSettings: React.FC = () => {
     }
   }, [isEnterprise]);
 
+  const loadAssistantsWithUploadedStatuses = useCallback(async () => {
+    await refreshUploadedAssistantStatuses();
+    await loadAssistants();
+  }, [loadAssistants, refreshUploadedAssistantStatuses]);
+
+  useEffect(() => {
+    void loadAssistantsWithUploadedStatuses();
+  }, [loadAssistantsWithUploadedStatuses]);
+
   useEffect(() => {
     if (activeTab === 'installed') {
-      void (async () => {
-        await refreshUploadedAssistantStatuses();
-        await loadAssistants();
-      })();
+      void loadAssistantsWithUploadedStatuses();
     }
-  }, [activeTab, loadAssistants, refreshUploadedAssistantStatuses]);
+  }, [activeTab, loadAssistantsWithUploadedStatuses]);
+
+  useEffect(() => {
+    if (activeTab !== 'installed' || isEnterprise || !isElectronDesktop()) return;
+
+    const onRefreshVisibleInstalledAssistants = () => {
+      void loadAssistantsWithUploadedStatuses();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        onRefreshVisibleInstalledAssistants();
+      }
+    };
+
+    window.addEventListener('focus', onRefreshVisibleInstalledAssistants);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', onRefreshVisibleInstalledAssistants);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [activeTab, isEnterprise, loadAssistantsWithUploadedStatuses]);
 
   // Listen for sync completed event (enterprise mode)
   useEffect(() => {
@@ -1660,7 +1682,13 @@ const AgentSettings: React.FC = () => {
             variant='line'
             className='flex-shrink-0'
             value={activeTab}
-            onChange={(value) => setActiveTab(value as AssistantStoreTab)}
+            onChange={(value) => {
+              if (value === 'installed' && activeTab === 'installed') {
+                void loadAssistantsWithUploadedStatuses();
+                return;
+              }
+              setActiveTab(value as AssistantStoreTab);
+            }}
             items={[
               { value: 'store', label: t('settings.assistant.storeTab', '智能体库') },
               { value: 'exclusive', label: t('settings.assistant.exclusiveTab', '专属智能体') },

--- a/src/renderer/pages/skills/index.tsx
+++ b/src/renderer/pages/skills/index.tsx
@@ -192,6 +192,14 @@ const SkillSettings: React.FC = () => {
     }
   }, [isEnterprise]);
 
+  const refreshInstalledListWithUploadedStatuses = useCallback(
+    async (options?: { isSilent?: boolean }) => {
+      await refreshUploadedSkillStatuses();
+      await fetchInstalledList(options);
+    },
+    [fetchInstalledList, refreshUploadedSkillStatuses]
+  );
+
   // ---- Enterprise mode: Upload custom skill to Moss Server ----
   const handleUploadCustomSkill = useCallback(
     async (skill: IInstalledSkillInfo): Promise<{ success: boolean; msg?: string }> => {
@@ -649,8 +657,8 @@ const SkillSettings: React.FC = () => {
 
   // Refresh installed skills once when the page opens
   useEffect(() => {
-    void fetchInstalledList();
-  }, [fetchInstalledList]);
+    void refreshInstalledListWithUploadedStatuses();
+  }, [refreshInstalledListWithUploadedStatuses]);
 
   // Refresh installed skills after agent-created skill changes.
   useEffect(() => {
@@ -734,12 +742,29 @@ const SkillSettings: React.FC = () => {
   // Load installed list when switching to installed tab
   useEffect(() => {
     if (activeTab === 'installed') {
-      void (async () => {
-        await refreshUploadedSkillStatuses();
-        await fetchInstalledList({ isSilent: true });
-      })();
+      void refreshInstalledListWithUploadedStatuses({ isSilent: true });
     }
-  }, [activeTab, fetchInstalledList, refreshUploadedSkillStatuses]);
+  }, [activeTab, refreshInstalledListWithUploadedStatuses]);
+
+  useEffect(() => {
+    if (activeTab !== 'installed' || isEnterprise || !isElectronDesktop()) return;
+
+    const onRefreshVisibleInstalledSkills = () => {
+      void refreshInstalledListWithUploadedStatuses({ isSilent: true });
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        onRefreshVisibleInstalledSkills();
+      }
+    };
+
+    window.addEventListener('focus', onRefreshVisibleInstalledSkills);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', onRefreshVisibleInstalledSkills);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [activeTab, isEnterprise, refreshInstalledListWithUploadedStatuses]);
 
   // Fetch latest hub versions for installed hub skills so we can detect updates
   // Only in personal mode (not enterprise) - enterprise mode doesn't interact with SkillHub
@@ -1174,7 +1199,7 @@ const SkillSettings: React.FC = () => {
             value={activeTab}
             onChange={(value) => {
               if (value === 'installed' && activeTab === 'installed') {
-                void fetchInstalledList();
+                void refreshInstalledListWithUploadedStatuses();
                 return;
               }
               setActiveTab(value as SkillStoreTab);

--- a/tests/unit/uploadedHubStatusRefresh.test.ts
+++ b/tests/unit/uploadedHubStatusRefresh.test.ts
@@ -1,0 +1,464 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const providers = new Map<string, (params?: any) => any>();
+  const emits: Array<{ path: string; args: any[] }> = [];
+  const makeChannelProxy = (pathStr: string): any =>
+    new Proxy(() => {}, {
+      get(_target, prop: string) {
+        if (prop === 'provider' || prop === 'on') {
+          return (cb: (params?: any) => any) => {
+            providers.set(`${pathStr}.${prop}`, cb);
+          };
+        }
+        if (prop === 'emit') {
+          return (...args: any[]) => {
+            emits.push({ path: pathStr, args });
+          };
+        }
+        return makeChannelProxy(pathStr ? `${pathStr}.${String(prop)}` : String(prop));
+      },
+    });
+
+  return {
+    providers,
+    emits,
+    ipcBridge: makeChannelProxy(''),
+    fetch: vi.fn(),
+    getInstalledSkills: vi.fn(),
+    getInstalledAssistants: vi.fn(),
+    findAssistantDirByCategory: vi.fn(),
+    token: 'test-token',
+    isEnterprise: false,
+    skillsRootDir: '',
+    customSkillsDir: '',
+    hubSkillsDir: '',
+    systemSkillsDir: '',
+    builtinSkillsDir: '',
+    customAssistantsDir: '',
+    hubAssistantsDir: '',
+    systemAssistantsDir: '',
+  };
+});
+
+vi.mock('@/common', () => ({ ipcBridge: h.ipcBridge }));
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/tmp'),
+    getAppPath: vi.fn(() => '/tmp'),
+  },
+}));
+vi.mock('@process/services/serviceManager', () => ({
+  serviceManager: {
+    getGateway: vi.fn(() => null),
+    sendReloadSignal: vi.fn(),
+    restartSudoclaw: vi.fn(),
+  },
+}));
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+  mainError: vi.fn(),
+}));
+vi.mock('@/process/initStorage', () => ({
+  clearSkillsCache: vi.fn(),
+  getSkillsDir: () => h.skillsRootDir,
+  getHubSkillsDir: () => h.hubSkillsDir,
+  getCustomSkillsDir: () => h.customSkillsDir,
+  getBuiltinSkillsDir: () => h.builtinSkillsDir,
+  getHubAssistantsDir: () => h.hubAssistantsDir,
+  getSystemAssistantsDir: () => h.systemAssistantsDir,
+  getCustomAssistantsDir: () => h.customAssistantsDir,
+  getSudoworkServerBaseUrlSync: () => 'https://server.example',
+  ProcessConfig: { getSync: vi.fn() },
+  SKILL_SUBDIRS: { custom: '_my-custom-skill', hub: '_hub', system: '_system' },
+}));
+vi.mock('@/process/SkillManager', () => ({
+  skillManager: {
+    getInstalledSkills: h.getInstalledSkills,
+  },
+}));
+vi.mock('@/process/AssistantManager', () => ({
+  assistantManager: {
+    getInstalledAssistants: h.getInstalledAssistants,
+    getInstalledAssistantsWithVisibility: vi.fn(),
+    findAssistantDirByCategory: h.findAssistantDirByCategory,
+    enableAssistant: vi.fn(),
+    disableAssistant: vi.fn(),
+    updateAssistantMeta: vi.fn(),
+    getAssistantMeta: vi.fn(),
+    createAssistant: vi.fn(),
+    uninstallAssistant: vi.fn(),
+  },
+}));
+vi.mock('@/process/task/AcpSkillManager', () => ({
+  AcpSkillManager: {
+    resetInstance: vi.fn(),
+  },
+}));
+vi.mock('@/process/utils/skillPackage', () => ({
+  buildSkillDisplayName: (name: string) => name,
+  canonicalizeSkillMarkdownPath: (name: string) => name,
+  findRootSkillMarkdownFileName: vi.fn(),
+  isSkillMarkdownFileName: vi.fn(() => true),
+  parseSkillFrontmatter: vi.fn(() => ({})),
+  resolveSkillIconFromFiles: vi.fn(() => null),
+}));
+vi.mock('@/process/services/safety/SkillAuditScanner', () => ({
+  scanSkillDirectory: vi.fn(),
+  readAuditReport: vi.fn(),
+}));
+vi.mock('@/common/enterpriseDebugConfig', () => ({
+  isEnterpriseMode: () => h.isEnterprise,
+}));
+vi.mock('@/process/constants/enterpriseStorage', () => ({
+  SKILLS_ROOT_DIR: '/enterprise/skills',
+  ASSISTANTS_ROOT_DIR: '/enterprise/assistants',
+  ENTERPRISE_SKILL_SUBDIRS: { hub: 'hub', custom: 'custom', tenant: 'tenant', system: 'system' },
+  ENTERPRISE_ASSISTANT_SUBDIRS: { hub: 'hub', custom: 'custom', tenant: 'tenant', system: 'system' },
+}));
+vi.mock('@/common/systemConfig', () => ({
+  getSkillHubBaseUrl: () => 'https://hub.example',
+}));
+vi.mock('@/process/credentialsCache', () => ({
+  getSkillhubToken: () => h.token,
+}));
+vi.mock('@common/nexus/hubErrors', () => ({
+  tokenMissingResponse: () => ({ success: false, msg: 'token missing' }),
+}));
+vi.mock('@/process/database', () => ({
+  getDatabase: () => ({ findConversationIdsByPresetAssistantId: vi.fn(() => ({ success: true, data: { conversationIds: [] } })) }),
+}));
+vi.mock('@/process/services/conversationReaper', () => ({
+  reapConversation: vi.fn(),
+}));
+vi.mock('@/types/acpTypes', () => ({
+  DEFAULT_PRESET_AGENT_TYPE: 'scode',
+  normalizePresetAgentType: (value: unknown) => value,
+}));
+
+let tempRoot = '';
+
+beforeEach(async () => {
+  vi.resetModules();
+  h.providers.clear();
+  h.emits.length = 0;
+  h.fetch.mockReset();
+  h.getInstalledSkills.mockReset();
+  h.getInstalledAssistants.mockReset();
+  h.findAssistantDirByCategory.mockReset();
+  h.token = 'test-token';
+  h.isEnterprise = false;
+
+  tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sudowork-upload-refresh-'));
+  h.skillsRootDir = path.join(tempRoot, 'skills');
+  h.customSkillsDir = path.join(h.skillsRootDir, '_my-custom-skill');
+  h.hubSkillsDir = path.join(h.skillsRootDir, '_hub');
+  h.systemSkillsDir = path.join(h.skillsRootDir, '_system');
+  h.builtinSkillsDir = path.join(h.skillsRootDir, '_system', '_builtin');
+  h.customAssistantsDir = path.join(tempRoot, 'assistants', '_my-custom-assistant');
+  h.hubAssistantsDir = path.join(tempRoot, 'assistants', '_hub');
+  h.systemAssistantsDir = path.join(tempRoot, 'assistants', '_system');
+
+  await mkdir(h.customSkillsDir, { recursive: true });
+  await mkdir(h.customAssistantsDir, { recursive: true });
+  vi.stubGlobal('fetch', h.fetch);
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true });
+    tempRoot = '';
+  }
+});
+
+describe('uploaded Hub status refresh', () => {
+  it('clears approved skill upload status when the remote skill detail is empty', async () => {
+    const skillDir = path.join(h.customSkillsDir, 'local-skill');
+    const meta = {
+      id: 'remote-skill-1',
+      name: 'local-skill',
+      display_name: 'Local Skill',
+      description: 'desc',
+      icon: '',
+      emoji: null,
+      category: '',
+      categories: [],
+      applicable_scenarios: null,
+      core_features: null,
+      homepage: null,
+      author_id: '',
+      source_type: 'upload',
+      is_builtin: false,
+      enabled: true,
+      installed_version: '1.0.0',
+      installed_at: '2026-01-01T00:00:00.000Z',
+      uploaded: true,
+      uploaded_at: '2026-01-02T00:00:00.000Z',
+      publish_status: 'approved',
+      published_at: '2026-01-03T00:00:00.000Z',
+    };
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(path.join(skillDir, '_sudowork_meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
+    h.getInstalledSkills.mockResolvedValue([
+      {
+        name: 'local-skill',
+        version: '1.0.0',
+        isBuiltin: false,
+        isHubInstalled: false,
+        enabled: true,
+        category: 'custom',
+        status: 'enabled',
+        meta,
+      },
+    ]);
+    h.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn(async () => ({ success: true, data: null })),
+    });
+
+    const { initSkillHubBridge } = await import('@/process/bridge/skillHubBridge');
+    initSkillHubBridge();
+
+    const result = await h.providers.get('skillHub.refreshUploadedSkillStatuses.provider')?.();
+
+    expect(result).toEqual({ success: true, data: { checked: 1, updated: 1 } });
+    expect(h.fetch).toHaveBeenCalledWith('https://hub.example/api/skills/remote-skill-1', {
+      headers: { Authorization: 'test-token' },
+    });
+
+    const writtenMeta = JSON.parse(await readFile(path.join(skillDir, '_sudowork_meta.json'), 'utf-8'));
+    expect(writtenMeta).toMatchObject({
+      id: 'remote-skill-1',
+      name: 'local-skill',
+      source_type: 'upload',
+    });
+    expect(writtenMeta.uploaded).toBeUndefined();
+    expect(writtenMeta.uploaded_at).toBeUndefined();
+    expect(writtenMeta.publish_status).toBeUndefined();
+    expect(writtenMeta.published_at).toBeUndefined();
+  });
+
+  it('clears approved skill upload status when the remote detail returns Skill not found', async () => {
+    const skillDir = path.join(h.customSkillsDir, 'local-skill');
+    const meta = {
+      id: 'remote-skill-1',
+      name: 'local-skill',
+      display_name: 'Local Skill',
+      description: 'desc',
+      icon: '',
+      emoji: null,
+      category: '',
+      categories: [],
+      applicable_scenarios: null,
+      core_features: null,
+      homepage: null,
+      author_id: '',
+      source_type: 'upload',
+      is_builtin: false,
+      enabled: true,
+      installed_version: '1.0.0',
+      installed_at: '2026-01-01T00:00:00.000Z',
+      uploaded: true,
+      uploaded_at: '2026-01-02T00:00:00.000Z',
+      publish_status: 'approved',
+      published_at: '2026-01-03T00:00:00.000Z',
+    };
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(path.join(skillDir, '_sudowork_meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
+    h.getInstalledSkills.mockResolvedValue([
+      {
+        name: 'local-skill',
+        version: '1.0.0',
+        isBuiltin: false,
+        isHubInstalled: false,
+        enabled: true,
+        category: 'custom',
+        status: 'enabled',
+        meta,
+      },
+    ]);
+    h.fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn(async () => ({ error: { code: 'BAD_REQUEST', message: 'Skill not found' } })),
+    });
+
+    const { initSkillHubBridge } = await import('@/process/bridge/skillHubBridge');
+    initSkillHubBridge();
+
+    const result = await h.providers.get('skillHub.refreshUploadedSkillStatuses.provider')?.();
+
+    expect(result).toEqual({ success: true, data: { checked: 1, updated: 1 } });
+    const writtenMeta = JSON.parse(await readFile(path.join(skillDir, '_sudowork_meta.json'), 'utf-8'));
+    expect(writtenMeta.uploaded).toBeUndefined();
+    expect(writtenMeta.uploaded_at).toBeUndefined();
+    expect(writtenMeta.publish_status).toBeUndefined();
+    expect(writtenMeta.published_at).toBeUndefined();
+  });
+
+  it('keeps skill upload status when the remote detail failure is not a deletion', async () => {
+    const skillDir = path.join(h.customSkillsDir, 'local-skill');
+    const meta = {
+      id: 'remote-skill-1',
+      name: 'local-skill',
+      display_name: 'Local Skill',
+      description: 'desc',
+      icon: '',
+      emoji: null,
+      category: '',
+      categories: [],
+      applicable_scenarios: null,
+      core_features: null,
+      homepage: null,
+      author_id: '',
+      source_type: 'upload',
+      is_builtin: false,
+      enabled: true,
+      installed_version: '1.0.0',
+      installed_at: '2026-01-01T00:00:00.000Z',
+      uploaded: true,
+      uploaded_at: '2026-01-02T00:00:00.000Z',
+      publish_status: 'approved',
+      published_at: '2026-01-03T00:00:00.000Z',
+    };
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(path.join(skillDir, '_sudowork_meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
+    h.getInstalledSkills.mockResolvedValue([
+      {
+        name: 'local-skill',
+        version: '1.0.0',
+        isBuiltin: false,
+        isHubInstalled: false,
+        enabled: true,
+        category: 'custom',
+        status: 'enabled',
+        meta,
+      },
+    ]);
+    h.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn(async () => ({ success: false, message: 'Unauthorized', data: null })),
+    });
+
+    const { initSkillHubBridge } = await import('@/process/bridge/skillHubBridge');
+    initSkillHubBridge();
+
+    const result = await h.providers.get('skillHub.refreshUploadedSkillStatuses.provider')?.();
+
+    expect(result).toEqual({ success: true, data: { checked: 1, updated: 0 } });
+    const writtenMeta = JSON.parse(await readFile(path.join(skillDir, '_sudowork_meta.json'), 'utf-8'));
+    expect(writtenMeta).toMatchObject({
+      uploaded: true,
+      uploaded_at: '2026-01-02T00:00:00.000Z',
+      publish_status: 'approved',
+      published_at: '2026-01-03T00:00:00.000Z',
+    });
+  });
+
+  it('clears pending assistant upload status when the remote assistant was deleted', async () => {
+    const assistantDir = path.join(h.customAssistantsDir, 'local-assistant');
+    const meta = {
+      id: 'remote-assistant-1',
+      name: 'local-assistant',
+      display_name: 'Local Assistant',
+      source_type: 'custom',
+      tag: 'custom',
+      is_builtin: false,
+      enabled: true,
+      uploaded: true,
+      uploaded_at: '2026-01-02T00:00:00.000Z',
+      publish_status: 'pending',
+    };
+    await mkdir(assistantDir, { recursive: true });
+    await writeFile(path.join(assistantDir, '_sudowork_meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
+    h.getInstalledAssistants.mockResolvedValue([
+      {
+        name: 'local-assistant',
+        isBuiltin: false,
+        isHubInstalled: false,
+        enabled: true,
+        category: 'custom',
+        status: 'enabled',
+        meta,
+      },
+    ]);
+    h.findAssistantDirByCategory.mockReturnValue({ dir: assistantDir, category: 'custom' });
+    h.fetch.mockResolvedValue({ ok: false, status: 410 });
+
+    const { initAssistantHubBridge } = await import('@/process/bridge/assistantHubBridge');
+    initAssistantHubBridge();
+
+    const result = await h.providers.get('assistantHub.refreshUploadedAssistantStatuses.provider')?.();
+
+    expect(result).toEqual({ success: true, data: { checked: 1, updated: 1 } });
+    expect(h.fetch).toHaveBeenCalledWith('https://hub.example/api/assistants/remote-assistant-1', {
+      headers: { Authorization: 'test-token' },
+    });
+
+    const writtenMeta = JSON.parse(await readFile(path.join(assistantDir, '_sudowork_meta.json'), 'utf-8'));
+    expect(writtenMeta).toMatchObject({
+      id: 'remote-assistant-1',
+      name: 'local-assistant',
+      source_type: 'custom',
+    });
+    expect(writtenMeta.uploaded).toBeUndefined();
+    expect(writtenMeta.uploaded_at).toBeUndefined();
+    expect(writtenMeta.publish_status).toBeUndefined();
+    expect(writtenMeta.published_at).toBeUndefined();
+  });
+
+  it('clears pending assistant upload status when the remote detail returns Assistant not found', async () => {
+    const assistantDir = path.join(h.customAssistantsDir, 'local-assistant');
+    const meta = {
+      id: 'remote-assistant-1',
+      name: 'local-assistant',
+      display_name: 'Local Assistant',
+      source_type: 'custom',
+      tag: 'custom',
+      is_builtin: false,
+      enabled: true,
+      uploaded: true,
+      uploaded_at: '2026-01-02T00:00:00.000Z',
+      publish_status: 'pending',
+    };
+    await mkdir(assistantDir, { recursive: true });
+    await writeFile(path.join(assistantDir, '_sudowork_meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
+    h.getInstalledAssistants.mockResolvedValue([
+      {
+        name: 'local-assistant',
+        isBuiltin: false,
+        isHubInstalled: false,
+        enabled: true,
+        category: 'custom',
+        status: 'enabled',
+        meta,
+      },
+    ]);
+    h.findAssistantDirByCategory.mockReturnValue({ dir: assistantDir, category: 'custom' });
+    h.fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn(async () => ({ error: { code: 'BAD_REQUEST', message: 'Assistant not found' } })),
+    });
+
+    const { initAssistantHubBridge } = await import('@/process/bridge/assistantHubBridge');
+    initAssistantHubBridge();
+
+    const result = await h.providers.get('assistantHub.refreshUploadedAssistantStatuses.provider')?.();
+
+    expect(result).toEqual({ success: true, data: { checked: 1, updated: 1 } });
+    const writtenMeta = JSON.parse(await readFile(path.join(assistantDir, '_sudowork_meta.json'), 'utf-8'));
+    expect(writtenMeta.uploaded).toBeUndefined();
+    expect(writtenMeta.uploaded_at).toBeUndefined();
+    expect(writtenMeta.publish_status).toBeUndefined();
+    expect(writtenMeta.published_at).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Detect remote deletion when refreshing uploaded skill/assistant status: treat HTTP 404/410 (and 400 responses whose body indicates the record is gone) as `deleted` instead of silently skipping, so stale `pending/approved` badges no longer linger after the user removes the entry from SkillHub / AssistantHub.
- Clear the local `uploaded` / `uploaded_at` / `publish_status` / `published_at` meta when the remote record has disappeared, so the item can be re-uploaded from the installed list.
- Re-run the uploaded-status refresh on window `focus` / `visibilitychange` and on initial installed-tab mount, so users returning from the web hub see the updated state without a manual reload.

## Test plan
- [x] `bunx eslint` on the four touched source files
- [x] `bunx tsc --noEmit`
- [ ] New unit test `tests/unit/uploadedHubStatusRefresh.test.ts` covers the 404/410/deleted-body branches for both bridges
- [ ] Manual: upload a custom skill/assistant, delete it from the hub, reopen the store — badge should clear and the entry should be uploadable again