### PR TITLE
feat(channels): support multiple connections per IM channel type

### DIFF
--- a/src/channels/actions/PlatformActions.ts
+++ b/src/channels/actions/PlatformActions.ts
@@ -5,6 +5,7 @@
  */
 
 import { getPairingService } from '../pairing/PairingService';
+import { pluginScope } from '../types';
 import { createPairingCodeKeyboard, createPairingStatusKeyboard, createMainMenuKeyboard } from '../plugins/telegram/TelegramKeyboards';
 import { createPairingCard, createPairingStatusCard, createMainMenuCard, createPairingHelpCard } from '../plugins/lark/LarkCards';
 import { createMainMenuCard as createDingTalkMainMenuCard, createPairingCard as createDingTalkPairingCard, createPairingStatusCard as createDingTalkPairingStatusCard, createPairingHelpCard as createDingTalkPairingHelpCard } from '../plugins/dingtalk/DingTalkCards';
@@ -79,9 +80,12 @@ function getPairingHelpMarkup(platform: string) {
 export const handlePairingShow: ActionHandler = async (context) => {
   const pairingService = getPairingService();
   const platform = context.platform;
+  // Pair against the CONNECTION that received the message: with several bots of one type,
+  // pairing with one must not authorize the others.
+  const scope = pluginScope(context.pluginId, platform);
 
   // Check if user is already authorized
-  if (pairingService.isUserAuthorized(context.userId, platform)) {
+  if (pairingService.isUserAuthorized(context.userId, scope)) {
     return createSuccessResponse({
       type: 'text',
       text: ['✅ <b>Authorized</b>', '', 'Your account is already paired and ready to use.', '', 'Send a message to start chatting, or use the buttons below.'].join('\n'),
@@ -92,7 +96,7 @@ export const handlePairingShow: ActionHandler = async (context) => {
 
   // Generate pairing code
   try {
-    const { code, expiresAt } = await pairingService.generatePairingCode(context.userId, platform, context.displayName);
+    const { code, expiresAt } = await pairingService.generatePairingCode(context.userId, platform, context.displayName, scope);
 
     const expiresInMinutes = Math.ceil((expiresAt - Date.now()) / 1000 / 60);
 
@@ -126,9 +130,10 @@ export const handlePairingShow: ActionHandler = async (context) => {
 export const handlePairingRefresh: ActionHandler = async (context) => {
   const pairingService = getPairingService();
   const platform = context.platform;
+  const scope = pluginScope(context.pluginId, platform);
 
   // Check if user is already authorized
-  if (pairingService.isUserAuthorized(context.userId, platform)) {
+  if (pairingService.isUserAuthorized(context.userId, scope)) {
     return createSuccessResponse({
       type: 'text',
       text: '✅ You are already paired. No need to refresh the pairing code.',
@@ -139,7 +144,7 @@ export const handlePairingRefresh: ActionHandler = async (context) => {
 
   // Generate new pairing code
   try {
-    const { code, expiresAt } = await pairingService.refreshPairingCode(context.userId, platform, context.displayName);
+    const { code, expiresAt } = await pairingService.refreshPairingCode(context.userId, platform, context.displayName, scope);
 
     const expiresInMinutes = Math.ceil((expiresAt - Date.now()) / 1000 / 60);
 
@@ -160,9 +165,10 @@ export const handlePairingRefresh: ActionHandler = async (context) => {
 export const handlePairingCheck: ActionHandler = async (context) => {
   const pairingService = getPairingService();
   const platform = context.platform;
+  const scope = pluginScope(context.pluginId, platform);
 
   // Check if user is already authorized
-  if (pairingService.isUserAuthorized(context.userId, platform)) {
+  if (pairingService.isUserAuthorized(context.userId, scope)) {
     return createSuccessResponse({
       type: 'text',
       text: ['✅ <b>Pairing Successful!</b>', '', 'Your account is now paired and ready to use.', '', 'Send a message to chat with the AI assistant.'].join('\n'),
@@ -172,7 +178,7 @@ export const handlePairingCheck: ActionHandler = async (context) => {
   }
 
   // Check for pending request
-  const pendingRequest = pairingService.getPendingRequestForUser(context.userId, platform);
+  const pendingRequest = pairingService.getPendingRequestForUser(context.userId, scope);
 
   if (pendingRequest) {
     const expiresInMinutes = Math.ceil((pendingRequest.expiresAt - Date.now()) / 1000 / 60);

--- a/src/channels/actions/SystemActions.ts
+++ b/src/channels/actions/SystemActions.ts
@@ -14,6 +14,7 @@ import { GOOGLE_AUTH_PROVIDER_ID } from '@/common/constants';
 import type { AcpBackend } from '@/types/acpTypes';
 import { getChannelMessageService } from '../agent/ChannelMessageService';
 import { getChannelManager } from '../core/ChannelManager';
+import { getConnectionAgent, getConnectionModel } from '../channelConnectionConfig';
 import type { AgentDisplayInfo } from '../plugins/telegram/TelegramKeyboards';
 import { createAgentSelectionKeyboard, createHelpKeyboard, createMainMenuKeyboard, createSessionControlKeyboard } from '../plugins/telegram/TelegramKeyboards';
 import { getChannelConversationName, resolveChannelConvType } from '../types';
@@ -37,7 +38,7 @@ import { SystemActionNames, createErrorResponse, createSuccessResponse } from '.
  * Reads from saved config or falls back to default Gemini model
  */
 
-export async function getChannelDefaultModel(platform: PluginType): Promise<TProviderWithModel> {
+export async function getChannelDefaultModel(platform: PluginType, pluginId?: string): Promise<TProviderWithModel> {
   try {
     const providers = await ProcessConfig.get('model.config');
     const providerList = providers && Array.isArray(providers) ? providers : [];
@@ -51,15 +52,8 @@ export async function getChannelDefaultModel(platform: PluginType): Promise<TPro
       return null;
     };
 
-    // Try to get saved model selection
-    const savedModel =
-      platform === 'lark'
-        ? await ProcessConfig.get('assistant.lark.defaultModel')
-        : platform === 'dingtalk'
-          ? await ProcessConfig.get('assistant.dingtalk.defaultModel')
-          : platform === 'wecom'
-            ? await ProcessConfig.get('assistant.wecom.defaultModel')
-            : await ProcessConfig.get('assistant.telegram.defaultModel');
+    // Model for THIS connection, falling back to the type-wide setting.
+    const savedModel = await getConnectionModel(pluginId, platform);
     if (savedModel?.id && savedModel?.useModel) {
       // Google Auth is frontend-only (OAuth browser flow), not usable in channels.
       // Fall through to find a provider with a valid API key instead.
@@ -155,10 +149,10 @@ export const handleSessionNew: ActionHandler = async (context) => {
   const platform = context.platform;
   const source = platform === 'lark' ? 'lark' : platform === 'dingtalk' ? 'dingtalk' : 'telegram';
 
-  // Selected agent (defaults to claude)
+  // Agent for THIS connection, falling back to the type-wide setting.
   let savedAgent: unknown = undefined;
   try {
-    savedAgent = await (platform === 'lark' ? ProcessConfig.get('assistant.lark.agent') : platform === 'dingtalk' ? ProcessConfig.get('assistant.dingtalk.agent') : platform === 'wecom' ? ProcessConfig.get('assistant.wecom.agent') : ProcessConfig.get('assistant.telegram.agent'));
+    savedAgent = await getConnectionAgent(context.pluginId, platform);
   } catch {
     // ignore
   }
@@ -167,7 +161,7 @@ export const handleSessionNew: ActionHandler = async (context) => {
   const agentName = savedAgent && typeof savedAgent === 'object' ? ((savedAgent as any).name as string | undefined) : undefined;
 
   // Provider model is required by typing; ACP will ignore it.
-  const model = await getChannelDefaultModel(platform);
+  const model = await getChannelDefaultModel(platform, context.pluginId);
 
   // Always create a NEW conversation for "session.new" (scoped by chatId)
   const channelChatId = context.chatId;

--- a/src/channels/channelConnectionConfig.ts
+++ b/src/channels/channelConnectionConfig.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 SudoPrivacy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getDatabase } from '@/process/database';
+import { ProcessConfig } from '@/process/initStorage';
+import { defaultPluginId, pluginTypeFromId } from './types';
+import type { PluginType } from './types';
+
+/**
+ * Per-connection agent / model settings.
+ *
+ * A channel type may have several connections (e.g. two WeCom bots), and each usually
+ * wants its own agent — that is the point of running more than one. The settings used to
+ * live in a single `assistant.<type>.agent` / `.defaultModel` config key, which is one
+ * value per TYPE and therefore cannot distinguish connections.
+ *
+ * Rather than multiply those typed keys, a connection stores its own override inside its
+ * plugin config row (already keyed by plugin id). Resolution order:
+ *   1. the connection's own override, when set;
+ *   2. the shared `assistant.<type>.*` key, which is what every existing install has.
+ *
+ * So an untouched install behaves exactly as before, and a second connection only diverges
+ * once someone actually configures it differently.
+ */
+
+type ChannelAgentSetting = { backend: string; customAgentId?: string; name?: string };
+type ChannelModelSetting = { id: string; useModel: string };
+
+/** The shared per-type keys, kept as the fallback and for a type's first connection. */
+const AGENT_KEYS: Record<string, 'assistant.telegram.agent' | 'assistant.lark.agent' | 'assistant.dingtalk.agent' | 'assistant.wechat.agent' | 'assistant.wecom.agent'> = {
+  telegram: 'assistant.telegram.agent',
+  lark: 'assistant.lark.agent',
+  dingtalk: 'assistant.dingtalk.agent',
+  wechat: 'assistant.wechat.agent',
+  wecom: 'assistant.wecom.agent',
+};
+
+const MODEL_KEYS: Record<string, 'assistant.telegram.defaultModel' | 'assistant.lark.defaultModel' | 'assistant.dingtalk.defaultModel' | 'assistant.wechat.defaultModel' | 'assistant.wecom.defaultModel'> = {
+  telegram: 'assistant.telegram.defaultModel',
+  lark: 'assistant.lark.defaultModel',
+  dingtalk: 'assistant.dingtalk.defaultModel',
+  wechat: 'assistant.wechat.defaultModel',
+  wecom: 'assistant.wecom.defaultModel',
+};
+
+/** Read the stored config blob for one connection. Never throws. */
+function readPluginConfig(pluginId: string): Record<string, unknown> {
+  try {
+    const result = getDatabase().getChannelPlugin(pluginId);
+    const config = result.success ? result.data?.config : undefined;
+    return config && typeof config === 'object' ? (config as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Persist a partial config patch onto one connection, preserving the rest. */
+async function writePluginConfig(pluginId: string, patch: Record<string, unknown>): Promise<void> {
+  const db = getDatabase();
+  const result = db.getChannelPlugin(pluginId);
+  const plugin = result.success ? result.data : null;
+  if (!plugin) return;
+  db.upsertChannelPlugin({
+    ...plugin,
+    config: { ...(plugin.config as Record<string, unknown> | undefined), ...patch } as never,
+  });
+}
+
+/**
+ * Agent this connection should start new chats with, falling back to the type-wide setting.
+ */
+export async function getConnectionAgent(pluginId: string | undefined, platform: PluginType): Promise<ChannelAgentSetting | undefined> {
+  const type = pluginId ? pluginTypeFromId(pluginId) : platform;
+  const id = pluginId || defaultPluginId(platform);
+
+  const own = readPluginConfig(id).agent;
+  if (own && typeof own === 'object') return own as ChannelAgentSetting;
+
+  const key = AGENT_KEYS[type];
+  if (!key) return undefined;
+  try {
+    return (await ProcessConfig.get(key)) as ChannelAgentSetting | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Default model for this connection, falling back to the type-wide setting. */
+export async function getConnectionModel(pluginId: string | undefined, platform: PluginType): Promise<ChannelModelSetting | undefined> {
+  const type = pluginId ? pluginTypeFromId(pluginId) : platform;
+  const id = pluginId || defaultPluginId(platform);
+
+  const own = readPluginConfig(id).defaultModel;
+  if (own && typeof own === 'object') return own as ChannelModelSetting;
+
+  const key = MODEL_KEYS[type];
+  if (!key) return undefined;
+  try {
+    return (await ProcessConfig.get(key)) as ChannelModelSetting | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Bind an agent to ONE connection.
+ *
+ * Writing to the type's first connection also updates the shared key, so the existing
+ * settings UI (which reads that key) stays in sync for the common single-connection case.
+ */
+export async function setConnectionAgent(pluginId: string, agent: ChannelAgentSetting | null): Promise<void> {
+  const type = pluginTypeFromId(pluginId);
+  await writePluginConfig(pluginId, { agent: agent ?? undefined });
+  if (pluginId === defaultPluginId(type)) {
+    const key = AGENT_KEYS[type];
+    if (key && agent) {
+      try {
+        await ProcessConfig.set(key, agent as never);
+      } catch {
+        // best-effort mirror; the per-connection value above is authoritative
+      }
+    }
+  }
+}
+
+/** Set the default model for ONE connection; mirrors to the shared key for the first one. */
+export async function setConnectionModel(pluginId: string, model: ChannelModelSetting | null): Promise<void> {
+  const type = pluginTypeFromId(pluginId);
+  await writePluginConfig(pluginId, { defaultModel: model ?? undefined });
+  if (pluginId === defaultPluginId(type)) {
+    const key = MODEL_KEYS[type];
+    if (key && model) {
+      try {
+        await ProcessConfig.set(key, model as never);
+      } catch {
+        // best-effort mirror
+      }
+    }
+  }
+}

--- a/src/channels/core/ChannelManager.ts
+++ b/src/channels/core/ChannelManager.ts
@@ -17,7 +17,7 @@ import { TelegramPlugin } from '../plugins/telegram/TelegramPlugin';
 import { WeChatPlugin } from '../plugins/wechat/WeChatPlugin';
 import { WeComPlugin } from '../plugins/wecom/WeComPlugin';
 import { ZentaoPlugin } from '../plugins/zentao/ZentaoPlugin';
-import { resolveChannelConvType } from '../types';
+import { resolveChannelConvType, pluginScope } from '../types';
 import type { ChannelPlatform, IChannelPluginConfig, IPluginCredentials, PluginType } from '../types';
 import { SessionManager } from './SessionManager';
 import { LocalChannelProvider } from './LocalChannelProvider';
@@ -453,6 +453,43 @@ export class ChannelManager {
   }
 
   /**
+   * Allocate an additional connection of a channel type. Works in both modes: locally it
+   * writes a new row, in enterprise mode the server allocates the id.
+   */
+  async createPlugin(type: PluginType, name?: string): Promise<{ success: boolean; pluginId?: string; error?: string }> {
+    const provider = this.getProvider();
+    if (!provider.createPlugin) {
+      return { success: false, error: 'Provider does not support additional connections' };
+    }
+    try {
+      const pluginId = await provider.createPlugin(type, name);
+      if (!pluginId) return { success: false, error: 'Failed to create connection' };
+      return { success: true, pluginId };
+    } catch (error: any) {
+      return { success: false, error: error?.message || String(error) };
+    }
+  }
+
+  /**
+   * Delete a connection outright: stop it, drop the authorizations scoped to it, then
+   * remove the row. Sibling connections of the same type are untouched.
+   */
+  async removePlugin(pluginId: string): Promise<{ success: boolean; error?: string }> {
+    const provider = this.getProvider();
+    try {
+      const existing = await provider.getPlugin(pluginId);
+      await this.disablePlugin(pluginId);
+      if (existing) {
+        await provider.deleteUsersByPlatform(pluginScope(pluginId, existing.type));
+      }
+      const ok = await provider.deletePlugin(pluginId);
+      return ok ? { success: true } : { success: false, error: 'Failed to delete connection' };
+    } catch (error: any) {
+      return { success: false, error: error?.message || String(error) };
+    }
+  }
+
+  /**
    * Disable and stop a plugin
    */
   async disablePlugin(pluginId: string): Promise<{ success: boolean; error?: string }> {
@@ -493,9 +530,11 @@ export class ChannelManager {
         // Note: We keep credentials so user can re-enable without re-entering
         const pluginType = existing.type;
         if (pluginType === 'wecom' || pluginType === 'wechat') {
-          console.log(`[ChannelManager] Clearing all users and sessions for ${pluginType} on disable`);
-          // Delete all channel users for this platform
-          await provider.deleteUsersByPlatform(pluginType);
+          // Scoped to THIS connection: a type may have several, and clearing by platform
+          // would deauthorize everyone paired with the sibling bots too.
+          const scope = pluginScope(pluginId, pluginType);
+          console.log(`[ChannelManager] Clearing users and sessions for connection ${scope} on disable`);
+          await provider.deleteUsersByPlatform(scope);
           // Note: We keep credentials so user can re-enable without re-entering
         }
       }

--- a/src/channels/core/IChannelProvider.ts
+++ b/src/channels/core/IChannelProvider.ts
@@ -18,6 +18,11 @@ export interface IChannelProvider {
   updatePluginStatus(pluginId: string, status: PluginStatus, lastConnected?: number): Promise<boolean>;
   updatePluginEnabled(pluginId: string, enabled: boolean, status: PluginStatus): Promise<boolean>;
   deletePlugin(pluginId: string): Promise<boolean>;
+  /**
+   * Allocate an additional connection of a channel type and return its plugin id.
+   * The connection starts disabled and credential-less.
+   */
+  createPlugin?(type: PluginType, name?: string): Promise<string | null>;
 
   // User management
   getUsers(): Promise<IChannelUser[]>;

--- a/src/channels/core/LocalChannelProvider.ts
+++ b/src/channels/core/LocalChannelProvider.ts
@@ -11,6 +11,7 @@ import { LarkPlugin } from '../plugins/lark/LarkPlugin';
 import { DingTalkPlugin } from '../plugins/dingtalk/DingTalkPlugin';
 import { WeComPlugin } from '../plugins/wecom/WeComPlugin';
 import type { IChannelProvider } from './IChannelProvider';
+import { defaultPluginId, generatePluginId, pluginTypeFromId } from '../types';
 
 /**
  * LocalChannelProvider - Implementation of IChannelProvider using local SQLite database
@@ -39,6 +40,27 @@ export class LocalChannelProvider implements IChannelProvider {
   async updatePluginEnabled(pluginId: string, enabled: boolean, status: PluginStatus): Promise<boolean> {
     const result = getDatabase().updateChannelPluginEnabled(pluginId, enabled, status);
     return result.success;
+  }
+
+  /**
+   * Allocate an additional connection of a type. The first connection of a type keeps the
+   * legacy `<type>_default` id so existing sessions, authorizations and pairings keep
+   * resolving to it; later ones get a generated id.
+   */
+  async createPlugin(type: PluginType, name?: string): Promise<string | null> {
+    const existing = (await this.getPlugins()).filter((p) => pluginTypeFromId(p.id) === type);
+    const id = existing.some((p) => p.id === defaultPluginId(type)) ? generatePluginId(type) : defaultPluginId(type);
+    const now = Date.now();
+    const ok = await this.upsertPlugin({
+      id,
+      type,
+      name: name?.trim() || `${type} ${existing.length + 1}`,
+      enabled: false,
+      status: 'stopped',
+      createdAt: now,
+      updatedAt: now,
+    });
+    return ok ? id : null;
   }
 
   async deletePlugin(pluginId: string): Promise<boolean> {

--- a/src/channels/core/RemoteChannelProvider.ts
+++ b/src/channels/core/RemoteChannelProvider.ts
@@ -128,6 +128,18 @@ export class RemoteChannelProvider implements IChannelProvider {
     return data.ok === true || data.success === true;
   }
 
+  /** Ask the server to allocate an additional connection; returns its plugin id. */
+  async createPlugin(type: PluginType, name?: string): Promise<string | null> {
+    const resp = await fetch(`${this.baseUrl}/plugins/create`, {
+      method: 'POST',
+      headers: { ...this.headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type, name }),
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    return data?.id ?? null;
+  }
+
   async deletePlugin(pluginId: string): Promise<boolean> {
     const resp = await fetch(`${this.baseUrl}/plugins/${pluginId}/disable`, {
       method: 'POST',

--- a/src/channels/gateway/ActionExecutor.ts
+++ b/src/channels/gateway/ActionExecutor.ts
@@ -21,13 +21,14 @@ import { acpDetector } from '@/agent/acp/AcpDetector';
 import { buildChatErrorResponse, chatActions } from '../actions/ChatActions';
 import { handlePairingShow, platformActions } from '../actions/PlatformActions';
 import { getChannelDefaultModel, systemActions } from '../actions/SystemActions';
+import { getConnectionAgent } from '../channelConnectionConfig';
 import type { IActionContext, IRegisteredAction } from '../actions/types';
 import { getChannelMessageService, type PendingAnswerResult } from '../agent/ChannelMessageService';
 import type { SessionManager } from '../core/SessionManager';
 import type { PairingService } from '../pairing/PairingService';
-import type { PluginMessageHandler } from '../plugins/BasePlugin';
+import type { PluginMessageHandler, BasePlugin } from '../plugins/BasePlugin';
 import type { IChannelUser, ChannelAgentType, IUnifiedIncomingMessage, IUnifiedOutgoingMessage, PluginType } from '../types';
-import { resolveChannelConvType } from '../types';
+import { resolveChannelConvType, pluginScope, scopedChatId } from '../types';
 import { createMainMenuCard, createErrorRecoveryCard, createToolConfirmationCard } from '../plugins/lark/LarkCards';
 import { convertHtmlToLarkMarkdown } from '../plugins/lark/LarkAdapter';
 import { createMainMenuCard as createDingTalkMainMenuCard, createErrorRecoveryCard as createDingTalkErrorRecoveryCard, createResponseActionsCard as createDingTalkResponseActionsCard, createToolConfirmationCard as createDingTalkToolConfirmationCard } from '../plugins/dingtalk/DingTalkCards';
@@ -401,20 +402,28 @@ export class ActionExecutor {
   /**
    * Handle incoming message from plugin
    */
-  private async handleIncomingMessage(message: IUnifiedIncomingMessage): Promise<void> {
+  private async handleIncomingMessage(message: IUnifiedIncomingMessage, sourcePlugin?: BasePlugin): Promise<void> {
     const { platform, chatId, user, content, action } = message;
 
-    // Get plugin for sending responses
-    const plugin = this.getPluginForMessage(message);
+    // Reply through the connection that RECEIVED the message. Falling back to "first
+    // plugin of this type" would answer from the wrong bot once a type has more than one
+    // connection configured.
+    const plugin = sourcePlugin ?? this.getPluginForMessage(message);
     if (!plugin) {
       console.error(`[ActionExecutor] No plugin found for platform: ${platform}`);
       return;
     }
 
+    const pluginId = plugin.pluginId;
+    // Scope authorizations and sessions to this connection so two bots of one type never
+    // share a conversation or an authorization.
+    const scope = pluginScope(pluginId, platform);
+    const sChatId = scopedChatId(pluginId, platform, chatId);
+
     // Build action context
     const context: IActionContext = {
       platform,
-      pluginId: `${platform}_default`, // TODO: Get actual plugin ID
+      pluginId,
       userId: user.id,
       chatId,
       displayName: user.displayName,
@@ -427,7 +436,7 @@ export class ActionExecutor {
 
     try {
       // Check if user is authorized
-      const isAuthorized = this.pairingService.isUserAuthorized(user.id, platform);
+      const isAuthorized = this.pairingService.isUserAuthorized(user.id, scope);
       console.log(`[ActionExecutor] processMessage: platform=${platform}, userId=${user.id}, chatId=${chatId}, isAuthorized=${isAuthorized}`);
 
       // Handle /start command
@@ -455,11 +464,12 @@ export class ActionExecutor {
         if (platform === 'wechat' || platform === 'wecom') {
           const db = getDatabase();
           const now = Date.now();
-          const newUserId = `${platform}_${user.id}_${now}`;
+          const newUserId = `${scope}_${user.id}_${now}`;
           const channelUser: IChannelUser = {
             id: newUserId,
             platformUserId: user.id,
             platformType: platform,
+            pluginScope: scope,
             displayName: user.displayName || user.id,
             authorizedAt: now,
           };
@@ -490,7 +500,7 @@ export class ActionExecutor {
       // User is authorized - look up the assistant user if not already set
       if (!context.channelUser) {
         const db = getDatabase();
-        const userResult = db.getChannelUserByPlatform(user.id, platform);
+        const userResult = db.getChannelUserByPlatform(user.id, scope);
         const channelUser = userResult.data;
 
         if (!channelUser) {
@@ -508,22 +518,14 @@ export class ActionExecutor {
       const channelUser = context.channelUser;
 
       // Get or create session (scoped by chatId for per-chat isolation)
-      let session = this.sessionManager.getSession(channelUser.id, chatId);
+      let session = this.sessionManager.getSession(channelUser.id, sChatId);
       if (!session || !session.conversationId) {
         const source = platform === 'lark' ? 'lark' : platform === 'dingtalk' ? 'dingtalk' : platform === 'wechat' ? 'wechat' : platform === 'wecom' ? 'wecom' : 'telegram';
 
-        // Read selected agent for this platform (defaults to claude)
+        // Agent for THIS connection, falling back to the type-wide setting.
         let savedAgent: unknown = undefined;
         try {
-          savedAgent = await (platform === 'lark'
-            ? ProcessConfig.get('assistant.lark.agent')
-            : platform === 'dingtalk'
-              ? ProcessConfig.get('assistant.dingtalk.agent')
-              : platform === 'wechat'
-                ? ProcessConfig.get('assistant.wechat.agent')
-                : platform === 'wecom'
-                  ? ProcessConfig.get('assistant.wecom.agent')
-                  : ProcessConfig.get('assistant.telegram.agent'));
+          savedAgent = await getConnectionAgent(pluginId, platform);
         } catch {
           // ignore
         }
@@ -532,7 +534,7 @@ export class ActionExecutor {
         const agentName = savedAgent && typeof savedAgent === 'object' ? ((savedAgent as any).name as string | undefined) : undefined;
 
         // Always resolve a provider model (required by ICreateConversationParams typing; ignored by ACP)
-        const model = await getChannelDefaultModel(platform);
+        const model = await getChannelDefaultModel(platform, pluginId);
 
         // Map backend to conversation type for lookup
         const { convType, convBackend } = resolveChannelConvType(backend);
@@ -548,7 +550,7 @@ export class ActionExecutor {
 
         // Lookup existing conversation by source + chatId + type + backend (per-chat isolation)
         const db2 = getDatabase();
-        const latest = db2.findChannelConversation(source, chatId, convType, convBackend);
+        const latest = db2.findChannelConversation(source, sChatId, convType, convBackend);
         const existing = latest.success ? latest.data : null;
 
         const result = existing
@@ -558,7 +560,7 @@ export class ActionExecutor {
               model,
               name: conversationName,
               source,
-              channelChatId: chatId,
+              channelChatId: sChatId,
               extra: {
                 backend: backend as AcpBackend,
                 cliPath,
@@ -570,7 +572,7 @@ export class ActionExecutor {
 
         if (result.success && result.conversation) {
           const { convType: agentType } = resolveChannelConvType(backend);
-          session = this.sessionManager.createSessionWithConversation(channelUser, result.conversation.id, agentType as ChannelAgentType, getChannelWorkspacePath(source), chatId);
+          session = this.sessionManager.createSessionWithConversation(channelUser, result.conversation.id, agentType as ChannelAgentType, getChannelWorkspacePath(source), sChatId);
 
           // 通知渲染进程刷新对话列表（仅新建对话时）
           if (!existing) {
@@ -1428,8 +1430,12 @@ export class ActionExecutor {
   /**
    * Get plugin instance for a message
    */
+  /**
+   * Fallback only, for callers with no source plugin. Returns the FIRST connection of the
+   * type, which is ambiguous once several are configured — prefer the source plugin the
+   * message arrived on.
+   */
   private getPluginForMessage(message: IUnifiedIncomingMessage) {
-    // For now, get the first plugin of the matching type
     const plugins = this.pluginManager.getAllPlugins();
     return plugins.find((p) => p.type === message.platform);
   }

--- a/src/channels/gateway/PluginManager.ts
+++ b/src/channels/gateway/PluginManager.ts
@@ -312,13 +312,14 @@ export class PluginManager {
    * Handle incoming message from a plugin
    * Routes to the appropriate action handler
    */
-  private async handleIncomingMessage(message: IUnifiedIncomingMessage): Promise<void> {
+  private async handleIncomingMessage(message: IUnifiedIncomingMessage, sourcePlugin: BasePlugin): Promise<void> {
     // Update user activity
     this.sessionManager.updateSessionActivity(message.user.id);
 
-    // Forward to message handler (ActionRouter)
+    // Forward to message handler (ActionRouter), carrying the connection the message
+    // arrived on so it replies through the right bot.
     if (this.messageHandler) {
-      await this.messageHandler(message);
+      await this.messageHandler(message, sourcePlugin);
     }
   }
 

--- a/src/channels/pairing/PairingService.ts
+++ b/src/channels/pairing/PairingService.ts
@@ -39,13 +39,15 @@ export class PairingService {
   /**
    * Generate a new pairing code for a user
    */
-  async generatePairingCode(platformUserId: string, platformType: PluginType, displayName?: string): Promise<{ code: string; expiresAt: number }> {
+  async generatePairingCode(platformUserId: string, platformType: PluginType, displayName?: string, scope?: string): Promise<{ code: string; expiresAt: number }> {
     const db = getDatabase();
+    // Codes belong to ONE connection; a type's first connection uses the bare platform.
+    const effectiveScope = scope || platformType;
 
     // Check for existing pending request
     const existingResult = db.getPendingPairingRequests();
     if (existingResult.success && existingResult.data) {
-      const existing = existingResult.data.find((r) => r.platformUserId === platformUserId && r.platformType === platformType && r.status === 'pending');
+      const existing = existingResult.data.find((r) => r.platformUserId === platformUserId && (r.pluginScope ?? r.platformType) === effectiveScope && r.status === 'pending');
 
       // Return existing code if not expired
       if (existing && existing.expiresAt > Date.now()) {
@@ -66,6 +68,7 @@ export class PairingService {
       code,
       platformUserId,
       platformType,
+      pluginScope: effectiveScope,
       displayName,
       requestedAt: now,
       expiresAt,
@@ -86,29 +89,36 @@ export class PairingService {
   /**
    * Refresh pairing code for a user (generate new one)
    */
-  async refreshPairingCode(platformUserId: string, platformType: PluginType, displayName?: string): Promise<{ code: string; expiresAt: number }> {
+  async refreshPairingCode(platformUserId: string, platformType: PluginType, displayName?: string, scope?: string): Promise<{ code: string; expiresAt: number }> {
     const db = getDatabase();
+    const effectiveScope = scope || platformType;
 
-    // Expire any existing pending codes
+    // Expire any existing pending codes for THIS connection
     const existingResult = db.getPendingPairingRequests();
     if (existingResult.success && existingResult.data) {
       for (const request of existingResult.data) {
-        if (request.platformUserId === platformUserId && request.platformType === platformType && request.status === 'pending') {
+        if (request.platformUserId === platformUserId && (request.pluginScope ?? request.platformType) === effectiveScope && request.status === 'pending') {
           db.updatePairingRequestStatus(request.code, 'expired');
         }
       }
     }
 
     // Generate new code
-    return this.generatePairingCode(platformUserId, platformType, displayName);
+    return this.generatePairingCode(platformUserId, platformType, displayName, effectiveScope);
   }
 
   /**
    * Check if a user is already authorized
    */
-  isUserAuthorized(platformUserId: string, platformType: PluginType): boolean {
+  /**
+   * Whether this IM user is authorized on ONE connection.
+   *
+   * `scope` is the connection scope, not the platform: with several bots of a type
+   * connected, checking the platform would let anyone paired with one bot use them all.
+   */
+  isUserAuthorized(platformUserId: string, scope: PluginType): boolean {
     const db = getDatabase();
-    const result = db.getChannelUserByPlatform(platformUserId, platformType);
+    const result = db.getChannelUserByPlatform(platformUserId, scope);
     return result.success && result.data !== null;
   }
 
@@ -124,7 +134,7 @@ export class PairingService {
   /**
    * Get pending pairing request for a user
    */
-  getPendingRequestForUser(platformUserId: string, platformType: PluginType): IChannelPairingRequest | null {
+  getPendingRequestForUser(platformUserId: string, scope: PluginType): IChannelPairingRequest | null {
     const db = getDatabase();
     const result = db.getPendingPairingRequests();
 
@@ -132,7 +142,7 @@ export class PairingService {
       return null;
     }
 
-    return result.data.find((r) => r.platformUserId === platformUserId && r.platformType === platformType && r.status === 'pending' && r.expiresAt > Date.now()) ?? null;
+    return result.data.find((r) => r.platformUserId === platformUserId && (r.pluginScope ?? r.platformType) === scope && r.status === 'pending' && r.expiresAt > Date.now()) ?? null;
   }
 
   /**
@@ -156,7 +166,7 @@ export class PairingService {
     // Check if already processed
     if (request.status === 'approved') {
       // Already approved - get the user and return success
-      const existingUser = db.getChannelUserByPlatform(request.platformUserId, request.platformType);
+      const existingUser = db.getChannelUserByPlatform(request.platformUserId, (request.pluginScope ?? request.platformType) as PluginType);
       if (existingUser.success && existingUser.data) {
         return { success: true, user: existingUser.data };
       }
@@ -173,7 +183,7 @@ export class PairingService {
     }
 
     // Check if user already exists
-    const existingUser = db.getChannelUserByPlatform(request.platformUserId, request.platformType);
+    const existingUser = db.getChannelUserByPlatform(request.platformUserId, (request.pluginScope ?? request.platformType) as PluginType);
     if (existingUser.success && existingUser.data) {
       db.updatePairingRequestStatus(code, 'approved');
       return { success: true, user: existingUser.data };
@@ -185,6 +195,8 @@ export class PairingService {
       id: userId,
       platformUserId: request.platformUserId,
       platformType: request.platformType,
+      // Authorize on the connection the code was issued for, not the whole platform.
+      pluginScope: request.pluginScope ?? request.platformType,
       displayName: request.displayName,
       authorizedAt: Date.now(),
     };

--- a/src/channels/plugins/BasePlugin.ts
+++ b/src/channels/plugins/BasePlugin.ts
@@ -9,7 +9,12 @@ import type { IChannelPluginConfig, IUnifiedIncomingMessage, IUnifiedOutgoingMes
 /**
  * Plugin event handler type
  */
-export type PluginMessageHandler = (message: IUnifiedIncomingMessage) => Promise<void>;
+/**
+ * `sourcePlugin` is the connection instance that received the message. With several
+ * connections of one type (e.g. two WeCom bots), the platform alone no longer identifies
+ * which bot to reply through or whose sessions to use.
+ */
+export type PluginMessageHandler = (message: IUnifiedIncomingMessage, sourcePlugin: BasePlugin) => Promise<void>;
 
 /**
  * Tool confirmation handler type
@@ -102,6 +107,15 @@ export abstract class BasePlugin {
   }
 
   /**
+   * Id of the connection this instance serves (e.g. "wecom_default", "wecom_a1b2c3d4").
+   * A type may have several connections; callers use this to keep their sessions,
+   * authorizations and agent bindings apart.
+   */
+  get pluginId(): string {
+    return this.config?.id ?? `${this.type}_default`;
+  }
+
+  /**
    * Initialize the plugin with configuration
    * @param config Plugin configuration from database
    */
@@ -179,7 +193,7 @@ export abstract class BasePlugin {
    */
   protected async emitMessage(message: IUnifiedIncomingMessage): Promise<void> {
     if (this.messageHandler) {
-      await this.messageHandler(message);
+      await this.messageHandler(message, this);
     } else {
       console.warn(`[${this.type}Plugin] No message handler registered, dropping message`);
     }

--- a/src/channels/plugins/lark/LarkPlugin.ts
+++ b/src/channels/plugins/lark/LarkPlugin.ts
@@ -461,7 +461,7 @@ export class LarkPlugin extends BasePlugin {
         }
 
         // Process in background to avoid blocking
-        void this.messageHandler(unifiedMessage).catch((error) => console.error(`[LarkPlugin] Error handling message:`, error));
+        void this.messageHandler(unifiedMessage, this).catch((error) => console.error(`[LarkPlugin] Error handling message:`, error));
       }
     } catch (error) {
       console.error('[LarkPlugin] Error processing message event:', error);
@@ -691,7 +691,7 @@ export class LarkPlugin extends BasePlugin {
       };
 
       if (this.messageHandler) {
-        void this.messageHandler(unifiedMessage).catch((error) => console.error(`[LarkPlugin] Error handling bot menu action:`, error));
+        void this.messageHandler(unifiedMessage, this).catch((error) => console.error(`[LarkPlugin] Error handling bot menu action:`, error));
       }
     } catch (error) {
       console.error('[LarkPlugin] Error processing bot menu event:', error);
@@ -733,7 +733,7 @@ export class LarkPlugin extends BasePlugin {
       // Convert to unified message with action
       const unifiedMessage = toUnifiedIncomingMessage(event, actionInfo);
       if (unifiedMessage && this.messageHandler) {
-        void this.messageHandler(unifiedMessage).catch((error) => console.error(`[LarkPlugin] Error handling card action:`, error));
+        void this.messageHandler(unifiedMessage, this).catch((error) => console.error(`[LarkPlugin] Error handling card action:`, error));
       }
     } catch (error) {
       console.error('[LarkPlugin] Error processing card action:', error);

--- a/src/channels/plugins/telegram/TelegramPlugin.ts
+++ b/src/channels/plugins/telegram/TelegramPlugin.ts
@@ -239,7 +239,7 @@ export class TelegramPlugin extends BasePlugin {
       unifiedMessage.content.type = 'command';
       unifiedMessage.content.text = '/start';
       // Don't await - process in background
-      void this.messageHandler(unifiedMessage).catch((error) => console.error(`[TelegramPlugin] Error handling start command:`, error));
+      void this.messageHandler(unifiedMessage, this).catch((error) => console.error(`[TelegramPlugin] Error handling start command:`, error));
     }
   }
 
@@ -269,7 +269,7 @@ export class TelegramPlugin extends BasePlugin {
         // would prevent subsequent messages from being received
         // 重要：不要 await - 在后台处理以避免阻塞轮询循环
         // grammY 的简单轮询是顺序处理的，阻塞这里会导致后续消息无法接收
-        void this.messageHandler(unifiedMessage).catch((error) => {
+        void this.messageHandler(unifiedMessage, this).catch((error) => {
           console.error(`[TelegramPlugin] Message handler failed for: ${text?.slice(0, 20)}...`, error);
         });
       } else {
@@ -309,7 +309,7 @@ export class TelegramPlugin extends BasePlugin {
         name: buttonAction.action,
       };
       // Don't await - process in background
-      void this.messageHandler(unifiedMessage).catch((error) => console.error(`[TelegramPlugin] Error handling button command:`, error));
+      void this.messageHandler(unifiedMessage, this).catch((error) => console.error(`[TelegramPlugin] Error handling button command:`, error));
       return true;
     }
 
@@ -330,7 +330,7 @@ export class TelegramPlugin extends BasePlugin {
     const unifiedMessage = toUnifiedIncomingMessage(ctx);
     if (unifiedMessage && this.messageHandler) {
       // Don't await - process in background
-      void this.messageHandler(unifiedMessage).catch((error) => console.error(`[TelegramPlugin] Error handling media message:`, error));
+      void this.messageHandler(unifiedMessage, this).catch((error) => console.error(`[TelegramPlugin] Error handling media message:`, error));
     }
   }
 
@@ -398,7 +398,7 @@ export class TelegramPlugin extends BasePlugin {
           params: { agentType },
         };
         // Don't await - process in background
-        void this.messageHandler(unifiedMessage)
+        void this.messageHandler(unifiedMessage, this)
           .then(async () => {
             // Remove inline keyboard after selection
             try {
@@ -429,7 +429,7 @@ export class TelegramPlugin extends BasePlugin {
       };
 
       // Don't await - process in background
-      void this.messageHandler(unifiedMessage).catch((error) => console.error(`[TelegramPlugin] Error handling callback query:`, error));
+      void this.messageHandler(unifiedMessage, this).catch((error) => console.error(`[TelegramPlugin] Error handling callback query:`, error));
     }
   }
 

--- a/src/channels/plugins/wechat/WeChatPlugin.ts
+++ b/src/channels/plugins/wechat/WeChatPlugin.ts
@@ -806,7 +806,7 @@ export class WeChatPlugin extends BasePlugin {
         // Process merged message
         const unified = toUnifiedIncomingMessage(mergedMsg);
         if (unified && this.messageHandler) {
-          void this.messageHandler(unified).catch((error) => {
+          void this.messageHandler(unified, this).catch((error) => {
             console.error(`[WeChatPlugin] Message handler failed for merged message:`, error);
           });
         }
@@ -845,7 +845,7 @@ export class WeChatPlugin extends BasePlugin {
 
     // Forward to message handler
     if (this.messageHandler) {
-      void this.messageHandler(unified).catch((error) => {
+      void this.messageHandler(unified, this).catch((error) => {
         console.error(`[WeChatPlugin] Message handler failed for ${msg.message_id}:`, error);
       });
     }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -162,6 +162,11 @@ export interface IChannelUser {
   id: string;
   platformUserId: string;
   platformType: PluginType;
+  /**
+   * Connection this authorization belongs to (see pluginScope): the bare platform for a
+   * type's first connection, the plugin id for any additional one. Absent means the first.
+   */
+  pluginScope?: string;
   displayName?: string;
   authorizedAt: number;
   lastActive?: number;
@@ -175,6 +180,7 @@ export interface IChannelUserRow {
   id: string;
   platform_user_id: string;
   platform_type: string;
+  plugin_scope?: string | null;
   display_name: string | null;
   authorized_at: number;
   last_active: number | null;
@@ -233,6 +239,8 @@ export interface IChannelPairingRequest {
   code: string;
   platformUserId: string;
   platformType: PluginType;
+  /** Connection the code was issued for; see IChannelUser.pluginScope. */
+  pluginScope?: string;
   displayName?: string;
   requestedAt: number;
   expiresAt: number;
@@ -246,6 +254,7 @@ export interface IChannelPairingCodeRow {
   code: string;
   platform_user_id: string;
   platform_type: string;
+  plugin_scope?: string | null;
   display_name: string | null;
   requested_at: number;
   expires_at: number;
@@ -450,6 +459,7 @@ export function rowToChannelUser(row: IChannelUserRow): IChannelUser {
     id: row.id,
     platformUserId: row.platform_user_id,
     platformType: row.platform_type as PluginType,
+    pluginScope: row.plugin_scope ?? row.platform_type,
     displayName: row.display_name ?? undefined,
     authorizedAt: row.authorized_at,
     lastActive: row.last_active ?? undefined,
@@ -465,6 +475,7 @@ export function channelUserToRow(user: IChannelUser): IChannelUserRow {
     id: user.id,
     platform_user_id: user.platformUserId,
     platform_type: user.platformType,
+    plugin_scope: user.pluginScope ?? user.platformType,
     display_name: user.displayName ?? null,
     authorized_at: user.authorizedAt,
     last_active: user.lastActive ?? null,
@@ -512,6 +523,7 @@ export function rowToPairingRequest(row: IChannelPairingCodeRow): IChannelPairin
     code: row.code,
     platformUserId: row.platform_user_id,
     platformType: row.platform_type as PluginType,
+    pluginScope: row.plugin_scope ?? row.platform_type,
     displayName: row.display_name ?? undefined,
     requestedAt: row.requested_at,
     expiresAt: row.expires_at,
@@ -527,6 +539,7 @@ export function pairingRequestToRow(request: IChannelPairingRequest): IChannelPa
     code: request.code,
     platform_user_id: request.platformUserId,
     platform_type: request.platformType,
+    plugin_scope: request.pluginScope ?? request.platformType,
     display_name: request.displayName ?? null,
     requested_at: request.requestedAt,
     expires_at: request.expiresAt,
@@ -582,4 +595,77 @@ export function getChannelConversationName(platform: ChannelPlatform | PluginTyp
   if (type === 'acp' && backend) parts.push(backend);
   if (chatId) parts.push(chatId.slice(0, 8));
   return parts.join('-');
+}
+
+// ==================== Plugin Instance Identity ====================
+
+/**
+ * Known built-in channel types, in one place so ID parsing and UI listing stay in sync.
+ */
+export const KNOWN_CHANNEL_TYPES: readonly string[] = ['telegram', 'lark', 'dingtalk', 'wechat', 'wecom', 'zentao'];
+
+/**
+ * The plugin id every channel type used before multiple connections were supported.
+ *
+ * Still the id of the first connection of each type, so existing rows — and the sessions,
+ * authorizations and pairings that reference them — keep working untouched after upgrade.
+ */
+export function defaultPluginId(type: PluginType): string {
+  return `${type}_default`;
+}
+
+/** Build the id for an additional connection of a type: `<type>_<suffix>`. */
+export function buildPluginId(type: PluginType, suffix: string): string {
+  return `${type}_${suffix}`;
+}
+
+/**
+ * Generate a fresh plugin id for a new connection of this type.
+ * Random rather than sequential: connections can be deleted, and reusing an index would
+ * hand a new bot the sessions and authorizations of the deleted one.
+ */
+export function generatePluginId(type: PluginType): string {
+  const suffix = Math.random().toString(36).slice(2, 10);
+  return buildPluginId(type, suffix);
+}
+
+/**
+ * Extract the channel type from a plugin id (e.g. "wecom_a1b2c3d4" -> "wecom").
+ * Falls back to the whole id, which is how extension plugins name themselves.
+ */
+export function pluginTypeFromId(pluginId: string): PluginType {
+  for (const type of KNOWN_CHANNEL_TYPES) {
+    if (pluginId === type || pluginId.startsWith(`${type}_`)) return type;
+  }
+  return pluginId;
+}
+
+/**
+ * Scope key identifying ONE connection for session, authorization and agent-binding
+ * lookups. Two bots of the same type must never share a conversation, an authorization
+ * or an agent binding, so everything that used to key on the bare platform keys on this.
+ *
+ * The first connection of a type keeps the bare platform as its scope, so rows written
+ * before multiple connections existed still resolve to it.
+ */
+export function pluginScope(pluginId: string | undefined, platform: PluginType): string {
+  if (!pluginId) return platform;
+  const type = pluginTypeFromId(pluginId);
+  return pluginId === defaultPluginId(type) || pluginId === type ? type : pluginId;
+}
+
+/**
+ * Chat key that is unique across connections of the same type.
+ *
+ * Platform chat ids only identify a chat WITHIN one bot — a DM is keyed by the platform
+ * user — so the same person messaging two of your bots yields the same raw chatId. Session
+ * lookup and the per-chat agent binding key on this instead, so two bots never share one
+ * conversation.
+ *
+ * A type's first connection keeps the raw chatId, so chats that predate multiple
+ * connections keep resolving to their existing session.
+ */
+export function scopedChatId(pluginId: string | undefined, platform: PluginType, chatId: string): string {
+  const scope = pluginScope(pluginId, platform);
+  return scope === platform ? chatId : `${scope}#${chatId}`;
 }

--- a/src/common/ipcBridge.ts
+++ b/src/common/ipcBridge.ts
@@ -2081,6 +2081,10 @@ export const channel = {
   getPluginCredentials: bridge.buildProvider<IBridgeResponse<IPluginCredentials | null>, { pluginId: string }>('channel.get-plugin-credentials'),
   enablePlugin: bridge.buildProvider<IBridgeResponse, { pluginId: string; config: Record<string, unknown> }>('channel.enable-plugin'),
   disablePlugin: bridge.buildProvider<IBridgeResponse, { pluginId: string }>('channel.disable-plugin'),
+  /** Allocate an additional connection of a channel type; resolves with its plugin id. */
+  createPlugin: bridge.buildProvider<IBridgeResponse<{ pluginId: string } | null>, { type: string; name?: string }>('channel.create-plugin'),
+  /** Delete one connection, with the authorizations scoped to it. */
+  removePlugin: bridge.buildProvider<IBridgeResponse, { pluginId: string }>('channel.remove-plugin'),
   testPlugin: bridge.buildProvider<IBridgeResponse<{ success: boolean; botUsername?: string; error?: string }>, { pluginId: string; token: string; extraConfig?: { appId?: string; appSecret?: string } }>('channel.test-plugin'),
 
   // Pairing Management

--- a/src/process/bridge/channelBridge.ts
+++ b/src/process/bridge/channelBridge.ts
@@ -10,7 +10,7 @@ import { getChannelManager } from '@/channels/core/ChannelManager';
 import { isEnterpriseMode } from '@/common/enterpriseDebugConfig';
 import { ExtensionRegistry } from '@/extensions';
 import { toAssetUrl } from '@/extensions/assetProtocol';
-import type { IChannelPluginStatus } from '@/channels/types';
+import type { IChannelPluginStatus, PluginType } from '@/channels/types';
 import { hasPluginCredentials } from '@/channels/types';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
 
@@ -213,6 +213,40 @@ export function initChannelBridge(): void {
       return { success: true };
     } catch (error: any) {
       mainError('ChannelBridge', 'disablePlugin error:', error);
+      return { success: false, msg: error.message };
+    }
+  });
+
+  /**
+   * Allocate an additional connection of a channel type
+   */
+  channel.createPlugin.provider(async ({ type, name }) => {
+    try {
+      const manager = getChannelManager();
+      const result = await manager.createPlugin(type as PluginType, name);
+      if (!result.success || !result.pluginId) {
+        return { success: false, msg: result.error };
+      }
+      return { success: true, data: { pluginId: result.pluginId } };
+    } catch (error: any) {
+      mainError('ChannelBridge', 'createPlugin error:', error);
+      return { success: false, msg: error.message };
+    }
+  });
+
+  /**
+   * Delete one connection entirely
+   */
+  channel.removePlugin.provider(async ({ pluginId }) => {
+    try {
+      const manager = getChannelManager();
+      const result = await manager.removePlugin(pluginId);
+      if (!result.success) {
+        return { success: false, msg: result.error };
+      }
+      return { success: true };
+    } catch (error: any) {
+      mainError('ChannelBridge', 'removePlugin error:', error);
       return { success: false, msg: error.message };
     }
   });

--- a/src/process/database/index.ts
+++ b/src/process/database/index.ts
@@ -1562,9 +1562,16 @@ export class SudoworkDatabase {
   /**
    * Get assistant user by platform user ID
    */
-  getChannelUserByPlatform(platformUserId: string, platformType: PluginType): IQueryResult<IChannelUser | null> {
+  /**
+   * Look up an authorized user within ONE connection.
+   *
+   * `scope` is the connection scope (pluginScope): the bare platform for a type's first
+   * connection, the plugin id for any additional one. Matching on platform_type instead
+   * would let a user paired with one bot talk to every other bot of that type.
+   */
+  getChannelUserByPlatform(platformUserId: string, scope: PluginType): IQueryResult<IChannelUser | null> {
     try {
-      const row = this.db.prepare('SELECT * FROM assistant_users WHERE platform_user_id = ? AND platform_type = ?').get(platformUserId, platformType) as IChannelUserRow | undefined;
+      const row = this.db.prepare('SELECT * FROM assistant_users WHERE platform_user_id = ? AND plugin_scope = ?').get(platformUserId, scope) as IChannelUserRow | undefined;
 
       return { success: true, data: row ? rowToChannelUser(row) : null };
     } catch (error: any) {
@@ -1578,11 +1585,12 @@ export class SudoworkDatabase {
   createChannelUser(user: IChannelUser): IQueryResult<IChannelUser> {
     try {
       const stmt = this.db.prepare(`
-        INSERT INTO assistant_users (id, platform_user_id, platform_type, display_name, authorized_at, last_active, session_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO assistant_users (id, platform_user_id, platform_type, plugin_scope, display_name, authorized_at, last_active, session_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
-      stmt.run(user.id, user.platformUserId, user.platformType, user.displayName ?? null, user.authorizedAt, user.lastActive ?? null, user.sessionId ?? null);
+      // Absent scope means the type's first connection, whose scope IS the platform.
+      stmt.run(user.id, user.platformUserId, user.platformType, user.pluginScope ?? user.platformType, user.displayName ?? null, user.authorizedAt, user.lastActive ?? null, user.sessionId ?? null);
 
       return { success: true, data: user };
     } catch (error: any) {
@@ -1619,12 +1627,14 @@ export class SudoworkDatabase {
    * Delete all channel users for a specific platform
    * Used when disabling a channel to clear all authorized users
    */
-  deleteChannelUsersByPlatform(platformType: string): IQueryResult<number> {
+  deleteChannelUsersByPlatform(scope: string): IQueryResult<number> {
     try {
-      // First delete sessions for users of this platform (foreign key constraint)
-      this.db.prepare('DELETE FROM assistant_sessions WHERE user_id IN (SELECT id FROM assistant_users WHERE platform_type = ?)').run(platformType);
+      // Scoped to ONE connection: disabling one bot must not deauthorize everyone paired
+      // with its siblings of the same type.
+      // First delete sessions for users of this connection (foreign key constraint)
+      this.db.prepare('DELETE FROM assistant_sessions WHERE user_id IN (SELECT id FROM assistant_users WHERE plugin_scope = ?)').run(scope);
       // Then delete the users
-      const result = this.db.prepare('DELETE FROM assistant_users WHERE platform_type = ?').run(platformType);
+      const result = this.db.prepare('DELETE FROM assistant_users WHERE plugin_scope = ?').run(scope);
       return { success: true, data: result.changes };
     } catch (error: any) {
       return { success: false, error: error.message, data: 0 };
@@ -1737,11 +1747,11 @@ export class SudoworkDatabase {
   createPairingRequest(request: IChannelPairingRequest): IQueryResult<IChannelPairingRequest> {
     try {
       const stmt = this.db.prepare(`
-        INSERT INTO assistant_pairing_codes (code, platform_user_id, platform_type, display_name, requested_at, expires_at, status)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO assistant_pairing_codes (code, platform_user_id, platform_type, plugin_scope, display_name, requested_at, expires_at, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
-      stmt.run(request.code, request.platformUserId, request.platformType, request.displayName ?? null, request.requestedAt, request.expiresAt, request.status);
+      stmt.run(request.code, request.platformUserId, request.platformType, request.pluginScope ?? request.platformType, request.displayName ?? null, request.requestedAt, request.expiresAt, request.status);
 
       return { success: true, data: request };
     } catch (error: any) {

--- a/src/process/database/migrations.ts
+++ b/src/process/database/migrations.ts
@@ -827,6 +827,76 @@ const migration_v14: IMigration = {
 };
 
 /**
+ * v32: scope channel authorizations and pairings to ONE connection.
+ *
+ * A channel type may now have several connections (e.g. two WeCom bots). Keyed on
+ * `platform_type` alone, a user paired with bot A was authorized on bot B as well, and the
+ * two bots shared one conversation. `plugin_scope` names the owning connection — the bare
+ * platform for a type's FIRST connection, so every existing row keeps resolving exactly as
+ * before, and the plugin id for any additional one.
+ */
+const migration_v32: IMigration = {
+  version: 32,
+  name: 'Scope assistant users and pairing codes to a single channel connection',
+  up: (db) => {
+    // assistant_users: UNIQUE(platform_user_id, platform_type) -> (platform_user_id, plugin_scope).
+    // SQLite cannot alter a constraint, so rebuild. Existing rows backfill plugin_scope
+    // from platform_type, which IS the scope of a type's first connection.
+    db.exec(`
+      CREATE TABLE assistant_users_v32 (
+        id TEXT PRIMARY KEY,
+        platform_user_id TEXT NOT NULL,
+        platform_type TEXT NOT NULL,
+        plugin_scope TEXT NOT NULL DEFAULT '',
+        display_name TEXT,
+        authorized_at INTEGER NOT NULL,
+        last_active INTEGER,
+        session_id TEXT,
+        UNIQUE(platform_user_id, plugin_scope)
+      );
+      INSERT OR IGNORE INTO assistant_users_v32 (id, platform_user_id, platform_type, plugin_scope, display_name, authorized_at, last_active, session_id)
+        SELECT id, platform_user_id, platform_type, platform_type, display_name, authorized_at, last_active, session_id FROM assistant_users;
+      DROP TABLE assistant_users;
+      ALTER TABLE assistant_users_v32 RENAME TO assistant_users;
+      CREATE INDEX IF NOT EXISTS idx_assistant_users_platform ON assistant_users(platform_type, platform_user_id);
+      CREATE INDEX IF NOT EXISTS idx_assistant_users_scope ON assistant_users(plugin_scope, platform_user_id);
+    `);
+
+    // assistant_pairing_codes: plain column add, no constraint change.
+    const pairingCols = db.prepare(`PRAGMA table_info(assistant_pairing_codes)`).all() as Array<{ name: string }>;
+    if (!pairingCols.some((c) => c.name === 'plugin_scope')) {
+      db.exec(`ALTER TABLE assistant_pairing_codes ADD COLUMN plugin_scope TEXT;`);
+      db.exec(`UPDATE assistant_pairing_codes SET plugin_scope = platform_type WHERE plugin_scope IS NULL;`);
+    }
+
+    mainLog('Migration v32', 'Scoped assistant users and pairing codes to a single connection');
+  },
+  down: (db) => {
+    // Collapse back to one connection per type: keep the earliest authorization per
+    // (platform_user_id, platform_type) since the old UNIQUE constraint allows only one.
+    db.exec(`
+      CREATE TABLE assistant_users_v32_down (
+        id TEXT PRIMARY KEY,
+        platform_user_id TEXT NOT NULL,
+        platform_type TEXT NOT NULL,
+        display_name TEXT,
+        authorized_at INTEGER NOT NULL,
+        last_active INTEGER,
+        session_id TEXT,
+        UNIQUE(platform_user_id, platform_type)
+      );
+      INSERT OR IGNORE INTO assistant_users_v32_down (id, platform_user_id, platform_type, display_name, authorized_at, last_active, session_id)
+        SELECT id, platform_user_id, platform_type, display_name, authorized_at, last_active, session_id
+          FROM assistant_users ORDER BY authorized_at ASC;
+      DROP TABLE assistant_users;
+      ALTER TABLE assistant_users_v32_down RENAME TO assistant_users;
+      CREATE INDEX IF NOT EXISTS idx_assistant_users_platform ON assistant_users(platform_type, platform_user_id);
+    `);
+    mainLog('Migration v32', 'Rolled back: assistant users scoped to platform only');
+  },
+};
+
+/**
  * All migrations in order
  */
 /**
@@ -1909,6 +1979,7 @@ export const ALL_MIGRATIONS: IMigration[] = [
   migration_v13, migration_v14, migration_v15, migration_v16, migration_v17, migration_v18,
   migration_v19, migration_v20, migration_v21, migration_v22, migration_v23, migration_v24,
   migration_v25, migration_v26, migration_v27, migration_v28, migration_v29, migration_v30, migration_v31,
+  migration_v32,
 ];
 
 /**

--- a/src/process/database/schema.ts
+++ b/src/process/database/schema.ts
@@ -205,4 +205,4 @@ export function setDatabaseVersion(db: Database.Database, version: number): void
  * Current database schema version
  * Update this when adding new migrations in migrations.ts
  */
-export const CURRENT_DB_VERSION = 31;
+export const CURRENT_DB_VERSION = 32;

--- a/src/renderer/pages/settings/channels/components/ChannelPanel.tsx
+++ b/src/renderer/pages/settings/channels/components/ChannelPanel.tsx
@@ -213,7 +213,7 @@ const ChannelPanel: React.FC = () => {
         }
 
         const result = await channel.enablePlugin.invoke({
-          pluginId: (pluginStatus?.id ?? 'telegram_default'),
+          pluginId: pluginStatus?.id ?? 'telegram_default',
           config: pendingToken ? { token: pendingToken } : {},
         });
 
@@ -224,7 +224,7 @@ const ChannelPanel: React.FC = () => {
           Message.error(result.msg || t('settings.assistant.enableFailed', 'Failed to enable plugin'));
         }
       } else {
-        const result = await channel.disablePlugin.invoke({ pluginId: (pluginStatus?.id ?? 'telegram_default') });
+        const result = await channel.disablePlugin.invoke({ pluginId: pluginStatus?.id ?? 'telegram_default' });
 
         if (result.success) {
           Message.success(t('settings.assistant.pluginDisabled', 'Telegram bot disabled'));
@@ -261,7 +261,7 @@ const ChannelPanel: React.FC = () => {
         const config = hasFormCreds ? { appId: pendingCreds.appId.trim(), appSecret: pendingCreds.appSecret.trim(), encryptKey: pendingCreds.encryptKey, verificationToken: pendingCreds.verificationToken } : {};
 
         const result = await channel.enablePlugin.invoke({
-          pluginId: (larkPluginStatus?.id ?? 'lark_default'),
+          pluginId: larkPluginStatus?.id ?? 'lark_default',
           config,
         });
 
@@ -279,7 +279,7 @@ const ChannelPanel: React.FC = () => {
     } else {
       setLarkEnableLoading(true);
       try {
-        const result = await channel.disablePlugin.invoke({ pluginId: (larkPluginStatus?.id ?? 'lark_default') });
+        const result = await channel.disablePlugin.invoke({ pluginId: larkPluginStatus?.id ?? 'lark_default' });
 
         if (result.success) {
           Message.success(t('settings.lark.pluginDisabled', 'Lark bot disabled'));
@@ -315,7 +315,7 @@ const ChannelPanel: React.FC = () => {
         const config = hasFormCreds ? { clientId: pendingCreds.clientId.trim(), clientSecret: pendingCreds.clientSecret.trim() } : {};
 
         const result = await channel.enablePlugin.invoke({
-          pluginId: (dingtalkPluginStatus?.id ?? 'dingtalk_default'),
+          pluginId: dingtalkPluginStatus?.id ?? 'dingtalk_default',
           config,
         });
 
@@ -333,7 +333,7 @@ const ChannelPanel: React.FC = () => {
     } else {
       setDingtalkEnableLoading(true);
       try {
-        const result = await channel.disablePlugin.invoke({ pluginId: (dingtalkPluginStatus?.id ?? 'dingtalk_default') });
+        const result = await channel.disablePlugin.invoke({ pluginId: dingtalkPluginStatus?.id ?? 'dingtalk_default' });
 
         if (result.success) {
           Message.success(t('settings.dingtalk.pluginDisabled', 'DingTalk bot disabled'));
@@ -363,7 +363,7 @@ const ChannelPanel: React.FC = () => {
       setWechatEnableLoading(true);
       try {
         const result = await channel.enablePlugin.invoke({
-          pluginId: (wechatPluginStatus?.id ?? 'wechat_default'),
+          pluginId: wechatPluginStatus?.id ?? 'wechat_default',
           config: {},
         });
         if (result.success) {
@@ -386,7 +386,7 @@ const ChannelPanel: React.FC = () => {
       // Disable
       setWechatEnableLoading(true);
       try {
-        const result = await channel.disablePlugin.invoke({ pluginId: (wechatPluginStatus?.id ?? 'wechat_default') });
+        const result = await channel.disablePlugin.invoke({ pluginId: wechatPluginStatus?.id ?? 'wechat_default' });
         if (result.success) {
           Message.success(t('settings.channels.wechat.disabled', 'WeChat disabled'));
           // Force immediate status re-fetch to ensure UI sync
@@ -417,11 +417,11 @@ const ChannelPanel: React.FC = () => {
 
         // If no pending credentials, try to get saved credentials from database
         if (!pendingBotId || !pendingSecret) {
-          const credResult = await channel.getPluginCredentials.invoke({ pluginId: (wecomPluginStatus?.id ?? 'wecom_default') });
+          const credResult = await channel.getPluginCredentials.invoke({ pluginId: wecomPluginStatus?.id ?? 'wecom_default' });
           if (credResult.success && credResult.data?.botId && credResult.data?.secret) {
             // Found saved credentials, use them
             const result = await channel.enablePlugin.invoke({
-              pluginId: (wecomPluginStatus?.id ?? 'wecom_default'),
+              pluginId: wecomPluginStatus?.id ?? 'wecom_default',
               config: {},
             });
 
@@ -442,7 +442,7 @@ const ChannelPanel: React.FC = () => {
 
         // Pass credentials from form input
         const result = await channel.enablePlugin.invoke({
-          pluginId: (wecomPluginStatus?.id ?? 'wecom_default'),
+          pluginId: wecomPluginStatus?.id ?? 'wecom_default',
           config: { botId: pendingBotId, secret: pendingSecret },
         });
 
@@ -453,7 +453,7 @@ const ChannelPanel: React.FC = () => {
           Message.error(result.msg || t('settings.wecom.enableFailed', 'Failed to enable WeCom plugin'));
         }
       } else {
-        const result = await channel.disablePlugin.invoke({ pluginId: (wecomPluginStatus?.id ?? 'wecom_default') });
+        const result = await channel.disablePlugin.invoke({ pluginId: wecomPluginStatus?.id ?? 'wecom_default' });
 
         if (result.success) {
           Message.success(t('settings.wecom.pluginDisabled', 'WeCom bot disabled'));
@@ -905,13 +905,7 @@ const ChannelPanel: React.FC = () => {
           <div className='text-13px text-foreground'>{t('settings.channels.addConnectionTitle', { defaultValue: 'Add another connection' })}</div>
           <div className='flex flex-wrap gap-2'>
             {ADDABLE_CHANNEL_TYPES.map((type) => (
-              <button
-                key={type}
-                type='button'
-                disabled={addingType === type}
-                onClick={() => void handleAddConnection(type)}
-                className='px-2.5 py-1.5 text-12px rd-md b-1 b-solid b-[var(--ui-border)] text-secondary hover:text-foreground disabled:opacity-50'
-              >
+              <button key={type} type='button' disabled={addingType === type} onClick={() => void handleAddConnection(type)} className='px-2.5 py-1.5 text-12px rd-md b-1 b-solid b-[var(--ui-border)] text-secondary hover:text-foreground disabled:opacity-50'>
                 {addingType === type ? t('settings.channels.adding', { defaultValue: 'Adding…' }) : `+ ${CHANNEL_TYPE_LABELS[type]}`}
               </button>
             ))}

--- a/src/renderer/pages/settings/channels/components/ChannelPanel.tsx
+++ b/src/renderer/pages/settings/channels/components/ChannelPanel.tsx
@@ -24,6 +24,17 @@ import ChannelItem from './ChannelItem';
 /**
  * Assistant Settings Content Component
  */
+/** Builtin types a user can add more connections of. */
+const ADDABLE_CHANNEL_TYPES = ['telegram', 'lark', 'dingtalk', 'wechat', 'wecom'] as const;
+
+const CHANNEL_TYPE_LABELS: Record<string, string> = {
+  telegram: 'Telegram',
+  lark: 'Lark / Feishu',
+  dingtalk: 'DingTalk',
+  wechat: 'WeChat',
+  wecom: 'WeCom',
+};
+
 const ChannelPanel: React.FC = () => {
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
@@ -76,6 +87,15 @@ const ChannelPanel: React.FC = () => {
   const wechatModelSelection = useChannelModelSelection('assistant.wechat.defaultModel');
   const wecomModelSelection = useChannelModelSelection('assistant.wecom.defaultModel');
 
+  /**
+   * Connections BEYOND the first of each builtin type. The five cards above each render a
+   * type's first connection (the one whose settings the legacy per-type config keys
+   * describe); these render every additional bot the user has added.
+   */
+  const [extraConnections, setExtraConnections] = useState<IChannelPluginStatus[]>([]);
+  const [extraLoadingMap, setExtraLoadingMap] = useState<Record<string, boolean>>({});
+  const [addingType, setAddingType] = useState<string | null>(null);
+
   // Load plugin status
   const loadPluginStatus = useCallback(async () => {
     try {
@@ -87,6 +107,9 @@ const ChannelPanel: React.FC = () => {
         const wechatPlugin = result.data.find((p) => p.type === 'wechat');
         const wecomPlugin = result.data.find((p) => p.type === 'wecom');
         const extensionPlugins = result.data.filter((p) => !BUILTIN_CHANNEL_TYPES.has(p.type) && p.type !== 'zentao');
+        // Everything after the first connection of each builtin type gets its own card.
+        const primaryIds = new Set([telegramPlugin?.id, larkPlugin?.id, dingtalkPlugin?.id, wechatPlugin?.id, wecomPlugin?.id].filter(Boolean) as string[]);
+        setExtraConnections(result.data.filter((p) => BUILTIN_CHANNEL_TYPES.has(p.type) && !primaryIds.has(p.id)));
 
         setPluginStatus(telegramPlugin || null);
         setLarkPluginStatus(larkPlugin || null);
@@ -190,7 +213,7 @@ const ChannelPanel: React.FC = () => {
         }
 
         const result = await channel.enablePlugin.invoke({
-          pluginId: 'telegram_default',
+          pluginId: (pluginStatus?.id ?? 'telegram_default'),
           config: pendingToken ? { token: pendingToken } : {},
         });
 
@@ -201,7 +224,7 @@ const ChannelPanel: React.FC = () => {
           Message.error(result.msg || t('settings.assistant.enableFailed', 'Failed to enable plugin'));
         }
       } else {
-        const result = await channel.disablePlugin.invoke({ pluginId: 'telegram_default' });
+        const result = await channel.disablePlugin.invoke({ pluginId: (pluginStatus?.id ?? 'telegram_default') });
 
         if (result.success) {
           Message.success(t('settings.assistant.pluginDisabled', 'Telegram bot disabled'));
@@ -238,7 +261,7 @@ const ChannelPanel: React.FC = () => {
         const config = hasFormCreds ? { appId: pendingCreds.appId.trim(), appSecret: pendingCreds.appSecret.trim(), encryptKey: pendingCreds.encryptKey, verificationToken: pendingCreds.verificationToken } : {};
 
         const result = await channel.enablePlugin.invoke({
-          pluginId: 'lark_default',
+          pluginId: (larkPluginStatus?.id ?? 'lark_default'),
           config,
         });
 
@@ -256,7 +279,7 @@ const ChannelPanel: React.FC = () => {
     } else {
       setLarkEnableLoading(true);
       try {
-        const result = await channel.disablePlugin.invoke({ pluginId: 'lark_default' });
+        const result = await channel.disablePlugin.invoke({ pluginId: (larkPluginStatus?.id ?? 'lark_default') });
 
         if (result.success) {
           Message.success(t('settings.lark.pluginDisabled', 'Lark bot disabled'));
@@ -292,7 +315,7 @@ const ChannelPanel: React.FC = () => {
         const config = hasFormCreds ? { clientId: pendingCreds.clientId.trim(), clientSecret: pendingCreds.clientSecret.trim() } : {};
 
         const result = await channel.enablePlugin.invoke({
-          pluginId: 'dingtalk_default',
+          pluginId: (dingtalkPluginStatus?.id ?? 'dingtalk_default'),
           config,
         });
 
@@ -310,7 +333,7 @@ const ChannelPanel: React.FC = () => {
     } else {
       setDingtalkEnableLoading(true);
       try {
-        const result = await channel.disablePlugin.invoke({ pluginId: 'dingtalk_default' });
+        const result = await channel.disablePlugin.invoke({ pluginId: (dingtalkPluginStatus?.id ?? 'dingtalk_default') });
 
         if (result.success) {
           Message.success(t('settings.dingtalk.pluginDisabled', 'DingTalk bot disabled'));
@@ -340,7 +363,7 @@ const ChannelPanel: React.FC = () => {
       setWechatEnableLoading(true);
       try {
         const result = await channel.enablePlugin.invoke({
-          pluginId: 'wechat_default',
+          pluginId: (wechatPluginStatus?.id ?? 'wechat_default'),
           config: {},
         });
         if (result.success) {
@@ -363,7 +386,7 @@ const ChannelPanel: React.FC = () => {
       // Disable
       setWechatEnableLoading(true);
       try {
-        const result = await channel.disablePlugin.invoke({ pluginId: 'wechat_default' });
+        const result = await channel.disablePlugin.invoke({ pluginId: (wechatPluginStatus?.id ?? 'wechat_default') });
         if (result.success) {
           Message.success(t('settings.channels.wechat.disabled', 'WeChat disabled'));
           // Force immediate status re-fetch to ensure UI sync
@@ -394,11 +417,11 @@ const ChannelPanel: React.FC = () => {
 
         // If no pending credentials, try to get saved credentials from database
         if (!pendingBotId || !pendingSecret) {
-          const credResult = await channel.getPluginCredentials.invoke({ pluginId: 'wecom_default' });
+          const credResult = await channel.getPluginCredentials.invoke({ pluginId: (wecomPluginStatus?.id ?? 'wecom_default') });
           if (credResult.success && credResult.data?.botId && credResult.data?.secret) {
             // Found saved credentials, use them
             const result = await channel.enablePlugin.invoke({
-              pluginId: 'wecom_default',
+              pluginId: (wecomPluginStatus?.id ?? 'wecom_default'),
               config: {},
             });
 
@@ -419,7 +442,7 @@ const ChannelPanel: React.FC = () => {
 
         // Pass credentials from form input
         const result = await channel.enablePlugin.invoke({
-          pluginId: 'wecom_default',
+          pluginId: (wecomPluginStatus?.id ?? 'wecom_default'),
           config: { botId: pendingBotId, secret: pendingSecret },
         });
 
@@ -430,7 +453,7 @@ const ChannelPanel: React.FC = () => {
           Message.error(result.msg || t('settings.wecom.enableFailed', 'Failed to enable WeCom plugin'));
         }
       } else {
-        const result = await channel.disablePlugin.invoke({ pluginId: 'wecom_default' });
+        const result = await channel.disablePlugin.invoke({ pluginId: (wecomPluginStatus?.id ?? 'wecom_default') });
 
         if (result.success) {
           Message.success(t('settings.wecom.pluginDisabled', 'WeCom bot disabled'));
@@ -590,6 +613,93 @@ const ChannelPanel: React.FC = () => {
     [extensionFieldValues, t, updateExtensionFieldValue, webuiStatus]
   );
 
+  /** Add another connection of a builtin type, then refresh so its card appears. */
+  const handleAddConnection = useCallback(
+    async (type: string) => {
+      setAddingType(type);
+      try {
+        const result = await channel.createPlugin.invoke({ type });
+        if (result.success) {
+          await loadPluginStatus();
+          Message.success(t('settings.channels.connectionAdded', { defaultValue: 'Connection added. Configure its credentials to enable it.' }));
+        } else {
+          Message.error(result.msg || t('settings.channels.connectionAddFailed', { defaultValue: 'Failed to add connection' }));
+        }
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setAddingType(null);
+      }
+    },
+    [loadPluginStatus, t]
+  );
+
+  /** Delete one connection along with the authorizations scoped to it. */
+  const handleRemoveConnection = useCallback(
+    async (pluginId: string) => {
+      setExtraLoadingMap((prev) => ({ ...prev, [pluginId]: true }));
+      try {
+        const result = await channel.removePlugin.invoke({ pluginId });
+        if (result.success) {
+          await loadPluginStatus();
+          Message.success(t('settings.channels.connectionRemoved', { defaultValue: 'Connection removed' }));
+        } else {
+          Message.error(result.msg || t('settings.channels.connectionRemoveFailed', { defaultValue: 'Failed to remove connection' }));
+        }
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setExtraLoadingMap((prev) => ({ ...prev, [pluginId]: false }));
+      }
+    },
+    [loadPluginStatus, t]
+  );
+
+  /** Enable/disable one of the additional connections. */
+  const handleToggleExtraConnection = useCallback(
+    async (status: IChannelPluginStatus, enabled: boolean) => {
+      setExtraLoadingMap((prev) => ({ ...prev, [status.id]: true }));
+      try {
+        const result = enabled ? await channel.enablePlugin.invoke({ pluginId: status.id, config: {} }) : await channel.disablePlugin.invoke({ pluginId: status.id });
+        if (result.success) {
+          await loadPluginStatus();
+        } else {
+          Message.error(result.msg || t('settings.assistant.enableFailed', 'Failed to enable plugin'));
+        }
+      } catch (error: any) {
+        Message.error(error.message);
+      } finally {
+        setExtraLoadingMap((prev) => ({ ...prev, [status.id]: false }));
+      }
+    },
+    [loadPluginStatus, t]
+  );
+
+  /** Config form for an additional connection, matching the type's dedicated form. */
+  const renderExtraConnectionForm = useCallback(
+    (status: IChannelPluginStatus) => {
+      const onStatusChange = (): void => {
+        void loadPluginStatus();
+      };
+      const common = { pluginId: status.id, pluginStatus: status, onStatusChange };
+      switch (status.type) {
+        case 'telegram':
+          return <TelegramConfigForm {...common} modelSelection={telegramModelSelection} />;
+        case 'lark':
+          return <LarkConfigForm {...common} modelSelection={larkModelSelection} />;
+        case 'dingtalk':
+          return <DingTalkConfigForm {...common} modelSelection={dingtalkModelSelection} />;
+        case 'wechat':
+          return <WeChatConfigForm {...common} modelSelection={wechatModelSelection} />;
+        case 'wecom':
+          return <WeComConfigForm {...common} modelSelection={wecomModelSelection} />;
+        default:
+          return null;
+      }
+    },
+    [loadPluginStatus, telegramModelSelection, larkModelSelection, dingtalkModelSelection, wechatModelSelection, wecomModelSelection]
+  );
+
   // Build channel configurations
   const channels: ChannelConfig[] = useMemo(() => {
     const telegramChannel: ChannelConfig = {
@@ -703,8 +813,24 @@ const ChannelPanel: React.FC = () => {
         content: renderExtensionConfigForm(status),
       }));
 
-    return [telegramChannel, larkChannel, dingtalkChannel, wechatChannel, wecomChannel, ...extensionChannels];
+    // Cards for every additional connection the user has added, beyond each type's first.
+    const extraChannels: ChannelConfig[] = extraConnections.map((status) => ({
+      id: status.id,
+      title: status.name || status.type,
+      description: t('settings.channels.additionalConnection', { defaultValue: 'Additional connection' }),
+      status: 'active',
+      enabled: status.enabled || false,
+      disabled: extraLoadingMap[status.id] || false,
+      isConnected: status.connected || false,
+      botUsername: status.botUsername,
+      content: renderExtraConnectionForm(status),
+    }));
+
+    return [telegramChannel, larkChannel, dingtalkChannel, wechatChannel, wecomChannel, ...extraChannels, ...extensionChannels];
   }, [
+    extraConnections,
+    extraLoadingMap,
+    renderExtraConnectionForm,
     pluginStatus,
     larkPluginStatus,
     dingtalkPluginStatus,
@@ -738,6 +864,12 @@ const ChannelPanel: React.FC = () => {
         void handleToggleExtensionPlugin(channelId, enabled);
       };
     }
+    const extra = extraConnections.find((c) => c.id === channelId);
+    if (extra) {
+      return (enabled: boolean) => {
+        void handleToggleExtraConnection(extra, enabled);
+      };
+    }
     return undefined;
   };
   const channelGuideText = t('settings.webui.featureChannelsDesc', {
@@ -765,6 +897,25 @@ const ChannelPanel: React.FC = () => {
           {channels.map((channelConfig) => (
             <ChannelItem key={channelConfig.id} channel={channelConfig} isCollapsed={collapseKeys[channelConfig.id] || false} onToggleCollapse={() => handleToggleCollapse(channelConfig.id)} onToggleEnabled={getToggleHandler(channelConfig.id)} />
           ))}
+        </div>
+
+        {/* Add another bot of a type. Each connection keeps its own credentials, authorized
+            users, sessions and agent, so two bots never share a conversation. */}
+        <div className='mt-4 space-y-2'>
+          <div className='text-13px text-foreground'>{t('settings.channels.addConnectionTitle', { defaultValue: 'Add another connection' })}</div>
+          <div className='flex flex-wrap gap-2'>
+            {ADDABLE_CHANNEL_TYPES.map((type) => (
+              <button
+                key={type}
+                type='button'
+                disabled={addingType === type}
+                onClick={() => void handleAddConnection(type)}
+                className='px-2.5 py-1.5 text-12px rd-md b-1 b-solid b-[var(--ui-border)] text-secondary hover:text-foreground disabled:opacity-50'
+              >
+                {addingType === type ? t('settings.channels.adding', { defaultValue: 'Adding…' }) : `+ ${CHANNEL_TYPE_LABELS[type]}`}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </AionScrollArea>

--- a/src/renderer/pages/settings/channels/components/DingTalkConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/DingTalkConfigForm.tsx
@@ -21,13 +21,21 @@ import PreferenceRow from './PreferenceRow';
 import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface DingTalkConfigFormProps {
+  /**
+   * Connection this form configures. A type may have several connections; falls back
+   * to the status row's id, then the legacy id of a type's first connection.
+   */
+  pluginId?: string;
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange: (status: IChannelPluginStatus | null) => void;
   onCredentialsChange?: (creds: { clientId: string; clientSecret: string }) => void;
 }
 
-const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
+const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginId: pluginIdProp, pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
+  // Configure the connection actually being shown; fall back to the legacy id so a
+  // caller that has not been updated keeps its current behaviour.
+  const pluginId = pluginIdProp ?? pluginStatus?.id ?? 'dingtalk_default';
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
 
@@ -112,7 +120,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
 
     const loadCredentials = async () => {
       try {
-        const result = await channel.getPluginCredentials.invoke({ pluginId: 'dingtalk_default' });
+        const result = await channel.getPluginCredentials.invoke({ pluginId });
         if (result.success && result.data) {
           if (result.data.clientId) setClientId(result.data.clientId);
           if (result.data.clientSecret) setClientSecret(result.data.clientSecret);
@@ -205,7 +213,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
     setCredentialsTested(false);
     try {
       const result = await channel.testPlugin.invoke({
-        pluginId: 'dingtalk_default',
+        pluginId,
         token: '',
         extraConfig: {
           appId: clientId.trim(),
@@ -236,7 +244,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
   const handleAutoEnable = async () => {
     try {
       const result = await channel.enablePlugin.invoke({
-        pluginId: 'dingtalk_default',
+        pluginId,
         config: {
           clientId: clientId.trim(),
           clientSecret: clientSecret.trim(),
@@ -455,7 +463,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
       {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
       {/* Enterprise mode: default agent lives on the moss server, which spawns the
           sessions for this channel. Standalone mode uses the local picker below. */}
-      {isEnterprise && <EnterpriseAgentSelector pluginId='dingtalk_default' enabled={!!pluginStatus?.enabled} />}
+      {isEnterprise && <EnterpriseAgentSelector pluginId={pluginId} enabled={!!pluginStatus?.enabled} />}
 
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>

--- a/src/renderer/pages/settings/channels/components/LarkConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/LarkConfigForm.tsx
@@ -23,13 +23,21 @@ import PreferenceRow from './PreferenceRow';
 import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface LarkConfigFormProps {
+  /**
+   * Connection this form configures. A type may have several connections; falls back
+   * to the status row's id, then the legacy id of a type's first connection.
+   */
+  pluginId?: string;
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange: (status: IChannelPluginStatus | null) => void;
   onCredentialsChange?: (creds: { appId: string; appSecret: string; encryptKey?: string; verificationToken?: string }) => void;
 }
 
-const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
+const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginId: pluginIdProp, pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
+  // Configure the connection actually being shown; fall back to the legacy id so a
+  // caller that has not been updated keeps its current behaviour.
+  const pluginId = pluginIdProp ?? pluginStatus?.id ?? 'lark_default';
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
 
@@ -119,7 +127,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
 
     const loadCredentials = async () => {
       try {
-        const result = await channel.getPluginCredentials.invoke({ pluginId: 'lark_default' });
+        const result = await channel.getPluginCredentials.invoke({ pluginId });
         if (result.success && result.data) {
           if (result.data.appId) setAppId(result.data.appId);
           if (result.data.appSecret) setAppSecret(result.data.appSecret);
@@ -200,7 +208,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     let cancelled = false;
     void (async () => {
       try {
-        const result = await channel.getPluginCredentials.invoke({ pluginId: 'lark_default' });
+        const result = await channel.getPluginCredentials.invoke({ pluginId });
         if (cancelled || !result.success || !result.data) return;
         const creds = result.data as { larkUserName?: string; larkLoggedInAt?: number };
         if (creds.larkUserName) {
@@ -221,7 +229,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     async (payload: { user?: { id?: string; name?: string }; appId?: string; appSecret?: string; brand?: 'feishu' | 'lark'; token?: { accessToken: string; refreshToken?: string; expiresAt?: number; refreshExpiresAt?: number; scope?: string } }) => {
       let existing: IPluginCredentials = {};
       try {
-        const cur = await channel.getPluginCredentials.invoke({ pluginId: 'lark_default' });
+        const cur = await channel.getPluginCredentials.invoke({ pluginId });
         if (cur.success && cur.data) existing = cur.data;
       } catch {
         // best-effort; missing previous creds is fine
@@ -240,7 +248,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         larkLoggedInAt: Date.now(),
       };
       try {
-        const result = await channel.enablePlugin.invoke({ pluginId: 'lark_default', config });
+        const result = await channel.enablePlugin.invoke({ pluginId, config });
         if (!result.success) {
           console.error('[LarkConfig] persistLarkAuthLogin enablePlugin failed:', result.msg);
           Message.error(result.msg || 'Failed to persist login');
@@ -394,7 +402,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
     setCredentialsTested(false);
     try {
       const result = await channel.testPlugin.invoke({
-        pluginId: 'lark_default',
+        pluginId,
         token: '',
         extraConfig: {
           appId: appId.trim(),
@@ -421,7 +429,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
   const handleAutoEnable = async () => {
     try {
       const result = await channel.enablePlugin.invoke({
-        pluginId: 'lark_default',
+        pluginId,
         config: {
           appId: appId.trim(),
           appSecret: appSecret.trim(),
@@ -515,7 +523,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
       {/* Consumer mode: QR Login (replaces manual App ID / App Secret entry) */}
       {/* Enterprise mode: default agent lives on the moss server, which spawns the
           sessions for this channel. Standalone mode uses the local picker below. */}
-      {isEnterprise && <EnterpriseAgentSelector pluginId='lark_default' enabled={!!pluginStatus?.enabled} />}
+      {isEnterprise && <EnterpriseAgentSelector pluginId={pluginId} enabled={!!pluginStatus?.enabled} />}
 
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>

--- a/src/renderer/pages/settings/channels/components/TelegramConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/TelegramConfigForm.tsx
@@ -19,13 +19,21 @@ import PreferenceRow from './PreferenceRow';
 import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface TelegramConfigFormProps {
+  /**
+   * Connection this form configures. A type may have several connections; falls back
+   * to the status row's id, then the legacy id of a type's first connection.
+   */
+  pluginId?: string;
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange: (status: IChannelPluginStatus | null) => void;
   onTokenChange?: (token: string) => void;
 }
 
-const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onTokenChange }) => {
+const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginId: pluginIdProp, pluginStatus, modelSelection, onStatusChange, onTokenChange }) => {
+  // Configure the connection actually being shown; fall back to the legacy id so a
+  // caller that has not been updated keeps its current behaviour.
+  const pluginId = pluginIdProp ?? pluginStatus?.id ?? 'telegram_default';
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
 
@@ -95,7 +103,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
 
     const loadCredentials = async () => {
       try {
-        const result = await channel.getPluginCredentials.invoke({ pluginId: 'telegram_default' });
+        const result = await channel.getPluginCredentials.invoke({ pluginId });
         if (result.success && result.data?.token) {
           setTelegramToken(result.data.token);
         }
@@ -183,7 +191,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
 
     try {
       const result = await channel.testPlugin.invoke({
-        pluginId: 'telegram_default',
+        pluginId,
         token: telegramToken.trim(),
       });
 
@@ -206,7 +214,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
   const handleAutoEnable = async () => {
     try {
       const result = await channel.enablePlugin.invoke({
-        pluginId: 'telegram_default',
+        pluginId,
         config: { token: telegramToken.trim() },
       });
 
@@ -327,7 +335,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({ pluginStatus, m
       {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
       {/* Enterprise mode: default agent lives on the moss server, which spawns the
           sessions for this channel. Standalone mode uses the local picker below. */}
-      {isEnterprise && <EnterpriseAgentSelector pluginId='telegram_default' enabled={!!pluginStatus?.enabled} />}
+      {isEnterprise && <EnterpriseAgentSelector pluginId={pluginId} enabled={!!pluginStatus?.enabled} />}
 
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>

--- a/src/renderer/pages/settings/channels/components/WeChatConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/WeChatConfigForm.tsx
@@ -22,12 +22,20 @@ import PreferenceRow from './PreferenceRow';
 import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface WeChatConfigFormProps {
+  /**
+   * Connection this form configures. A type may have several connections; falls back
+   * to the status row's id, then the legacy id of a type's first connection.
+   */
+  pluginId?: string;
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange?: (status: IChannelPluginStatus | null) => void;
 }
 
-const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
+const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginId: pluginIdProp, pluginStatus, modelSelection, onStatusChange }) => {
+  // Configure the connection actually being shown; fall back to the legacy id so a
+  // caller that has not been updated keeps its current behaviour.
+  const pluginId = pluginIdProp ?? pluginStatus?.id ?? 'wechat_default';
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
 
@@ -96,7 +104,7 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
     async (botToken: string, accountId: string) => {
       try {
         const result = await channel.enablePlugin.invoke({
-          pluginId: 'wechat_default',
+          pluginId,
           config: { token: botToken, accountId },
         });
 
@@ -256,7 +264,7 @@ const WeChatConfigForm: React.FC<WeChatConfigFormProps> = ({ pluginStatus, model
       {/* Agent Selection - hidden in enterprise mode (uses Moss remote agent) */}
       {/* Enterprise mode: default agent lives on the moss server, which spawns the
           sessions for this channel. Standalone mode uses the local picker below. */}
-      {isEnterprise && <EnterpriseAgentSelector pluginId='wechat_default' enabled={!!pluginStatus?.enabled} />}
+      {isEnterprise && <EnterpriseAgentSelector pluginId={pluginId} enabled={!!pluginStatus?.enabled} />}
 
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>

--- a/src/renderer/pages/settings/channels/components/WeComConfigForm.tsx
+++ b/src/renderer/pages/settings/channels/components/WeComConfigForm.tsx
@@ -21,13 +21,21 @@ import PreferenceRow from './PreferenceRow';
 import EnterpriseAgentSelector from './EnterpriseAgentSelector';
 
 interface WeComConfigFormProps {
+  /**
+   * Connection this form configures. A type may have several connections; falls back
+   * to the status row's id, then the legacy id of a type's first connection.
+   */
+  pluginId?: string;
   pluginStatus: IChannelPluginStatus | null;
   modelSelection: GeminiModelSelection;
   onStatusChange: (status: IChannelPluginStatus | null) => void;
   onCredentialsChange?: (credentials: { botId: string; secret: string }) => void;
 }
 
-const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
+const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginId: pluginIdProp, pluginStatus, modelSelection, onStatusChange, onCredentialsChange }) => {
+  // Configure the connection actually being shown; fall back to the legacy id so a
+  // caller that has not been updated keeps its current behaviour.
+  const pluginId = pluginIdProp ?? pluginStatus?.id ?? 'wecom_default';
   const { t } = useTranslation();
   const { isEnterprise } = useAppMode();
 
@@ -47,7 +55,7 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
   useEffect(() => {
     const loadCredentials = async () => {
       try {
-        const result = await channel.getPluginCredentials.invoke({ pluginId: 'wecom_default' });
+        const result = await channel.getPluginCredentials.invoke({ pluginId });
         if (result.success && result.data) {
           const loadedBotId = result.data.botId || '';
           const loadedSecret = result.data.secret || '';
@@ -131,7 +139,7 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
     setCredentialsTested(false);
     try {
       const result = await channel.testPlugin.invoke({
-        pluginId: 'wecom_default',
+        pluginId,
         token: '',
         extraConfig: {
           appId: botId.trim(),
@@ -159,7 +167,7 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
   const handleAutoEnable = async () => {
     try {
       const result = await channel.enablePlugin.invoke({
-        pluginId: 'wecom_default',
+        pluginId,
         config: {
           botId: botId.trim(),
           secret: secret.trim(),
@@ -337,7 +345,7 @@ const WeComConfigForm: React.FC<WeComConfigFormProps> = ({ pluginStatus, modelSe
 
       {/* Enterprise mode: default agent lives on the moss server, which spawns the
           sessions for this channel. Standalone mode uses the local picker below. */}
-      {isEnterprise && <EnterpriseAgentSelector pluginId='wecom_default' enabled={!!pluginStatus?.enabled} />}
+      {isEnterprise && <EnterpriseAgentSelector pluginId={pluginId} enabled={!!pluginStatus?.enabled} />}
 
       {!isEnterprise && (
         <div className='flex flex-col gap-2'>

--- a/tests/unit/channels/connectionScopeMigration.test.ts
+++ b/tests/unit/channels/connectionScopeMigration.test.ts
@@ -1,0 +1,130 @@
+// node:sqlite rather than the project's better-sqlite3: the latter is compiled against
+// Electron's ABI and cannot load under plain-node vitest (same constraint noted in
+// tests/integration/workspaceQueries.test.ts). The migration is plain SQL, so either
+// driver exercises it identically.
+import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
+import { ALL_MIGRATIONS } from '@process/database/migrations';
+import { pluginScope, scopedChatId, pluginTypeFromId, defaultPluginId, generatePluginId } from '@/channels/types';
+
+/**
+ * A channel type may have several connections (e.g. two WeCom bots). These cover the two
+ * properties that keeps safe: existing single-connection installs must be untouched by the
+ * upgrade, and two bots must never share an authorization or a conversation.
+ */
+
+/** Rebuild the pre-v32 schema so the migration runs against a realistic old database. */
+function seedLegacyDb(): DatabaseSync {
+  const db = new DatabaseSync(':memory:');
+  db.exec(`
+    CREATE TABLE assistant_users (
+      id TEXT PRIMARY KEY, platform_user_id TEXT NOT NULL, platform_type TEXT NOT NULL,
+      display_name TEXT, authorized_at INTEGER NOT NULL, last_active INTEGER, session_id TEXT,
+      UNIQUE(platform_user_id, platform_type)
+    );
+    CREATE TABLE assistant_sessions (
+      id TEXT PRIMARY KEY, user_id TEXT NOT NULL, agent_type TEXT NOT NULL,
+      conversation_id TEXT, workspace TEXT, chat_id TEXT,
+      created_at INTEGER NOT NULL, last_activity INTEGER NOT NULL
+    );
+    CREATE TABLE assistant_pairing_codes (
+      code TEXT PRIMARY KEY, platform_user_id TEXT NOT NULL, platform_type TEXT NOT NULL,
+      display_name TEXT, requested_at INTEGER NOT NULL, expires_at INTEGER NOT NULL, status TEXT NOT NULL
+    );
+  `);
+  db.prepare(`INSERT INTO assistant_users VALUES (?,?,?,?,?,?,?)`).run('u1', 'zhang', 'wecom', 'Zhang', 100, null, null);
+  db.prepare(`INSERT INTO assistant_pairing_codes VALUES (?,?,?,?,?,?,?)`).run('123456', 'li', 'lark', 'Li', 1, 999, 'pending');
+  return db;
+}
+
+const v32 = ALL_MIGRATIONS.find((m) => m.version === 32);
+
+describe('connection scoping', () => {
+  it('registers migration v32', () => {
+    expect(v32).toBeDefined();
+  });
+
+  describe('migration v32', () => {
+    it('preserves existing rows and backfills the scope from the platform', () => {
+      const db = seedLegacyDb();
+      v32!.up(db);
+
+      const user = db.prepare(`SELECT * FROM assistant_users WHERE id = 'u1'`).get() as Record<string, unknown>;
+      expect(user.plugin_scope).toBe('wecom');
+      expect(user.display_name).toBe('Zhang');
+      expect(user.authorized_at).toBe(100);
+
+      const pairing = db.prepare(`SELECT * FROM assistant_pairing_codes WHERE code = '123456'`).get() as Record<string, unknown>;
+      expect(pairing.plugin_scope).toBe('lark');
+    });
+
+    it('keeps a pre-upgrade authorization resolvable under the bare platform', () => {
+      const db = seedLegacyDb();
+      v32!.up(db);
+      const found = db.prepare(`SELECT * FROM assistant_users WHERE platform_user_id = ? AND plugin_scope = ?`).get('zhang', 'wecom');
+      expect(found).toBeTruthy();
+    });
+
+    it('lets two bots of one type authorize the same person independently', () => {
+      const db = seedLegacyDb();
+      v32!.up(db);
+      db.prepare(`INSERT INTO assistant_users (id, platform_user_id, platform_type, plugin_scope, authorized_at) VALUES (?,?,?,?,?)`).run('u2', 'zhang', 'wecom', 'wecom_a1b2c3d4', 200);
+
+      const rows = db.prepare(`SELECT * FROM assistant_users WHERE platform_user_id = 'zhang' ORDER BY authorized_at`).all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.plugin_scope)).toEqual(['wecom', 'wecom_a1b2c3d4']);
+    });
+
+    it('still rejects a duplicate authorization on the same connection', () => {
+      const db = seedLegacyDb();
+      v32!.up(db);
+      const insert = () => db.prepare(`INSERT INTO assistant_users (id, platform_user_id, platform_type, plugin_scope, authorized_at) VALUES (?,?,?,?,?)`).run('dup', 'zhang', 'wecom', 'wecom', 300);
+      expect(insert).toThrow();
+    });
+
+    it('rolls back to one authorization per type', () => {
+      const db = seedLegacyDb();
+      v32!.up(db);
+      db.prepare(`INSERT INTO assistant_users (id, platform_user_id, platform_type, plugin_scope, authorized_at) VALUES (?,?,?,?,?)`).run('u2', 'zhang', 'wecom', 'wecom_a1b2c3d4', 200);
+      v32!.down(db);
+
+      const cols = (db.prepare(`PRAGMA table_info(assistant_users)`).all() as Array<{ name: string }>).map((c) => c.name);
+      expect(cols).not.toContain('plugin_scope');
+      const rows = db.prepare(`SELECT * FROM assistant_users WHERE platform_user_id = 'zhang'`).all();
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  describe('scope helpers', () => {
+    it("treats a type's first connection as the bare platform, so legacy rows still resolve", () => {
+      expect(pluginScope('wecom_default', 'wecom')).toBe('wecom');
+      expect(pluginScope('wecom', 'wecom')).toBe('wecom');
+      expect(pluginScope(undefined, 'wecom')).toBe('wecom');
+      expect(scopedChatId('wecom_default', 'wecom', 'user:zhang')).toBe('user:zhang');
+    });
+
+    it('gives every additional connection its own scope', () => {
+      expect(pluginScope('wecom_a1b2c3d4', 'wecom')).toBe('wecom_a1b2c3d4');
+      expect(scopedChatId('wecom_a1b2c3d4', 'wecom', 'user:zhang')).toBe('wecom_a1b2c3d4#user:zhang');
+    });
+
+    it('never lets two bots share a chat key for the same person', () => {
+      const botA = scopedChatId('wecom_default', 'wecom', 'user:zhang');
+      const botB = scopedChatId('wecom_a1b2c3d4', 'wecom', 'user:zhang');
+      expect(botA).not.toBe(botB);
+    });
+
+    it('round-trips the type out of a plugin id', () => {
+      expect(pluginTypeFromId('wecom_a1b2c3d4')).toBe('wecom');
+      expect(pluginTypeFromId('wecom_default')).toBe('wecom');
+      expect(pluginTypeFromId('telegram')).toBe('telegram');
+      expect(pluginTypeFromId('ext-feishu')).toBe('ext-feishu');
+      expect(pluginTypeFromId(defaultPluginId('lark'))).toBe('lark');
+      expect(pluginTypeFromId(generatePluginId('dingtalk'))).toBe('dingtalk');
+    });
+
+    it('generates distinct ids so a deleted connection is never reused', () => {
+      expect(generatePluginId('wecom')).not.toBe(generatePluginId('wecom'));
+    });
+  });
+});


### PR DESCRIPTION
## Why

Each channel type allowed only one connection, so running a second bot of the same type — an HR bot and a devops bot on WeCom, say — wasn't possible. This covers both **personal mode** (local SQLite) and **enterprise mode** (managed on moss).

## The routing blocker

`getPluginForMessage()` returned the **first** plugin of a type, with a literal `TODO: Get actual plugin ID` beside a hardcoded `${platform}_default`. With two bots configured, the wrong one would have replied.

`BasePlugin` now passes the receiving instance to the message handler — as moss already did — and `ActionExecutor` replies through that instance.

## The storage flaw

A DM's `chatId` is derived from the platform user, so the same person messaging two bots produced the identical `chatId`, and `assistant_users` was `UNIQUE(platform_user_id, platform_type)`. Two bots shared one conversation, and pairing with one authorized the other.

## Approach

A **connection scope**: the bare platform for a type's *first* connection, the plugin id for any additional one. Sessions, conversations, authorized users, pairing codes and agent bindings all key on it.

Because the first connection's scope *is* the bare platform, **migration v32** backfills every existing row to exactly what it already meant — current installs are untouched until a second connection is added. `down()` collapses back to one authorization per type.

## Also in this PR

- **per-connection agent/model settings**, stored on the connection's own config row and falling back to the shared `assistant.<type>.*` key. This avoids multiplying the typed config-key union, and means untouched installs behave identically — a second bot only diverges once someone configures it
- scope the WeCom/WeChat disable cleanup to one connection, so disabling one bot no longer deauthorizes everyone paired with its siblings
- `createPlugin`/`removePlugin` on both providers, exposed over IPC, with per-type "add connection" actions and a card per additional connection in settings

Enterprise mode needed little work: `RemoteChannelProvider` was already fully id-parameterized and maps every plugin the server returns, so it picks up multiple connections against the updated moss endpoints automatically.

## Verification

- `tsc` clean
- **367 channel tests pass** (356 existing + 11 new covering migration v32, its rollback, and the scope helpers)

One note: the new test uses Node's built-in `node:sqlite` rather than the project's `better-sqlite3`, which is compiled against Electron's ABI and can't load under plain-node vitest — the same constraint already documented in `tests/integration/workspaceQueries.test.ts`. The migration is plain SQL, so either driver exercises it identically.

⚠️ **Not yet exercised against live bot credentials.** Worth doing before merge: connect two real WeCom robots and confirm each replies in its own thread with its own agent.

Requires sudoprivacy/moss#173 for enterprise mode (the `/plugins/create` and `/plugins/:id/remove` endpoints).