### PR TITLE
fix(assistant-hub): trust package metadata over stale list fields on install

### DIFF
--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -426,6 +426,17 @@ function firstStringArray(...values: unknown[]): string[] | undefined {
   return undefined;
 }
 
+function stringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const entries = Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string');
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function hasRecordKey(value: unknown, key: string): value is Record<string, unknown> {
+  return isRecord(value) && Object.prototype.hasOwnProperty.call(value, key);
+}
+
 function tenantIdsWithFallback(tenantIdsValue: unknown, tenantIdsSnakeValue: unknown, tenantIdValue: unknown, tenantIdSnakeValue: unknown): string[] {
   const tenantIds = firstStringArray(tenantIdsValue, tenantIdsSnakeValue);
   if (tenantIds) return tenantIds;
@@ -448,6 +459,11 @@ function firstPromptsI18n(...values: unknown[]): AssistantPromptsI18n | undefine
     if (normalized) return normalized;
   }
   return undefined;
+}
+
+function normalizePackagePromptsI18n(value: unknown): AssistantPromptsI18n | undefined {
+  if (!isRecord(value)) return undefined;
+  return { 'zh-CN': normalizeStringList(stringArray(value['zh-CN'])) };
 }
 
 async function fetchVisibleAssistantOverlayMap(accessToken?: string): Promise<Map<string, VisibleAssistantOverlay> | null> {
@@ -974,7 +990,7 @@ export function initAssistantHubBridge(): void {
         return {
           id: a.id as string,
           name: a.name as string,
-          display_name: (a.profession as string) || (a.name as string),
+          display_name: firstNonEmptyString(a.display_name, a.profession, a.name) || (a.name as string),
           description: a.description as string,
           avatar: a.avatar as string | null,
           emoji: null as string | null,
@@ -1189,7 +1205,6 @@ export function initAssistantHubBridge(): void {
   // Download and install assistant from Hub, optionally installing selected associated skills
   ipcBridge.assistantHub.downloadAndInstallAssistant.provider(async ({ assistantName, displayName, sourceUrl, version, checksum, assistantMeta, selectedSkillIds }) => {
     try {
-      console.log('displayName', displayName);
       const token = getSkillhubToken();
       if (!token) {
         mainError('AssistantHub', 'skillhub token not provisioned, skip downloadAndInstallAssistant');
@@ -1238,7 +1253,27 @@ export function initAssistantHubBridge(): void {
           mainWarn('AssistantHub', `Failed to parse extracted assistant meta for "${assistantName}"`);
         }
       }
-      const promptsI18n = firstPromptsI18n(assistantMeta.promptsI18n, assistantMeta.prompts_i18n, extractedMeta?.promptsI18n);
+      const extractedMetaRecord = extractedMeta as Record<string, unknown> | null;
+      const extractedNameI18n = stringRecord(extractedMeta?.nameI18n);
+      const extractedDescriptionI18n = stringRecord(extractedMeta?.descriptionI18n);
+      const extractedCategories = hasRecordKey(extractedMetaRecord, 'categories') ? (stringArray(extractedMetaRecord.categories) ?? []) : undefined;
+      const categories = extractedCategories ?? firstStringArray(assistantMeta.categories) ?? [];
+      const promptsI18n = hasRecordKey(extractedMetaRecord, 'promptsI18n') ? (normalizePackagePromptsI18n(extractedMetaRecord.promptsI18n) ?? { 'zh-CN': [] }) : firstPromptsI18n(assistantMeta.promptsI18n, assistantMeta.prompts_i18n);
+      const packageDisplayName = firstNonEmptyString(extractedMeta?.display_name, extractedNameI18n?.['zh-CN'], extractedNameI18n?.['en-US'], extractedMeta?.name);
+      const resolvedDisplayName = firstNonEmptyString(packageDisplayName, assistantMeta.display_name, displayName, assistantMeta.name, assistantName) || assistantName;
+      const resolvedName = firstNonEmptyString(extractedMeta?.name, assistantMeta.name, assistantName) || assistantName;
+      const nameI18n = extractedNameI18n ?? { 'zh-CN': resolvedDisplayName };
+      const assistantDescription = firstString(assistantMeta.description);
+      const descriptionI18n = hasRecordKey(extractedMetaRecord, 'descriptionI18n') ? (extractedDescriptionI18n ?? {}) : assistantDescription !== undefined ? { 'zh-CN': assistantDescription } : undefined;
+      const defaultInitPrompt = hasRecordKey(extractedMetaRecord, 'defaultInitPrompt') ? (firstString(extractedMetaRecord.defaultInitPrompt) ?? null) : (firstString(assistantMeta.defaultInitPrompt) ?? null);
+      const categoryId = firstNonEmptyString(extractedMeta?.category_id) ?? (extractedCategories !== undefined ? categories[0] || '' : firstNonEmptyString(assistantMeta.category, categories[0]) || '');
+      const packageTenantIds = tenantIdsWithFallback(extractedMeta?.tenantIds, extractedMetaRecord?.tenant_ids, extractedMeta?.tenantId, extractedMetaRecord?.tenant_id);
+      const tenantIds = packageTenantIds.length > 0 ? packageTenantIds : tenantIdsWithFallback(assistantMeta.tenantIds, assistantMeta.tenant_ids, assistantMeta.tenantId, assistantMeta.tenant_id);
+      const tenantId = firstString(extractedMeta?.tenantId, extractedMetaRecord?.tenant_id, assistantMeta.tenantId, assistantMeta.tenant_id) ?? tenantIds[0] ?? null;
+      const avatar = hasRecordKey(extractedMetaRecord, 'avatar') ? firstString(extractedMetaRecord.avatar) : firstString(assistantMeta.avatar, assistantMeta.emoji);
+      const emoji = hasRecordKey(extractedMetaRecord, 'emoji') ? (firstString(extractedMetaRecord.emoji) ?? null) : assistantMeta.emoji;
+      const profession = firstString(extractedMeta?.profession, assistantMeta.display_name, assistantMeta.name) ?? resolvedDisplayName;
+      const resolvedRuleFile = ruleFile || firstNonEmptyString(extractedMeta?.ruleFile);
 
       // Install selected associated skills FIRST, collect skill IDs for meta
       const installedSkillNames: string[] = [];
@@ -1390,34 +1425,36 @@ export function initAssistantHubBridge(): void {
       // Write assistant meta with skill IDs in enabledSkills
       const meta: AssistantHubMeta = {
         id: assistantMeta.id,
-        name: assistantMeta.name,
-        nameI18n: { 'zh-CN': assistantMeta.display_name },
-        descriptionI18n: assistantMeta.description ? { 'zh-CN': assistantMeta.description } : undefined,
-        avatar: assistantMeta.avatar || assistantMeta.emoji || undefined,
-        emoji: assistantMeta.emoji,
+        name: resolvedName,
+        display_name: resolvedDisplayName,
+        profession,
+        nameI18n,
+        descriptionI18n,
+        avatar,
+        emoji,
         presetAgentType: normalizePresetAgentType(assistantMeta.preset_agent_type) || DEFAULT_PRESET_AGENT_TYPE,
         source_type: assistantMeta.tag === 'system' ? 'builtin' : 'hub',
         tag: assistantMeta.tag || 'hub',
         // skills: store skill IDs (UUID format)
         skills: allAssociatedSkillIds,
-        category_id: assistantMeta.category,
-        categories: assistantMeta.categories,
+        category_id: categoryId,
+        categories,
         author_id: assistantMeta.author_id,
         homepage: assistantMeta.homepage,
         applicable_scenarios: assistantMeta.applicable_scenarios,
         core_features: assistantMeta.core_features,
         is_builtin: assistantMeta.tag === 'system',
         enabled: true,
-        defaultInitPrompt: assistantMeta.defaultInitPrompt || null,
-        tenantId: assistantMeta.tenantId ?? assistantMeta.tenant_id ?? null,
-        tenantIds: tenantIdsWithFallback(assistantMeta.tenantIds, assistantMeta.tenant_ids, assistantMeta.tenantId, assistantMeta.tenant_id),
+        defaultInitPrompt,
+        tenantId,
+        tenantIds,
         promptsI18n,
         installed_version: version,
         installed_at: new Date().toISOString(),
         // enabledSkills: skill IDs that will be enabled for this assistant
         enabledSkills: allAssociatedSkillIds,
         // Rule file for displaying assistant rules
-        ruleFile: ruleFile,
+        ruleFile: resolvedRuleFile,
       };
       await writeAssistantMetaFile(assistantDir, meta);
 

--- a/src/process/constants/assistantStorage.ts
+++ b/src/process/constants/assistantStorage.ts
@@ -47,6 +47,8 @@ export interface IAssistantMeta {
   name?: string;
   /** Display name from API (may be snake_case) */
   display_name?: string;
+  /** Role/profession label from Assistant Hub package metadata */
+  profession?: string;
   nameI18n?: Record<string, string>;
   descriptionI18n?: Record<string, string>;
   promptsI18n?: Record<string, string[]>;

--- a/tests/unit/uploadedHubStatusRefresh.test.ts
+++ b/tests/unit/uploadedHubStatusRefresh.test.ts
@@ -1,6 +1,9 @@
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
+import JSZip from 'jszip';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const h = vi.hoisted(() => {
@@ -176,6 +179,35 @@ afterEach(async () => {
     tempRoot = '';
   }
 });
+
+async function serveBuffer(buffer: Buffer): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((_req, res) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Length', String(buffer.length));
+    res.end(buffer);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to start local zip server');
+  }
+
+  return {
+    url: `http://127.0.0.1:${(address as AddressInfo).port}/assistant.zip`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
 
 describe('uploaded Hub status refresh', () => {
   it('clears approved skill upload status when the remote skill detail is empty', async () => {
@@ -460,5 +492,158 @@ describe('uploaded Hub status refresh', () => {
     expect(writtenMeta.uploaded_at).toBeUndefined();
     expect(writtenMeta.publish_status).toBeUndefined();
     expect(writtenMeta.published_at).toBeUndefined();
+  });
+});
+
+describe('assistant Hub install metadata', () => {
+  it('prefers display_name over profession when listing personal hub assistants', async () => {
+    h.fetch.mockResolvedValue({
+      json: vi.fn(async () => ({
+        data: {
+          assistants: [
+            {
+              id: 'assistant-1',
+              name: '正式智能体名称',
+              display_name: '正式展示名',
+              profession: '销售',
+              description: 'desc',
+              avatar: null,
+              categories: ['销售'],
+              skills: [],
+              tag: 'hub',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        },
+      })),
+    });
+
+    const { initAssistantHubBridge } = await import('@/process/bridge/assistantHubBridge');
+    initAssistantHubBridge();
+
+    const result = await h.providers.get('assistantHub.fetchAssistants.provider')?.({ limit: 40 });
+
+    expect(result.success).toBe(true);
+    expect(result.data.assistants[0]).toMatchObject({
+      name: '正式智能体名称',
+      display_name: '正式展示名',
+      category: '销售',
+    });
+  });
+
+  it('uses package metadata over stale assistant list fields when installing a hub assistant update', async () => {
+    const assistantName = '联想AI可信一体机销售专家';
+    const description = '联想AI可信一体机的企业销售专家。';
+    const promptFile = `${assistantName}.md`;
+    const zip = new JSZip();
+    zip.file(promptFile, '# prompt');
+    zip.file(
+      '_sudowork_meta.json',
+      JSON.stringify({
+        id: '8a452f65-e435-42a0-a4a8-c1e0ad6cf95b',
+        name: assistantName,
+        display_name: assistantName,
+        profession: assistantName,
+        nameI18n: {
+          'zh-CN': assistantName,
+          'en-US': assistantName,
+        },
+        descriptionI18n: {
+          'zh-CN': description,
+          'en-US': description,
+        },
+        promptsI18n: {
+          'zh-CN': ['新的案例提示词'],
+        },
+        categories: ['销售'],
+        defaultInitPrompt: '',
+        tenantId: 'sudo',
+        tenantIds: ['sudo', '112211'],
+        ruleFile: promptFile,
+      })
+    );
+    const zipBuffer = await zip.generateAsync({ type: 'nodebuffer' });
+    const server = await serveBuffer(zipBuffer);
+
+    try {
+      const { initAssistantHubBridge } = await import('@/process/bridge/assistantHubBridge');
+      initAssistantHubBridge();
+
+      const result = await h.providers.get('assistantHub.downloadAndInstallAssistant.provider')?.({
+        assistantName,
+        displayName: '销售',
+        sourceUrl: server.url,
+        version: '1.0.13',
+        checksum: '',
+        selectedSkillIds: [],
+        assistantMeta: {
+          id: '8a452f65-e435-42a0-a4a8-c1e0ad6cf95b',
+          name: assistantName,
+          display_name: '销售',
+          description: '',
+          avatar: null,
+          emoji: null,
+          category: '',
+          categories: [],
+          preset_agent_type: null,
+          skills: [],
+          tag: 'hub',
+          homepage: null,
+          author_id: '',
+          star_count: 0,
+          applicable_scenarios: null,
+          core_features: null,
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+          defaultInitPrompt: '旧默认问候语',
+          promptsI18n: {
+            'zh-CN': ['旧案例提示词'],
+          },
+          tenantId: '112211',
+          tenantIds: ['112211'],
+        },
+      });
+
+      expect(result).toMatchObject({
+        success: true,
+        data: {
+          assistantName,
+          installedVersion: '1.0.13',
+          installedSkills: [],
+          failedSkills: [],
+        },
+      });
+
+      const writtenMeta = JSON.parse(await readFile(path.join(h.hubAssistantsDir, assistantName, '_sudowork_meta.json'), 'utf-8'));
+      expect(writtenMeta).toMatchObject({
+        id: '8a452f65-e435-42a0-a4a8-c1e0ad6cf95b',
+        name: assistantName,
+        display_name: assistantName,
+        profession: assistantName,
+        nameI18n: {
+          'zh-CN': assistantName,
+          'en-US': assistantName,
+        },
+        descriptionI18n: {
+          'zh-CN': description,
+          'en-US': description,
+        },
+        categories: ['销售'],
+        category_id: '销售',
+        defaultInitPrompt: '',
+        promptsI18n: {
+          'zh-CN': ['新的案例提示词'],
+        },
+        tenantId: 'sudo',
+        tenantIds: ['sudo', '112211'],
+        installed_version: '1.0.13',
+        ruleFile: promptFile,
+      });
+      expect(writtenMeta.nameI18n['zh-CN']).not.toBe('销售');
+      expect(writtenMeta.promptsI18n['zh-CN']).not.toEqual(['旧案例提示词']);
+    } finally {
+      await server.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Hub assistant installs were overwriting fresh package metadata (`nameI18n`, `descriptionI18n`, `promptsI18n`, `categories`, `tenantIds`, `ruleFile`, `defaultInitPrompt`, `emoji`, `avatar`) with older values from the assistant list response. Updated assistants ended up displayed with stale names / prompts / rules even after re-downloading.
- Now the install path prefers values from the downloaded package's `_sudowork_meta.json` and falls back to the list payload only when the package omits a field. Also uses `display_name` over `profession` when listing personal hub assistants, and drops a stray `console.log`.
- Added `profession` to `IAssistantMeta` so it round-trips through the meta file.

## Test plan

- [x] `bunx vitest run tests/unit/uploadedHubStatusRefresh.test.ts` — new cases cover the list `display_name` preference and the install-time metadata merge (with a local HTTP server serving a real zip package)
- [ ] Manual: reinstall an updated hub assistant and confirm the displayed name, prompts, and rule file reflect the latest package