### PR TITLE
chore(runtime): pin scode 0.1.24 (tool-output offload)

### DIFF
--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -6,5 +6,5 @@
   "nexus-fuse-plugin": "0.5.0",
   "fuse-t": "1.2.7",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
-  "scode": "0.1.17"
+  "scode": "0.1.24"
 }


### PR DESCRIPTION
Bumps the pinned scode 0.1.17 → **0.1.24**, the first release with the oversized tool-output offload (sudocode #447 core, #449 byte-windowed read-more, #451 nexus-backend verification). 

**Merge only after** sudocode's v0.1.24 release binaries are published (sudocode PR #452 → tag `v0.1.24` → release.yml), otherwise sudowork's ScodeInstallService will fail to download a nonexistent release.