### PR TITLE
feat(ffmpeg): add macOS source (martin-riedl) + reconcile COS SHA256s

### DIFF
--- a/.github/workflows/mirror-ffmpeg-to-cos.yml
+++ b/.github/workflows/mirror-ffmpeg-to-cos.yml
@@ -46,7 +46,7 @@ jobs:
           set -euo pipefail
           # download-ffmpeg.js runs on any OS — it just fetches the BtbN archive
           # (verifying the pinned source SHA256) and repacks the flat binaries.
-          for key in win32-x64 win32-arm64 linux-x64 linux-arm64; do
+          for key in win32-x64 win32-arm64 linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             echo "::group::$key"
             node scripts/download-ffmpeg.js "$key" --force
             echo "::endgroup::"
@@ -60,7 +60,7 @@ jobs:
           TAG=$(node -p "require('./src/shared/ffmpeg-runtime.json').tag")
           echo "Pinned tag: $TAG"
           echo "===== RECORD THESE INTO ffmpeg-runtime.json cos.sha256 ====="
-          for key in win32-x64 win32-arm64 linux-x64 linux-arm64; do
+          for key in win32-x64 win32-arm64 linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             sha=$(sha256sum "resources/ffmpeg-$key.tar.gz" | cut -d' ' -f1)
             echo "  $key : $sha"
             echo "        https://$COS_BUCKET.cos.$COS_REGION.myqcloud.com/ffmpeg/$TAG/ffmpeg-$key.tar.gz"
@@ -84,7 +84,7 @@ jobs:
           coscmd config -a "$TENCENT_SECRET_ID" -s "$TENCENT_SECRET_KEY" -b "$COS_BUCKET" -e cos.accelerate.myqcloud.com
 
           TAG=$(node -p "require('./src/shared/ffmpeg-runtime.json').tag")
-          for key in win32-x64 win32-arm64 linux-x64 linux-arm64; do
+          for key in win32-x64 win32-arm64 linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             coscmd upload "resources/ffmpeg-$key.tar.gz" "ffmpeg/$TAG/ffmpeg-$key.tar.gz"
           done
           echo "============================================================"

--- a/scripts/download-ffmpeg.js
+++ b/scripts/download-ffmpeg.js
@@ -203,8 +203,11 @@ async function main() {
       if (!name.endsWith('.exe')) fs.chmodSync(dst, 0o755);
     }
 
-    // Max gzip level: static ffmpeg binaries barely compress, but it's a free
-    // few MB off a ~114 MB archive and build CPU is not the bottleneck here.
+    // NOTE: node-tar's output is NOT byte-reproducible across runs, so every
+    // mirror run produces a fresh tar.gz with a NEW SHA256 — and a re-mirror
+    // re-uploads ALL platforms. After ANY mirror run, re-record EVERY
+    // cos.sha256 entry (the workflow prints them), not just the bumped one.
+    // gzip level 9 is a free few MB off the ~114 MB archive.
     await tar.create({ gzip: { level: 9 }, file: outResource, cwd: flatDir, portable: true }, fs.readdirSync(flatDir));
     console.log(`[ffmpeg:download] wrote ${outResource} (${(fs.statSync(outResource).size / 1e6).toFixed(1)} MB)`);
   } finally {

--- a/scripts/download-ffmpeg.js
+++ b/scripts/download-ffmpeg.js
@@ -121,6 +121,23 @@ function findBinary(dir, name) {
   return null;
 }
 
+/** Download `url` to a temp file, verify its SHA256, and extract into `extractDir`. */
+async function downloadVerifyExtract(url, expectedSha, isZip, extractDir, tmp, label) {
+  const archivePath = path.join(tmp, `${label}.${isZip ? 'zip' : 'tar.xz'}`);
+  await download(url, archivePath);
+  const actualSha = sha256OfFile(archivePath);
+  if (actualSha !== expectedSha) {
+    throw new Error(`SHA256 mismatch for ${label} (${url}): expected ${expectedSha}, got ${actualSha}`);
+  }
+  console.log(`[ffmpeg:download] SHA256 verified: ${actualSha} (${label})`);
+  if (isZip) {
+    await unzip(archivePath, extractDir);
+  } else {
+    // .tar.xz — rely on the build machine's `tar` (xz-capable on linux/mac).
+    execFileSync('tar', ['-xf', archivePath, '-C', extractDir], { stdio: 'inherit' });
+  }
+}
+
 async function main() {
   const explicitKey = process.argv.find((a) => /^[a-z0-9]+-[a-z0-9]+$/i.test(a));
   const key = explicitKey || currentKey();
@@ -143,33 +160,32 @@ async function main() {
 
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ffmpeg-dl-'));
   try {
-    const archivePath = path.join(tmp, `src.${cfg.archive === 'zip' ? 'zip' : 'tar.xz'}`);
-    try {
-      await download(assetUrl(cfg), archivePath);
-    } catch (err) {
-      if (/HTTP 404/.test(err.message)) {
-        throw new Error(
-          `${assetName(cfg)} is gone from BtbN tag ${FFMPEG_TAG} (old autobuilds get pruned). ` +
-            `Re-pin src/shared/ffmpeg-runtime.json to a current autobuild-* tag + refresh its SHA256s.`,
-        );
-      }
-      throw err;
-    }
-
-    // Integrity gate: the pinned SHA256 must match before we trust the bytes.
-    const actualSha = sha256OfFile(archivePath);
-    if (actualSha !== cfg.sha256) {
-      throw new Error(`SHA256 mismatch for ${assetName(cfg)}: expected ${cfg.sha256}, got ${actualSha}`);
-    }
-    console.log(`[ffmpeg:download] SHA256 verified: ${actualSha}`);
-
     const extractDir = path.join(tmp, 'extract');
     fs.mkdirSync(extractDir, { recursive: true });
-    if (cfg.archive === 'zip') {
-      await unzip(archivePath, extractDir);
+
+    if (cfg.ffmpeg) {
+      // macOS (martin-riedl): ffmpeg + ffprobe are SEPARATE zips at explicit,
+      // per-binary immutable URLs, each with its own pinned SHA256.
+      for (const [bin, entry] of [
+        ['ffmpeg', cfg.ffmpeg],
+        ['ffprobe', cfg.ffprobe],
+      ]) {
+        if (!entry) continue;
+        await downloadVerifyExtract(entry.url, entry.sha256, true, extractDir, tmp, bin);
+      }
     } else {
-      // .tar.xz — rely on the build machine's `tar` (xz-capable on linux/mac).
-      execFileSync('tar', ['-xf', archivePath, '-C', extractDir], { stdio: 'inherit' });
+      // BtbN (win/linux): one archive holding both binaries, derived URL + pinned SHA.
+      try {
+        await downloadVerifyExtract(assetUrl(cfg), cfg.sha256, cfg.archive === 'zip', extractDir, tmp, 'src');
+      } catch (err) {
+        if (/HTTP 404/.test(err.message)) {
+          throw new Error(
+            `${assetName(cfg)} is gone from BtbN tag ${FFMPEG_TAG} (old autobuilds get pruned). ` +
+              `Re-pin src/shared/ffmpeg-runtime.json to a current autobuild-* tag + refresh its SHA256s.`,
+          );
+        }
+        throw err;
+      }
     }
 
     const flatDir = path.join(tmp, 'flat');
@@ -178,7 +194,7 @@ async function main() {
     for (const name of wanted) {
       const found = findBinary(extractDir, name);
       if (!found) {
-        if (name.startsWith('ffmpeg')) throw new Error(`ffmpeg binary not found in ${assetName(cfg)}`);
+        if (name.startsWith('ffmpeg')) throw new Error(`ffmpeg binary not found for ${key}`);
         console.warn(`[ffmpeg:download] optional ${name} not found — skipping`);
         continue;
       }

--- a/src/shared/ffmpeg-runtime.json
+++ b/src/shared/ffmpeg-runtime.json
@@ -12,14 +12,29 @@
       "win32-x64": "2f102c53dfd78e2cbfb0940bd24b1ac9cc5839cded4c9887a8bf88e786ac9005",
       "win32-arm64": "f815e84b46e1c12854ab639d33ed39dfa8c6bdb3c4682f666d405d0709e37fae",
       "linux-x64": "0fad1886ac731adbf24a41dc70174c89b665c1eaefc3f44d3ff9ab8023b44bac",
-      "linux-arm64": "1e181b09f0d83d4b47b17aaaa177d07342f6155150f3d54b154f120628bb4fce"
+      "linux-arm64": "1e181b09f0d83d4b47b17aaaa177d07342f6155150f3d54b154f120628bb4fce",
+      "darwin-x64": "",
+      "darwin-arm64": ""
     }
   },
 
+  "_darwin_doc": "macOS: BtbN ships no macOS build, so darwin uses martin-riedl.de static release builds (same FFmpeg 9.0.1, --enable-gpl --enable-libass --enable-libx264). Unlike BtbN, ffmpeg and ffprobe are SEPARATE zips at immutable per-arch build-id URLs, so darwin entries carry explicit {url,sha256} per binary (verified against the source's .sha256 sidecar) instead of the derived-name/single-archive BtbN shape. To bump: pick a new release build id from https://ffmpeg.martin-riedl.de (macos/arm64 + macos/amd64, MATCH the versions) and refresh url+sha256.",
   "platforms": {
     "win32-x64": { "btbn": "win64", "archive": "zip", "sha256": "ae937d5807fa7a281a0b9fbbfe976bfe60423a75c0892c0e6dcd266f37de43d5" },
     "win32-arm64": { "btbn": "winarm64", "archive": "zip", "sha256": "ee488b5d138bc24557203b4b81a6a5895ef9b9a3f3b906c9669de2c6b07f63ef" },
     "linux-x64": { "btbn": "linux64", "archive": "tar.xz", "sha256": "25557a63e38bbf2c03c27b647a40e3d1eaad391b6f0adfce501d62665b7c443c" },
-    "linux-arm64": { "btbn": "linuxarm64", "archive": "tar.xz", "sha256": "d6b7e2952b324b4f8f04d828778ca393668a34b00abd1a445000fbf97ba3e350" }
+    "linux-arm64": { "btbn": "linuxarm64", "archive": "tar.xz", "sha256": "d6b7e2952b324b4f8f04d828778ca393668a34b00abd1a445000fbf97ba3e350" },
+    "darwin-arm64": {
+      "source": "martin-riedl",
+      "archive": "zip",
+      "ffmpeg": { "url": "https://ffmpeg.martin-riedl.de/download/macos/arm64/1787073674_9.0.1/ffmpeg.zip", "sha256": "8287a1b2229e05eb41859f073e18e6c52c60a778f2f5e6881070fe51b79407fe" },
+      "ffprobe": { "url": "https://ffmpeg.martin-riedl.de/download/macos/arm64/1787073674_9.0.1/ffprobe.zip", "sha256": "102a26b8940a053298d9929bfaae71e4b6ef65ba5f19a99a88c433108560741a" }
+    },
+    "darwin-x64": {
+      "source": "martin-riedl",
+      "archive": "zip",
+      "ffmpeg": { "url": "https://ffmpeg.martin-riedl.de/download/macos/amd64/1787081194_9.0.1/ffmpeg.zip", "sha256": "5bdead62ff504ab9b447cc72b212c4fb481e3f7de5877d427a51bee8136dda40" },
+      "ffprobe": { "url": "https://ffmpeg.martin-riedl.de/download/macos/amd64/1787081194_9.0.1/ffprobe.zip", "sha256": "34511bbcf1988ad2886023bf5ace4f44cf62e6defeb3d194d6f7619e5b061f7f" }
+    }
   }
 }

--- a/src/shared/ffmpeg-runtime.json
+++ b/src/shared/ffmpeg-runtime.json
@@ -5,16 +5,16 @@
   "version": "n9.0.1-4-gb3ef323dd2",
   "releaseSuffix": "9.0",
 
-  "_cos_doc": "Runtime download source. FfmpegRuntimeService downloads <cos.baseUrl>/ffmpeg/<tag>/ffmpeg-<key>.tar.gz on demand (China-reachable) when an ffmpeg-needing skill is installed, and verifies it against cos.sha256[key] (the SHA256 of the flat tar.gz produced+uploaded by .github/workflows/mirror-ffmpeg-to-cos.yml). Refresh these after re-running the mirror on a pin bump.",
+  "_cos_doc": "Runtime download source. FfmpegRuntimeService downloads <cos.baseUrl>/ffmpeg/<tag>/ffmpeg-<key>.tar.gz on demand (China-reachable) when an ffmpeg-needing skill is installed, and verifies it against cos.sha256[key] (the SHA256 of the flat tar.gz produced+uploaded by .github/workflows/mirror-ffmpeg-to-cos.yml). IMPORTANT: node-tar's repack is NOT byte-reproducible, so EVERY mirror run re-uploads ALL platforms with fresh SHA256s — after ANY mirror run, replace EVERY entry below with the values the workflow printed, not just the one you bumped.",
   "cos": {
     "baseUrl": "https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com",
     "sha256": {
-      "win32-x64": "2f102c53dfd78e2cbfb0940bd24b1ac9cc5839cded4c9887a8bf88e786ac9005",
-      "win32-arm64": "f815e84b46e1c12854ab639d33ed39dfa8c6bdb3c4682f666d405d0709e37fae",
-      "linux-x64": "0fad1886ac731adbf24a41dc70174c89b665c1eaefc3f44d3ff9ab8023b44bac",
-      "linux-arm64": "1e181b09f0d83d4b47b17aaaa177d07342f6155150f3d54b154f120628bb4fce",
-      "darwin-x64": "",
-      "darwin-arm64": ""
+      "win32-x64": "10085a07553767019a9d3d198f4fb7487dd9c3c1cfd9029008b16cf0464d1af6",
+      "win32-arm64": "a04d6d587c613408b7b1678e7ad00295edacab1ab8db4cb6971139782f5dbae9",
+      "linux-x64": "a31668e1fbb9df98ec2ba7e77a42064e3da5095f3aca7ec9cd2534adeb3c27bf",
+      "linux-arm64": "4771b40691cf6cdb4c4a589d64cff6d5f24d9c806d379f9f46fe2f30a027d480",
+      "darwin-x64": "d6ed0741dd4d231da40c0ae7c698c0b184b2dcb39abae1921930e7911fe3c6b1",
+      "darwin-arm64": "6df2b84c0b32853c11da6aee66d72aafdab13a6eb528337c7f594550bc4469fb"
     }
   },
 


### PR DESCRIPTION
## Why

BtbN ships no macOS ffmpeg build, so darwin was skipped — macOS installs got no
ffmpeg for the video/subtitle skills. Add a macOS source.

## What

- **Source: martin-riedl.de** static release builds — native **arm64 + x86_64**,
  both **FFmpeg 9.0.1** (matches our BtbN pin), GPL, **libx264 + libass** (subtitle
  burning), immutable per-arch build-id URLs, SHA256 sidecars. (evermeet is
  Intel-only; osxexperts has arm64/Intel version skew — both rejected.)
- **`ffmpeg-runtime.json`** — darwin entries carry explicit per-binary
  `{url, sha256}` (macOS ships ffmpeg + ffprobe as separate zips), verified
  against the source's `.sha256` sidecar.
- **`download-ffmpeg.js`** — branches on entry shape: BtbN single-archive
  (win/linux) vs mac two-zip. Extract/flatten/repack path is shared.
- **`mirror-ffmpeg-to-cos.yml`** — mirrors the darwin flat tar.gz to COS
  alongside win/linux.
- **`FfmpegRuntimeService`** — no change; `cos.sha256[darwin-*]` switches macOS on.

## SHA reconciliation (important)

Adding darwin re-ran the mirror, which re-uploads **all** platforms. node-tar's
repack isn't byte-reproducible, so win/linux got new SHA256s too — this PR
records **all six** to match the objects now on COS. (This also corrects the
prior dev values, which the re-mirror had left stale.)

## Verified

- From a **China host**: COS download of `ffmpeg-win32-x64.tar.gz` (108 MB) and
  `ffmpeg-darwin-arm64.tar.gz` (57 MB) — both SHA256 **match** the recorded pins.
- `tsc` clean; 17 ffmpeg unit tests pass; prettier clean.

macOS runtime (extract + run on a real Mac) isn't validated from this Windows
host — but the COS object + integrity chain is proven, and extraction is the
same path as win/linux.
