### PR TITLE
fix(assistant-hub): drop stale hub fetch responses to prevent list flicker

### DIFF
--- a/src/renderer/pages/agents/index.tsx
+++ b/src/renderer/pages/agents/index.tsx
@@ -79,6 +79,10 @@ const AgentSettings: React.FC = () => {
   const [hubSearchQuery, setHubSearchQuery] = useState('');
   const [hubLoading, setHubLoading] = useState(true);
   const [hubLoadingMore, setHubLoadingMore] = useState(false);
+  const hubLoadingRef = useRef(hubLoading);
+  hubLoadingRef.current = hubLoading;
+  const hubLoadingMoreRef = useRef(hubLoadingMore);
+  hubLoadingMoreRef.current = hubLoadingMore;
   // Typed error from the most recent hub fetch — null on success.
   // Drives the differentiated empty state (token-missing vs
   // network-failed vs actually-empty). See HubEmptyState component.
@@ -205,6 +209,7 @@ const AgentSettings: React.FC = () => {
   latestAssistantVersionsRef.current = latestAssistantVersions;
   const failedAssistantVersionFetchesRef = useRef<Map<string, number>>(new Map());
   const fetchingAssistantVersionIdsRef = useRef<Set<string>>(new Set());
+  const hubRequestIdRef = useRef(0);
 
   // Resolve tenant ID for exclusive tab
   const resolveAssistantTenantId = useCallback(
@@ -350,9 +355,22 @@ const AgentSettings: React.FC = () => {
   // Fetch Hub assistants list
   const fetchHubAssistants = useCallback(
     async (cursor?: string, append = false) => {
+      if (append && hubLoadingRef.current) return;
+      const requestId = append ? hubRequestIdRef.current : hubRequestIdRef.current + 1;
+      if (!append) {
+        hubRequestIdRef.current = requestId;
+      }
+      const isLatestHubRequest = () => requestId === hubRequestIdRef.current;
       try {
-        if (append) setHubLoadingMore(true);
-        else setHubLoading(true);
+        if (append) {
+          hubLoadingMoreRef.current = true;
+          setHubLoadingMore(true);
+        } else {
+          hubLoadingRef.current = true;
+          hubLoadingMoreRef.current = false;
+          setHubLoading(true);
+          setHubLoadingMore(false);
+        }
 
         const category = selectedHubCategoryRef.current === 'all' ? '' : selectedHubCategoryRef.current;
         const query = hubSearchQueryRef.current.trim();
@@ -373,6 +391,7 @@ const AgentSettings: React.FC = () => {
             accessToken: accessToken || undefined,
           });
           if (res.success && res.data) {
+            if (!isLatestHubRequest()) return;
             // Successful fetch — clear any prior typed error so the
             // empty-state UI falls back to the generic "暂无智能体"
             // case if the catalog is genuinely empty.
@@ -403,6 +422,7 @@ const AgentSettings: React.FC = () => {
               void fetchLatestAssistantVersions(newAssistants, append ? latestAssistantVersionsRef.current : undefined);
             }
           } else if (!res.success) {
+            if (!isLatestHubRequest()) return;
             // Bridge returned a typed failure — surface to the empty
             // state instead of silently showing "暂无智能体". Cast
             // is safe inside this !success branch; the bridge type
@@ -413,14 +433,24 @@ const AgentSettings: React.FC = () => {
           }
         }
       } catch (err) {
+        if (!isLatestHubRequest()) return;
         console.error('Failed to fetch Hub assistants:', err);
         // Caught exception path → coerce into FETCH_FAILED so the
         // empty-state UI offers a retry CTA.
         setHubError({ code: 'FETCH_FAILED', message: err instanceof Error ? err.message : String(err), retriable: true });
         Message.error(t('settings.assistant.fetchFailed', '获取助手失败'));
       } finally {
-        setHubLoading(false);
-        setHubLoadingMore(false);
+        if (isLatestHubRequest()) {
+          if (append) {
+            hubLoadingMoreRef.current = false;
+            setHubLoadingMore(false);
+          } else {
+            hubLoadingRef.current = false;
+            hubLoadingMoreRef.current = false;
+            setHubLoading(false);
+            setHubLoadingMore(false);
+          }
+        }
       }
     },
     [ensureValidToken, fetchLatestAssistantVersions, isEnterprise, t]
@@ -428,10 +458,10 @@ const AgentSettings: React.FC = () => {
 
   // Load more Hub assistants (infinite scroll)
   const loadMoreHubAssistants = useCallback(() => {
-    if (!hubLoadingMore && hubHasMore && hubNextCursor) {
+    if (!hubLoadingRef.current && !hubLoadingMoreRef.current && hubHasMore && hubNextCursor) {
       void fetchHubAssistants(hubNextCursor, true);
     }
-  }, [hubLoadingMore, hubHasMore, hubNextCursor, fetchHubAssistants]);
+  }, [hubHasMore, hubNextCursor, fetchHubAssistants]);
 
   const loadMoreRef = useRef(loadMoreHubAssistants);
   loadMoreRef.current = loadMoreHubAssistants;
@@ -1855,7 +1885,7 @@ const AgentSettings: React.FC = () => {
               )}
 
               {/* Loading skeleton cards */}
-              {hubLoadingMore && (
+              {activeTab === 'store' && hubLoadingMore && (
                 <div className='grid gap-4 pb-4' style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
                   {Array.from({ length: 4 }).map((_, i) => (
                     <div key={`skel-${i}`} className='bg-fill-1 rd-12px border p-3 flex items-start gap-3 animate-pulse'>


### PR DESCRIPTION
## Summary
- Track the active Hub fetch via a request-id ref so only the newest response mutates state — rapid category/search switches no longer let older in-flight requests overwrite the current list.
- Mirror `hubLoading` / `hubLoadingMore` in refs so `loadMoreHubAssistants` and the fetch guard see the current value synchronously, preventing overlapping fetches that produced flicker and duplicated appends.
- Scope the load-more skeleton to `activeTab === 'store'` so it does not linger on other tabs after switching away mid-fetch.

## Test plan
- [ ] In Agent Settings → Store, rapidly toggle categories and type in the search box; verify the list settles on the latest query with no flicker or stale results.
- [ ] Scroll to trigger load-more, then immediately change category; verify no duplicate cards and no leftover skeleton.
- [ ] Switch tabs while a Hub fetch is in flight; verify the skeleton does not appear on non-store tabs.