### PR TITLE
feat(acp): read scode conversation history from the transcript (messages→view, nexus-2 #84)

### DIFF
--- a/src/process/providers/LocalConversationProvider.ts
+++ b/src/process/providers/LocalConversationProvider.ts
@@ -205,6 +205,7 @@ export class LocalConversationProvider implements IConversationProvider {
     const content = await fs.readFile(file, 'utf-8').catch((): null => null);
     if (content === null) return null;
     const all = transcriptToMessages(content, conversationId);
+    mainLog('LocalProvider', `scode transcript SSOT: projected ${all.length} message(s) for ${conversationId} (backend=scode)`);
     const start = page * pageSize;
     return all.slice(start, start + pageSize);
   }

--- a/src/process/providers/LocalConversationProvider.ts
+++ b/src/process/providers/LocalConversationProvider.ts
@@ -197,7 +197,7 @@ export class LocalConversationProvider implements IConversationProvider {
    * no session id/workspace, or no transcript on disk yet).
    */
   private async projectScodeTranscript(conversationId: string, db: ReturnType<typeof getDatabase>, page: number, pageSize: number): Promise<TMessage[] | null> {
-    if (WorkerManage.getTaskById(conversationId)) return null; // active turn → DB path (in-flight ids align; a live turn drops transcript history otherwise)
+    if (WorkerManage.getTaskById(conversationId)) return null; // active turn → DB path (live in-flight ids align)
     const extra = db.getConversation(conversationId).data?.extra as { backend?: string; workspace?: string; acpSessionId?: string } | undefined;
     if (extra?.backend !== 'scode' || !extra.workspace || !extra.acpSessionId) return null;
     const file = await findScodeSessionFile(extra.workspace, extra.acpSessionId);

--- a/src/process/providers/LocalConversationProvider.ts
+++ b/src/process/providers/LocalConversationProvider.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs/promises';
 import type { TChatConversation } from '@/common/storage';
 import type { TMessage } from '@/common/chatLib';
 import type { ICreateConversationParams, IBridgeResponse, ISendMessageParams } from '@/common/ipcBridge';
 import { getDatabase } from '@process/database';
+import { findScodeSessionFile } from '@process/task/acpUsageReconciliation';
+import { transcriptToMessages } from '@process/task/acp/transcriptProjection';
 import { ConversationService } from '@process/services/conversationService';
 import WorkerManage from '@process/WorkerManage';
 import { ProcessChat } from '@process/initStorage';
@@ -173,12 +176,37 @@ export class LocalConversationProvider implements IConversationProvider {
   async getMessages(conversationId: string, page = 0, pageSize = 10000): Promise<TMessage[]> {
     try {
       const db = getDatabase();
+      // For an INACTIVE scode conversation, scode's transcript is the SSOT — read
+      // history from it rather than the duplicate `messages` table (nexus-2 #84).
+      // An active turn keeps the DB path: this projection synthesizes ids that
+      // would not dedup against the live in-flight stream. Non-scode / no-session
+      // / no-transcript conversations fall through to the table unchanged.
+      const projected = await this.projectScodeTranscript(conversationId, db, page, pageSize);
+      if (projected) return projected;
       const result = db.getConversationMessages(conversationId, page, pageSize);
       return result.data || [];
     } catch (error) {
       mainError('LocalProvider', 'Failed to get messages:', error);
       return [];
     }
+  }
+
+  /**
+   * Rebuild an inactive scode conversation's messages from its transcript, or
+   * `null` to fall back to the `messages` table (active turn, non-scode backend,
+   * no session id/workspace, or no transcript on disk yet).
+   */
+  private async projectScodeTranscript(conversationId: string, db: ReturnType<typeof getDatabase>, page: number, pageSize: number): Promise<TMessage[] | null> {
+    if (WorkerManage.getTaskById(conversationId)) return null; // active turn → DB path (in-flight ids align)
+    const extra = db.getConversation(conversationId).data?.extra as { backend?: string; workspace?: string; acpSessionId?: string } | undefined;
+    if (extra?.backend !== 'scode' || !extra.workspace || !extra.acpSessionId) return null;
+    const file = await findScodeSessionFile(extra.workspace, extra.acpSessionId);
+    if (!file) return null;
+    const content = await fs.readFile(file, 'utf-8').catch((): null => null);
+    if (content === null) return null;
+    const all = transcriptToMessages(content, conversationId);
+    const start = page * pageSize;
+    return all.slice(start, start + pageSize);
   }
 
   async sendMessage(params: ISendMessageParams): Promise<IBridgeResponse> {

--- a/src/process/providers/LocalConversationProvider.ts
+++ b/src/process/providers/LocalConversationProvider.ts
@@ -197,7 +197,7 @@ export class LocalConversationProvider implements IConversationProvider {
    * no session id/workspace, or no transcript on disk yet).
    */
   private async projectScodeTranscript(conversationId: string, db: ReturnType<typeof getDatabase>, page: number, pageSize: number): Promise<TMessage[] | null> {
-    if (WorkerManage.getTaskById(conversationId)) return null; // active turn → DB path (in-flight ids align)
+    if (WorkerManage.getTaskById(conversationId)) return null; // active turn → DB path (in-flight ids align; a live turn drops transcript history otherwise)
     const extra = db.getConversation(conversationId).data?.extra as { backend?: string; workspace?: string; acpSessionId?: string } | undefined;
     if (extra?.backend !== 'scode' || !extra.workspace || !extra.acpSessionId) return null;
     const file = await findScodeSessionFile(extra.workspace, extra.acpSessionId);

--- a/src/process/task/acp/transcriptProjection.ts
+++ b/src/process/task/acp/transcriptProjection.ts
@@ -20,8 +20,9 @@ import { normalizeScodeUsageForMessage } from '@/process/task/acpUsageReconcilia
  * `tool_use.input` is a full JSON string (verified lossless), so — exactly like
  * Claude Code — the rich rendering is DERIVED here from the structured
  * input/output rather than read back from a pre-computed copy: a str-replace
- * edit (`old_string`+`new_string`) becomes a `diff` content item, everything
- * else falls back to its raw input + text output (the generic tool view). Live
+ * edit (`old_string`+`new_string`) becomes a `diff` content item, a `thinking`
+ * block becomes a collapsible `thought`, everything else falls back to its raw
+ * input + text output (the generic tool view). Live
  * rendering is unchanged (it replays the ACP stream directly, not this
  * projection). The transcript carries no per-message id, so ids are synthesized
  * deterministically (stable across reloads of the same transcript).
@@ -43,6 +44,24 @@ function asRecord(value: unknown): JsonRecord | undefined {
 
 function asString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Recover the user's actual words from a transcript text block. scode persists
+ * the whole prompt sudowork sent — sudowork wraps the message as
+ * `[Assistant Rules …]\n<instructions>\n\n[User Request]\n<message>` (see
+ * `agentUtils` build fns) and prepends `<system-reminder>` blocks — so a
+ * persisted "user message" is mostly sudowork's own injected context, not the
+ * user's words. Take everything after the last `[User Request]\n` marker
+ * (sudowork's own format, so it's reliable), then drop any `<system-reminder>`
+ * blocks. Assistant/tool text has neither marker and passes through unchanged.
+ * Empty result ⇒ the block was pure injected context and the message is dropped.
+ */
+const USER_REQUEST_MARKER = '[User Request]\n';
+function stripInjectedContext(text: string): string {
+  const at = text.lastIndexOf(USER_REQUEST_MARKER);
+  const body = at >= 0 ? text.slice(at + USER_REQUEST_MARKER.length) : text;
+  return body.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '').trim();
 }
 
 /** scode stores tool_use.input as a string; surface parsed JSON when it is one. */
@@ -138,8 +157,8 @@ export function transcriptToMessages(jsonl: string, conversationId: string): TMe
       if (!block) continue;
 
       if (block.type === 'text') {
-        const text = asString(block.text);
-        if (!text) continue;
+        const text = stripInjectedContext(asString(block.text));
+        if (!text) continue; // block was pure injected <system-reminder> context
         messages.push({
           id: nextId(),
           type: 'text',
@@ -148,6 +167,21 @@ export function transcriptToMessages(jsonl: string, conversationId: string): TMe
           conversation_id: conversationId,
           ...stamp(),
           content: { content: text, ...(usage ? { tokenUsage: usage } : {}) },
+        });
+      } else if (block.type === 'thinking') {
+        // scode persists reasoning as `{ type:'thinking', thinking }`. Project it
+        // to the renderer's collapsible `thought` bubble (first line → header),
+        // so reconstructed history keeps the thinking the live stream showed.
+        const thinking = asString(block.thinking).trim();
+        if (!thinking) continue;
+        messages.push({
+          id: nextId(),
+          type: 'thought',
+          msg_id: nextId(),
+          position: 'left',
+          conversation_id: conversationId,
+          ...stamp(),
+          content: { subject: thinking.split('\n', 1)[0].slice(0, 60), description: thinking },
         });
       } else if (block.type === 'tool_use') {
         const toolCallId = asString(block.id) || nextId();
@@ -192,7 +226,7 @@ export function transcriptToMessages(jsonl: string, conversationId: string): TMe
           });
         }
       }
-      // unknown block types (thinking, images, …) are dropped from the historical view.
+      // unknown block types (images, …) are dropped from the historical view.
     }
   }
 

--- a/src/process/task/acp/transcriptProjection.ts
+++ b/src/process/task/acp/transcriptProjection.ts
@@ -97,10 +97,17 @@ export function transcriptToMessages(jsonl: string, conversationId: string): TMe
   let seq = 0;
   const nextId = (): string => `scode-${conversationId}-${seq++}`;
   let sessionId = conversationId;
+  // Reconstructed history is complete; the transcript has no per-message id or
+  // timestamp, so synthesize a monotonic `createdAt` + a terminal `status` so
+  // the renderer's list hook orders + keys these like DB rows (without them the
+  // list does not render). Base off `session_meta.created_at_ms` when present.
+  let createdBase = 0;
+  let order = 0;
+  const stamp = (): { status: 'finish'; createdAt: number } => ({ status: 'finish', createdAt: createdBase + order++ });
 
   const pushToolCall = (msgId: string, update: ToolCallUpdate): void => {
     toolUpdates.set(update.update.toolCallId, update);
-    messages.push({ id: nextId(), type: 'acp_tool_call', msg_id: msgId, position: 'left', conversation_id: conversationId, content: update });
+    messages.push({ id: nextId(), type: 'acp_tool_call', msg_id: msgId, position: 'left', conversation_id: conversationId, content: update, ...stamp() });
   };
 
   for (const line of jsonl.split('\n')) {
@@ -115,6 +122,7 @@ export function transcriptToMessages(jsonl: string, conversationId: string): TMe
     }
     if (entry.type === 'session_meta') {
       sessionId = asString(entry.session_id) || sessionId;
+      if (typeof entry.created_at_ms === 'number') createdBase = entry.created_at_ms;
       continue;
     }
 
@@ -138,6 +146,7 @@ export function transcriptToMessages(jsonl: string, conversationId: string): TMe
           msg_id: nextId(),
           position: role === 'user' ? 'right' : 'left',
           conversation_id: conversationId,
+          ...stamp(),
           content: { content: text, ...(usage ? { tokenUsage: usage } : {}) },
         });
       } else if (block.type === 'tool_use') {

--- a/src/process/task/acp/transcriptProjection.ts
+++ b/src/process/task/acp/transcriptProjection.ts
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TMessage } from '@/common/chatLib';
+import type { ToolCallContentItem, ToolCallUpdate } from '@/types/acpTypes';
+import { normalizeScodeUsageForMessage } from '@/process/task/acpUsageReconciliation';
+
+/**
+ * Project scode's persisted transcript (`<sessions-dir>/<sid>/transcript.jsonl`)
+ * into the renderer's `TMessage[]`, so sudowork can treat the transcript as the
+ * single SSOT for a scode conversation's history instead of keeping a full copy
+ * in the `messages` table (nexus-2 #84).
+ *
+ * The transcript is scode's raw record: a `session_meta` entry then `message`
+ * entries `{ role, blocks[], model?, usage? }` where a block is `text{ text }` ·
+ * `tool_use{ id, name, input }` · `tool_result{ tool_use_id, output, is_error }`.
+ * `tool_use.input` is a full JSON string (verified lossless), so — exactly like
+ * Claude Code — the rich rendering is DERIVED here from the structured
+ * input/output rather than read back from a pre-computed copy: a str-replace
+ * edit (`old_string`+`new_string`) becomes a `diff` content item, everything
+ * else falls back to its raw input + text output (the generic tool view). Live
+ * rendering is unchanged (it replays the ACP stream directly, not this
+ * projection). The transcript carries no per-message id, so ids are synthesized
+ * deterministically (stable across reloads of the same transcript).
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+interface TranscriptMessage {
+  role?: string;
+  blocks?: JsonRecord[];
+  model?: string;
+  usage?: unknown;
+  _meta?: unknown;
+}
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as JsonRecord) : undefined;
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** scode stores tool_use.input as a string; surface parsed JSON when it is one. */
+function parseRawInput(input: unknown): Record<string, unknown> | undefined {
+  if (input && typeof input === 'object' && !Array.isArray(input)) return input as Record<string, unknown>;
+  if (typeof input !== 'string' || input.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(input);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : { value: parsed };
+  } catch {
+    return { input };
+  }
+}
+
+function textContentItem(output: string): ToolCallContentItem[] {
+  return [{ type: 'content', content: { type: 'text', text: output } }];
+}
+
+/**
+ * A str-replace edit (`old_string`+`new_string`) → the `diff` content item the
+ * renderer turns into a file-diff panel. Detected by SCHEMA, not tool name, so
+ * it survives tool renames. Field aliases match scode's `file_path`/`filePath`/
+ * `path` (see `extract_file_path_from_tool_input` in sudocode). `null` when the
+ * input is not an edit.
+ */
+function editDiffContent(input: Record<string, unknown> | undefined): ToolCallContentItem[] | null {
+  if (!input) return null;
+  const oldText = input.old_string;
+  const newText = input.new_string;
+  if (typeof oldText !== 'string' || typeof newText !== 'string') return null;
+  return [{ type: 'diff', path: asString(input.file_path ?? input.filePath ?? input.path), oldText, newText }];
+}
+
+function deriveKind(name: string, isEdit: boolean): ToolCallUpdate['update']['kind'] {
+  if (isEdit) return 'edit';
+  const n = name.toLowerCase();
+  if (/write|create|patch|multi_?edit/.test(n)) return 'edit';
+  if (/read|glob|grep|search|list|^ls$|cat|find/.test(n)) return 'read';
+  return 'execute';
+}
+
+/**
+ * Parse a transcript's JSONL into `TMessage[]`. Skips `session_meta` and any
+ * malformed line. A `tool_result` is folded into the `acp_tool_call` emitted for
+ * its `tool_use` (matched by id, by mutating the shared update object), so a
+ * tool call surfaces as one message with its rich view + terminal status.
+ */
+export function transcriptToMessages(jsonl: string, conversationId: string): TMessage[] {
+  const messages: TMessage[] = [];
+  // toolCallId → the update object already pushed, so a later tool_result completes it.
+  const toolUpdates = new Map<string, ToolCallUpdate>();
+  let seq = 0;
+  const nextId = (): string => `scode-${conversationId}-${seq++}`;
+  let sessionId = conversationId;
+
+  const pushToolCall = (msgId: string, update: ToolCallUpdate): void => {
+    toolUpdates.set(update.update.toolCallId, update);
+    messages.push({ id: nextId(), type: 'acp_tool_call', msg_id: msgId, position: 'left', conversation_id: conversationId, content: update });
+  };
+
+  for (const line of jsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let entry: JsonRecord;
+    try {
+      entry = JSON.parse(trimmed) as JsonRecord;
+    } catch {
+      continue; // partially-written / malformed line
+    }
+    if (entry.type === 'session_meta') {
+      sessionId = asString(entry.session_id) || sessionId;
+      continue;
+    }
+
+    const message = (asRecord(entry.message) ?? entry) as TranscriptMessage;
+    const role = message.role;
+    if (role !== 'user' && role !== 'assistant' && role !== 'tool') continue;
+
+    const blocks = Array.isArray(message.blocks) ? message.blocks : [];
+    const usage = role === 'assistant' ? normalizeScodeUsageForMessage(message.usage, message._meta ?? entry._meta) : null;
+
+    for (const rawBlock of blocks) {
+      const block = asRecord(rawBlock);
+      if (!block) continue;
+
+      if (block.type === 'text') {
+        const text = asString(block.text);
+        if (!text) continue;
+        messages.push({
+          id: nextId(),
+          type: 'text',
+          msg_id: nextId(),
+          position: role === 'user' ? 'right' : 'left',
+          conversation_id: conversationId,
+          content: { content: text, ...(usage ? { tokenUsage: usage } : {}) },
+        });
+      } else if (block.type === 'tool_use') {
+        const toolCallId = asString(block.id) || nextId();
+        const rawInput = parseRawInput(block.input);
+        const diff = editDiffContent(rawInput);
+        pushToolCall(toolCallId, {
+          sessionId,
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId,
+            status: 'pending',
+            title: asString(block.name) || 'tool',
+            kind: deriveKind(asString(block.name), diff !== null),
+            ...(rawInput ? { rawInput } : {}),
+            ...(diff ? { content: diff } : {}),
+          },
+        });
+      } else if (block.type === 'tool_result') {
+        const toolUseId = asString(block.tool_use_id);
+        const output = asString(block.output);
+        const isError = block.is_error === true;
+        const existing = toolUseId ? toolUpdates.get(toolUseId) : undefined;
+        if (existing) {
+          existing.update.status = isError ? 'failed' : 'completed';
+          // Keep a derived diff as the primary view; add the output text only when
+          // there's nothing yet, or when it's an error the user must see.
+          if (output && (isError || !existing.update.content?.length)) {
+            existing.update.content = [...(existing.update.content ?? []), ...textContentItem(output)];
+          }
+        } else {
+          // Orphan result (its tool_use is outside this transcript slice).
+          pushToolCall(toolUseId || nextId(), {
+            sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId: toolUseId || nextId(),
+              status: isError ? 'failed' : 'completed',
+              title: asString(block.tool_name) || 'tool',
+              kind: 'execute',
+              ...(output ? { content: textContentItem(output) } : {}),
+            },
+          });
+        }
+      }
+      // unknown block types (thinking, images, …) are dropped from the historical view.
+    }
+  }
+
+  return messages;
+}

--- a/tests/unit/transcriptProjection.test.ts
+++ b/tests/unit/transcriptProjection.test.ts
@@ -102,6 +102,30 @@ describe('transcriptToMessages', () => {
     expect(update.rawInput).toEqual({ input: 'not json' });
   });
 
+  it('projects a thinking block to a collapsible thought (header = first line)', () => {
+    const out = transcriptToMessages(jsonl({ type: 'message', message: { role: 'assistant', blocks: [{ type: 'thinking', thinking: 'first line of reasoning\nmore detail here' }] } }), 'c1');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ type: 'thought', position: 'left', content: { subject: 'first line of reasoning', description: 'first line of reasoning\nmore detail here' } });
+  });
+
+  it('preserves order across a multi-block assistant turn (thinking, text, tool_use)', () => {
+    const out = transcriptToMessages(
+      jsonl({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          blocks: [
+            { type: 'thinking', thinking: 'hmm' },
+            { type: 'text', text: 'the answer' },
+            { type: 'tool_use', id: 'z', name: 'ls', input: '{}' },
+          ],
+        },
+      }),
+      'c1'
+    );
+    expect(out.map((m) => m.type)).toEqual(['thought', 'text', 'acp_tool_call']);
+  });
+
   it('preserves order across a multi-block assistant turn (text then tool_use)', () => {
     const out = transcriptToMessages(
       jsonl({
@@ -133,5 +157,17 @@ describe('transcriptToMessages', () => {
 
   it('returns [] for an empty transcript', () => {
     expect(transcriptToMessages('', 'c1')).toEqual([]);
+  });
+
+  it('recovers the real user message from sudowork-injected prompt context', () => {
+    const wrapped = '<system-reminder>语言约定…</system-reminder>\n[Assistant Rules - You MUST follow these instructions]\n[File Intent Marking …]\n\n[User Request]\nwhat is 2+2?';
+    const out = transcriptToMessages(jsonl({ type: 'message', message: { role: 'user', blocks: [{ type: 'text', text: wrapped }] } }), 'c1');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ type: 'text', position: 'right', content: { content: 'what is 2+2?' } });
+  });
+
+  it('drops a user block that is pure injected context (no real message)', () => {
+    const out = transcriptToMessages(jsonl({ type: 'message', message: { role: 'user', blocks: [{ type: 'text', text: '<system-reminder>Today is X</system-reminder>' }] } }), 'c1');
+    expect(out).toEqual([]);
   });
 });

--- a/tests/unit/transcriptProjection.test.ts
+++ b/tests/unit/transcriptProjection.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ToolCallUpdate } from '@/types/acpTypes';
+import { transcriptToMessages } from '@/process/task/acp/transcriptProjection';
+
+// Fixture shaped exactly like scode's on-disk transcript.jsonl (verified against
+// real ~/.scode sessions): session_meta + user/assistant/tool messages whose
+// blocks are text / tool_use / tool_result.
+function jsonl(...entries: unknown[]): string {
+  return entries.map((e) => JSON.stringify(e)).join('\n');
+}
+
+const META = { type: 'session_meta', session_id: 's1', model: 'sonnet', workspace_root: '/w', version: 1, created_at_ms: 1, updated_at_ms: 2 };
+
+describe('transcriptToMessages', () => {
+  it('skips session_meta and projects a user text turn to a right-positioned bubble', () => {
+    const out = transcriptToMessages(jsonl(META, { type: 'message', message: { role: 'user', blocks: [{ type: 'text', text: 'hi there' }] } }), 'c1');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ type: 'text', position: 'right', conversation_id: 'c1', content: { content: 'hi there' } });
+  });
+
+  it('projects an assistant text turn to a left bubble carrying normalized token usage', () => {
+    const out = transcriptToMessages(
+      jsonl({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          model: 'sonnet',
+          blocks: [{ type: 'text', text: 'the answer' }],
+          usage: { input_tokens: 10, output_tokens: 5, cost_units: 100, cost_currency: 'sudo_point' },
+        },
+      }),
+      'c1'
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      type: 'text',
+      position: 'left',
+      content: { content: 'the answer', tokenUsage: { totalTokens: 15, inputTokens: 10, outputTokens: 5, costUnits: 100, costCurrency: 'sudo_point' } },
+    });
+  });
+
+  it('pairs a tool_use with its later tool_result into one completed acp_tool_call', () => {
+    const out = transcriptToMessages(
+      jsonl({ type: 'message', message: { role: 'assistant', blocks: [{ type: 'tool_use', id: 'tc1', name: 'read_file', input: '{"path":"a.ts"}' }] } }, { type: 'message', message: { role: 'tool', blocks: [{ type: 'tool_result', tool_use_id: 'tc1', output: 'file contents', is_error: false }] } }),
+      'c1'
+    );
+    expect(out).toHaveLength(1);
+    const msg = out[0];
+    expect(msg.type).toBe('acp_tool_call');
+    expect(msg.msg_id).toBe('tc1');
+    const update = (msg.content as ToolCallUpdate).update;
+    expect(update).toMatchObject({ toolCallId: 'tc1', title: 'read_file', status: 'completed', kind: 'read', rawInput: { path: 'a.ts' } });
+    expect(update.content).toEqual([{ type: 'content', content: { type: 'text', text: 'file contents' } }]);
+  });
+
+  it('derives a diff content item + edit kind from a str-replace edit (CC-style, by schema not name)', () => {
+    const out = transcriptToMessages(
+      jsonl(
+        { type: 'message', message: { role: 'assistant', blocks: [{ type: 'tool_use', id: 'e1', name: 'apply_patch', input: JSON.stringify({ file_path: '/w/a.ts', old_string: 'const a = 1', new_string: 'const a = 2' }) }] } },
+        { type: 'message', message: { role: 'tool', blocks: [{ type: 'tool_result', tool_use_id: 'e1', output: 'edited', is_error: false }] } }
+      ),
+      'c1'
+    );
+    expect(out).toHaveLength(1);
+    const update = (out[0].content as ToolCallUpdate).update;
+    expect(update.kind).toBe('edit');
+    // the diff is the primary view; the "edited" success text is NOT appended over it
+    expect(update.content).toEqual([{ type: 'diff', path: '/w/a.ts', oldText: 'const a = 1', newText: 'const a = 2' }]);
+  });
+
+  it('appends the error text over a diff when an edit fails', () => {
+    const out = transcriptToMessages(
+      jsonl(
+        { type: 'message', message: { role: 'assistant', blocks: [{ type: 'tool_use', id: 'e2', name: 'edit', input: JSON.stringify({ path: 'a.ts', old_string: 'x', new_string: 'y' }) }] } },
+        { type: 'message', message: { role: 'tool', blocks: [{ type: 'tool_result', tool_use_id: 'e2', output: 'no match for old_string', is_error: true }] } }
+      ),
+      'c1'
+    );
+    const update = (out[0].content as ToolCallUpdate).update;
+    expect(update.status).toBe('failed');
+    expect(update.content).toEqual([
+      { type: 'diff', path: 'a.ts', oldText: 'x', newText: 'y' },
+      { type: 'content', content: { type: 'text', text: 'no match for old_string' } },
+    ]);
+  });
+
+  it('marks a tool_result with is_error as failed', () => {
+    const out = transcriptToMessages(
+      jsonl({ type: 'message', message: { role: 'assistant', blocks: [{ type: 'tool_use', id: 'tc2', name: 'bash', input: 'not json' }] } }, { type: 'message', message: { role: 'tool', blocks: [{ type: 'tool_result', tool_use_id: 'tc2', output: 'boom', is_error: true }] } }),
+      'c1'
+    );
+    expect(out).toHaveLength(1);
+    const update = (out[0].content as ToolCallUpdate).update;
+    expect(update.status).toBe('failed');
+    // non-JSON input is preserved verbatim under `input`
+    expect(update.rawInput).toEqual({ input: 'not json' });
+  });
+
+  it('preserves order across a multi-block assistant turn (text then tool_use)', () => {
+    const out = transcriptToMessages(
+      jsonl({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          blocks: [
+            { type: 'text', text: 'let me check' },
+            { type: 'tool_use', id: 'tc3', name: 'ls', input: '{}' },
+          ],
+        },
+      }),
+      'c1'
+    );
+    expect(out.map((m) => m.type)).toEqual(['text', 'acp_tool_call']);
+    expect((out[1].content as ToolCallUpdate).update.status).toBe('pending'); // no result yet
+  });
+
+  it('emits deterministic ids stable across two runs of the same transcript', () => {
+    const t = jsonl(META, { type: 'message', message: { role: 'user', blocks: [{ type: 'text', text: 'x' }] } });
+    expect(transcriptToMessages(t, 'c1').map((m) => m.id)).toEqual(transcriptToMessages(t, 'c1').map((m) => m.id));
+  });
+
+  it('handles the flat (unwrapped) record shape and skips malformed lines', () => {
+    const out = transcriptToMessages([JSON.stringify({ role: 'user', blocks: [{ type: 'text', text: 'flat' }] }), 'not json', ''].join('\n'), 'c1');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ type: 'text', content: { content: 'flat' } });
+  });
+
+  it('returns [] for an empty transcript', () => {
+    expect(transcriptToMessages('', 'c1')).toEqual([]);
+  });
+});

--- a/tests/unit/transcriptRender.dom.test.tsx
+++ b/tests/unit/transcriptRender.dom.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { IMessageAcpToolCall } from '@/common/chatLib';
+import MessageAcpToolCall from '@/renderer/messages/acp/MessageAcpToolCall';
+import { transcriptToMessages } from '@/process/task/acp/transcriptProjection';
+
+// The diff preview click-handlers hook reaches into the app's PreviewProvider —
+// orthogonal to the diff DISPLAY we're verifying, so stub it.
+vi.mock('@/renderer/hooks/useDiffPreviewHandlers', () => ({
+  useDiffPreviewHandlers: () => ({ handleFileClick: () => {}, handleDiffClick: () => {} }),
+}));
+// MarkdownView renders nothing in jsdom; pass its text through so we can assert
+// the tool output actually reaches the markdown renderer.
+vi.mock('@/renderer/components/Markdown', () => ({ default: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
+
+// Render transcript-reconstructed tool calls through the REAL renderer to prove
+// the projection produces exactly the ToolCallUpdate shape the UI consumes —
+// the render-side of the messages→view collapse (nexus-2 #84), headless.
+function jsonl(...entries: unknown[]): string {
+  return entries.map((e) => JSON.stringify(e)).join('\n');
+}
+
+function firstToolCall(t: string): IMessageAcpToolCall {
+  const msgs = transcriptToMessages(t, 'c1');
+  const tc = msgs.find((m) => m.type === 'acp_tool_call');
+  if (!tc) throw new Error('no tool call projected');
+  return tc as IMessageAcpToolCall;
+}
+
+describe('reconstructed tool call renders in the real MessageAcpToolCall', () => {
+  it('renders a bash tool call: title, completed status, and its output', () => {
+    const tc = firstToolCall(
+      jsonl(
+        { type: 'message', message: { role: 'assistant', blocks: [{ type: 'tool_use', id: 't1', name: 'bash', input: JSON.stringify({ command: 'ls -la' }) }] } },
+        { type: 'message', message: { role: 'tool', blocks: [{ type: 'tool_result', tool_use_id: 't1', output: 'total 0 done-output', is_error: false }] } }
+      )
+    );
+    const { container } = render(<MessageAcpToolCall message={tc} />);
+    const text = container.textContent ?? '';
+    expect(screen.getByText('bash')).toBeTruthy(); // title
+    expect(screen.getByText('completed')).toBeTruthy(); // status tag
+    expect(text).toContain('done-output'); // tool output (MarkdownView splits nodes)
+    expect(text).toContain('ls -la'); // rawInput command
+  });
+
+  it('renders a str-replace edit as a file diff (the derived-at-render path)', () => {
+    const tc = firstToolCall(jsonl({ type: 'message', message: { role: 'assistant', blocks: [{ type: 'tool_use', id: 't2', name: 'apply_patch', input: JSON.stringify({ file_path: '/w/hello.ts', old_string: 'ALPHA_was_here', new_string: 'BETA_is_here' }) }] } }));
+    const { container } = render(<MessageAcpToolCall message={tc} />);
+    const text = container.textContent ?? '';
+    // the derived diff panel surfaces the file name + both sides of the change
+    expect(text).toContain('hello.ts');
+    expect(text).toContain('ALPHA_was_here');
+    expect(text).toContain('BETA_is_here');
+  });
+});


### PR DESCRIPTION
Read side of the `messages`→transcript collapse (nexus-2 #84): for a scode conversation, `<sessions-dir>/<sid>/transcript.jsonl` becomes the read-authority for conversation **content**.

## What it does
- **`transcriptToMessages`** — projects scode's transcript into `TMessage[]` the **CC way**: transcript is SSOT, rich rendering **derived** at projection time (str-replace edits → diff panels, detected by *schema* not tool name; `thinking` → collapsible `thought`; text/tokenUsage reconstructed). No scode change; renderer untouched.
- **User-message recovery** — scode persists sudowork's *whole* injected prompt as the user turn (`[Assistant Rules]` / `[User Request]` / `<system-reminder>` wrapper). The projection strips it back to the user's actual words via the `[User Request]` delimiter (sudowork's own format).
- **`LocalConversationProvider.getMessages`** — for an **inactive** scode conversation, rebuilds history from the transcript (via `findScodeSessionFile`) instead of the `messages` table. Falls back to the table when a turn is active, the backend isn't scode, or no transcript exists.

## Verification
- **Unit**: 14 tests for the transform (+ real on-disk transcripts).
- **Component render (jsdom)**: through the real `MessageAcpToolCall` — bash tool call + a derived file-diff panel.
- **Full GUI e2e** (ai-dev-browser vs the dev app): inactive scode conversations reconstruct history from the transcript and render correctly — text, tool calls, thinking, timestamps, and **clean user messages** (injected context stripped). Log-proven transcript-sourced.

## Scope — why this is read-only (corrected after investigation)
Comparing a real conversation's DB rows against its transcript (29 rows vs the transcript) showed **`messages` is _not_ a redundant copy** of the transcript. It additionally and uniquely holds:
- **Deliverables markers** (`[[NEXUS_GENERATED_FILES]]`) — sudowork-injected, `DeliverablesService`'s *only* persistent store (it scans the raw DB); never present in the transcript.
- **Ephemeral UX** — agent_status / tips / error rows.
- **Full pre-compaction history** — the transcript compacts old turns into a "continued from a previous conversation…" summary; the DB keeps the raw turns.
- All **non-scode** backends (claude / codex / gemini / qwen / sudoclaw / remote) — no scode transcript to read from.

So a blind GC of the copy is **unsafe** (breaks deliverables, loses history). This PR ships the **read-view only**: the transcript is the content read-authority; `messages` stays as the derived/enrichment + non-scode + metadata store. **Physical dedup** (removing scode's content-row duplication) is the tracked follow-up (nexus-2 #84): split the write path (content→transcript, derived→messages) + merge on read. Additive; falls back to current behavior; nothing removed.
