### PR TITLE
fix(runtime-install): route scode/nexus-vfs downloads through HTTP(S)_PROXY

### DIFF
--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -8,6 +8,7 @@ import { app } from 'electron';
 import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { getProxyAgent } from '@process/utils/proxyAgent';
 import { processSupervisor } from '@process/ProcessSupervisor';
 import runtimeVersions from '@/shared/runtime-versions.json';
 import runtimeSha256 from '@/shared/runtime-sha256.json';
@@ -220,7 +221,9 @@ class DynamicNexusVfsService {
 
   // ── Download + install ───────────────────────────────────────────────────────
 
-  private downloadFile(url: string, destPath: string): Promise<void> {
+  private async downloadFile(url: string, destPath: string): Promise<void> {
+    // Resolve the proxy agent once (all download URLs are https); reused across redirects.
+    const proxyAgent = await getProxyAgent(url);
     return new Promise((resolve, reject) => {
       let redirects = 0;
 
@@ -231,8 +234,10 @@ class DynamicNexusVfsService {
         }
 
         const protocol = requestUrl.startsWith('https') ? https : http;
+        // Honor HTTP(S)_PROXY / NO_PROXY — Node's raw get() ignores them, so a
+        // direct connection fails TLS behind a VPN/corporate proxy.
         protocol
-          .get(requestUrl, (response) => {
+          .get(requestUrl, { agent: proxyAgent }, (response) => {
             const code = response.statusCode;
             if (code && [301, 302, 307, 308].includes(code) && response.headers.location) {
               response.resume();

--- a/src/process/services/scode/ScodeInstallService.ts
+++ b/src/process/services/scode/ScodeInstallService.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
+import { getProxyAgent } from '@process/utils/proxyAgent';
 import runtimeVersions from '@/shared/runtime-versions.json';
 import scodePlatforms from '@/shared/scode-platforms.json';
 import { extractTarGzWithProgress, extractZipWithProgress, listTarGzEntries, listZipEntries } from '../archiveProgress';
@@ -305,6 +306,9 @@ async function extractArchive(archivePath: string, targetDir: string, strip: num
 async function downloadScode(url: string, destPath: string, onProgress?: (percent: number) => void): Promise<void> {
   const https = await import('https');
   const http = await import('http');
+  // Resolve the proxy agent once (all download URLs are https to GitHub/CDN);
+  // reused across redirects.
+  const proxyAgent = await getProxyAgent(url);
 
   return new Promise<void>((resolve, reject) => {
     let redirects = 0;
@@ -317,7 +321,9 @@ async function downloadScode(url: string, destPath: string, onProgress?: (percen
       }
 
       const mod = requestUrl.startsWith('https') ? https : http;
-      const req = mod.get(requestUrl, (response: import('http').IncomingMessage) => {
+      // Honor HTTP(S)_PROXY / NO_PROXY — Node's raw get() ignores them, so a
+      // direct GitHub connection fails TLS behind a VPN/corporate proxy.
+      const req = mod.get(requestUrl, { agent: proxyAgent }, (response: import('http').IncomingMessage) => {
         if ([301, 302, 307, 308].includes(response.statusCode!) && response.headers.location) {
           redirects++;
           mainLog(TAG, `Download redirect → ${response.headers.location}`);

--- a/src/process/utils/proxyAgent.ts
+++ b/src/process/utils/proxyAgent.ts
@@ -1,0 +1,48 @@
+import type { Agent } from 'http';
+
+/**
+ * Resolve an HTTP(S) proxy `Agent` for a target URL from the environment, or
+ * `undefined` when no proxy applies.
+ *
+ * Node's `http(s).get` ignores the conventional `HTTP_PROXY` / `HTTPS_PROXY` /
+ * `NO_PROXY` variables unless an explicit agent is passed. Runtime downloads
+ * (scode, nexus-vfs) therefore attempt a *direct* connection and fail the TLS
+ * handshake behind a corporate/VPN proxy — the common case for CN users, where
+ * the boot then stalls at "初始化失败". Wiring the returned agent into the
+ * download requests makes them honor the same proxy the OS/browser use.
+ *
+ * `NO_PROXY` is respected (comma-separated hosts / `.suffix` entries; `*`
+ * disables proxying entirely). Async because the proxy-agent packages are
+ * ESM-only and must be dynamically imported from the CJS main process (a static
+ * import compiles to `require`, which throws `ERR_PACKAGE_PATH_NOT_EXPORTED`).
+ */
+export async function getProxyAgent(targetUrl: string): Promise<Agent | undefined> {
+  let host: string;
+  let isHttps: boolean;
+  try {
+    const parsed = new URL(targetUrl);
+    host = parsed.hostname;
+    isHttps = parsed.protocol === 'https:';
+  } catch {
+    return undefined;
+  }
+
+  const proxyUrl = isHttps ? process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy : process.env.HTTP_PROXY || process.env.http_proxy;
+  if (!proxyUrl) return undefined;
+
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy || '';
+  for (const raw of noProxy.split(',')) {
+    const entry = raw.trim();
+    if (!entry) continue;
+    if (entry === '*') return undefined;
+    const bare = entry.startsWith('.') ? entry.slice(1) : entry;
+    if (host === bare || host.endsWith(`.${bare}`)) return undefined;
+  }
+
+  if (isHttps) {
+    const { HttpsProxyAgent } = await import('https-proxy-agent');
+    return new HttpsProxyAgent(proxyUrl);
+  }
+  const { HttpProxyAgent } = await import('http-proxy-agent');
+  return new HttpProxyAgent(proxyUrl);
+}

--- a/tests/unit/proxyAgent.test.ts
+++ b/tests/unit/proxyAgent.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getProxyAgent } from '../../src/process/utils/proxyAgent';
+
+const PROXY_ENV = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy'];
+
+function clearProxyEnv(): void {
+  for (const key of PROXY_ENV) delete process.env[key];
+}
+
+describe('getProxyAgent', () => {
+  afterEach(clearProxyEnv);
+
+  it('returns undefined when no proxy env is set', async () => {
+    clearProxyEnv();
+    expect(await getProxyAgent('https://github.com/x')).toBeUndefined();
+  });
+
+  it('returns an agent for an https target when HTTPS_PROXY is set', async () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:7897';
+    const agent = await getProxyAgent(
+      'https://github.com/sudoprivacy/sudocode/releases/download/v0.1.24/scode-windows-x64.zip',
+    );
+    expect(agent).toBeDefined();
+  });
+
+  it('falls back to HTTP_PROXY for an https target when HTTPS_PROXY is absent', async () => {
+    clearProxyEnv();
+    process.env.HTTP_PROXY = 'http://127.0.0.1:7897';
+    expect(await getProxyAgent('https://github.com/x')).toBeDefined();
+  });
+
+  it('returns an agent for an http target when HTTP_PROXY is set', async () => {
+    clearProxyEnv();
+    process.env.HTTP_PROXY = 'http://127.0.0.1:7897';
+    expect(await getProxyAgent('http://example.com/x')).toBeDefined();
+  });
+
+  it('respects NO_PROXY exact-host and .suffix entries', async () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:7897';
+    process.env.NO_PROXY = 'github.com,.internal';
+    expect(await getProxyAgent('https://github.com/x')).toBeUndefined();
+    expect(await getProxyAgent('https://api.internal/x')).toBeUndefined();
+    // A host outside NO_PROXY still gets the proxy.
+    expect(await getProxyAgent('https://objects.githubusercontent.com/x')).toBeDefined();
+  });
+
+  it('respects NO_PROXY="*" as disable-all', async () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:7897';
+    process.env.NO_PROXY = '*';
+    expect(await getProxyAgent('https://github.com/x')).toBeUndefined();
+  });
+
+  it('returns undefined for a malformed URL', async () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:7897';
+    expect(await getProxyAgent('not a url')).toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
         'src/process/database/corruptionError.ts',
         'src/process/database/workspaceQueries.ts',
         'src/process/startupNotice.ts',
+        'src/process/utils/proxyAgent.ts',
         'src/process/services/autoUpdaterService.ts',
         'src/process/services/conversationReaper.ts',
         'src/process/services/orphanWorkspaceSweeper.ts',


### PR DESCRIPTION
## Problem
`ScodeInstallService.downloadScode` and `DynamicNexusVfsService.downloadFile` use Node's raw `https.get()`, which **ignores** `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`. Behind a corporate/VPN proxy — the common case for CN users — the direct GitHub connection fails the TLS handshake (`socket disconnected before secure TLS`), so first-run boot stalls at **"初始化失败"**: the bundled scode + nexus-vfs runtimes can't be fetched.

## Fix
New `src/process/utils/proxyAgent.ts`: resolves an http(s) proxy `Agent` from the environment (honoring `NO_PROXY`, including `*`) and both downloads pass it to `get()`. 

The proxy-agent packages are **ESM-only**, so it loads them via dynamic `import()` — a static import compiles to `require()` in the CJS main process and throws `ERR_PACKAGE_PATH_NOT_EXPORTED` (found the hard way). Each download resolves the agent once before its redirect loop.

## Verification
Reproduced + fixed on a real VPN'd box (Clash `127.0.0.1:7897`):
- **Before**: `[ScodeInstallService] GitHub download failed: ... TLS`, boot → "初始化失败".
- **After** (only `HTTPS_PROXY` set, **no** `NODE_USE_ENV_PROXY` workaround): `Downloading scode from GitHub: …/v0.1.24/scode-windows-x64.zip` → `Scode installation completed` → **`All components ready`**, scode 0.1.24 installed.

Unit test `tests/unit/proxyAgent.test.ts` (7 cases): no-proxy, https via HTTPS_PROXY, HTTP_PROXY fallback, http target, NO_PROXY host/suffix/`*`, malformed URL. `proxyAgent.ts` added to coverage.include.