### PR TITLE
feat(channels): pick a default agent per IM channel in enterprise mode

### DIFF
--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -474,15 +474,10 @@ export const moss = {
   setUserModel: bridge.buildProvider<IBridgeResponse<{ modelId: string; updatedAt: number }>, { modelId: string }>('moss.set-user-model'),
 
   /** Agents an IM channel can use + its current default (enterprise mode: served by moss). */
-  getChannelAgents: bridge.buildProvider<
-    IBridgeResponse<{ agents: Array<{ name: string; displayName: string; description?: string }>; defaultAgent: string | null }>,
-    { pluginId: string }
-  >('moss.get-channel-agents'),
+  getChannelAgents: bridge.buildProvider<IBridgeResponse<{ agents: Array<{ name: string; displayName: string; description?: string }>; defaultAgent: string | null }>, { pluginId: string }>('moss.get-channel-agents'),
 
   /** Set/clear the agent new chats on an IM channel start with. */
-  setChannelDefaultAgent: bridge.buildProvider<IBridgeResponse<void>, { pluginId: string; agentName: string | null }>(
-    'moss.set-channel-default-agent',
-  ),
+  setChannelDefaultAgent: bridge.buildProvider<IBridgeResponse<void>, { pluginId: string; agentName: string | null }>('moss.set-channel-default-agent'),
   /** Set model for current session (via WebSocket) */
   setModel: bridge.buildProvider<IBridgeResponse, { sessionId: string; modelId: string }>('moss.set-model'),
   /** Model changed event (emitted when model switch completes) */

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -472,6 +472,17 @@ export const moss = {
   getUserModel: bridge.buildProvider<IBridgeResponse<{ modelId: string; updatedAt: number; systemDefaultModel: string } | null>, void>('moss.get-user-model'),
   /** Set user's model preference */
   setUserModel: bridge.buildProvider<IBridgeResponse<{ modelId: string; updatedAt: number }>, { modelId: string }>('moss.set-user-model'),
+
+  /** Agents an IM channel can use + its current default (enterprise mode: served by moss). */
+  getChannelAgents: bridge.buildProvider<
+    IBridgeResponse<{ agents: Array<{ name: string; displayName: string; description?: string }>; defaultAgent: string | null }>,
+    { pluginId: string }
+  >('moss.get-channel-agents'),
+
+  /** Set/clear the agent new chats on an IM channel start with. */
+  setChannelDefaultAgent: bridge.buildProvider<IBridgeResponse<void>, { pluginId: string; agentName: string | null }>(
+    'moss.set-channel-default-agent',
+  ),
   /** Set model for current session (via WebSocket) */
   setModel: bridge.buildProvider<IBridgeResponse, { sessionId: string; modelId: string }>('moss.set-model'),
   /** Model changed event (emitted when model switch completes) */

--- a/src/process/bridge/mossBridge.ts
+++ b/src/process/bridge/mossBridge.ts
@@ -400,6 +400,38 @@ export function initMossBridge(): void {
     }
   });
 
+  // moss.get-channel-agents
+  ipcBridge.moss.getChannelAgents.provider(async ({ pluginId }) => {
+    try {
+      const api = await ensureMossApiInitialized();
+      if (!api) {
+        return { success: false, msg: 'Moss API not initialized. Please login first.' };
+      }
+
+      const data = await api.getChannelAgents(pluginId);
+      return { success: true, data };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { success: false, msg };
+    }
+  });
+
+  // moss.set-channel-default-agent
+  ipcBridge.moss.setChannelDefaultAgent.provider(async ({ pluginId, agentName }) => {
+    try {
+      const api = await ensureMossApiInitialized();
+      if (!api) {
+        return { success: false, msg: 'Moss API not initialized. Please login first.' };
+      }
+
+      await api.setChannelDefaultAgent(pluginId, agentName);
+      return { success: true, data: undefined };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { success: false, msg };
+    }
+  });
+
   // moss.set-model - Set model for current session via WebSocket
   ipcBridge.moss.setModel.provider(async ({ sessionId, modelId }) => {
     try {

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -681,6 +681,57 @@ export class MossSessionApi {
    */
   // 返回类型：用户偏好 + 系统默认模型
   // 保持返回类型声明不变，或者改成更完整的结构
+  /**
+   * Agents (智能体) this IM channel can use, plus the connection-level default.
+   * GET /api/v1/channels/plugins/{pluginId}/agents
+   *
+   * The roster is what the signed-in moss user can see, so it matches the moss admin UI.
+   */
+  async getChannelAgents(pluginId: string): Promise<{
+    agents: Array<{ name: string; displayName: string; description?: string }>;
+    defaultAgent: string | null;
+  }> {
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/channels/plugins/${pluginId}/agents`, {
+      method: 'GET',
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to get channel agents: ${response.status} ${text}`);
+    }
+
+    const res = await response.json();
+    return { agents: res.agents || [], defaultAgent: res.defaultAgent ?? null };
+  }
+
+  /**
+   * Set the agent new chats on this channel start with; pass null to clear it.
+   * PUT /api/v1/channels/plugins/{pluginId}/agents/default
+   *
+   * Existing chats keep whatever they were switched to in-chat via /agent.
+   */
+  async setChannelDefaultAgent(pluginId: string, agentName: string | null): Promise<void> {
+    const response = await this.fetchWithRetry(
+      `${this.serverUrl}/api/v1/channels/plugins/${pluginId}/agents/default`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agentName }),
+      },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      // The server answers 400 with a readable message (e.g. unknown agent); surface it.
+      let message = text;
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed?.message) message = parsed.message;
+      } catch { /* keep raw text */ }
+      throw new Error(message || `Failed to set channel default agent: ${response.status}`);
+    }
+  }
+
   async getUserModelPreference(): Promise<{
     modelId: string;
     updatedAt: number;

--- a/src/process/remote/MossSessionApi.ts
+++ b/src/process/remote/MossSessionApi.ts
@@ -711,14 +711,11 @@ export class MossSessionApi {
    * Existing chats keep whatever they were switched to in-chat via /agent.
    */
   async setChannelDefaultAgent(pluginId: string, agentName: string | null): Promise<void> {
-    const response = await this.fetchWithRetry(
-      `${this.serverUrl}/api/v1/channels/plugins/${pluginId}/agents/default`,
-      {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ agentName }),
-      },
-    );
+    const response = await this.fetchWithRetry(`${this.serverUrl}/api/v1/channels/plugins/${pluginId}/agents/default`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentName }),
+    });
 
     if (!response.ok) {
       const text = await response.text();
@@ -727,7 +724,9 @@ export class MossSessionApi {
       try {
         const parsed = JSON.parse(text);
         if (parsed?.message) message = parsed.message;
-      } catch { /* keep raw text */ }
+      } catch {
+        /* keep raw text */
+      }
       throw new Error(message || `Failed to set channel default agent: ${response.status}`);
     }
   }

--- a/src/renderer/pages/settings/channels/components/DingTalkConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/DingTalkConfigForm.tsx
@@ -18,6 +18,7 @@ import type { GeminiModelSelection } from '../types';
 import { DINGTALK_DEV_DOCS_URL } from '../utils';
 import GeminiModelSelector from './GeminiModelSelector';
 import PreferenceRow from './PreferenceRow';
+import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface DingTalkConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
@@ -452,6 +453,10 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
       )}
 
       {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {/* Enterprise mode: default agent lives on the moss server, which spawns the
+          sessions for this channel. Standalone mode uses the local picker below. */}
+      {isEnterprise && <EnterpriseAgentSelector pluginId='dingtalk_default' enabled={!!pluginStatus?.enabled} />}
+
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>
           <PreferenceRow label={t('settings.dingtalk.agent', 'Agent')} description={t('settings.dingtalk.agentDesc', 'Used for DingTalk conversations')}>

--- a/src/renderer/pages/settings/channels/components/EnterpriseAgentSelector.tsx
+++ b/src/renderer/pages/settings/channels/components/EnterpriseAgentSelector.tsx
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2026 SudoPrivacy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Button, Dropdown, Menu, Message } from '@arco-design/web-react';
+import { IconDown, IconLoading } from '@arco-design/web-react/icon';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { moss } from '@/common/ipcBridge';
+import PreferenceRow from './PreferenceRow';
+
+/**
+ * Default agent (智能体) picker for an IM channel in ENTERPRISE mode.
+ *
+ * Standalone mode keeps its own per-platform picker backed by local ConfigStorage. In
+ * enterprise mode the channel runs on the moss server, which spawns sessions from
+ * channel_plugins.config_json — so this reads and writes moss directly. Pointing it at
+ * local config instead would create two sources of truth and silently not affect the
+ * sessions moss actually creates.
+ *
+ * Only the default for NEW chats is set here. A chat that was switched with /agent keeps
+ * its own agent, because one connection serves many chats (several groups plus DMs) and
+ * each holds its own session.
+ */
+interface EnterpriseAgentSelectorProps {
+  /** Channel plugin id, e.g. "wecom_default". */
+  pluginId: string;
+  /** Hide entirely until the channel is configured — there is no row to write to yet. */
+  enabled: boolean;
+}
+
+const NONE_KEY = '__none__';
+
+const EnterpriseAgentSelector: React.FC<EnterpriseAgentSelectorProps> = ({ pluginId, enabled }) => {
+  const { t } = useTranslation();
+  const [agents, setAgents] = useState<Array<{ name: string; displayName: string }>>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!enabled) return;
+    setLoading(true);
+    try {
+      const res = await moss.getChannelAgents.invoke({ pluginId });
+      if (res.success && res.data) {
+        setAgents(res.data.agents);
+        setSelected(res.data.defaultAgent);
+      }
+    } catch (error) {
+      console.warn('[EnterpriseAgentSelector] failed to load agents:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [pluginId, enabled]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleSelect = async (agentName: string | null) => {
+    if (agentName === selected) return;
+    const previous = selected;
+    setSelected(agentName);
+    setSaving(true);
+    try {
+      const res = await moss.setChannelDefaultAgent.invoke({ pluginId, agentName });
+      if (!res.success) throw new Error(res.msg || 'save failed');
+      Message.success(t('settings.channels.agentSaved', '默认智能体已更新'));
+    } catch (error) {
+      // Roll back so the control never shows a value the server did not accept.
+      setSelected(previous);
+      Message.error(error instanceof Error ? error.message : t('common.saveFailed', 'Failed to save'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!enabled) return null;
+
+  const noneLabel = t('settings.channels.agentNone', '未指定（通用会话）');
+  const currentLabel = selected ? (agents.find((a) => a.name === selected)?.displayName ?? selected) : noneLabel;
+
+  return (
+    <PreferenceRow
+      label={t('settings.channels.defaultAgent', '默认智能体')}
+      description={t(
+        'settings.channels.defaultAgentDesc',
+        '新会话将使用该智能体；已有会话保持各自在聊天中切换的结果。用户可在聊天中发送 /agents 查看、/agent <名称> 切换。',
+      )}
+    >
+      <Dropdown
+        trigger='click'
+        position='br'
+        droplist={
+          <Menu selectedKeys={[selected ?? NONE_KEY]}>
+            <Menu.Item key={NONE_KEY} onClick={() => void handleSelect(null)}>
+              {noneLabel}
+            </Menu.Item>
+            {agents.map((a) => (
+              <Menu.Item key={a.name} onClick={() => void handleSelect(a.name)}>
+                {a.displayName}
+              </Menu.Item>
+            ))}
+          </Menu>
+        }
+      >
+        <Button
+          type='secondary'
+          className='min-w-40'
+          disabled={saving || loading}
+          icon={saving || loading ? <IconLoading style={{ fontSize: 14 }} /> : <IconDown style={{ fontSize: 14 }} />}
+        >
+          {currentLabel}
+        </Button>
+      </Dropdown>
+    </PreferenceRow>
+  );
+};
+
+export default EnterpriseAgentSelector;

--- a/src/renderer/pages/settings/channels/components/EnterpriseAgentSelector.tsx
+++ b/src/renderer/pages/settings/channels/components/EnterpriseAgentSelector.tsx
@@ -84,13 +84,7 @@ const EnterpriseAgentSelector: React.FC<EnterpriseAgentSelectorProps> = ({ plugi
   const currentLabel = selected ? (agents.find((a) => a.name === selected)?.displayName ?? selected) : noneLabel;
 
   return (
-    <PreferenceRow
-      label={t('settings.channels.defaultAgent', '默认智能体')}
-      description={t(
-        'settings.channels.defaultAgentDesc',
-        '新会话将使用该智能体；已有会话保持各自在聊天中切换的结果。用户可在聊天中发送 /agents 查看、/agent <名称> 切换。',
-      )}
-    >
+    <PreferenceRow label={t('settings.channels.defaultAgent', '默认智能体')} description={t('settings.channels.defaultAgentDesc', '新会话将使用该智能体；已有会话保持各自在聊天中切换的结果。用户可在聊天中发送 /agents 查看、/agent <名称> 切换。')}>
       <Dropdown
         trigger='click'
         position='br'
@@ -107,12 +101,7 @@ const EnterpriseAgentSelector: React.FC<EnterpriseAgentSelectorProps> = ({ plugi
           </Menu>
         }
       >
-        <Button
-          type='secondary'
-          className='min-w-40'
-          disabled={saving || loading}
-          icon={saving || loading ? <IconLoading style={{ fontSize: 14 }} /> : <IconDown style={{ fontSize: 14 }} />}
-        >
+        <Button type='secondary' className='min-w-40' disabled={saving || loading} icon={saving || loading ? <IconLoading style={{ fontSize: 14 }} /> : <IconDown style={{ fontSize: 14 }} />}>
           {currentLabel}
         </Button>
       </Dropdown>

--- a/src/renderer/pages/settings/channels/components/LarkConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/LarkConfigForm.tsx
@@ -20,6 +20,7 @@ import type { GeminiModelSelection, LarkAuthPhase } from '../types';
 import { LARK_DEV_DOCS_URL } from '../utils';
 import GeminiModelSelector from './GeminiModelSelector';
 import PreferenceRow from './PreferenceRow';
+import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface LarkConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
@@ -512,6 +513,10 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
   return (
     <div className='flex flex-col gap-6'>
       {/* Consumer mode: QR Login (replaces manual App ID / App Secret entry) */}
+      {/* Enterprise mode: default agent lives on the moss server, which spawns the
+          sessions for this channel. Standalone mode uses the local picker below. */}
+      {isEnterprise && <EnterpriseAgentSelector pluginId='lark_default' enabled={!!pluginStatus?.enabled} />}
+
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>
           <div className='flex items-center justify-between mb-3'>

--- a/src/renderer/pages/settings/channels/components/TelegramConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/TelegramConfigForm.tsx
@@ -16,6 +16,7 @@ import { useAppMode } from '@/renderer/hooks/useAppMode';
 import type { GeminiModelSelection } from '../types';
 import GeminiModelSelector from './GeminiModelSelector';
 import PreferenceRow from './PreferenceRow';
+import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface TelegramConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
@@ -324,6 +325,10 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
       </PreferenceRow>
 
       {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {/* Enterprise mode: default agent lives on the moss server, which spawns the
+          sessions for this channel. Standalone mode uses the local picker below. */}
+      {isEnterprise && <EnterpriseAgentSelector pluginId='telegram_default' enabled={!!pluginStatus?.enabled} />}
+
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>
           <PreferenceRow label={t('settings.lark.agent', 'Agent')} description={t('settings.assistant.agentDescTelegram', 'Used for Telegram conversations')}>

--- a/src/renderer/pages/settings/channels/components/WeChatConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/WeChatConfigForm.tsx
@@ -19,6 +19,7 @@ import type { GeminiModelSelection, LoginPhase } from '../types';
 import { WECHAT_GUIDE_URL } from '../utils';
 import GeminiModelSelector from './GeminiModelSelector';
 import PreferenceRow from './PreferenceRow';
+import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface WeChatConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
@@ -253,6 +254,10 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
       {renderQRCodeSection()}
 
       {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {/* Enterprise mode: default agent lives on the moss server, which spawns the
+          sessions for this channel. Standalone mode uses the local picker below. */}
+      {isEnterprise && <EnterpriseAgentSelector pluginId='wechat_default' enabled={!!pluginStatus?.enabled} />}
+
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>
           <PreferenceRow label={t('settings.channels.wechat.agent', 'Agent')} description={t('settings.channels.wechat.agentDesc', 'Used for WeChat conversations')}>

--- a/src/renderer/pages/settings/channels/components/WeComConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/WeComConfigForm.tsx
@@ -18,6 +18,7 @@ import type { GeminiModelSelection } from '../types';
 import { WECOM_DEV_DOCS_URL } from '../utils';
 import GeminiModelSelector from './GeminiModelSelector';
 import PreferenceRow from './PreferenceRow';
+import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface WeComConfigFormProps {
   pluginStatus: IChannelPluginStatus | null;
@@ -334,7 +335,10 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
         </div>
       )}
 
-      {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
+      {/* Enterprise mode: default agent lives on the moss server, which spawns the
+          sessions for this channel. Standalone mode uses the local picker below. */}
+      {isEnterprise && <EnterpriseAgentSelector pluginId='wecom_default' enabled={!!pluginStatus?.enabled} />}
+
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>
           <PreferenceRow label={t('settings.wecom.agent', 'Agent')} description={t('settings.wecom.agentDesc', 'Used for WeCom conversations')}>


### PR DESCRIPTION
## Problem

Every channel config form already has an agent picker — WeCom, Lark, DingTalk, WeChat, Telegram. But each one is wrapped in:

```tsx
{!isEnterprise && ( ...the agent dropdown... )}
```

So in **enterprise mode there is no way to pick an agent at all**, on any platform. That is why 设置 → 远程连接 → 渠道配置 shows no agent control in enterprise deployments.

## Approach

Standalone mode is untouched — it keeps its local picker backed by `ConfigStorage`.

Enterprise mode gets a sibling `{isEnterprise && ...}` selector that reads and writes the **moss server** instead. That matters: in enterprise mode the channel runs on moss, and moss spawns sessions from `channel_plugins.config_json`. Pointing the enterprise control at local `ConfigStorage` would have created two sources of truth and silently not affected the sessions moss actually creates.

The two controls are mutually exclusive by construction, so exactly one renders in each mode.

## Behaviour

- Roster = whatever the signed-in moss user can see — global, tenant and custom alike. Same rule as the moss admin UI, so both surfaces list the same agents and edit the same stored value.
- Default is **未指定（通用会话）** — no agent bound, generic session. That is the existing behaviour, so nothing changes until someone picks an agent.
- Only the default for **new** chats is set here. A chat switched in-band with `/agent` keeps its own agent, because one connection serves many chats (several groups plus DMs) and each holds its own session.
- A failed save rolls the value back, so the control never displays something the server rejected.

## Changes

| Layer | What |
|---|---|
| `MossSessionApi` | `getChannelAgents` / `setChannelDefaultAgent` |
| `mossBridge` + `ipcBridge` | `moss.get-channel-agents`, `moss.set-channel-default-agent` |
| `EnterpriseAgentSelector` | shared control, so the five forms don't each reimplement it |
| 5 config forms | one line each, next to the existing standalone picker |

## Server side

Requires the moss endpoints from **sudoprivacy/moss#160**:

```
GET  /api/v1/channels/plugins/:id/agents
PUT  /api/v1/channels/plugins/:id/agents/default
```

That PR also adds in-chat `/agents` and `/agent <name>` switching, which works across all five platforms for moss-backed conversations.

## Verification

`npx tsc --noEmit` passes with **0 errors** across the project. All five forms confirmed wired with the correct `pluginId`, each sitting beside its standalone counterpart.

Not yet exercised against a live enterprise deployment — the selector is hidden until a channel is configured (`enabled={!!pluginStatus?.enabled}`), so it needs a configured connection plus a moss server on #160 to click through. Worth a manual pass before merge.
