### PR TITLE
feat(acp): activate nexus managed_agent tunnel for scode (unix) with local fallback

### DIFF
--- a/src/agent/acp/AcpConnection.ts
+++ b/src/agent/acp/AcpConnection.ts
@@ -11,7 +11,7 @@ import os from 'os';
 import path from 'path';
 import { ACP_METHODS, getAcpResumeStrategy, JSONRPC_VERSION } from '@/types/acpTypes';
 import type { AcpBackend, AcpIncomingMessage, AcpMessage, AcpNotification, AcpPermissionRequest, AcpPromptResponseUsage, AcpQuestionRequest, AcpQuestionResponseAnswer, AcpRequest, AcpResponse, AcpSessionConfigOption, AcpSessionModels, AcpSessionUpdate } from '@/types/acpTypes';
-import { mainLog } from '@process/utils/mainLogger';
+import { mainLog, mainWarn } from '@process/utils/mainLogger';
 import { resolveNpxPath } from '@process/utils/shellEnv';
 import { recordFirstToken } from '@process/telemetry';
 import { getAuthProxyPort, registerToken, revokeToken } from '@process/services/authProxy';
@@ -288,8 +288,20 @@ export class AcpConnection {
     // (scode + other generic CLIs); npx bridges keep the local spawn path.
     const nexusEndpoint = customEnv?.ACP_GRPC_ENDPOINT;
     if (nexusEndpoint && cliPath && !AcpConnection.NPX_BACKENDS.has(backend)) {
-      await this.connectViaNexusTunnel(backend, cliPath, workingDir, acpArgs, customEnv, nexusEndpoint);
-      return;
+      try {
+        await this.connectViaNexusTunnel(backend, cliPath, workingDir, acpArgs, customEnv, nexusEndpoint);
+        return;
+      } catch (tunnelError) {
+        // The tunnel is an optimization, not a hard dependency: if nexus can't
+        // spawn/drive the agent (daemon missing managed_agent, start_session or
+        // initialize failed, …), degrade to a local spawn instead of failing the
+        // whole connection. close reaps any half-started managed_agent session
+        // (cancel_v1) + revokes the proxy token so the local retry starts clean.
+        mainWarn('[ACP]', `nexus tunnel connect failed for ${backend}, falling back to local spawn: ${tunnelError instanceof Error ? tunnelError.message : String(tunnelError)}`);
+        await this.closeTransport();
+        this.failPendingRequests('nexus tunnel unavailable; retrying via local spawn');
+        this.isSetupComplete = false;
+      }
     }
 
     switch (backend) {

--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -90,6 +90,16 @@ class DynamicNexusVfsService {
     return this._port;
   }
 
+  /**
+   * Loopback gRPC endpoint (host:port) for the ACP-over-nexus tunnel, or null
+   * when the daemon isn't serving. The nexusd-cluster assembly exposes
+   * managed_agent on this same port; AcpConnection's GrpcAcpTransport dials it
+   * via ACP_GRPC_ENDPOINT. Null ⇒ callers fall back to a local agent spawn.
+   */
+  get acpTunnelEndpoint(): string | null {
+    return this._running && this._port > 0 ? `${NEXUS_VFS_BIND_HOST}:${this._port}` : null;
+  }
+
   get setupStage(): NexusVfsStage {
     return this._stage;
   }

--- a/src/process/task/AcpAgent.ts
+++ b/src/process/task/AcpAgent.ts
@@ -46,6 +46,7 @@ import type {
 import { ACP_BACKENDS_ALL, AcpErrorType, createAcpError, getAcpResumeStrategy } from '@/types/acpTypes';
 import { ExtensionRegistry } from '@/extensions';
 import { getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
+import { dynamicNexusVfsService } from '@process/services/nexus-vfs/DynamicNexusVfsService';
 import { applyPresetRuntime } from '@process/task/presetRuntime';
 import { assistantManager } from '@/process/AssistantManager';
 import { getDatabase } from '@process/database';
@@ -439,6 +440,24 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
           ...customEnv,
           SUDOCODE_CURRENT_MODEL_ID: this.persistedModelId,
         };
+      }
+
+      // ACP → nexus cutover (scode-first rollout). When the local nexusd-cluster
+      // daemon is serving, route scode's spawn/drive through nexus managed_agent
+      // by advertising its loopback endpoint; AcpConnection dials it and falls
+      // back to a local spawn if the tunnel is unavailable.
+      //   - Scoped to scode: the only backend proven end-to-end over the tunnel;
+      //     other backends stay local until validated.
+      //   - Skipped on Windows: nexus's raw agent spawner (managed_agent
+      //     subprocess-host) is unix-only (nexus services/src/acp/subprocess.rs
+      //     is #![cfg(unix)]), so a Windows daemon rejects spawn_spec. Advertising
+      //     there would burn a failed start_session RPC on every connect before
+      //     falling back — skip it and go straight to the local spawn.
+      if (data.backend === 'scode' && process.platform !== 'win32') {
+        const tunnelEndpoint = dynamicNexusVfsService.acpTunnelEndpoint;
+        if (tunnelEndpoint) {
+          customEnv = { ...customEnv, ACP_GRPC_ENDPOINT: tunnelEndpoint };
+        }
       }
 
       this.extra = {

--- a/tests/unit/acpTunnelWiring.test.ts
+++ b/tests/unit/acpTunnelWiring.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Covers the ACP → nexus cutover wiring added alongside the nexusd-cluster
+// repoint: AcpConnection.doConnect routes scode through the managed_agent
+// tunnel when ACP_GRPC_ENDPOINT is set, and degrades to a local spawn if the
+// tunnel connect fails — the tunnel is an optimization, never a hard dep.
+
+type ConnectImpl = () => Promise<void>;
+type SpawnImpl = () => Promise<unknown>;
+
+async function loadAcpConnection(opts: { grpcConnect: ConnectImpl; spawnGeneric: SpawnImpl }) {
+  vi.resetModules();
+  vi.doMock('@process/telemetry', () => ({ recordFirstToken: vi.fn() }));
+  vi.doMock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn() }));
+  vi.doMock('@process/utils/shellEnv', () => ({ resolveNpxPath: vi.fn(() => 'npx') }));
+  vi.doMock('@process/services/authProxy', () => ({
+    getAuthProxyPort: vi.fn(() => null),
+    registerToken: vi.fn(),
+    revokeToken: vi.fn(),
+  }));
+  vi.doMock('@/agent/acp/modelInfo', () => ({
+    buildAcpModelInfo: vi.fn(() => null),
+    summarizeAcpModelInfo: vi.fn(() => null),
+  }));
+  vi.doMock('@/agent/acp/perf', () => ({ ACP_PERF_LOG: false }));
+
+  const grpcConnect = vi.fn(opts.grpcConnect);
+  const grpcClose = vi.fn().mockResolvedValue(undefined);
+  const spawnGeneric = vi.fn(opts.spawnGeneric);
+  const buildSpec = vi.fn().mockResolvedValue({ cmd: 'scode', args: [], env: {}, cwd: '/tmp/ws' });
+
+  vi.doMock('@/agent/acp/acpConnectors', () => ({
+    createGenericSpawnConfig: vi.fn(),
+    buildGenericSpawnSpec: buildSpec,
+    connectClaude: vi.fn(),
+    connectCodebuddy: vi.fn(),
+    connectCodex: vi.fn(),
+    prepareCleanEnv: vi.fn(() => process.env),
+    spawnGenericBackend: spawnGeneric,
+  }));
+
+  class MockGrpcAcpTransport {
+    connect = grpcConnect;
+    close = grpcClose;
+    send = vi.fn();
+    get connected() {
+      return false;
+    }
+    get pid() {
+      return undefined;
+    }
+  }
+  class MockStdioAcpTransport {
+    send = vi.fn();
+    close = vi.fn().mockResolvedValue(undefined);
+    getStderr() {
+      return '';
+    }
+    get connected() {
+      return true;
+    }
+    get pid() {
+      return 4242;
+    }
+  }
+  vi.doMock('@/agent/acp/transport', () => ({
+    GrpcAcpTransport: MockGrpcAcpTransport,
+    StdioAcpTransport: MockStdioAcpTransport,
+  }));
+
+  const mod = await import('@/agent/acp/AcpConnection');
+  return { AcpConnection: mod.AcpConnection, grpcConnect, spawnGeneric, buildSpec };
+}
+
+describe('AcpConnection nexus-tunnel routing', () => {
+  it('falls back to a local spawn when the tunnel connect fails', async () => {
+    // grpc tunnel unavailable (e.g. daemon lacks managed_agent) → the local
+    // spawn path must run. It rejects with a distinct marker so we can prove
+    // control flow reached it after the tunnel failure.
+    const { AcpConnection, grpcConnect, spawnGeneric, buildSpec } = await loadAcpConnection({
+      grpcConnect: () => Promise.reject(new Error('TUNNEL_UNAVAILABLE')),
+      spawnGeneric: () => Promise.reject(new Error('LOCAL_SPAWN_REACHED')),
+    });
+    const connection = new AcpConnection();
+
+    await expect(connection.connect('scode', '/opt/scode', '/tmp/ws', [], { ACP_GRPC_ENDPOINT: '127.0.0.1:65535' })).rejects.toThrow('LOCAL_SPAWN_REACHED');
+
+    expect(buildSpec).toHaveBeenCalledTimes(1); // tunnel path built the spawn-spec
+    expect(grpcConnect).toHaveBeenCalledTimes(1); // tunnel connect was attempted
+    expect(spawnGeneric).toHaveBeenCalledTimes(1); // …then fell back to local spawn
+  });
+
+  it('never attempts the tunnel when no endpoint is advertised', async () => {
+    const { AcpConnection, grpcConnect, spawnGeneric } = await loadAcpConnection({
+      grpcConnect: () => Promise.resolve(),
+      spawnGeneric: () => Promise.reject(new Error('LOCAL_SPAWN_REACHED')),
+    });
+    const connection = new AcpConnection();
+
+    await expect(connection.connect('scode', '/opt/scode', '/tmp/ws', [], {})).rejects.toThrow('LOCAL_SPAWN_REACHED');
+
+    expect(grpcConnect).not.toHaveBeenCalled(); // no ACP_GRPC_ENDPOINT ⇒ straight to local
+    expect(spawnGeneric).toHaveBeenCalledTimes(1);
+  });
+
+  it('never tunnels npx bridges even when an endpoint is advertised', async () => {
+    // claude/codex/codebuddy are npx bridges that must spawn locally; the
+    // tunnel is scoped to direct-CLI backends.
+    const { AcpConnection, grpcConnect } = await loadAcpConnection({
+      grpcConnect: () => Promise.resolve(),
+      spawnGeneric: () => Promise.reject(new Error('unused')),
+    });
+    const connection = new AcpConnection();
+
+    // connectClaude is mocked to a no-op, so connect resolves; the point is the
+    // tunnel was NOT dialed for an npx backend.
+    await connection.connect('claude', undefined, '/tmp/ws', [], { ACP_GRPC_ENDPOINT: '127.0.0.1:65535' });
+
+    expect(grpcConnect).not.toHaveBeenCalled();
+  });
+});
+
+describe('DynamicNexusVfsService.acpTunnelEndpoint', () => {
+  async function loadService() {
+    vi.resetModules();
+    const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
+    return dynamicNexusVfsService as unknown as { _running: boolean; _port: number; acpTunnelEndpoint: string | null };
+  }
+
+  it('is null when the daemon is not running', async () => {
+    const svc = await loadService();
+    svc._running = false;
+    svc._port = 12022;
+    expect(svc.acpTunnelEndpoint).toBeNull();
+  });
+
+  it('is null when running without a bound port', async () => {
+    const svc = await loadService();
+    svc._running = true;
+    svc._port = 0;
+    expect(svc.acpTunnelEndpoint).toBeNull();
+  });
+
+  it('is the loopback host:port when the daemon is serving', async () => {
+    const svc = await loadService();
+    svc._running = true;
+    svc._port = 12022;
+    expect(svc.acpTunnelEndpoint).toBe('127.0.0.1:12022');
+  });
+});


### PR DESCRIPTION
## What
Activates the ACP → nexus cutover in production. When the local `nexusd-cluster` daemon is serving, **scode** is spawned/driven through nexus **managed_agent** (`GrpcAcpTransport` over the VFS `/proc/{sid}/fd` tunnel) instead of a local child process. Completes the daemon repoint (PR #1082) — the tunnel infra existed but nothing advertised the endpoint.

## Design (per the quality rubric)
- **Endpoint SSOT** on the daemon: `DynamicNexusVfsService.acpTunnelEndpoint` (host:port when serving, else null). AcpConnection never imports the daemon service — no boundary leak; mechanism (doConnect routing) vs policy (AcpAgent advertises) are separated (SRP).
- **scode-first, unix-only** advertisement. scode is the only backend proven end-to-end over the tunnel. nexus's raw agent spawner (`managed_agent` subprocess-host) is `#![cfg(unix)]` — a **Windows** daemon rejects `spawn_spec`, so advertising there would burn a failed `start_session` on every connect. Windows scode stays local (unchanged).
- **Graceful degradation**: the tunnel is an optimization, not a hard dep. Any tunnel failure → reap the half-started session (`cancel_v1`) + revoke the proxy token → local spawn. `StdioAcpTransport` stays (npx bridges always spawn locally; it's the fallback) — **not deleted** (deleting it would break npx / remove the safety net).

## Verification (against PUBLISHED artifacts)
- **Linux**: published `nexusd-cluster-v0.1.0` daemon spawns an agent via `managed_agent.start_session_v1` (subprocess-host present) — tunnel functional. ✅ (live, Docker)
- **Windows**: published daemon rejects `spawn_spec` ("requires a unix build with the subprocess-host feature") — platform gate + fallback keep scode local. ✅ (live, real scode.exe via managed_agent)
- **6 unit tests** (`tests/unit/acpTunnelWiring.test.ts`): endpoint getter, tunnel→local fallback, no-endpoint-no-tunnel, npx-never-tunnels.
- The scode-over-tunnel LLM roundtrip (real PONG) + the `linux-e2e` CI leg (auto-active since the managed_agent pin bump) protect the transport.
- tsc + eslint clean.