### PR TITLE
fix(scode): enable Anthropic prompt caching for proxy models

### DIFF
--- a/src/common/scodeConfig.ts
+++ b/src/common/scodeConfig.ts
@@ -130,14 +130,25 @@ function isCustomApiKeyModelEntry(entry: ScodeModelEntry | undefined, providerId
 }
 
 export function buildSudorouterModelEntry(modelId: string, alias = modelId): ScodeModelEntry {
-  return {
+  // For proxy (sudorouter) models, omit the `api` field so scode dynamically
+  // resolves the API format from sudorouter's endpoint_type via model capabilities
+  // SSOT. Hardcoding `api: "openai-completions"` here previously forced all
+  // models through the OpenAI-compat provider — breaking Anthropic prompt
+  // caching (cache_creation_input_tokens / cache_read_input_tokens = 0).
+  const entry: ScodeModelEntry = {
     alias,
     name: alias,
     input: modelInputForModelId(modelId),
     providers: {
-      proxy: { provider: SUDOROUTER_PROVIDER_ID, model: modelId, api: getScodeModelApiType(modelId) },
+      proxy: { provider: SUDOROUTER_PROVIDER_ID, model: modelId },
     },
   };
+  // Only set explicit api for models that need a non-default wire format
+  // (e.g. gpt-5.x needs openai-responses instead of openai-completions).
+  if (shouldUseOpenAIResponsesApi(modelId)) {
+    entry.providers!.proxy!.api = OPENAI_RESPONSES_API;
+  }
+  return entry;
 }
 
 export function addScodeAutoModel(models: Record<string, ScodeModelEntry>, modelIds: string[], pricingItems?: SpecificPricingItem[], explicitAutoModelId?: string): string | null {


### PR DESCRIPTION
## Summary
- Omit hardcoded `api: 'openai-completions'` from sudorouter proxy model entries in sudocode.json
- Let scode dynamically resolve API format from sudorouter's `endpoint_type` via model capabilities SSOT
- Only gpt-5.x models retain explicit `api: 'openai-responses'` override

## Root cause
`buildSudorouterModelEntry` was writing `api: "openai-completions"` for all proxy models (including Claude). In scode's `resolve_api_format`, an explicit `api` field takes priority over the dynamic capabilities lookup. This forced all Claude models through the OpenAI-compat provider, which:
1. Doesn't send `cache_control: {type: "ephemeral"}` on system/message blocks
2. Hardcodes `cache_creation_input_tokens` to 0 in response parsing

Result: `/cost` shows `Cache create = 0, Cache read = 0` for all users on `auto` model.

## Fix
Remove the `api` field from proxy model entries. scode's `resolve_api_format` then falls through to the capabilities SSOT path (line 463-468 in registry.rs), which correctly returns `ApiFormat::AnthropicMessages` for Claude models based on sudorouter's `endpoint_types: ["anthropic", "openai"]`.

## Test plan
- [x] `bunx tsc --noEmit` — no type errors
- [ ] Start scode with proxy auth, send message, `/cost` should show non-zero Cache create/read