### PR TITLE
perf(acp): blocking long-poll for the nexus tunnel stdout reader (nexus #219)

### DIFF
--- a/src/agent/acp/transport.ts
+++ b/src/agent/acp/transport.ts
@@ -237,15 +237,15 @@ export interface GrpcTransportOptions {
   /** What nexus spawns — sudowork owns this spec (SSOT). */
   spawnSpec: GenericSpawnSpec;
   events: AcpTransportEvents;
-  /** Idle re-read interval for the non-blocking stdout reader (ms). */
-  idlePollMs?: number;
+  /** Blocking long-poll timeout for the stdout reader (ms). Default 30_000. */
+  longPollMs?: number;
 }
 
 /**
  * ACP transport where nexus spawns + supervises the agent and exposes its
  * stdio as VFS fd streams. sudowork drives it over grpc-js:
  *   - start_session (Call) → session_id + os_pid; nexus spawns spawn_spec
- *   - reader: StreamReadAt (non-blocking) /proc/{sid}/fd/1 → NDJSON → onMessage
+ *   - reader: StreamReadAt (blocking long-poll) /proc/{sid}/fd/1 → NDJSON → onMessage
  *   - writer: StreamWriteNowait /proc/{sid}/fd/0 (agent stdin)
  *   - close:  cancel_v1
  * nexus never parses ACP; NDJSON framing stays here.
@@ -255,13 +255,13 @@ export class GrpcAcpTransport implements AcpTransport {
   private sessionId: string | null = null;
   private osPid: number | null = null;
   private readonly options: GrpcTransportOptions;
-  private readonly idlePollMs: number;
+  private readonly longPollMs: number;
   private _connected = false;
   private closing = false;
 
   constructor(options: GrpcTransportOptions) {
     this.options = options;
-    this.idlePollMs = options.idlePollMs ?? 30;
+    this.longPollMs = options.longPollMs ?? 30_000;
   }
 
   get connected(): boolean {
@@ -310,10 +310,14 @@ export class GrpcAcpTransport implements AcpTransport {
   }
 
   /**
-   * Non-blocking read loop over the agent's stdout stream. Per the DT_STREAM
-   * contract: data → deliver + advance offset + read again immediately;
-   * empty (eof=true) → "no data now", retry the SAME offset after a short wait;
-   * a rejection (is_error=true = stream closed+drained = agent exited) is the
+   * Blocking long-poll read loop over the agent's stdout stream. The daemon
+   * holds each StreamReadAt until a frame is ready or longPollMs expires, so
+   * there is no client-side idle poll — zero wakeups when the agent is quiet
+   * and zero added latency when it speaks (a frame wakes the read at once).
+   * Per the DT_STREAM contract: data → deliver + advance offset + read again;
+   * empty (eof=true, both "nothing ready" and a long-poll timeout) → "no frame
+   * yet", re-issue the read at the SAME offset (next_offset == offset); a
+   * rejection (is_error=true = stream closed+drained = agent exited) is the
    * real disconnect.
    */
   private async readStdout(): Promise<void> {
@@ -323,7 +327,7 @@ export class GrpcAcpTransport implements AcpTransport {
     while (this._connected && this.client) {
       let res;
       try {
-        res = await this.client.streamReadAt(stdoutPath, offset, { blocking: false });
+        res = await this.client.streamReadAt(stdoutPath, offset, { blocking: true, timeoutMs: this.longPollMs });
       } catch {
         this.handleClose();
         return;
@@ -333,10 +337,9 @@ export class GrpcAcpTransport implements AcpTransport {
           this.options.events.onMessage(message);
         }
         offset = res.nextOffset;
-        // immediate re-read (no wait) keeps streaming latency low
-      } else {
-        await delay(this.idlePollMs);
       }
+      // else: eof (no frame within the long-poll window) — re-issue immediately
+      // at the same offset; the blocking read is itself the wait.
     }
   }
 
@@ -369,8 +372,4 @@ function toStringEnv(env: Record<string, string | undefined>): Record<string, st
     if (typeof v === 'string') out[k] = v;
   }
   return out;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/integration/acpTunnelTransport.integration.test.ts
+++ b/tests/integration/acpTunnelTransport.integration.test.ts
@@ -55,7 +55,7 @@ suite('GrpcAcpTransport ↔ live nexusd-cluster', () => {
         },
         onSetupError: () => {},
       },
-      idlePollMs: 20,
+      longPollMs: 1000,
     });
 
     await transport.connect();

--- a/tests/unit/grpcAcpTransportReadLoop.test.ts
+++ b/tests/unit/grpcAcpTransportReadLoop.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The GrpcAcpTransport stdout reader is a blocking long-poll loop (nexus #219):
+// data → deliver + advance offset; eof (nothing ready / long-poll timeout) →
+// re-read the SAME offset; a client rejection (is_error) → disconnect. This
+// locks that contract in fast CI (the live path is the linux-e2e integration
+// test, which only runs in the slower e2e leg).
+
+type ReadStep = { data?: Buffer; nextOffset?: string; eof?: boolean; reject?: boolean };
+
+async function loadTransport(readSeq: ReadStep[]) {
+  vi.resetModules();
+  const streamReadAtCalls: Array<{ offset: string; blocking?: boolean; timeoutMs?: number }> = [];
+  let i = 0;
+  const client = {
+    call: vi.fn(async (method: string) => (method === 'managed_agent.start_session_v1' ? { session_id: 's1', os_pid: 7 } : {})),
+    streamReadAt: vi.fn(async (_path: string, offset: string, opts: { blocking?: boolean; timeoutMs?: number } = {}) => {
+      streamReadAtCalls.push({ offset, blocking: opts.blocking, timeoutMs: opts.timeoutMs });
+      const step = readSeq[Math.min(i, readSeq.length - 1)];
+      i += 1;
+      if (step.reject) throw new Error('stream closed');
+      return { data: step.data ?? Buffer.alloc(0), nextOffset: step.nextOffset ?? offset, eof: step.eof ?? false };
+    }),
+    streamWrite: vi.fn(async () => {}),
+    close: vi.fn(),
+  };
+  vi.doMock('@common/nexus/nexusVfsGrpcClient', () => ({
+    NexusVfsGrpcClient: vi.fn(function () {
+      return client;
+    }),
+  }));
+  const mod = await import('@/agent/acp/transport');
+  return { GrpcAcpTransport: mod.GrpcAcpTransport, client, streamReadAtCalls };
+}
+
+const frame = (method: string): Buffer => Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', method })}\n`, 'utf-8');
+
+describe('GrpcAcpTransport blocking long-poll reader', () => {
+  it('delivers frames, re-reads the same offset on eof, disconnects on error — all via blocking reads', async () => {
+    const { GrpcAcpTransport, streamReadAtCalls } = await loadTransport([
+      { data: frame('a'), nextOffset: '30', eof: false }, // deliver a → advance to 30
+      { data: Buffer.alloc(0), nextOffset: '30', eof: true }, // idle/timeout → re-read same offset 30
+      { data: frame('b'), nextOffset: '60', eof: false }, // deliver b → advance to 60
+      { reject: true }, // stream closed → disconnect
+    ]);
+
+    const msgs: string[] = [];
+    let closed = false;
+    const t = new GrpcAcpTransport({
+      endpoint: '127.0.0.1:1',
+      authToken: '',
+      agentId: 'x',
+      spawnSpec: { cmd: 'x', args: [], env: {}, cwd: '/' },
+      events: {
+        onMessage: (m) => msgs.push((m as { method: string }).method),
+        onClose: () => {
+          closed = true;
+        },
+        onSetupError: () => {},
+      },
+    });
+
+    await t.connect();
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline && !closed) await new Promise((r) => setTimeout(r, 10));
+
+    expect(msgs).toEqual(['a', 'b']); // both frames delivered, idle frame carried nothing
+    expect(closed).toBe(true); // is_error rejection = real disconnect
+    expect(streamReadAtCalls.every((c) => c.blocking === true)).toBe(true); // long-poll, not the old 30ms non-blocking poll
+    expect(streamReadAtCalls.map((c) => c.offset)).toEqual(['0', '30', '30', '60']); // eof → same offset re-read
+  });
+});


### PR DESCRIPTION
## What
Replace the tunnel reader's non-blocking `StreamReadAt` + **30ms client-side idle poll** with a **blocking long-poll**: the daemon holds each read until a frame is ready or `longPollMs` (30s) expires.

## Why
On a multi-agent server, every quiet session was firing ~**33 empty `StreamReadAt` gRPC/s**. Blocking long-poll eliminates that idle traffic entirely, while adding **zero latency on data** (a frame wakes the blocked read immediately). Critical-path efficiency for the AgentOPS server.

## Safe now (no pin bump)
sudowork pins the `nexusd-cluster` assembly (nexus-vfs rev `6cad75f7`, **post-#219**): a blocking read that reaches its timeout returns `eof` + the **same offset** with `is_error=false` — identical to the non-blocking "nothing ready" case — so the reader re-issues at the same offset; only a real close (`is_error`) disconnects. **No proto change.** Removed the now-dead `idlePollMs` option + `delay()`.

## Verified against the PUBLISHED linux daemon (Docker)
- frame delivered **3ms after connect** (wakes on data, « the 800ms test timeout)
- a **3s idle survived ~4 long-poll windows** via same-offset re-reads, no disconnect

Unit test `tests/unit/grpcAcpTransportReadLoop.test.ts` locks the contract (deliver+advance / eof→re-read-same-offset / is_error→disconnect / blocking). The `linux-e2e` integration test drives it live (updated `idlePollMs`→`longPollMs`). tsc + eslint clean.