### PR TITLE
fix(nexus): self-heal stale plugin signature mismatch on startup

### DIFF
--- a/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -81,6 +81,8 @@ class DynamicNexusVfsService {
   private _stage: NexusVfsStage = 'idle';
   private _callbacks: NexusVfsCallback[] = [];
   private readonly isWindows = process.platform === 'win32';
+  /** Recent stderr from the last start() attempt — reset on each start(). */
+  private _lastStderr = '';
 
   get isRunning(): boolean {
     return this._running;
@@ -481,6 +483,7 @@ class DynamicNexusVfsService {
 
     fs.mkdirSync(this.getDaemonDataDir(), { recursive: true });
 
+    this._lastStderr = '';
     const spawnStart = Date.now();
     this.emit('starting', `Starting nexus-vfs on ${NEXUS_VFS_BIND_HOST}:${this._port}`);
     mainLog('NexusVfs', `Spawning: ${launchCommand.command} ${launchCommand.args.join(' ')}`);
@@ -504,6 +507,7 @@ class DynamicNexusVfsService {
     this.process.stderr?.on('data', (d: Buffer) => {
       const msg = d.toString().trim();
       if (!msg) return;
+      this._lastStderr += msg + '\n';
       // nexusd-cluster writes structured tracing logs (INFO/WARN) to stderr;
       // only escalate genuine errors.
       if (/\b(ERROR|CRITICAL)\b/.test(msg)) {
@@ -558,6 +562,37 @@ class DynamicNexusVfsService {
     // Fallback: clear anything still bound to the port.
     await this.forceKillProcessesOnPort(this._port || NEXUS_VFS_DEFAULT_PORT);
     this.process = null;
+  }
+
+  /**
+   * Self-heal after a startup failure: if the last stderr indicates a plugin
+   * signature mismatch (stale plugin vs. upgraded binary), purge the offending
+   * plugin files so the next install() re-downloads matching versions.
+   *
+   * Returns true if stale plugins were cleaned (caller should retry).
+   */
+  tryHealStalePlugins(): boolean {
+    if (!/signature did not verify|plugin.*failed to load/.test(this._lastStderr)) {
+      return false;
+    }
+    const pluginDir = this.getPluginDir();
+    if (!fs.existsSync(pluginDir)) return false;
+
+    let cleaned = false;
+    try {
+      for (const entry of fs.readdirSync(pluginDir)) {
+        if (entry.endsWith('.dylib') || entry.endsWith('.so') || entry.endsWith('.dll') || entry.endsWith('.sig') || (entry.startsWith('.nexus-') && entry.endsWith('-ready'))) {
+          fs.unlinkSync(path.join(pluginDir, entry));
+          cleaned = true;
+        }
+      }
+      if (cleaned) {
+        mainWarn('NexusVfs', 'Purged stale plugins after signature mismatch — will re-download on next install');
+      }
+    } catch (err) {
+      mainWarn('NexusVfs', `Failed to purge stale plugins: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return cleaned;
   }
 
   async installAndStart(onSetupStatus?: NexusVfsCallback): Promise<void> {

--- a/src/process/services/serviceManager/ServiceManager.ts
+++ b/src/process/services/serviceManager/ServiceManager.ts
@@ -250,6 +250,12 @@ export class ServiceManager {
 
           initStatusManager.addLog(`↻ Nexus 启动失败，准备重试（第 ${attempt + 1}/${attempts} 次）...`);
           await dynamicNexusVfsService.stop().catch(() => {});
+          // Self-heal: purge stale plugins if the failure was a signature
+          // mismatch (binary upgraded but old plugins remained). The next
+          // iteration's install() will re-download matching versions.
+          if (dynamicNexusVfsService.tryHealStalePlugins()) {
+            initStatusManager.addLog('↻ 已清理过期插件，将重新下载匹配版本');
+          }
           await this.killProcessesOnPort(12022, 'Nexus');
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }


### PR DESCRIPTION
## Summary
- When nexusd-cluster exits with a plugin signature verification error (binary upgraded but old plugins remain), automatically purge stale plugin files between retries
- Next retry boots without `--plugin-dir` (graceful degradation) — app enters main UI instead of stuck at init 0%
- Plugins re-download on next full install cycle

## Root cause
After nexus-vfs binary upgrade (e.g. 0.1.x → 0.6.0), old plugins in `~/.nexus-vfs/plugins/` have signatures signed with the old key. The new binary rejects them: `signature did not verify against any of 2 trusted key(s)`, exits with code 1, and all 3 retries fail identically.

## Changes
- `DynamicNexusVfsService`: buffer stderr per start attempt; new `tryHealStalePlugins()` detects signature errors and purges `.dylib/.so/.dll/.sig/marker` files
- `ServiceManager`: call `tryHealStalePlugins()` between retry attempts

## Test plan
- [x] Manual: verified on local machine — stale plugins caused 0% init failure, after fix app self-heals on retry 2 and boots to main UI