### PR TITLE
fix(scode): resolve session transcript across per-session-dir + legacy layouts

### DIFF
--- a/src/process/task/acpUsageReconciliation.ts
+++ b/src/process/task/acpUsageReconciliation.ts
@@ -4,16 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TurnTokenUsage } from '@/common/chatLib';
-import type { AcpPromptResponseUsage } from '@/types/acpTypes';
 import type { Dirent } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as nodePath from 'node:path';
+import type { AcpPromptResponseUsage } from '@/types/acpTypes';
+import type { TurnTokenUsage } from '@/common/chatLib';
 
 type JsonRecord = Record<string, unknown>;
 
 const SCODE_SESSION_POLL_ATTEMPTS = 24;
 const SCODE_SESSION_POLL_INTERVAL_MS = 15_000;
+// SCode's per-session-directory transcript member (mirrors sudocode's
+// `TRANSCRIPT_FILE`). Older SCode builds wrote a flat `<session-id>.jsonl`.
+const SCODE_TRANSCRIPT_FILE = 'transcript.jsonl';
 
 function numberOrUndefined(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
@@ -131,45 +134,41 @@ export function extractLatestScodeAssistantUsageFromJsonl(content: string): Scod
   return null;
 }
 
+/**
+ * Resolve SCode's persisted transcript file for `sessionId` under
+ * `<workspace>/.scode/sessions/`.
+ *
+ * SCode partitions sessions by a workspace-fingerprint directory, so the
+ * transcript lives at either the current per-session-directory layout
+ * `<sessions>/<workspace-hash>/<sessionId>/transcript.jsonl` or the legacy flat
+ * layout `<sessions>/<workspace-hash>/<sessionId>.jsonl`. We deliberately do
+ * NOT reproduce SCode's fingerprint algorithm (that would duplicate engine-owned
+ * logic and drift): instead we probe the (usually single) partition dirs for
+ * both layouts. Bounded to two levels — no unbounded recursion.
+ */
 export async function findScodeSessionFile(workspace: string, sessionId: string): Promise<string | null> {
   const sessionsRoot = nodePath.join(workspace, '.scode', 'sessions');
-  const directCandidates = [nodePath.join(sessionsRoot, sessionId, 'session.jsonl'), nodePath.join(sessionsRoot, `${sessionId}.jsonl`)];
 
-  for (const candidate of directCandidates) {
-    try {
-      const stat = await fs.stat(candidate);
-      if (stat.isFile()) return candidate;
-    } catch {
-      // Try the next candidate.
+  // Probe both on-disk layouts directly under `root`.
+  const probe = async (root: string): Promise<string | null> => {
+    const candidates = [nodePath.join(root, sessionId, SCODE_TRANSCRIPT_FILE), nodePath.join(root, `${sessionId}.jsonl`)];
+    for (const candidate of candidates) {
+      const stat = await fs.stat(candidate).catch((): null => null);
+      if (stat?.isFile()) return candidate;
     }
-  }
-
-  let entries;
-  try {
-    entries = await fs.readdir(sessionsRoot, { withFileTypes: true });
-  } catch {
     return null;
-  }
+  };
 
-  const stack = entries.map((entry) => nodePath.join(sessionsRoot, entry.name));
-  while (stack.length > 0) {
-    const current = stack.pop()!;
-    let stat;
-    try {
-      stat = await fs.stat(current);
-    } catch {
-      continue;
-    }
+  // The transcript sits under a workspace-fingerprint partition dir; also probe
+  // the sessions root directly for robustness against an unpartitioned layout.
+  const direct = await probe(sessionsRoot);
+  if (direct) return direct;
 
-    if (stat.isDirectory()) {
-      const children = await fs.readdir(current, { withFileTypes: true }).catch((): Dirent[] => []);
-      for (const child of children) stack.push(nodePath.join(current, child.name));
-      continue;
-    }
-
-    if (stat.isFile() && nodePath.basename(current) === `${sessionId}.jsonl`) {
-      return current;
-    }
+  const partitions = await fs.readdir(sessionsRoot, { withFileTypes: true }).catch((): Dirent[] => []);
+  for (const entry of partitions) {
+    if (!entry.isDirectory()) continue;
+    const hit = await probe(nodePath.join(sessionsRoot, entry.name));
+    if (hit) return hit;
   }
 
   return null;

--- a/tests/unit/acpUsageHandling.test.ts
+++ b/tests/unit/acpUsageHandling.test.ts
@@ -145,24 +145,39 @@ describe('extractLatestScodeAssistantUsageFromJsonl', () => {
   });
 
   it('ignores compaction and tool entries without assistant message usage', () => {
-    const jsonl = [
-      JSON.stringify({ type: 'compaction', usage: { input_tokens: 1, output_tokens: 1 } }),
-      JSON.stringify({ message: { role: 'tool' }, type: 'message' }),
-    ].join('\n');
+    const jsonl = [JSON.stringify({ type: 'compaction', usage: { input_tokens: 1, output_tokens: 1 } }), JSON.stringify({ message: { role: 'tool' }, type: 'message' })].join('\n');
 
     expect(extractLatestScodeAssistantUsageFromJsonl(jsonl)).toBeNull();
   });
 });
 
 describe('findScodeSessionFile', () => {
-  it('finds nested SCode session files named after the ACP session id', async () => {
+  it('finds the legacy flat transcript under the workspace-fingerprint partition', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'scode-session-'));
     const sessionId = 'session-1781507199209-0';
-    const sessionDir = path.join(root, '.scode', 'sessions', 'f4975f5977d43141');
-    await mkdir(sessionDir, { recursive: true });
-    const sessionFile = path.join(sessionDir, `${sessionId}.jsonl`);
+    const partitionDir = path.join(root, '.scode', 'sessions', 'f4975f5977d43141');
+    await mkdir(partitionDir, { recursive: true });
+    const sessionFile = path.join(partitionDir, `${sessionId}.jsonl`);
     await writeFile(sessionFile, '{}\n');
 
     await expect(findScodeSessionFile(root, sessionId)).resolves.toBe(sessionFile);
+  });
+
+  it('finds the current per-session-directory transcript.jsonl under the partition', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'scode-session-'));
+    const sessionId = 'session-1781507199209-1';
+    const sessionDir = path.join(root, '.scode', 'sessions', 'f4975f5977d43141', sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    const sessionFile = path.join(sessionDir, 'transcript.jsonl');
+    await writeFile(sessionFile, '{}\n');
+
+    await expect(findScodeSessionFile(root, sessionId)).resolves.toBe(sessionFile);
+  });
+
+  it('returns null when no transcript exists for the session id', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'scode-session-'));
+    await mkdir(path.join(root, '.scode', 'sessions', 'f4975f5977d43141'), { recursive: true });
+
+    await expect(findScodeSessionFile(root, 'no-such-session')).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Problem
sudocode moved session persistence to a **per-session directory** (`<sessions>/<workspace-hash>/<sid>/transcript.jsonl`) in a newer build (sudocode #479). sudowork's usage **late-reconciliation** reader (`findScodeSessionFile`, used to recover post-timeout token usage from scode's persisted transcript) only matched the **legacy flat** `<sid>.jsonl` (+ a `session.jsonl` candidate scode **never** wrote). So on the next scode version bump, `findScodeSessionFile` would return null → post-timeout usage silently not recovered. Not broken today (pinned scode 0.1.24 is flat), but a **latent cross-repo break**.

## Fix (systematic, not a 4th candidate)
Rewrite `findScodeSessionFile` as a single **bounded, fingerprint-agnostic** resolver that probes **both** layouts (current `<sid>/transcript.jsonl` + legacy `<sid>.jsonl`) under each partition dir + the sessions root. Removes the two **dead** candidates and the **unbounded recursive walk** (two-level bounded scan — faster + correct). Deliberately does **not** reproduce sudocode's workspace-fingerprint algorithm (no duplicated engine logic / no DRY drift); scode's transcript stays the usage SSOT. The residual file-read coupling is a rare timeout-recovery path from scode's SSOT transcript; the eventual systematic removal is the sudowork `messages`→view collapse (tracked, nexus-2 #84).

## Tests
Cover the current per-session-dir layout, legacy flat layout, and not-found. tsc clean; eslint clean on changed files; 10/10 unit tests pass.