### PR TITLE
fix(assistant-hub): filter tenant assistants by overlay-adjusted category

### DIFF
--- a/src/process/bridge/assistantHubBridge.ts
+++ b/src/process/bridge/assistantHubBridge.ts
@@ -543,6 +543,12 @@ function applyVisibleAssistantOverlay(raw: Record<string, unknown>, overlay?: Vi
   return merged;
 }
 
+function matchesAssistantCategory(assistant: IAssistantHubSkill, category: string): boolean {
+  const normalizedCategory = category.trim();
+  if (!normalizedCategory || normalizedCategory === 'all') return true;
+  return assistant.categories.some((assistantCategory) => assistantCategory.trim() === normalizedCategory);
+}
+
 // ==================== Helper Functions ====================
 
 /**
@@ -954,11 +960,14 @@ export function initAssistantHubBridge(): void {
 
       // 个人模式：从 SudoPrivacy Assistant Hub API 获取数据
       const params = new URLSearchParams();
+      const isTenantScopedAssistantList = typeof tenantId === 'string' && tenantId.trim().length > 0;
+      const visibleOverlayMap = isTenantScopedAssistantList ? await fetchVisibleAssistantOverlayMap(accessToken) : null;
+      const isOverlayCategoryFilter = Boolean(category && category !== 'all' && visibleOverlayMap);
       if (cursor) params.set('cursor', cursor);
       if (limit) params.set('limit', String(limit));
       if (query) params.set('query', query);
-      if (category) params.set('category', category);
-      if (typeof tenantId === 'string' && tenantId.trim()) params.set('tenant_id', tenantId.trim());
+      if (category && !isOverlayCategoryFilter) params.set('category', category);
+      if (isTenantScopedAssistantList) params.set('tenant_id', tenantId.trim());
 
       const token = getSkillhubToken();
       if (!token) {
@@ -973,54 +982,56 @@ export function initAssistantHubBridge(): void {
       // Map API response to our type structure
       // API returns: { data: { assistants: [{ id, name, profession, description, avatar, categories, sourceUrl, ... }] } }
       const rawAssistants = result.data?.assistants || [];
-      const visibleOverlayMap = typeof tenantId === 'string' && tenantId.trim() ? await fetchVisibleAssistantOverlayMap(accessToken) : null;
       const visibleAssistants = visibleOverlayMap ? rawAssistants.filter((a: Record<string, unknown>) => typeof a.id === 'string' && visibleOverlayMap.has(a.id)) : rawAssistants;
 
-      const mappedAssistants = visibleAssistants.map((raw: Record<string, unknown>): IAssistantHubSkill => {
-        const overlay = typeof raw.id === 'string' ? visibleOverlayMap?.get(raw.id) : undefined;
-        const a = applyVisibleAssistantOverlay(raw, overlay);
-        const versions = a.versions as IAssistantHubVersionLike[] | undefined;
-        const latestVersion = (a.latestVersion as IAssistantHubVersionLike | undefined) || versions?.[0] || null;
-        const version = [a.version, a.latest_version, latestVersion?.version, versions?.[0]?.version].find((value): value is string => typeof value === 'string' && value.length > 0);
-        const sourceUrl = [a.sourceUrl, a.source_url, latestVersion?.source_url, versions?.[0]?.source_url].find((value): value is string => typeof value === 'string' && value.length > 0);
-        const promptsI18n = firstPromptsI18n(a.promptsI18n, a.prompts_i18n);
-        const tenantIds = tenantIdsWithFallback(a.tenantIds, a.tenant_ids, a.tenantId, a.tenant_id);
-        const tenantId = firstNonEmptyString(a.tenantId, a.tenant_id) || tenantIds[0] || null;
+      const mappedAssistants: IAssistantHubSkill[] = visibleAssistants
+        .map((raw: Record<string, unknown>): IAssistantHubSkill => {
+          const overlay = typeof raw.id === 'string' ? visibleOverlayMap?.get(raw.id) : undefined;
+          const a = applyVisibleAssistantOverlay(raw, overlay);
+          const versions = a.versions as IAssistantHubVersionLike[] | undefined;
+          const latestVersion = (a.latestVersion as IAssistantHubVersionLike | undefined) || versions?.[0] || null;
+          const version = [a.version, a.latest_version, latestVersion?.version, versions?.[0]?.version].find((value): value is string => typeof value === 'string' && value.length > 0);
+          const sourceUrl = [a.sourceUrl, a.source_url, latestVersion?.source_url, versions?.[0]?.source_url].find((value): value is string => typeof value === 'string' && value.length > 0);
+          const promptsI18n = firstPromptsI18n(a.promptsI18n, a.prompts_i18n);
+          const tenantIds = tenantIdsWithFallback(a.tenantIds, a.tenant_ids, a.tenantId, a.tenant_id);
+          const tenantId = firstNonEmptyString(a.tenantId, a.tenant_id) || tenantIds[0] || null;
+          const categories = (a.categories as string[]) || [];
 
-        return {
-          id: a.id as string,
-          name: a.name as string,
-          display_name: firstNonEmptyString(a.display_name, a.profession, a.name) || (a.name as string),
-          description: a.description as string,
-          avatar: a.avatar as string | null,
-          emoji: null as string | null,
-          // Use categories array from API (may be null)
-          categories: (a.categories as string[]) || [],
-          category: ((a.categories as string[]) || [])[0] || '',
-          preset_agent_type: null as string | null,
-          skills: (a.skills as string[]) || ([] as string[]),
-          tag: 'hub' as const,
-          homepage: null as string | null,
-          author_id: '',
-          star_count: 0,
-          applicable_scenarios: null as string | null,
-          core_features: null as string | null,
-          created_at: a.createdAt as string,
-          updated_at: a.updatedAt as string,
-          // Default init prompt from API
-          defaultInitPrompt: (a.defaultInitPrompt as string) || null,
-          promptsI18n,
-          prompts_i18n: promptsI18n,
-          tenantId,
-          tenantIds,
-          tenant_id: tenantId,
-          tenant_ids: tenantIds,
-          version,
-          latestVersion,
-          // Store sourceUrl for download (not in original type but needed for install)
-          _sourceUrl: sourceUrl,
-        };
-      });
+          return {
+            id: a.id as string,
+            name: a.name as string,
+            display_name: firstNonEmptyString(a.display_name, a.profession, a.name) || (a.name as string),
+            description: a.description as string,
+            avatar: a.avatar as string | null,
+            emoji: null as string | null,
+            // Use categories array from API or visible assistant overlay.
+            categories,
+            category: categories[0] || '',
+            preset_agent_type: null as string | null,
+            skills: (a.skills as string[]) || ([] as string[]),
+            tag: 'hub' as const,
+            homepage: null as string | null,
+            author_id: '',
+            star_count: 0,
+            applicable_scenarios: null as string | null,
+            core_features: null as string | null,
+            created_at: a.createdAt as string,
+            updated_at: a.updatedAt as string,
+            // Default init prompt from API
+            defaultInitPrompt: (a.defaultInitPrompt as string) || null,
+            promptsI18n,
+            prompts_i18n: promptsI18n,
+            tenantId,
+            tenantIds,
+            tenant_id: tenantId,
+            tenant_ids: tenantIds,
+            version,
+            latestVersion,
+            // Store sourceUrl for download (not in original type but needed for install)
+            _sourceUrl: sourceUrl,
+          };
+        })
+        .filter((assistant: IAssistantHubSkill) => !isOverlayCategoryFilter || matchesAssistantCategory(assistant, category));
 
       const mappedData = {
         assistants: mappedAssistants,

--- a/tests/unit/uploadedHubStatusRefresh.test.ts
+++ b/tests/unit/uploadedHubStatusRefresh.test.ts
@@ -532,6 +532,70 @@ describe('assistant Hub install metadata', () => {
     });
   });
 
+  it('filters tenant assistants after applying visible assistant category overlays', async () => {
+    h.fetch.mockImplementation(async (url: string) => {
+      if (url.startsWith('https://server.example/api/v1/agents/visible')) {
+        return {
+          ok: true,
+          json: vi.fn(async () => ({
+            success: true,
+            data: [
+              {
+                assistant_id: 'assistant-1',
+                display_name: 'R&D 协同 Agent',
+                categories: ['FDE'],
+              },
+            ],
+          })),
+        };
+      }
+
+      return {
+        json: vi.fn(async () => ({
+          data: {
+            assistants: [
+              {
+                id: 'assistant-1',
+                name: 'rnd-agent',
+                profession: 'R&D 协同 Agent',
+                description: 'desc',
+                avatar: null,
+                categories: ['工程技术'],
+                skills: [],
+                tag: 'hub',
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+              },
+            ],
+          },
+        })),
+      };
+    });
+
+    const { initAssistantHubBridge } = await import('@/process/bridge/assistantHubBridge');
+    initAssistantHubBridge();
+
+    const result = await h.providers.get('assistantHub.fetchAssistants.provider')?.({
+      limit: 40,
+      category: 'FDE',
+      tenantId: 'tenant-a',
+      accessToken: 'user-token',
+    });
+
+    const hubRequestUrl = String(h.fetch.mock.calls.find(([url]) => String(url).startsWith('https://hub.example'))?.[0]);
+    expect(hubRequestUrl).toContain('/api/assistants/cursor?');
+    expect(hubRequestUrl).toContain('tenant_id=tenant-a');
+    expect(hubRequestUrl).not.toContain('category=FDE');
+    expect(result.success).toBe(true);
+    expect(result.data.assistants).toHaveLength(1);
+    expect(result.data.assistants[0]).toMatchObject({
+      id: 'assistant-1',
+      display_name: 'R&D 协同 Agent',
+      category: 'FDE',
+      categories: ['FDE'],
+    });
+  });
+
   it('uses package metadata over stale assistant list fields when installing a hub assistant update', async () => {
     const assistantName = '联想AI可信一体机销售专家';
     const description = '联想AI可信一体机的企业销售专家。';


### PR DESCRIPTION
## Summary

- Tenant-scoped hub listings apply a visible-assistant overlay that can rewrite each assistant's `categories`. Forwarding the raw `category` filter to the upstream hub API filtered rows against the *original* hub categories, so any assistant the overlay reassigned into a new category was silently dropped from the results the tenant expected.
- Now: when the request is tenant-scoped and a specific category is requested, skip the upstream `category` param, apply the overlay first, and filter locally against the overlay-adjusted categories via a new `matchesAssistantCategory` helper.
- Behavior for non-tenant (personal) requests and for `category=all` is unchanged — the upstream filter is still used when no overlay is in play.

## Test plan

- [x] `bunx vitest run tests/unit/uploadedHubStatusRefresh.test.ts` — new case `filters tenant assistants after applying visible assistant category overlays` covers the overlay-then-filter path (8/8 pass).
- [x] `bunx tsc --noEmit`
- [x] `bunx eslint src/process/bridge/assistantHubBridge.ts tests/unit/uploadedHubStatusRefresh.test.ts`