### PR TITLE
feat(nexus): repoint daemon to nexusd-cluster assembly + ABI-6 plugin pins (managed_agent)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,8 @@ vx.toml
 resources/nexus.tar.gz
 resources/nexusd
 resources/nexusd.exe
-resources/v*-nexus-cluster-*
+resources/v*-nexusd-cluster-*
+resources/v*-nexus-vault-*
 resources/claude-code.tgz
 resources/gemini-cli.tgz
 resources/node-*.tar.gz

--- a/scripts/dev/validate-abi6-dropin.sh
+++ b/scripts/dev/validate-abi6-dropin.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Drop-in ABI-6 validation: boot the published nexusd-cluster assembly with the
+# published vault/local-connector/fuse plugins in a clean Linux env and assert
+# every plugin loads (no "plugin API version mismatch") + the daemon serves.
+#
+# Run INSIDE a debian container. Env in, no NEXUS_PEERS:
+#   docker run --rm -e ASM_VER -e VAULT_VER -e LC_VER -e FUSE_VER \
+#     -v "$PWD/scripts/dev":/s debian:bookworm-slim bash /s/validate-abi6-dropin.sh
+set -uo pipefail
+
+ASM_VER="${ASM_VER:-0.1.0}"
+VAULT_VER="${VAULT_VER:-0.5.44}"
+LC_VER="${LC_VER:-0.4.44}"
+FUSE_VER="${FUSE_VER:-0.6.44}"
+BASE="https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com"
+PLAT="linux-x86_64"
+
+echo "== deps =="
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq >/dev/null 2>&1
+apt-get install -yqq curl ca-certificates fuse3 libfuse3-3 >/dev/null 2>&1 || \
+  apt-get install -yqq curl ca-certificates fuse3 >/dev/null 2>&1
+
+ROOT=/tmp/dropin; BIN=$ROOT/bin; PLUG=$ROOT/plugins; DATA=$ROOT/data
+mkdir -p "$BIN" "$PLUG" "$DATA"
+
+dl() { # url dest
+  echo "  GET $1"
+  curl -fsSL "$1" -o "$2" || { echo "  !! download failed: $1"; return 1; }
+}
+
+echo "== assembly nexusd-cluster v$ASM_VER =="
+dl "$BASE/nexusd-cluster/release/v$ASM_VER/nexusd-cluster-$PLAT.tar.gz" "$ROOT/asm.tgz" || exit 2
+tar xzf "$ROOT/asm.tgz" -C "$BIN"
+# archive may nest under a dir; find the binary
+DAEMON=$(find "$BIN" -type f -name 'nexusd-cluster' | head -1)
+chmod +x "$DAEMON" 2>/dev/null
+echo "  daemon: $DAEMON"
+
+echo "== plugins =="
+for spec in "nexus-vault/$VAULT_VER" "nexus-local-connector/$LC_VER" "nexus-fuse-plugin/$FUSE_VER"; do
+  name="${spec%/*}"; ver="${spec#*/}"
+  dl "$BASE/$name/release/v$ver/$name-$PLAT.tar.gz" "$ROOT/$name.tgz" || exit 3
+  tar xzf "$ROOT/$name.tgz" -C "$PLUG"
+done
+echo "  plugin dir contents:"; ls -la "$PLUG"
+
+echo "== boot (clean env, no NEXUS_PEERS) =="
+env -i HOME=/root PATH=/usr/bin:/bin NEXUS_DATA_DIR="$DATA" \
+  "$DAEMON" serve-local --port 25808 --hostname localhost \
+  --data-dir "$DATA" --plugin-dir "$PLUG" >"$ROOT/daemon.log" 2>&1 &
+PID=$!
+sleep 8
+
+echo "== daemon log =="
+cat "$ROOT/daemon.log"
+echo "== verdict =="
+RC=0
+if grep -qiE "plugin API version mismatch|version mismatch: plugin" "$ROOT/daemon.log"; then
+  echo "FAIL: ABI version mismatch present"; RC=1
+fi
+if ! kill -0 "$PID" 2>/dev/null; then
+  echo "NOTE: daemon process not alive after 8s (check log above for panic vs clean plugin-scan exit)"
+fi
+# count plugin-loaded lines
+echo "-- plugin load lines --"
+grep -iE "plugin|loaded|register|vault|connector|fuse|managed.agent" "$ROOT/daemon.log" | head -40
+kill "$PID" 2>/dev/null
+exit $RC

--- a/scripts/download-nexus-vfs.js
+++ b/scripts/download-nexus-vfs.js
@@ -38,15 +38,18 @@ const {
   getPluginSig,
 } = require('./plugin-naming.js');
 
-const VERSION = runtimeVersions['nexus-vfs'];
+// The daemon is now the nexus ASSEMBLY nexusd-cluster (VFS cluster + managed_agent),
+// pinned + published independently of nexus-vfs under the distinct COS prefix
+// `nexusd-cluster/`. Superset of the old pure-cluster pull.
+const VERSION = runtimeVersions['nexusd-cluster'];
 const VAULT_VERSION = runtimeVersions['nexus-vault'];
 const LOCAL_CONNECTOR_VERSION = runtimeVersions['nexus-local-connector'];
 const FUSE_PLUGIN_VERSION = runtimeVersions['nexus-fuse-plugin'];
 
 // Runtime bucket is primary; legacy bucket stays live as a fallback during deprecation.
 const COS_BASE_URLS = [
-  `https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com/nexus-vfs/release/v${VERSION}`,
-  `https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/nexus-vfs/release/v${VERSION}`,
+  `https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com/nexusd-cluster/release/v${VERSION}`,
+  `https://sudoclaw-download-1309794936.cos.ap-beijing.myqcloud.com/nexusd-cluster/release/v${VERSION}`,
 ];
 
 // GitHub Release fallback for nexus-vfs cluster, mirroring the same pattern
@@ -56,7 +59,7 @@ const COS_BASE_URLS = [
 // release (`publish-github-release` step, `softprops/action-gh-release@v2`)
 // is unconditional on tag push, so the GH-release fallback is always
 // available even when the COS mirror is empty.
-const NEXUS_VFS_GITHUB_URL = `https://github.com/nexi-lab/nexus-vfs/releases/download/v${VERSION}`;
+const NEXUS_VFS_GITHUB_URL = `https://github.com/nexi-lab/nexus/releases/download/nexusd-cluster-v${VERSION}`;
 
 // Vault plugin is released from the nexus repo (separate from nexus-vfs).
 const VAULT_COS_BASE_URLS = [

--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -47,8 +47,8 @@ const NEXUS_VFS_READY_MARKER = '.nexus-vfs-bin-ready';
 /** COS mirrors hosting the nexus-vfs artifacts. Runtime bucket is primary; the
  *  legacy bucket stays live as a fallback during deprecation. Both serve the same
  *  bytes (server-side copy), so the SHA256 check below holds for either source. */
-const NEXUS_VFS_RUNTIME_BASE_URL = `${COS_RUNTIME_BASE}/nexus-vfs/release`;
-const NEXUS_VFS_LEGACY_BASE_URL = `${COS_LEGACY_NEXUS_VFS_BASE}/nexus-vfs/release`;
+const NEXUS_VFS_RUNTIME_BASE_URL = `${COS_RUNTIME_BASE}/nexusd-cluster/release`;
+const NEXUS_VFS_LEGACY_BASE_URL = `${COS_LEGACY_NEXUS_VFS_BASE}/nexusd-cluster/release`;
 
 /** Node.js process.platform → artifact OS token. */
 const OS_NAME_MAP: Record<string, string> = { darwin: 'macos', win32: 'windows', linux: 'linux' };
@@ -143,7 +143,7 @@ class DynamicNexusVfsService {
   // ── Version / artifact resolution ────────────────────────────────────────────
 
   getBundledVersion(): string {
-    return (runtimeVersions as Record<string, string>)['nexus-vfs'];
+    return (runtimeVersions as Record<string, string>)['nexusd-cluster'];
   }
 
   private getArtifactName(): string {

--- a/src/renderer/pages/conversation/workspace/TaskPanel.tsx
+++ b/src/renderer/pages/conversation/workspace/TaskPanel.tsx
@@ -781,14 +781,17 @@ const TaskPanel: React.FC<TaskPanelProps> = ({ workspaceFiles = [], workspace })
           <div
             ref={listRef}
             className='task-panel__card-list'
-            style={{ maxHeight: 240, overflow: 'auto' } as React.CSSProperties}
             onScroll={checkScroll}
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 8,
-              paddingRight: 1,
-            }}
+            style={
+              {
+                maxHeight: 240,
+                overflow: 'auto',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+                paddingRight: 1,
+              } as React.CSSProperties
+            }
           >
             {dags.map((d) => {
               const p = d.progress.total > 0 ? Math.round((d.progress.completed / d.progress.total) * 100) : 0;

--- a/src/shared/runtime-sha256.json
+++ b/src/shared/runtime-sha256.json
@@ -8,17 +8,17 @@
   "nexusd-cluster-windows-aarch64.zip": "9004f997f8d44db8a0964999e32bc9670e5d8c99ca0f78b49dd0ee94155b7e3f",
   "nexusd-cluster-windows-x86_64.zip": "4b7e0f5708d34c959e3169486ec4dce2ed8873283df0cb54293d33312e20aec1",
 
-  "nexus-vault-linux-x86_64.tar.gz": "19b4baabc30e3d0901acc991ddefe807d22f410d98205f79c474b47c18e1eae7",
-  "nexus-vault-macos-arm64.tar.gz": "d237646c214c99d6779b2cb709e974b0911f99ffd3d7384c8951254873a22217",
-  "nexus-vault-macos-x86_64.tar.gz": "2a21941ce7c8fd58d692947549ef158b4d0d745309aea72228a2c5c5951b1753",
-  "nexus-vault-windows-x86_64.zip": "05a734e884b332966867535da2604d0179743c094464f36fbab263267a5cece5",
+  "nexus-vault-linux-x86_64.tar.gz": "675c72efcff64557f69452625f2c312558e7f0b924e62bd84844165f716a7395",
+  "nexus-vault-macos-arm64.tar.gz": "8ad59f175c9079709ced75dabea5b90fe89ea6d133c8cb37e5153f1ab0a0e67b",
+  "nexus-vault-macos-x86_64.tar.gz": "7bce4cfa6de33f886b8bdc6ca9fd3c6f6f1cd732358d0a361179f54c2bd64111",
+  "nexus-vault-windows-x86_64.zip": "23619d44c877dbd377dca96fdef944efe14553f9e4a4580f668df29eb504c603",
 
-  "nexus-local-connector-linux-x86_64.tar.gz": "55981e400d4945624f06b93ea96b28646ba6fa8469f412517040dae85bba6159",
-  "nexus-local-connector-macos-arm64.tar.gz": "1a7fc7a80ef4d827b7788b598b3733b996a0f40bce38a1cad480993e217974e1",
-  "nexus-local-connector-macos-x86_64.tar.gz": "898f5b651c426d411dfef8a22eabac0a534cf4eecfe8a85f9aae9b6c3d1b6cd7",
-  "nexus-local-connector-windows-x86_64.zip": "b9d3c37093686ea5cc62a50dec3e22c494f8ccaf25053920f3b7813db492ee51",
+  "nexus-local-connector-linux-x86_64.tar.gz": "88a0a181c7b1d0094f507956dea732467802b0669acca5dc62f97598582c2cd5",
+  "nexus-local-connector-macos-arm64.tar.gz": "f941e929a6b3255e1ab28efa93b28cc9203ae717d7d3f8857df90c518938f22e",
+  "nexus-local-connector-macos-x86_64.tar.gz": "319d01b914fa4c4dc2786dafdda47fae016313d3b05b42da5d03275b923a4c98",
+  "nexus-local-connector-windows-x86_64.zip": "96463f7e3cecec0c3ef0ead88d3b78fe40be3f5852516991c0e43dfc1a02c385",
 
-  "nexus-fuse-plugin-linux-x86_64.tar.gz": "180a62d01c19df729dcee2993a441bd7258334581f0e86b8c2b8a6e27e3a68c3",
-  "nexus-fuse-plugin-macos-arm64.tar.gz": "57866e1161dae72d7d74a7e2255b3d1f7a697ca716d782a89e417ab8ee385094",
-  "nexus-fuse-plugin-macos-x86_64.tar.gz": "262c83d7ad5c7f5ea6a08aa338a6ab68dfdb580e6b968709e465291cb46c82b9"
+  "nexus-fuse-plugin-linux-x86_64.tar.gz": "b0fe6c63fdfe1d527efa9f5eea471f5892937126a3985c33e5e9ce1a1123aba5",
+  "nexus-fuse-plugin-macos-arm64.tar.gz": "03b5dc07a99105a094933d54630f080349fd126fa6e7cba58ecc80e825256e11",
+  "nexus-fuse-plugin-macos-x86_64.tar.gz": "cdaf4b695eb07d4185247154704dc5c27d3ef4e88bca136ce1fe3feb3b2c7c2e"
 }

--- a/src/shared/runtime-sha256.json
+++ b/src/shared/runtime-sha256.json
@@ -1,12 +1,12 @@
 {
   "_doc": "Canonical SHA256 sums for every downloadable nexus-vfs runtime artifact. Single source of truth — scripts/download-nexus-vfs.js (build/install-time), DynamicNexusVfsService.ts (runtime cluster re-installer), and VaultPluginInstaller.ts (runtime vault re-installer) all read from this file. Bump versions in runtime-versions.json AND update the matching entry here in one commit; do NOT inline a SHA back into any source file. Verified against the per-release SHA256SUMS.txt in the COS bucket.",
 
-  "nexusd-cluster-linux-aarch64.tar.gz": "2c9177cf36575a1c12f0b0c17fe7b3b706dcd2a90620b3e121340d2525236c4c",
-  "nexusd-cluster-linux-x86_64.tar.gz": "6b52b926900c4fa0cb0a51a938f5365792c9605e508eb6358dd85cccac652c90",
-  "nexusd-cluster-macos-aarch64.tar.gz": "ece4219abba8506262da9f18165d473a134182209a889e019998474faa8d0f57",
-  "nexusd-cluster-macos-x86_64.tar.gz": "7b4ce0efb201884e3231e860dec968b6de55debc26a9f82b054e39f217b072c5",
-  "nexusd-cluster-windows-aarch64.zip": "9732a9d7419be0dd9b33cda514a806b5c2ceeb3ad4973cae81e7612867c80935",
-  "nexusd-cluster-windows-x86_64.zip": "f1933a28f19d9032a6bf8c2599061f4cb65d6f5470f624842576f98040e7e040",
+  "nexusd-cluster-linux-aarch64.tar.gz": "f51d24ef84e8c7e5659eaf55b109e7ed28eb42dae121260378215bec339de1a2",
+  "nexusd-cluster-linux-x86_64.tar.gz": "8eeabeca9c40173df4954d5189ba9a0f1016b593d48c0da93372703f2d8f94d9",
+  "nexusd-cluster-macos-aarch64.tar.gz": "1abb9b395c7115279986bb309d024e2c3fc9e9b4808d29f971a9992898655606",
+  "nexusd-cluster-macos-x86_64.tar.gz": "330cd75ab143d11a8b1e529e87c3e4e6c4b1dc2d807ad28feb2adb59d4e5be62",
+  "nexusd-cluster-windows-aarch64.zip": "9004f997f8d44db8a0964999e32bc9670e5d8c99ca0f78b49dd0ee94155b7e3f",
+  "nexusd-cluster-windows-x86_64.zip": "4b7e0f5708d34c959e3169486ec4dce2ed8873283df0cb54293d33312e20aec1",
 
   "nexus-vault-linux-x86_64.tar.gz": "19b4baabc30e3d0901acc991ddefe807d22f410d98205f79c474b47c18e1eae7",
   "nexus-vault-macos-arm64.tar.gz": "d237646c214c99d6779b2cb709e974b0911f99ffd3d7384c8951254873a22217",

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -1,6 +1,7 @@
 {
   "nexus": "0.9.43",
   "nexus-vfs": "0.6.0",
+  "nexusd-cluster": "0.1.0",
   "nexus-vault": "0.4.0",
   "nexus-local-connector": "0.3.0",
   "nexus-fuse-plugin": "0.5.0",

--- a/src/shared/runtime-versions.json
+++ b/src/shared/runtime-versions.json
@@ -2,9 +2,9 @@
   "nexus": "0.9.43",
   "nexus-vfs": "0.6.0",
   "nexusd-cluster": "0.1.0",
-  "nexus-vault": "0.4.0",
-  "nexus-local-connector": "0.3.0",
-  "nexus-fuse-plugin": "0.5.0",
+  "nexus-vault": "0.5.44",
+  "nexus-local-connector": "0.4.44",
+  "nexus-fuse-plugin": "0.6.44",
   "fuse-t": "1.2.7",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
   "scode": "0.1.24"


### PR DESCRIPTION
## What

Repoints sudowork's nexus daemon from the pure `nexus-vfs` cluster to the nexus **assembly** `nexusd-cluster` (VFS cluster **+ managed_agent** control plane — a superset), and bumps the vault/local-connector/fuse plugin pins to matching **ABI-6** releases. This unblocks the ACP→nexus cutover (managed_agent spawn/drive + `/proc/{sid}/fd` tunnel).

## Why together (atomic)

The assembly is kernel plugin-ABI **6** (`nexus-plugin-abi` rev `6cad75f7`, `PLUGIN_API_VERSION=6`). The previously-pinned plugins (vault 0.4.0 / local-connector 0.3.0 / fuse 0.5.0) are ABI-**5**, so the daemon aborted at `--plugin-dir` load (`plugin API version mismatch: plugin=5, kernel=6`). Daemon + plugins are a matched ABI set and must land in one change.

## Changes
- `runtime-versions.json`: `nexusd-cluster=0.1.0`; plugins → `vault 0.5.44 / local-connector 0.4.44 / fuse 0.6.44` (tags @ commit a58a00f5, same abi rev `6cad75f7` as the assembly).
- `runtime-sha256.json`: cluster + 11 plugin SHA256s from the COS archives (SSOT).
- `download-nexus-vfs.js` + `DynamicNexusVfsService.ts`: COS prefix `nexus-vfs/release`→`nexusd-cluster/release`, GH tag `nexusd-cluster-v*`, bundled-version key.
- `TaskPanel.tsx`: fix a pre-existing dev tsc error (TS17001 duplicate `style`).
- `.gitignore`: fix stale post-rename staging pattern; ignore staged vault archives.
- `scripts/dev/validate-abi6-dropin.sh`: reproducible Docker drop-in harness.

## Verification
- **Linux drop-in (Docker, glibc 2.39, clean env)**: assembly + all 3 plugins load — **no ABI mismatch, no signature rejection**; daemon boots, Raft zone up, gRPC serving. `managed_agent`/`start_session_v1`/`/proc/` confirmed in the published binary.
- **Windows**: sudowork's real download path SHA256-verifies nexusd-cluster 0.1.0 + vault 0.5.44 + local-connector 0.4.44 (fuse n/a on win).
- tsc + eslint clean.