### PR TITLE
feat(webui): migrate message-leak fix, avatar proxy, model persistence, custom Moss URL

### DIFF
--- a/apps/webui/migrations/003_conversation_model.sql
+++ b/apps/webui/migrations/003_conversation_model.sql
@@ -1,0 +1,4 @@
+-- 003_conversation_model.sql — 会话模型持久化（webui 本地）
+-- Moss 模型为用户级设置（PUT /api/v1/users/me/model），无会话级查询接口；
+-- webui 本地记录每个会话所选模型，用于重新打开会话时回读显示。
+ALTER TABLE conversation_meta ADD COLUMN IF NOT EXISTS model_id text;

--- a/apps/webui/migrations/004_custom_moss_url.sql
+++ b/apps/webui/migrations/004_custom_moss_url.sql
@@ -1,0 +1,9 @@
+-- 004_custom_moss_url.sql — 登录页自定义 Moss 服务器地址
+-- 会话/身份按「moss 地址 + org + user」区分：自定义地址登录的用户与默认地址下同 org+user 不互相覆盖。
+ALTER TABLE web_sessions ADD COLUMN IF NOT EXISTS moss_base_url text;
+ALTER TABLE web_principals ADD COLUMN IF NOT EXISTS moss_base_url text;
+
+-- 原内联 UNIQUE (org_id, moss_user_id)（PG 默认命名）替换为「地址归一 + org + user」表达式唯一索引
+ALTER TABLE web_principals DROP CONSTRAINT IF EXISTS web_principals_org_id_moss_user_id_key;
+CREATE UNIQUE INDEX IF NOT EXISTS web_principals_identity_key
+  ON web_principals (COALESCE(moss_base_url, ''), org_id, moss_user_id);

--- a/apps/webui/src/client/components/agentAvatar.ts
+++ b/apps/webui/src/client/components/agentAvatar.ts
@@ -1,0 +1,29 @@
+/**
+ * 智能体头像解析（agents 与 conversations 两个 feature 共用的单一入口）。
+ * moss 返回的 avatar 可能是：绝对 URL（hub=COS 图床）、emoji 字符、data: URI、
+ * moss 相对路径（tenant=/uploads/tenant-assistant-avatars/<file>）。
+ * 相对路径浏览器不可直达 moss（容器网络地址），须经 webui 同源代理转发。
+ */
+
+/** tenant 相对路径头像的 webui 同源代理端点，须与后端 conversationRoutes 的 zod 白名单同口径 */
+export const AGENT_AVATAR_PROXY_PATH = '/api/conversations/agent-avatar'
+
+/** moss 相对路径头像的唯一生成形态（moss saveTenantAssistantAvatar） */
+const MOSS_TENANT_AVATAR_PREFIX = '/uploads/tenant-assistant-avatars/'
+
+export type ResolvedAgentAvatar = { kind: 'emoji' | 'image'; value: string } | null
+
+// 单个 emoji（含 ZWJ 序列，如 👨‍💻）；与 AgentsPage 原本地实现同口径，收敛到此处统一使用
+const EMOJI_AVATAR_REGEX = /^(?:\p{Emoji_Presentation}|\p{Emoji}️)(?:‍(?:\p{Emoji_Presentation}|\p{Emoji}️))*$/u
+
+export function resolveAgentAvatar(avatar: string | null | undefined): ResolvedAgentAvatar {
+  const value = (avatar ?? '').trim()
+  if (!value) return null
+  if (/^(?:https?:|data:)/i.test(value)) return { kind: 'image', value }
+  if (EMOJI_AVATAR_REGEX.test(value)) return { kind: 'emoji', value }
+  if (value.startsWith(MOSS_TENANT_AVATAR_PREFIX)) {
+    return { kind: 'image', value: `${AGENT_AVATAR_PROXY_PATH}?path=${encodeURIComponent(value)}` }
+  }
+  // 其余形态（其他相对路径、blob: 等）不生成必然 400 的代理 URL，交各处兜底图标
+  return null
+}

--- a/apps/webui/src/client/features/agents/AgentsPage.tsx
+++ b/apps/webui/src/client/features/agents/AgentsPage.tsx
@@ -8,6 +8,7 @@ import React, { useMemo, useState } from 'react'
 import { useSWRConfig } from 'swr'
 import { Button, Input, Message, Popconfirm, Spin } from '@arco-design/web-react'
 import { Bot, Search, Shield, SquarePen, Trash2 } from 'lucide-react'
+import { resolveAgentAvatar } from '@client/components/agentAvatar'
 import { useAgents } from './useAgents'
 import { agentApi, type AgentItem } from './agentApi'
 import { AssistantDetailModal } from './AssistantDetailModal'
@@ -316,21 +317,16 @@ function AgentCard({
 }): React.ReactElement {
   const displayName = String(agent.displayName ?? agent.display_name ?? agent.name ?? '')
   const version = resolveVersionLabel((agent as { latestVersion?: unknown }).latestVersion)
-  // 图标链对齐 sudowork HubAssistantCard：avatar（emoji 正则判断）→ emoji 字段 → Bot 兜底
-  const resolvedAvatar = typeof agent.avatar === 'string' ? agent.avatar.trim() : ''
-  const emojiRegex =
-    /^(?:\p{Emoji_Presentation}|\p{Emoji}️)(?:‍(?:\p{Emoji_Presentation}|\p{Emoji}️))*$/u
-  const hasEmojiAvatar = Boolean(resolvedAvatar && emojiRegex.test(resolvedAvatar))
+  // 图标链对齐 sudowork HubAssistantCard：avatar（resolveAgentAvatar：emoji/图片，tenant 相对路径走同源代理）→ emoji 字段 → Bot 兜底
+  const resolvedAvatar = resolveAgentAvatar(agent.avatar)
   return (
     <div className='card group flex items-start gap-3 relative overflow-hidden' data-testid='assistant-card' onClick={onDetail}>
       <div className='w-48px flex-shrink-0'>
         <div className='size-12 rd-8px overflow-hidden bg-control f-center'>
-          {resolvedAvatar ? (
-            hasEmojiAvatar ? (
-              <div className='w-full h-full f-center text-22px'>{resolvedAvatar}</div>
-            ) : (
-              <img src={resolvedAvatar} alt={displayName} className='w-full h-full object-cover' />
-            )
+          {resolvedAvatar?.kind === 'image' ? (
+            <img src={resolvedAvatar.value} alt={displayName} className='w-full h-full object-cover' />
+          ) : resolvedAvatar?.kind === 'emoji' ? (
+            <div className='w-full h-full f-center text-22px'>{resolvedAvatar.value}</div>
           ) : agent.emoji ? (
             <div className='w-full h-full f-center text-22px'>{agent.emoji}</div>
           ) : (

--- a/apps/webui/src/client/features/auth/LoginPage.css
+++ b/apps/webui/src/client/features/auth/LoginPage.css
@@ -55,7 +55,22 @@
   border: 1px solid var(--border-default, #e5e6eb);
   border-radius: 4px;
   font-size: 14px;
-  line-height: 18px;
+  /* 20px（非 18px）：100% 缩放下原生 input overflow:clip 会裁掉用户名下划线字形 */
+  line-height: 20px;
+}
+
+.login-custom-toggle {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary, #86909c);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.login-custom-toggle:hover {
+  color: var(--primary, #165dff);
 }
 
 .login-error {

--- a/apps/webui/src/client/features/auth/LoginPage.tsx
+++ b/apps/webui/src/client/features/auth/LoginPage.tsx
@@ -3,8 +3,8 @@ import { ApiError, loginApiKey, loginPassword } from './authApi'
 import './LoginPage.css'
 
 /**
- * 登录页（计划 Task 3）：只显示密码/API Key 两种方式；
- * 不显示模式选择、OAuth、注册和 Moss 地址。
+ * 登录页（计划 Task 3）：密码/API Key 两种方式；
+ * 自定义 Moss 地址默认折叠、永不自动展开，展开填写后该会话所有 moss 调用走此地址。
  * 视觉在 Task 4 摘取 Sudowork design tokens 后统一替换。
  */
 
@@ -21,6 +21,8 @@ export function LoginPage({ onSuccess }: { onSuccess?: (result: { ok: true }) =>
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [apiKey, setApiKey] = useState('')
+  const [mossUrl, setMossUrl] = useState<string>(() => localStorage.getItem('login.mossBaseUrl') ?? '')
+  const [customUrlExpanded, setCustomUrlExpanded] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -32,12 +34,32 @@ export function LoginPage({ onSuccess }: { onSuccess?: (result: { ok: true }) =>
   async function handleSubmit(e: FormEvent): Promise<void> {
     e.preventDefault()
     setError(null)
+
+    // 自定义地址：仅展开时生效。非空须为 http(s) 完整 URL 并记忆；展开且清空则移除记忆。
+    let mossBaseUrl: string | undefined
+    if (customUrlExpanded) {
+      const trimmed = mossUrl.trim()
+      if (trimmed) {
+        try {
+          const parsed = new URL(trimmed)
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') throw new Error('scheme')
+        } catch {
+          setError('地址必须是以 http:// 或 https:// 开头的完整 URL')
+          return
+        }
+        mossBaseUrl = trimmed
+        localStorage.setItem('login.mossBaseUrl', trimmed)
+      } else {
+        localStorage.removeItem('login.mossBaseUrl')
+      }
+    }
+
     setLoading(true)
     try {
       const result =
         mode === 'password'
-          ? await loginPassword({ username, password })
-          : await loginApiKey(apiKey)
+          ? await loginPassword({ username, password, ...(mossBaseUrl ? { mossBaseUrl } : {}) })
+          : await loginApiKey(apiKey, mossBaseUrl)
       onSuccess?.(result)
     } catch (err) {
       if (err instanceof ApiError) {
@@ -103,6 +125,22 @@ export function LoginPage({ onSuccess }: { onSuccess?: (result: { ok: true }) =>
             API Key
             <input value={apiKey} onChange={(e) => setApiKey(e.target.value)} required />
           </label>
+        )}
+
+        {customUrlExpanded ? (
+          <label className="login-field">
+            Moss 服务器地址
+            <input
+              value={mossUrl}
+              onChange={(e) => setMossUrl(e.target.value)}
+              autoComplete="off"
+              inputMode="url"
+            />
+          </label>
+        ) : (
+          <button type="button" className="login-custom-toggle" onClick={() => setCustomUrlExpanded(true)}>
+            使用自定义服务器地址
+          </button>
         )}
 
         {error ? (

--- a/apps/webui/src/client/features/auth/authApi.ts
+++ b/apps/webui/src/client/features/auth/authApi.ts
@@ -47,17 +47,21 @@ export function fetchSession(): Promise<SessionResponse> {
   return apiRequest<SessionResponse>('/api/auth/session')
 }
 
-export function loginPassword(input: { username: string; password: string }): Promise<{ ok: true }> {
+export function loginPassword(input: {
+  username: string
+  password: string
+  mossBaseUrl?: string
+}): Promise<{ ok: true }> {
   return apiRequest<{ ok: true }>('/api/auth/login/password', {
     method: 'POST',
     body: JSON.stringify(input),
   })
 }
 
-export function loginApiKey(apiKey: string): Promise<{ ok: true }> {
+export function loginApiKey(apiKey: string, mossBaseUrl?: string): Promise<{ ok: true }> {
   return apiRequest<{ ok: true }>('/api/auth/login/api-key', {
     method: 'POST',
-    body: JSON.stringify({ apiKey }),
+    body: JSON.stringify(mossBaseUrl ? { apiKey, mossBaseUrl } : { apiKey }),
   })
 }
 

--- a/apps/webui/src/client/features/conversations/AgentSelectedView.tsx
+++ b/apps/webui/src/client/features/conversations/AgentSelectedView.tsx
@@ -5,12 +5,15 @@
  */
 import React from 'react'
 import { ArrowLeft, Bot } from 'lucide-react'
+import { resolveAgentAvatar } from '@client/components/agentAvatar'
 
 export interface SelectedAgentInfo {
   name: string
   displayName: string
   emoji: string
   description: string
+  avatar: string
+  promptsI18n: { 'zh-CN': string[] }
 }
 
 export function AgentSelectedView({
@@ -32,11 +35,22 @@ export function AgentSelectedView({
           <ArrowLeft size={18} color='var(--color-text-2)' />
         </div>
         <div className='flex-shrink-0'>
-          {agent.emoji ? (
-            <span style={{ fontSize: 24, lineHeight: '28px' }}>{agent.emoji}</span>
-          ) : (
-            <Bot size={24} />
-          )}
+          {(() => {
+            const resolved = resolveAgentAvatar(agent.avatar)
+            if (resolved?.kind === 'image') {
+              return (
+                <img src={resolved.value} alt={agent.displayName} className='w-24px h-24px rd-full object-cover' />
+              )
+            }
+            if (resolved?.kind === 'emoji') {
+              return <span style={{ fontSize: 24, lineHeight: '28px' }}>{resolved.value}</span>
+            }
+            return agent.emoji ? (
+              <span style={{ fontSize: 24, lineHeight: '28px' }}>{agent.emoji}</span>
+            ) : (
+              <Bot size={24} />
+            )
+          })()}
         </div>
         <span className='text-xl font-semibold text-foreground truncate'>{agent.displayName}</span>
       </div>

--- a/apps/webui/src/client/features/conversations/ConversationHeader.tsx
+++ b/apps/webui/src/client/features/conversations/ConversationHeader.tsx
@@ -24,6 +24,7 @@ export function ConversationHeader({
   onSetModel,
   onTogglePanel,
   statusHint,
+  modelError,
 }: {
   title: string
   socketStatus: 'connecting' | 'open' | 'closed'
@@ -32,6 +33,7 @@ export function ConversationHeader({
   onSetModel: (modelId: string) => void
   onTogglePanel: () => void
   statusHint: string | null
+  modelError: string | null
 }): React.ReactElement {
   const currentName =
     models.find((m) => m.id === currentModel || m.id === currentModel?.replace(/^proxy\//, ''))?.name
@@ -71,6 +73,7 @@ export function ConversationHeader({
         <div className='min-w-0 truncate text-14px font-600 text-foreground'>{title}</div>
       </div>
       <div className='flex items-center gap-3 shrink-0'>
+        {modelError ? <span className='text-12px text-warning'>{modelError}</span> : null}
         {statusHint ? <span className='text-12px text-warning'>{statusHint}</span> : null}
         {/* 连接状态点 */}
         <span

--- a/apps/webui/src/client/features/conversations/ConversationHistory.tsx
+++ b/apps/webui/src/client/features/conversations/ConversationHistory.tsx
@@ -59,9 +59,9 @@ export function ConversationHistory({ isScheduled }: { isScheduled: boolean }): 
   )
   const [confirmDelete, setConfirmDelete] = useState<ConversationListItem | null>(null)
 
-  const emojiByName = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const a of options?.agents ?? []) map.set(a.displayName, a.emoji)
+  const agentIconByName = useMemo(() => {
+    const map = new Map<string, { emoji: string; avatar: string }>()
+    for (const a of options?.agents ?? []) map.set(a.displayName, { emoji: a.emoji, avatar: a.avatar })
     return map
   }, [options])
 
@@ -154,7 +154,8 @@ export function ConversationHistory({ isScheduled }: { isScheduled: boolean }): 
                     key={c.id}
                     item={c}
                     active={pathname === `/conversation/${c.id}`}
-                    emoji={c.assistantName ? (emojiByName.get(c.assistantName) ?? '') : ''}
+                    emoji={c.assistantName ? (agentIconByName.get(c.assistantName)?.emoji ?? '') : ''}
+                    avatar={c.assistantName ? (agentIconByName.get(c.assistantName)?.avatar ?? '') : ''}
                     onOpen={() => handleOpen(c.id)}
                     onPin={() => handlePin(c)}
                     onRename={(t) => handleRename(c, t)}
@@ -173,7 +174,7 @@ export function ConversationHistory({ isScheduled }: { isScheduled: boolean }): 
     items={items}
     pathname={pathname}
     collapsed={collapsed}
-    emojiByName={emojiByName}
+    agentIconByName={agentIconByName}
     onToggle={toggleSection}
     onOpen={handleOpen}
     onPin={handlePin}
@@ -214,7 +215,7 @@ function TimelineHistory({
   items,
   pathname,
   collapsed,
-  emojiByName,
+  agentIconByName,
   onToggle,
   onOpen,
   onPin,
@@ -226,7 +227,7 @@ function TimelineHistory({
   items: ConversationListItem[]
   pathname: string
   collapsed: Set<string>
-  emojiByName: Map<string, string>
+  agentIconByName: Map<string, { emoji: string; avatar: string }>
   onToggle: (label: string) => void
   onOpen: (id: string) => void
   onPin: (item: ConversationListItem) => void
@@ -277,7 +278,8 @@ function TimelineHistory({
                   key={c.id}
                   item={c}
                   active={pathname === `/conversation/${c.id}`}
-                  emoji={c.assistantName ? (emojiByName.get(c.assistantName) ?? '') : ''}
+                  emoji={c.assistantName ? (agentIconByName.get(c.assistantName)?.emoji ?? '') : ''}
+                  avatar={c.assistantName ? (agentIconByName.get(c.assistantName)?.avatar ?? '') : ''}
                   onOpen={() => onOpen(c.id)}
                   onPin={() => onPin(c)}
                   onRename={(t) => onRename(c, t)}
@@ -304,7 +306,8 @@ function TimelineHistory({
                   key={c.id}
                   item={c}
                   active={pathname === `/conversation/${c.id}`}
-                  emoji={c.assistantName ? (emojiByName.get(c.assistantName) ?? '') : ''}
+                  emoji={c.assistantName ? (agentIconByName.get(c.assistantName)?.emoji ?? '') : ''}
+                  avatar={c.assistantName ? (agentIconByName.get(c.assistantName)?.avatar ?? '') : ''}
                   onOpen={() => onOpen(c.id)}
                   onPin={() => onPin(c)}
                   onRename={(t) => onRename(c, t)}

--- a/apps/webui/src/client/features/conversations/ConversationPage.tsx
+++ b/apps/webui/src/client/features/conversations/ConversationPage.tsx
@@ -40,7 +40,20 @@ const FOCUS_RING = {
 interface InitialState {
   initialMessage?: string
   initialImages?: PendingImage[]
+  /** guid 携带的所选模型：仅作会话头显示种子（模型已在建会话时服务端生效），不触发 set_model */
   initialModel?: string
+}
+
+/** 模型切换失败 code → 会话头可读文案（含本地 SET_MODEL_TIMEOUT） */
+const MODEL_ERROR_TEXT: Record<string, string> = {
+  LOCK_UNCERTAIN: '会话状态不确定，暂无法切换模型',
+  CONVERSATION_BUSY: '会话忙（另一设备正在输入），暂无法切换',
+  UPSTREAM_NOT_CONNECTED: '连接未就绪，请稍后重试',
+  UPSTREAM_FAILED: '上游连接失败，请稍后重试',
+  UPSTREAM_OWNER_MISMATCH: '会话被其他连接占用，切换失败',
+  SESSION_NOT_FOUND: '会话不存在或已结束',
+  MOSS_UNAVAILABLE: '服务暂不可用，请稍后重试',
+  SET_MODEL_TIMEOUT: '模型切换超时，请稍后重试',
 }
 
 export function ConversationPage(): React.ReactElement {
@@ -56,7 +69,7 @@ export function ConversationPage(): React.ReactElement {
     // 轻量轮询：中途打开的观察者在 turn 完成后也能看到完整历史
     { refreshInterval: turnActive ? 0 : 5_000 },
   )
-  const socket = useConversationSocket(id)
+  const socket = useConversationSocket(id, initial?.initialModel ?? null)
   const { data: options } = useSWR('conversation-options', getConversationOptions)
   const [text, setText] = useState('')
   const [focused, setFocused] = useState(false)
@@ -111,16 +124,21 @@ export function ConversationPage(): React.ReactElement {
     }
   }, [socket.state.lockState, socket.state.lastError, socket.status])
 
-  // guid 跳转携带的首条消息：WS 就绪后（可选切模型）自动发送
+  // guid 跳转携带的首条消息：WS 就绪后自动发送（模型已在建会话时服务端 setUserModel + 持久化，
+  // initialModel 仅作显示种子，不再前端 setModel）
   useEffect(() => {
     if (!id || initialSent || socket.status !== 'open' || !initial?.initialMessage) return
     setInitialSent(true)
     setTurnActive(true)
-    if (initial.initialModel) socket.setModel(initial.initialModel)
     socket.appendLocalUser(initial.initialMessage, initial.initialImages ?? [])
     socket.send(initial.initialMessage, initial.initialImages ?? [])
     void navigate(location.pathname, { replace: true, state: null })
   }, [id, initialSent, socket, initial, navigate, location.pathname])
+
+  // 重开会话回读：用本地持久化的 modelId 种子化模型显示（不触发 set_model）
+  useEffect(() => {
+    if (context?.modelId) socket.hydrateModel(context.modelId)
+  }, [context?.modelId, socket, id])
 
   // 新消息自动滚动到底
   useEffect(() => {
@@ -226,10 +244,15 @@ export function ConversationPage(): React.ReactElement {
           title={context?.customTitle ?? context?.title ?? `会话 ${id?.slice(0, 8) ?? ''}`}
           socketStatus={socket.status}
           models={options?.models ?? []}
-          currentModel={socket.state.currentModel}
+          currentModel={socket.state.currentModel ?? socket.state.hydratedModel}
           onSetModel={(modelId) => socket.setModel(modelId)}
           onTogglePanel={toggleRightPanel}
           statusHint={uncertain ? '状态不确定（写入端中断）' : busyByOther ? '只读（另一设备正在输入）' : null}
+          modelError={
+            socket.state.modelSwitchError
+              ? (MODEL_ERROR_TEXT[socket.state.modelSwitchError] ?? '模型切换失败，请稍后重试')
+              : null
+          }
         />
 
         {uncertain ? (

--- a/apps/webui/src/client/features/conversations/ConversationRow.tsx
+++ b/apps/webui/src/client/features/conversations/ConversationRow.tsx
@@ -8,11 +8,13 @@ import { Dropdown, Menu, Modal, Input, Message as ArcoMessage } from '@arco-desi
 import { MessageOne } from '@icon-park/react'
 import { Pin } from 'lucide-react'
 import type { ConversationListItem } from '@sudowork/contracts/conversations'
+import { resolveAgentAvatar } from '@client/components/agentAvatar'
 
 export function ConversationRow({
   item,
   active,
   emoji,
+  avatar,
   onOpen,
   onPin,
   onRename,
@@ -21,6 +23,7 @@ export function ConversationRow({
   item: ConversationListItem
   active: boolean
   emoji: string | null
+  avatar: string | null
   onOpen: () => void
   onPin: () => void
   onRename: (title: string) => void
@@ -40,13 +43,22 @@ export function ConversationRow({
         }`}
         onClick={onOpen}
       >
-        {/* 前置图标：智能体 emoji / 兜底 MessageOne（对齐 Sudowork ConversationRow 兜底图标） */}
+        {/* 前置图标：头像（tenant 走同源代理）/ emoji / 兜底 MessageOne（对齐 Sudowork ConversationRow） */}
         <span className='mr-2 inline-flex size-20px shrink-0 items-center justify-center overflow-hidden'>
-          {emoji ? (
-            <span className='text-14px leading-none'>{emoji}</span>
-          ) : (
-            <MessageOne theme='outline' size='20' className='line-height-0 flex-shrink-0' />
-          )}
+          {(() => {
+            const resolved = resolveAgentAvatar(avatar)
+            if (resolved?.kind === 'image') {
+              return <img src={resolved.value} alt='' className='h-20px w-20px object-contain' />
+            }
+            if (resolved?.kind === 'emoji') {
+              return <span className='text-14px leading-none'>{resolved.value}</span>
+            }
+            return emoji ? (
+              <span className='text-14px leading-none'>{emoji}</span>
+            ) : (
+              <MessageOne theme='outline' size='20' className='line-height-0 flex-shrink-0' />
+            )
+          })()}
         </span>
         {/* 标题（单行截断；不显示时间戳，对齐 Sudowork） */}
         <span

--- a/apps/webui/src/client/features/conversations/NewConversationPage.tsx
+++ b/apps/webui/src/client/features/conversations/NewConversationPage.tsx
@@ -11,6 +11,7 @@ import { Button, Dropdown, Input, Menu, Message, Popover, Tag } from '@arco-desi
 import type { RefTextAreaType } from '@arco-design/web-react/es/Input/textarea'
 import { ArrowUp, AtSign, Bot, Brain, Plus, Zap } from 'lucide-react'
 import { ApiError } from '../auth/authApi'
+import { resolveAgentAvatar } from '@client/components/agentAvatar'
 import { createConversation, getConversationOptions } from './conversationApi'
 import { AgentSelectedView, type SelectedAgentInfo } from './AgentSelectedView'
 import { SkillSelectorMenu } from './SkillSelectorMenu'
@@ -123,6 +124,8 @@ export function NewConversationPage(): React.ReactElement {
   const agents = options?.agents ?? []
   const skills = options?.skills ?? []
   const models = options?.models ?? []
+  // 选中 agent 的 zh-CN 案例提示词（moss 未返回该字段时为空，案例块不渲染）
+  const agentExamplePrompts = (selectedAgent?.promptsI18n['zh-CN'] ?? []).filter((prompt) => prompt.trim())
 
   // @ 触发控制器（对齐 Sudowork useSkillSelectorController）
   const skillSelector = useSkillSelector({
@@ -451,8 +454,24 @@ export function NewConversationPage(): React.ReactElement {
             </div>
           </div>
 
-          {/* 底部智能体列表（对齐 Sudowork AssistantSelectionArea：空列表整块不渲染） */}
-          {agents.length > 0 ? (
+          {/* 底部（对齐 Sudowork AssistantSelectionArea）：已选中且有案例→案例提示词；未选中→智能体列表；否则不渲染 */}
+          {selectedAgent && agentExamplePrompts.length > 0 ? (
+            <div className='mt-16px w-full' data-testid='agent-example-prompts'>
+              <div className='flex flex-col gap-2'>
+                {agentExamplePrompts.map((prompt) => (
+                  <button
+                    key={prompt}
+                    type='button'
+                    className='text-left text-14px text-2 hover:text-1 px-16px py-8px rd-12px b-1 b-solid cursor-pointer bg-fill-0 hover:bg-fill-1'
+                    style={{ borderColor: 'var(--bg-3)' }}
+                    onClick={() => setInput(prompt)}
+                  >
+                    {prompt}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : !selectedAgent && agents.length > 0 ? (
             <div className='mt-16px w-full' data-testid='assistant-list'>
               <div className='f-center flex-wrap gap-2'>
                 {agents.map((a) => (
@@ -461,16 +480,30 @@ export function NewConversationPage(): React.ReactElement {
                     data-testid={`assistant-chip-${a.name}`}
                     className='h-28px group flex items-center gap-8px px-16px rd-100px cursor-pointer transition-all b-1 b-solid bg-fill-0 hover:bg-fill-1 select-none'
                     style={{ borderWidth: 1, borderColor: 'var(--bg-3)' }}
-                    onClick={() =>
-                      setSelectedAgent(
-                        selectedAgent?.name === a.name
-                          ? null
-                          : { name: a.name, displayName: a.displayName, emoji: a.emoji, description: a.description },
-                      )
-                    }
+                    onClick={() => {
+                      setSelectedAgent({
+                        name: a.name,
+                        displayName: a.displayName,
+                        emoji: a.emoji,
+                        description: a.description,
+                        avatar: a.avatar,
+                        promptsI18n: a.promptsI18n,
+                      })
+                      const prompt = a.defaultInitPrompt.trim()
+                      if (prompt) setInput(prompt)
+                    }}
                   >
                     <span className='inline-flex h-16px w-16px shrink-0 items-center justify-center leading-none'>
-                      {a.emoji ? <span className='text-16px leading-none'>{a.emoji}</span> : <Bot size={16} />}
+                      {(() => {
+                        const resolved = resolveAgentAvatar(a.avatar)
+                        if (resolved?.kind === 'image') {
+                          return <img src={resolved.value} alt={a.displayName} className='h-16px w-16px object-contain' />
+                        }
+                        if (resolved?.kind === 'emoji') {
+                          return <span className='text-16px leading-none'>{resolved.value}</span>
+                        }
+                        return a.emoji ? <span className='text-16px leading-none'>{a.emoji}</span> : <Bot size={16} />
+                      })()}
                     </span>
                     <span className='text-14px text-2 hover:text-1'>{a.displayName}</span>
                   </div>

--- a/apps/webui/src/client/features/conversations/NewConversationPage.tsx
+++ b/apps/webui/src/client/features/conversations/NewConversationPage.tsx
@@ -27,7 +27,7 @@ const SEND_ERROR_MESSAGES: Record<string, string> = {
   MOSS_ERROR: 'Moss 服务错误，请稍后重试',
   INTERNAL: '服务器内部错误，请稍后重试',
   INVALID_REQUEST: '请求参数无效',
-  SELECTION_NOT_AVAILABLE: '所选智能体或技能当前不可用',
+  SELECTION_NOT_AVAILABLE: '所选模型、智能体或技能当前不可用',
 }
 
 /** 提示词模板分类（文案与图标逐字对齐 Sudowork guid.json / DEFAULT_PROMPT_CATEGORIES）：
@@ -157,6 +157,7 @@ export function NewConversationPage(): React.ReactElement {
       const created = await createConversation({
         assistantName: selectedAgent?.name ?? '',
         enabledSkills: selectedSkills,
+        ...(selectedModel ? { modelId: selectedModel } : {}),
       })
       void navigate(`/conversation/${created.id}`, {
         state: { initialMessage: input.trim(), initialImages: images, initialModel: selectedModel || undefined },

--- a/apps/webui/src/client/features/conversations/conversationApi.ts
+++ b/apps/webui/src/client/features/conversations/conversationApi.ts
@@ -3,7 +3,15 @@ import { ApiError } from '@client/features/auth/authApi'
 
 export interface ConversationOptions {
   models: { id: string; name: string }[]
-  agents: { name: string; displayName: string; emoji: string; description: string }[]
+  agents: {
+    name: string
+    displayName: string
+    emoji: string
+    description: string
+    avatar: string
+    defaultInitPrompt: string
+    promptsI18n: { 'zh-CN': string[] }
+  }[]
   skills: { name: string; displayName: string; description: string; icon: string; emoji: string }[]
 }
 

--- a/apps/webui/src/client/features/conversations/conversationApi.ts
+++ b/apps/webui/src/client/features/conversations/conversationApi.ts
@@ -69,6 +69,7 @@ export function deleteConversation(id: string): Promise<{ ok: true }> {
 export function createConversation(input: {
   assistantName: string
   enabledSkills: string[]
+  modelId?: string
 }): Promise<{ id: string }> {
   return api('/api/conversations', { method: 'POST', body: JSON.stringify(input) })
 }

--- a/apps/webui/src/client/features/conversations/useConversationSocket.ts
+++ b/apps/webui/src/client/features/conversations/useConversationSocket.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ServerInboundEvent } from '@sudowork/contracts/conversations'
 
 /**
@@ -182,11 +182,16 @@ export function useConversationSocket(conversationId: string | undefined): Conve
   const [state, setState] = useState<ConversationStreamState>(initialStreamState)
   const wsRef = useRef<WebSocket | null>(null)
 
-  useEffect(() => {
+  // useLayoutEffect（非 useEffect）：会话切换的整体重置须在 paint 前 flush——passive effect
+  // 在 paint 后运行，id 变化的首帧仍持旧会话 messages，会把上一会话消息泄漏渲染到新会话底部。
+  useLayoutEffect(() => {
     if (!conversationId) return
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
     const ws = new WebSocket(`${proto}://${window.location.host}/ws/conversations/${conversationId}`)
     wsRef.current = ws
+    // 会话切换：整体重置（messages/lockState/isWriter/lastError/isStopping/currentModel 不得跨会话
+    // 继承——lock/writer 由服务端连接即推重建，模型由后续 model_changed 回填）
+    setState(initialStreamState)
     setStatus('connecting')
 
     ws.onopen = () => setStatus('open')

--- a/apps/webui/src/client/features/conversations/useConversationSocket.ts
+++ b/apps/webui/src/client/features/conversations/useConversationSocket.ts
@@ -27,16 +27,40 @@ export interface ConversationStreamState {
   isStopping: boolean
   /** 最近一次 system/model_changed 的模型标识（上游带 proxy/ 前缀） */
   currentModel: string | null
+  /** hydrateModel 最近写入的值（重开会话回读种子） */
+  hydratedModel: string | null
+  /** 发出 set_model 待确认的目标模型（裸 id）；model_changed 到达 / 白名单 error / 15s 超时清空 */
+  modelSwitchPending: string | null
+  /** 模型切换失败错误 code（服务端白名单内 code 或本地 SET_MODEL_TIMEOUT） */
+  modelSwitchError: string | null
 }
 
-export const initialStreamState: ConversationStreamState = {
-  messages: [],
-  lockState: null,
-  isWriter: false,
-  lastError: null,
-  isStopping: false,
-  currentModel: null,
+function createInitialStreamState(initialModel: string | null = null): ConversationStreamState {
+  return {
+    messages: [],
+    lockState: null,
+    isWriter: false,
+    lastError: null,
+    isStopping: false,
+    currentModel: initialModel,
+    hydratedModel: null,
+    modelSwitchPending: null,
+    modelSwitchError: null,
+  }
 }
+
+export const initialStreamState: ConversationStreamState = createInitialStreamState()
+
+/** 服务端可归因为「模型切换失败」的 error code 白名单（其余 error 不置 modelSwitchError） */
+export const MODEL_SWITCH_ERROR_CODES = new Set([
+  'LOCK_UNCERTAIN',
+  'CONVERSATION_BUSY',
+  'UPSTREAM_NOT_CONNECTED',
+  'UPSTREAM_FAILED',
+  'UPSTREAM_OWNER_MISMATCH',
+  'SESSION_NOT_FOUND',
+  'MOSS_UNAVAILABLE',
+])
 
 interface UpstreamEvent {
   type?: string
@@ -74,12 +98,18 @@ export function reduceStreamEvent(
       return { ...state, lockState: inbound.state }
     case 'writer':
       return { ...state, isWriter: inbound.isWriter }
-    case 'error':
+    case 'error': {
+      // 模型切换归因：有 pending 且 code 在白名单内 → 记为切换失败并清 pending
+      const modelPatch =
+        state.modelSwitchPending !== null && MODEL_SWITCH_ERROR_CODES.has(inbound.code)
+          ? { modelSwitchError: inbound.code, modelSwitchPending: null }
+          : {}
       // 抢占失败：复位乐观 isWriter，随后的 lock:running + writer:false 会落入只读观察
       if (inbound.code === 'CONVERSATION_BUSY') {
-        return { ...state, lastError: inbound.code, isWriter: false }
+        return { ...state, lastError: inbound.code, isWriter: false, ...modelPatch }
       }
-      return { ...state, lastError: inbound.code }
+      return { ...state, lastError: inbound.code, ...modelPatch }
+    }
     case 'upstream': {
       const event = inbound.event as UpstreamEvent
       const type = event?.type
@@ -157,7 +187,14 @@ export function reduceStreamEvent(
         }
       }
       if (type === 'system' && event.subtype === 'model_changed') {
-        return { ...state, currentModel: event.model ?? state.currentModel }
+        // model_changed 到达即确认：清 pending/error；hydratedModel 归零（已由真实 currentModel 取代）
+        const confirmed = state.modelSwitchPending !== null
+        return {
+          ...state,
+          currentModel: event.model ?? state.currentModel,
+          hydratedModel: null,
+          ...(confirmed ? { modelSwitchPending: null, modelSwitchError: null } : {}),
+        }
       }
       return state
     }
@@ -172,14 +209,20 @@ export interface ConversationSocket {
   send: (text: string, images?: { mediaType: string; data: string }[]) => void
   answerQuestion: (parentToolUseId: string, text: string) => void
   setModel: (modelId: string) => void
+  /** 重开会话回读：用本地持久化的 modelId 种子化显示（不触发 set_model，仅显示，等 model_changed 覆盖） */
+  hydrateModel: (modelId: string) => void
   /** 停止当前回复（转发上游 interrupt）；isStopping 由 reducer 在 result/lock idle 复位 */
   stop: () => void
   appendLocalUser: (text: string, images?: { mediaType: string; data: string }[]) => void
 }
 
-export function useConversationSocket(conversationId: string | undefined): ConversationSocket {
+export function useConversationSocket(
+  conversationId: string | undefined,
+  initialModel: string | null = null,
+): ConversationSocket {
   const [status, setStatus] = useState<'connecting' | 'open' | 'closed'>('connecting')
-  const [state, setState] = useState<ConversationStreamState>(initialStreamState)
+  const [state, setState] = useState<ConversationStreamState>(() => createInitialStreamState(initialModel))
+  const modelSwitchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
 
   // useLayoutEffect（非 useEffect）：会话切换的整体重置须在 paint 前 flush——passive effect
@@ -189,9 +232,10 @@ export function useConversationSocket(conversationId: string | undefined): Conve
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
     const ws = new WebSocket(`${proto}://${window.location.host}/ws/conversations/${conversationId}`)
     wsRef.current = ws
-    // 会话切换：整体重置（messages/lockState/isWriter/lastError/isStopping/currentModel 不得跨会话
-    // 继承——lock/writer 由服务端连接即推重建，模型由后续 model_changed 回填）
-    setState(initialStreamState)
+    // 会话切换：整体重置（messages/lockState/isWriter/lastError/isStopping/模型态 不得跨会话继承——
+    // lock/writer 由服务端连接即推重建，currentModel 由 initialModel 种子 + 后续 model_changed 回填）
+    if (modelSwitchTimerRef.current) clearTimeout(modelSwitchTimerRef.current)
+    setState(createInitialStreamState(initialModel))
     setStatus('connecting')
 
     ws.onopen = () => setStatus('open')
@@ -215,8 +259,9 @@ export function useConversationSocket(conversationId: string | undefined): Conve
       ws.onmessage = null
       ws.close()
       wsRef.current = null
+      if (modelSwitchTimerRef.current) clearTimeout(modelSwitchTimerRef.current)
     }
-  }, [conversationId])
+  }, [conversationId, initialModel])
 
   const rawSend = useCallback((payload: unknown): void => {
     const ws = wsRef.current
@@ -239,12 +284,29 @@ export function useConversationSocket(conversationId: string | undefined): Conve
     [rawSend],
   )
 
-  const setModel = useCallback(
-    (modelId: string): void => {
-      rawSend({ kind: 'set_model', modelId })
-    },
-    [rawSend],
-  )
+  const setModel = useCallback((modelId: string): void => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      setState((prev) => ({ ...prev, modelSwitchError: 'UPSTREAM_NOT_CONNECTED', modelSwitchPending: null }))
+      return
+    }
+    ws.send(JSON.stringify({ kind: 'set_model', modelId }))
+    setState((prev) => ({ ...prev, modelSwitchPending: modelId, modelSwitchError: null }))
+    if (modelSwitchTimerRef.current) clearTimeout(modelSwitchTimerRef.current)
+    // 15s 未收到 model_changed / 白名单 error：本地判超时（避免 pending 永久转圈）
+    modelSwitchTimerRef.current = setTimeout(() => {
+      setState((prev) =>
+        prev.modelSwitchPending === modelId
+          ? { ...prev, modelSwitchPending: null, modelSwitchError: 'SET_MODEL_TIMEOUT' }
+          : prev,
+      )
+    }, 15_000)
+  }, [])
+
+  const hydrateModel = useCallback((modelId: string): void => {
+    // 重开会话回读：仅写显示种子（不发 set_model）；真实 model_changed 到达后 reducer 会清零
+    setState((prev) => (prev.hydratedModel === modelId ? prev : { ...prev, hydratedModel: modelId }))
+  }, [])
 
   const stop = useCallback((): void => {
     rawSend({ kind: 'stop' })
@@ -269,7 +331,7 @@ export function useConversationSocket(conversationId: string | undefined): Conve
   )
 
   return useMemo(
-    () => ({ status, state, send, answerQuestion, setModel, stop, appendLocalUser }),
-    [status, state, send, answerQuestion, setModel, stop, appendLocalUser],
+    () => ({ status, state, send, answerQuestion, setModel, hydrateModel, stop, appendLocalUser }),
+    [status, state, send, answerQuestion, setModel, hydrateModel, stop, appendLocalUser],
   )
 }

--- a/apps/webui/src/server/app.ts
+++ b/apps/webui/src/server/app.ts
@@ -6,7 +6,7 @@ import { WebSocketServer } from 'ws'
 import type { AppConfig } from './config.js'
 import type { MossAuthPort } from '@sudowork/moss-client'
 import { createMossSessionPort, type MossSessionPort } from '@sudowork/moss-client'
-import { type MossFetch, MossHttpError, MossNetworkError, mossRequest } from '@sudowork/moss-client'
+import { type MossFetch, MossHttpError, MossNetworkError, mossFetchAsset, mossRequest } from '@sudowork/moss-client'
 import { createOriginGuard, isOriginAllowed, noStore, securityHeaders } from './security/requestSecurity.js'
 import { createAuthRouter } from './features/auth/authRoutes.js'
 import { MossUnauthorizedError } from './features/auth/authService.js'
@@ -94,6 +94,8 @@ export interface ApiDeps {
   mossAuth: MossAuthPort
   /** 测试注入桩；缺省用真实 mossRequest */
   mossFetch?: MossFetch
+  /** 测试注入桩；缺省用真实 mossFetchAsset（tenant 头像代理） */
+  mossFetchAsset?: typeof mossFetchAsset
   /** 测试注入桩；缺省用真实 MossSessionPort */
   mossSession?: MossSessionPort
   /** 测试注入桩 */
@@ -138,6 +140,7 @@ export function registerApiRoutes(app: Express, deps: ApiDeps): ApiHandles {
       auth,
       moss: mossSession,
       mossFetch,
+      mossFetchAsset: deps.mossFetchAsset,
       coordinator,
       closeTerminals: (conversationId) => globalTerminalManager.closeByConversation(conversationId),
     }),

--- a/apps/webui/src/server/app.ts
+++ b/apps/webui/src/server/app.ts
@@ -6,7 +6,7 @@ import { WebSocketServer } from 'ws'
 import type { AppConfig } from './config.js'
 import type { MossAuthPort } from '@sudowork/moss-client'
 import { createMossSessionPort, type MossSessionPort } from '@sudowork/moss-client'
-import { type MossFetch, MossHttpError, MossNetworkError, mossFetchAsset, mossRequest } from '@sudowork/moss-client'
+import { type MossCallContext, type MossFetch, MossHttpError, MossNetworkError, mossFetchAsset, mossRequest } from '@sudowork/moss-client'
 import { createOriginGuard, isOriginAllowed, noStore, securityHeaders } from './security/requestSecurity.js'
 import { createAuthRouter } from './features/auth/authRoutes.js'
 import { MossUnauthorizedError } from './features/auth/authService.js'
@@ -107,7 +107,7 @@ export interface ApiDeps {
   /** 测试注入桩 */
   cron?: import('@sudowork/moss-client').MossCronPort
   /** 测试注入桩 */
-  fetchVisibleAgentNames?: (accessToken: string) => Promise<Set<string>>
+  fetchVisibleAgentNames?: (ctx: MossCallContext) => Promise<Set<string>>
   /** 测试注入桩 */
   mcp?: MossMcpPort
 }
@@ -126,11 +126,11 @@ export function registerApiRoutes(app: Express, deps: ApiDeps): ApiHandles {
 
   const mossFetch = deps.mossFetch ?? mossRequest
   const auth = { pool, config, mossAuth: deps.mossAuth }
-  const mossSession = deps.mossSession ?? createMossSessionPort(mossFetch, config.moss.baseUrl)
+  const mossSession = deps.mossSession ?? createMossSessionPort(mossFetch)
   const coordinator =
     deps.coordinator ?? new ConversationCoordinator({ pool, config, auth, moss: mossSession })
-  const agents = deps.agents ?? createMossAgentPort(mossFetch, config.moss.baseUrl)
-  const skills = deps.skills ?? createMossSkillPort(mossFetch, config.moss.baseUrl)
+  const agents = deps.agents ?? createMossAgentPort(mossFetch)
+  const skills = deps.skills ?? createMossSkillPort(mossFetch)
 
   app.use(
     '/api/conversations',
@@ -150,11 +150,11 @@ export function registerApiRoutes(app: Express, deps: ApiDeps): ApiHandles {
 
   const fetchVisibleAgentNames =
     deps.fetchVisibleAgentNames ??
-    (async (accessToken: string): Promise<Set<string>> => {
-      const list = (await mossFetch(config.moss.baseUrl, {
+    (async (ctx: MossCallContext): Promise<Set<string>> => {
+      const list = (await mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: '/api/v1/agents/installed',
-        accessToken,
+        accessToken: ctx.accessToken,
       })) as { name?: string }[]
       const names = new Set<string>()
       if (Array.isArray(list)) {
@@ -170,13 +170,13 @@ export function registerApiRoutes(app: Express, deps: ApiDeps): ApiHandles {
       pool,
       config,
       auth,
-      cron: deps.cron ?? createMossCronPort(mossFetch, config.moss.baseUrl),
+      cron: deps.cron ?? createMossCronPort(mossFetch),
       sessions: mossSession,
       fetchVisibleAgentNames,
     }),
   )
 
-  const mcp = deps.mcp ?? createMossMcpPort(mossFetch, config.moss.baseUrl)
+  const mcp = deps.mcp ?? createMossMcpPort(mossFetch)
   app.use('/api/settings', createSettingsRouter({ pool, config, auth, mcp }))
   app.use('/api/mcp', createMcpRouter({ pool, config, auth, mcp }))
 

--- a/apps/webui/src/server/features/agents/agentRoutes.ts
+++ b/apps/webui/src/server/features/agents/agentRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, type NextFunction, type Response } from 'express'
 import { ZodError } from 'zod'
-import { getAccessToken } from '../auth/authService.js'
+import { getMossContext } from '../auth/authService.js'
+import type { MossCallContext } from '@sudowork/moss-client'
 import { requireSession, type AuthedRequest } from '../auth/sessionMiddleware.js'
 import { MossHttpError } from '@sudowork/moss-client'
 import {
@@ -41,8 +42,8 @@ import {
 export function createAgentRouter(deps: AgentDeps): Router {
   const router = Router()
 
-  async function token(req: AuthedRequest): Promise<string> {
-    return getAccessToken(deps.auth, req.webSession!)
+  async function token(req: AuthedRequest): Promise<MossCallContext> {
+    return getMossContext(deps.auth, req.webSession!)
   }
 
   function handle(err: unknown, res: Response, next: NextFunction): void {

--- a/apps/webui/src/server/features/agents/agentService.ts
+++ b/apps/webui/src/server/features/agents/agentService.ts
@@ -1,7 +1,7 @@
 import type { AppConfig } from '../../config.js'
 import type { Pool } from 'pg'
 import type { AuthDeps } from '../auth/authService.js'
-import type { MossAgentPort } from '@sudowork/moss-client'
+import type { MossAgentPort, MossCallContext } from '@sudowork/moss-client'
 import { MossHttpError, MossNetworkError } from '@sudowork/moss-client'
 
 /**
@@ -36,10 +36,10 @@ async function mapErr<T>(fn: () => Promise<T>): Promise<T> {
 /** 校验当前 token 具备任一 scope；不具备抛 ForbiddenError。 */
 export async function requireAnyScope(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   scopes: string[],
 ): Promise<void> {
-  const me = await mapErr(() => deps.auth.mossAuth.me(accessToken))
+  const me = await mapErr(() => deps.auth.mossAuth.me(ctx.accessToken, ctx.baseUrl))
   const owned: string[] = Array.isArray(me.scopes) ? me.scopes : []
   const isAdmin = me.role === 'admin' || me.role === 'super_admin' || me.isSuperAdmin === true
   if (isAdmin) return
@@ -48,8 +48,8 @@ export async function requireAnyScope(
   }
 }
 
-export async function getScopes(deps: AgentDeps, accessToken: string): Promise<string[]> {
-  const me = await mapErr(() => deps.auth.mossAuth.me(accessToken))
+export async function getScopes(deps: AgentDeps, ctx: MossCallContext): Promise<string[]> {
+  const me = await mapErr(() => deps.auth.mossAuth.me(ctx.accessToken, ctx.baseUrl))
   return Array.isArray(me.scopes) ? me.scopes : []
 }
 
@@ -57,8 +57,8 @@ interface InstalledItem {
   name?: unknown
 }
 
-async function installedNames(deps: AgentDeps, accessToken: string): Promise<Map<string, Record<string, unknown>>> {
-  const list = (await mapErr(() => deps.agents.installed(accessToken))) as InstalledItem[]
+async function installedNames(deps: AgentDeps, ctx: MossCallContext): Promise<Map<string, Record<string, unknown>>> {
+  const list = (await mapErr(() => deps.agents.installed(ctx))) as InstalledItem[]
   const map = new Map<string, Record<string, unknown>>()
   if (Array.isArray(list)) {
     for (const item of list) {
@@ -73,31 +73,31 @@ async function installedNames(deps: AgentDeps, accessToken: string): Promise<Map
 /** fresh 核验：目标 name 必须在当前用户可见 installed 列表（IDOR 防线，计划 3.4）。 */
 async function requireVisibleAgent(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
 ): Promise<void> {
-  const names = await installedNames(deps, accessToken)
+  const names = await installedNames(deps, ctx)
   if (!names.has(name)) throw new NotFoundError()
 }
 
 // ---------- 查询 ----------
 
-export async function listInstalled(deps: AgentDeps, accessToken: string): Promise<unknown> {
-  return mapErr(() => deps.agents.installed(accessToken))
+export async function listInstalled(deps: AgentDeps, ctx: MossCallContext): Promise<unknown> {
+  return mapErr(() => deps.agents.installed(ctx))
 }
 
-export async function hubCategories(deps: AgentDeps, accessToken: string): Promise<unknown> {
-  return mapErr(() => deps.agents.hubCategories(accessToken))
+export async function hubCategories(deps: AgentDeps, ctx: MossCallContext): Promise<unknown> {
+  return mapErr(() => deps.agents.hubCategories(ctx))
 }
 
 export async function hubList(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   searchParams: Record<string, string>,
 ): Promise<unknown> {
   // moss 上游返回 { assistants, next_cursor, has_more }（agentStore.ts fetchAgentHubAssistants），
   // 与 installFromHub 的兼容读取一致，统一归一化为 items 供前端消费
-  const hub = (await mapErr(() => deps.agents.hubList(accessToken, searchParams))) as {
+  const hub = (await mapErr(() => deps.agents.hubList(ctx, searchParams))) as {
     items?: Record<string, unknown>[]
     assistants?: Record<string, unknown>[]
     next_cursor?: unknown
@@ -110,30 +110,30 @@ export async function hubList(
   }
 }
 
-export async function hubDetail(deps: AgentDeps, accessToken: string, id: string): Promise<unknown> {
-  return mapErr(() => deps.agents.hubDetail(accessToken, id))
+export async function hubDetail(deps: AgentDeps, ctx: MossCallContext, id: string): Promise<unknown> {
+  return mapErr(() => deps.agents.hubDetail(ctx, id))
 }
 
-export async function syncStatus(deps: AgentDeps, accessToken: string): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  return mapErr(() => deps.agents.syncStatus(accessToken))
+export async function syncStatus(deps: AgentDeps, ctx: MossCallContext): Promise<unknown> {
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  return mapErr(() => deps.agents.syncStatus(ctx))
 }
 
-export async function tenantList(deps: AgentDeps, accessToken: string): Promise<unknown> {
-  return mapErr(() => deps.agents.tenantList(accessToken))
+export async function tenantList(deps: AgentDeps, ctx: MossCallContext): Promise<unknown> {
+  return mapErr(() => deps.agents.tenantList(ctx))
 }
 
 // ---------- 变更 ----------
 
 export async function installFromHub(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
+  await requireAnyScope(deps, ctx, ['admin:settings'])
   // assistantMeta 由后端从 fresh hub 列表解析（不信任浏览器提交）
   const hub = (await mapErr(() =>
-    deps.agents.hubList(accessToken, { limit: '100' }),
+    deps.agents.hubList(ctx, { limit: '100' }),
   )) as { items?: Record<string, unknown>[]; assistants?: Record<string, unknown>[] }
   const items = hub?.items ?? hub?.assistants ?? []
   const meta = items.find(
@@ -141,108 +141,108 @@ export async function installFromHub(
   )
   if (!meta) throw new NotFoundError()
   return mapErr(() =>
-    deps.agents.install(accessToken, { assistantMeta: meta, selectedSkillIds: [] }),
+    deps.agents.install(ctx, { assistantMeta: meta, selectedSkillIds: [] }),
   )
 }
 
 export async function createAgent(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  return mapErr(() => deps.agents.create(accessToken, body))
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  return mapErr(() => deps.agents.create(ctx, body))
 }
 
 export async function uploadCustom(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   file: string,
 ): Promise<unknown> {
-  return mapErr(() => deps.agents.uploadCustom(accessToken, { file }))
+  return mapErr(() => deps.agents.uploadCustom(ctx, { file }))
 }
 
 export async function updateMeta(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
   updates: Record<string, unknown>,
 ): Promise<unknown> {
-  await requireVisibleAgent(deps, accessToken, name)
-  return mapErr(() => deps.agents.updateMeta(accessToken, { assistantName: name, updates }))
+  await requireVisibleAgent(deps, ctx, name)
+  return mapErr(() => deps.agents.updateMeta(ctx, { assistantName: name, updates }))
 }
 
 export async function uninstall(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  await requireVisibleAgent(deps, accessToken, name)
-  return mapErr(() => deps.agents.uninstall(accessToken, { assistantName: name }))
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  await requireVisibleAgent(deps, ctx, name)
+  return mapErr(() => deps.agents.uninstall(ctx, { assistantName: name }))
 }
 
-export async function syncFromHub(deps: AgentDeps, accessToken: string): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  return mapErr(() => deps.agents.syncFromHub(accessToken))
+export async function syncFromHub(deps: AgentDeps, ctx: MossCallContext): Promise<unknown> {
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  return mapErr(() => deps.agents.syncFromHub(ctx))
 }
 
 export async function installedRules(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  await requireVisibleAgent(deps, accessToken, name)
-  return mapErr(() => deps.agents.installedRules(accessToken, name))
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  await requireVisibleAgent(deps, ctx, name)
+  return mapErr(() => deps.agents.installedRules(ctx, name))
 }
 
 export async function tenantCreate(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings', 'store:tenant:write'])
-  return mapErr(() => deps.agents.tenantCreate(accessToken, body))
+  await requireAnyScope(deps, ctx, ['admin:settings', 'store:tenant:write'])
+  return mapErr(() => deps.agents.tenantCreate(ctx, body))
 }
 
 export async function tenantUpdate(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   id: string,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  await requireTenantVisible(deps, accessToken, id)
-  return mapErr(() => deps.agents.tenantUpdate(accessToken, id, body))
+  await requireTenantVisible(deps, ctx, id)
+  return mapErr(() => deps.agents.tenantUpdate(ctx, id, body))
 }
 
-export async function tenantDelete(deps: AgentDeps, accessToken: string, id: string): Promise<unknown> {
-  await requireTenantVisible(deps, accessToken, id)
-  return mapErr(() => deps.agents.tenantDelete(accessToken, id))
+export async function tenantDelete(deps: AgentDeps, ctx: MossCallContext, id: string): Promise<unknown> {
+  await requireTenantVisible(deps, ctx, id)
+  return mapErr(() => deps.agents.tenantDelete(ctx, id))
 }
 
-export async function tenantDownload(deps: AgentDeps, accessToken: string, id: string): Promise<unknown> {
-  return mapErr(() => deps.agents.tenantDownload(accessToken, id))
+export async function tenantDownload(deps: AgentDeps, ctx: MossCallContext, id: string): Promise<unknown> {
+  return mapErr(() => deps.agents.tenantDownload(ctx, id))
 }
 
 export async function tenantPublish(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   sourceName: string,
 ): Promise<unknown> {
-  await requireVisibleAgent(deps, accessToken, sourceName)
+  await requireVisibleAgent(deps, ctx, sourceName)
   return mapErr(() =>
-    deps.agents.tenantPublish(accessToken, { assistantName: sourceName }),
+    deps.agents.tenantPublish(ctx, { assistantName: sourceName }),
   )
 }
 
 /** tenant 目标必须来自当前 fresh tenant 列表（can_manage 之上的 WebUI 防线）。 */
 async function requireTenantVisible(
   deps: AgentDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   id: string,
 ): Promise<void> {
-  const list = (await mapErr(() => deps.agents.tenantList(accessToken))) as Record<string, unknown>[]
+  const list = (await mapErr(() => deps.agents.tenantList(ctx))) as Record<string, unknown>[]
   const row = Array.isArray(list) ? list.find((it) => it && it.id === id) : undefined
   if (!row) throw new NotFoundError()
   if (row.can_manage === false) throw new ForbiddenError()

--- a/apps/webui/src/server/features/auth/authRoutes.ts
+++ b/apps/webui/src/server/features/auth/authRoutes.ts
@@ -78,7 +78,7 @@ export function createAuthRouter(deps: AuthDeps): Router {
   router.post('/login/api-key', loginLimiter, (req, res, next) => {
     void (async () => {
       const input = LoginApiKeyRequestSchema.parse(req.body)
-      const result = await loginWithApiKey(deps, input.apiKey)
+      const result = await loginWithApiKey(deps, input.apiKey, input.mossBaseUrl)
       setSessionCookie(res, deps.config, result.cookieToken)
       res.status(200).json({ ok: true })
     })().catch((err: unknown) => authErrorHandler(err, res, next))

--- a/apps/webui/src/server/features/auth/authService.ts
+++ b/apps/webui/src/server/features/auth/authService.ts
@@ -1,6 +1,6 @@
 import type { Pool } from 'pg'
 import type { AppConfig } from '../../config.js'
-import type { MossAuthPort } from '@sudowork/moss-client'
+import type { MossAuthPort, MossCallContext } from '@sudowork/moss-client'
 import { MossHttpError, MossNetworkError } from '@sudowork/moss-client'
 import { digestToken, generateSessionToken } from '../../security/sessionToken.js'
 import { decryptToken, encryptToken } from '../../security/tokenCipher.js'
@@ -73,6 +73,20 @@ function mapLoginError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err))
 }
 
+/**
+ * 归一化登录期的 moss 地址：
+ * - baseUrl：本次登录/该会话所有 moss 调用实际使用的地址（无自定义→配置默认）
+ * - identityBaseUrl：落库到 principal/session 的身份地址（与配置同 origin→null，视为未自定义，
+ *   避免同一 moss 下身份分裂）；仅真正自定义（异 origin）时非 null
+ */
+export function resolveLoginMoss(config: AppConfig, mossBaseUrl?: string): { baseUrl: string; identityBaseUrl: string | null } {
+  if (!mossBaseUrl) return { baseUrl: config.moss.baseUrl, identityBaseUrl: null }
+  const configuredOrigin = new URL(config.moss.baseUrl).origin
+  const origin = new URL(mossBaseUrl).origin
+  if (origin === configuredOrigin) return { baseUrl: config.moss.baseUrl, identityBaseUrl: null }
+  return { baseUrl: origin, identityBaseUrl: origin }
+}
+
 function serializeTokens(tokens: MossTokenSet): StoredTokens {
   return {
     accessToken: tokens.access_token,
@@ -96,7 +110,12 @@ function decryptStored(deps: AuthDeps, session: WebSessionRow): Promise<StoredTo
   )
 }
 
-async function performLogin(deps: AuthDeps, tokens: MossTokenSet, me: MossMe): Promise<LoginResult> {
+async function performLogin(
+  deps: AuthDeps,
+  tokens: MossTokenSet,
+  me: MossMe,
+  identityBaseUrl: string | null,
+): Promise<LoginResult> {
   if (!me.organization) {
     // principal 需要组织归属；无组织的 Moss 账户不支持登录 WebUI
     throw new InvalidCredentialsError()
@@ -105,6 +124,7 @@ async function performLogin(deps: AuthDeps, tokens: MossTokenSet, me: MossMe): P
     mossUserId: me.user.id,
     orgId: me.organization.id,
     username: me.user.name,
+    mossBaseUrl: identityBaseUrl,
   })
 
   // 登录成功总是生成全新 Web Session token（防 session fixation，计划 3.5）
@@ -117,14 +137,15 @@ async function performLogin(deps: AuthDeps, tokens: MossTokenSet, me: MossMe): P
     encrypted: encryptToken(JSON.stringify(stored), deps.config.tokenAesKey),
     accessExpiresAt: new Date(stored.expiresAt - 30_000),
     expiresAt: new Date(Date.now() + deps.config.session.ttlSeconds * 1000),
+    mossBaseUrl: identityBaseUrl,
   })
 
   return { cookieToken, webSessionId: session.id }
 }
 
-async function fetchMe(deps: AuthDeps, accessToken: string): Promise<MossMe> {
+async function fetchMe(deps: AuthDeps, accessToken: string, baseUrl: string): Promise<MossMe> {
   try {
-    return await deps.mossAuth.me(accessToken)
+    return await deps.mossAuth.me(accessToken, baseUrl)
   } catch (err) {
     if (err instanceof MossHttpError && err.status === 401) {
       throw new InvalidCredentialsError()
@@ -138,27 +159,30 @@ async function fetchMe(deps: AuthDeps, accessToken: string): Promise<MossMe> {
 
 export async function loginWithPassword(
   deps: AuthDeps,
-  input: { username: string; password: string },
+  input: { username: string; password: string; mossBaseUrl?: string },
 ): Promise<LoginResult> {
+  const { baseUrl, identityBaseUrl } = resolveLoginMoss(deps.config, input.mossBaseUrl)
   let tokens: MossTokenSet
   try {
-    tokens = await deps.mossAuth.loginWithPassword(input)
+    tokens = await deps.mossAuth.loginWithPassword({ username: input.username, password: input.password }, baseUrl)
   } catch (err) {
     throw mapLoginError(err)
   }
-  const me = await fetchMe(deps, tokens.access_token)
-  return performLogin(deps, tokens, me)
+  // 登录期无 session：me 必须走 resolveLoginMoss 的 baseUrl（用配置默认会向错误 moss 拿 me 致失败）
+  const me = await fetchMe(deps, tokens.access_token, baseUrl)
+  return performLogin(deps, tokens, me, identityBaseUrl)
 }
 
-export async function loginWithApiKey(deps: AuthDeps, apiKey: string): Promise<LoginResult> {
+export async function loginWithApiKey(deps: AuthDeps, apiKey: string, mossBaseUrl?: string): Promise<LoginResult> {
+  const { baseUrl, identityBaseUrl } = resolveLoginMoss(deps.config, mossBaseUrl)
   let tokens: MossTokenSet
   try {
-    tokens = await deps.mossAuth.loginWithApiKey(apiKey)
+    tokens = await deps.mossAuth.loginWithApiKey(apiKey, baseUrl)
   } catch (err) {
     throw mapLoginError(err)
   }
-  const me = await fetchMe(deps, tokens.access_token)
-  return performLogin(deps, tokens, me)
+  const me = await fetchMe(deps, tokens.access_token, baseUrl)
+  return performLogin(deps, tokens, me, identityBaseUrl)
 }
 
 /** 按 webSessionId 进程内 single-flight 刷新；成功后原子替换加密 token（计划 3.1）。 */
@@ -168,7 +192,7 @@ async function refreshTokensFor(deps: AuthDeps, session: WebSessionRow): Promise
 
   const task = (async () => {
     const stored = await decryptStored(deps, session)
-    const tokens = await deps.mossAuth.refresh(stored.refreshToken)
+    const tokens = await deps.mossAuth.refresh(stored.refreshToken, session.mossBaseUrl ?? deps.config.moss.baseUrl)
     const next = serializeTokens(tokens)
     await replaceSessionTokens(
       deps.pool,
@@ -219,14 +243,15 @@ export async function resolveSession(
     }
   }
 
+  const sessionBaseUrl = session.mossBaseUrl ?? deps.config.moss.baseUrl
   let me: MossMe
   try {
-    me = await deps.mossAuth.me(stored.accessToken)
+    me = await deps.mossAuth.me(stored.accessToken, sessionBaseUrl)
   } catch (err) {
     if (err instanceof MossHttpError && err.status === 401) {
       try {
         stored = await refreshTokensFor(deps, session)
-        me = await deps.mossAuth.me(stored.accessToken)
+        me = await deps.mossAuth.me(stored.accessToken, sessionBaseUrl)
       } catch {
         return null
       }
@@ -246,16 +271,18 @@ export async function logout(deps: AuthDeps, webSessionId: string): Promise<void
 }
 
 /**
- * 供 Conversation 等后续 feature 复用：按 session 行拿到可用 access token（必要时刷新）。
+ * 供 Conversation 等后续 feature 复用：按 session 行拿到 MossCallContext（access token + 该会话生效地址）。
+ * 地址：session.mossBaseUrl（自定义登录）优先，否则配置默认。
  * 刷新失败不再静默回退旧 token：moss 拒绝刷新（401/403）说明登录态已失效，
  * 抛 MossUnauthorizedError（→401 引导重新登录）；网络类错误原样上抛（→503，不误报登录过期）。
  */
-export async function getAccessToken(deps: AuthDeps, session: WebSessionRow): Promise<string> {
+export async function getMossContext(deps: AuthDeps, session: WebSessionRow): Promise<MossCallContext> {
+  const baseUrl = session.mossBaseUrl ?? deps.config.moss.baseUrl
   const stored = await decryptStored(deps, session)
   if (stored.expiresAt - Date.now() < 60_000) {
     try {
       const refreshed = await refreshTokensFor(deps, session)
-      return refreshed.accessToken
+      return { accessToken: refreshed.accessToken, baseUrl }
     } catch (err) {
       if (err instanceof MossHttpError && (err.status === 401 || err.status === 403)) {
         throw new MossUnauthorizedError(err)
@@ -263,5 +290,5 @@ export async function getAccessToken(deps: AuthDeps, session: WebSessionRow): Pr
       throw err
     }
   }
-  return stored.accessToken
+  return { accessToken: stored.accessToken, baseUrl }
 }

--- a/apps/webui/src/server/features/auth/principalRepository.ts
+++ b/apps/webui/src/server/features/auth/principalRepository.ts
@@ -11,24 +11,27 @@ export interface Principal {
   mossUserId: string
   orgId: string
   username: string
+  /** 自定义 Moss 地址登录时的身份地址（默认地址为 null）；身份键 = (地址, org, user) */
+  mossBaseUrl: string | null
   createdAt: Date
   lastLoginAt: Date
 }
 
 const PRINCIPAL_COLUMNS = `id, moss_user_id AS "mossUserId", org_id AS "orgId",
-  username, created_at AS "createdAt", last_login_at AS "lastLoginAt"`
+  username, moss_base_url AS "mossBaseUrl", created_at AS "createdAt", last_login_at AS "lastLoginAt"`
 
 export async function upsertPrincipal(
   pool: Pool,
-  input: { mossUserId: string; orgId: string; username: string },
+  input: { mossUserId: string; orgId: string; username: string; mossBaseUrl?: string | null },
 ): Promise<Principal> {
   const { rows } = await pool.query<Principal>(
-    `INSERT INTO web_principals (id, moss_user_id, org_id, username, created_at, last_login_at)
-     VALUES ($1, $2, $3, $4, now(), now())
-     ON CONFLICT (org_id, moss_user_id) DO UPDATE
+    // ON CONFLICT 目标须与 004 迁移的表达式唯一索引一致：(COALESCE(moss_base_url,''), org_id, moss_user_id)
+    `INSERT INTO web_principals (id, moss_user_id, org_id, username, moss_base_url, created_at, last_login_at)
+     VALUES ($1, $2, $3, $4, $5, now(), now())
+     ON CONFLICT (COALESCE(moss_base_url, ''), org_id, moss_user_id) DO UPDATE
        SET username = EXCLUDED.username, last_login_at = now()
      RETURNING ${PRINCIPAL_COLUMNS}`,
-    [randomUUID(), input.mossUserId, input.orgId, input.username],
+    [randomUUID(), input.mossUserId, input.orgId, input.username, input.mossBaseUrl ?? null],
   )
   const row = rows[0]
   if (!row) throw new Error('upsertPrincipal returned no row')

--- a/apps/webui/src/server/features/auth/sessionRepository.ts
+++ b/apps/webui/src/server/features/auth/sessionRepository.ts
@@ -17,6 +17,8 @@ export interface WebSessionRow {
   tokenAuthTag: Buffer
   accessExpiresAt: Date
   expiresAt: Date
+  /** 该会话生效的自定义 Moss 地址（默认地址为 null）；getMossContext 据此路由所有 moss 调用 */
+  mossBaseUrl: string | null
   createdAt: Date
   lastSeenAt: Date
 }
@@ -24,7 +26,7 @@ export interface WebSessionRow {
 const SESSION_COLUMNS = `id, principal_id AS "principalId", token_digest AS "tokenDigest",
   encrypted_moss_tokens AS "encryptedMossTokens", token_iv AS "tokenIv",
   token_auth_tag AS "tokenAuthTag", access_expires_at AS "accessExpiresAt",
-  expires_at AS "expiresAt", created_at AS "createdAt", last_seen_at AS "lastSeenAt"`
+  expires_at AS "expiresAt", moss_base_url AS "mossBaseUrl", created_at AS "createdAt", last_seen_at AS "lastSeenAt"`
 
 export interface CreateWebSessionInput {
   principalId: string
@@ -32,6 +34,7 @@ export interface CreateWebSessionInput {
   encrypted: EncryptedToken
   accessExpiresAt: Date
   expiresAt: Date
+  mossBaseUrl?: string | null
 }
 
 export async function createWebSession(
@@ -41,8 +44,8 @@ export async function createWebSession(
   const { rows } = await pool.query<WebSessionRow>(
     `INSERT INTO web_sessions
        (id, token_digest, principal_id, encrypted_moss_tokens, token_iv, token_auth_tag,
-        access_expires_at, expires_at, created_at, last_seen_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), now())
+        access_expires_at, expires_at, moss_base_url, created_at, last_seen_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now(), now())
      RETURNING ${SESSION_COLUMNS}`,
     [
       randomUUID(),
@@ -53,6 +56,7 @@ export async function createWebSession(
       input.encrypted.authTag,
       input.accessExpiresAt,
       input.expiresAt,
+      input.mossBaseUrl ?? null,
     ],
   )
   const row = rows[0]

--- a/apps/webui/src/server/features/conversations/ConversationCoordinator.ts
+++ b/apps/webui/src/server/features/conversations/ConversationCoordinator.ts
@@ -2,10 +2,10 @@ import type { Pool } from 'pg'
 import type WebSocket from 'ws'
 import type { AppConfig } from '../../config.js'
 import type { AuthDeps } from '../auth/authService.js'
-import { getAccessToken } from '../auth/authService.js'
+import { getMossContext } from '../auth/authService.js'
 import type { WebSessionRow } from '../auth/sessionRepository.js'
 import type { MossSessionPort } from '@sudowork/moss-client'
-import { MossHttpError, MossNetworkError } from '@sudowork/moss-client'
+import { MossHttpError, MossNetworkError, deriveWsBaseUrl } from '@sudowork/moss-client'
 import {
   MossUpstreamSocket,
   buildAnswerQuestionMessage,
@@ -196,8 +196,8 @@ export class ConversationCoordinator {
       }
     }
 
-    const accessToken = await getAccessToken(this.deps.auth, conn.webSession)
-    const resumed = await this.deps.moss.resume(accessToken, entry.mossSessionId).catch((err: unknown) => {
+    const ctx = await getMossContext(this.deps.auth, conn.webSession)
+    const resumed = await this.deps.moss.resume(ctx, entry.mossSessionId).catch((err: unknown) => {
       if (err instanceof MossHttpError && err.status === 404) {
         throw new Error('SESSION_NOT_FOUND')
       }
@@ -209,9 +209,10 @@ export class ConversationCoordinator {
 
     entry.upstream = new MossUpstreamSocket(
       resumed.wsUrl,
-      accessToken,
+      ctx.accessToken,
       entry.mossSessionId,
-      this.deps.config.moss.wsBaseUrl,
+      // WS 校验基准用会话生效地址（自定义 moss 会话的 ws 在其自定义 host）
+      deriveWsBaseUrl(ctx.baseUrl),
       {
         onEvent: (event) => void this.handleUpstreamEvent(entry, event),
         onClose: () => void this.handleUpstreamClose(entry),

--- a/apps/webui/src/server/features/conversations/ConversationCoordinator.ts
+++ b/apps/webui/src/server/features/conversations/ConversationCoordinator.ts
@@ -25,7 +25,9 @@ import {
   getLock,
   markUncertain,
   releaseToIdle,
+  releaseToIdleIfHeld,
 } from './lockRepository.js'
+import { upsertConversationModel } from './conversationMetaRepository.js'
 
 /**
  * 会话协调器（计划 3.3/3.8）：
@@ -231,6 +233,25 @@ export class ConversationCoordinator {
     }
     this.broadcast(entry, { kind: 'upstream', event })
 
+    // 会话内切模型：本地持久化（重开会话时回读显示）。失败隔离：写库失败不影响事件转发
+    // （对齐 generateTitleIfMissing 吞错模式）。上游 model 带 proxy/ 前缀，剥离后落库。
+    if (type === 'system') {
+      const subtype = (event as { subtype?: unknown }).subtype
+      const model = (event as { model?: unknown }).model
+      if (subtype === 'model_changed' && typeof model === 'string' && model) {
+        await upsertConversationModel(
+          this.deps.pool,
+          entry.principalId,
+          entry.mossSessionId,
+          model.replace(/^proxy\//, ''),
+        ).catch((err: unknown) =>
+          console.warn(
+            `[coordinator] persist model failed (session=${entry.mossSessionId.slice(0, 8)}): ${(err as Error).message}`,
+          ),
+        )
+      }
+    }
+
     if (type === 'result') {
       await releaseToIdle(this.deps.pool, {
         principalId: entry.principalId,
@@ -307,13 +328,48 @@ export class ConversationCoordinator {
           principalId: conn.principalId,
           mossSessionId: entry.mossSessionId,
         })
-        if (lock?.writerWebSessionId !== conn.webSession.id) {
-          this.sendTo(conn.ws, { kind: 'error', code: 'NOT_WRITER' })
+        if (lock?.state === 'uncertain') {
+          this.sendTo(conn.ws, { kind: 'error', code: 'LOCK_UNCERTAIN' })
           return
         }
-        await this.ensureUpstream(entry, conn)
-        if (!entry.upstream?.send(buildSetModelMessage(msg.modelId))) {
-          this.sendTo(conn.ws, { kind: 'error', code: 'UPSTREAM_NOT_CONNECTED' })
+        // 有进行中回合且 writer 是他人：拒绝（不打断对方回合）
+        if (lock?.state === 'running' && lock.writerWebSessionId !== conn.webSession.id) {
+          this.sendTo(conn.ws, { kind: 'error', code: 'CONVERSATION_BUSY' })
+          return
+        }
+        // idle 期任意订阅者可切模型：非 writer 先经 idle 抢占成为 writer，切完守卫回收
+        const isWriter = lock?.writerWebSessionId === conn.webSession.id
+        if (!isWriter) {
+          const acquired = await acquireWriteLock(this.deps.pool, {
+            principalId: conn.principalId,
+            mossSessionId: entry.mossSessionId,
+            webSessionId: conn.webSession.id,
+          })
+          if (!acquired.ok) {
+            const code = acquired.reason === 'UNCERTAIN' ? 'LOCK_UNCERTAIN' : 'CONVERSATION_BUSY'
+            this.sendTo(conn.ws, { kind: 'error', code })
+            return
+          }
+        }
+        try {
+          if (!isWriter) await this.broadcastLockState(entry)
+          await this.ensureUpstream(entry, conn)
+          if (!entry.upstream?.send(buildSetModelMessage(msg.modelId))) {
+            this.sendTo(conn.ws, { kind: 'error', code: 'UPSTREAM_NOT_CONNECTED' })
+          }
+        } finally {
+          if (!isWriter) {
+            const released = await releaseToIdleIfHeld(this.deps.pool, {
+              principalId: conn.principalId,
+              mossSessionId: entry.mossSessionId,
+              webSessionId: conn.webSession.id,
+            })
+            if (released) {
+              await this.broadcastLockState(entry).catch((err: unknown) =>
+                console.warn(`[coordinator] broadcast after set_model release failed: ${(err as Error).message}`),
+              )
+            }
+          }
         }
       }
 

--- a/apps/webui/src/server/features/conversations/conversationMetaRepository.ts
+++ b/apps/webui/src/server/features/conversations/conversationMetaRepository.ts
@@ -9,6 +9,8 @@ export interface ConversationMeta {
   title: string | null
   pinned: boolean
   pinnedAt: number | null
+  /** 会话所选模型（getConversationMetaMap 的列表场景不提供该字段） */
+  modelId?: string | null
 }
 
 export async function getConversationMeta(
@@ -16,14 +18,24 @@ export async function getConversationMeta(
   principalId: string,
   mossSessionId: string,
 ): Promise<ConversationMeta | null> {
-  const { rows } = await pool.query<{ title: string | null; pinned: boolean; pinned_at: string | null }>(
-    `SELECT title, pinned, pinned_at FROM conversation_meta
+  const { rows } = await pool.query<{
+    title: string | null
+    pinned: boolean
+    pinned_at: string | null
+    model_id: string | null
+  }>(
+    `SELECT title, pinned, pinned_at, model_id FROM conversation_meta
      WHERE principal_id = $1 AND moss_session_id = $2`,
     [principalId, mossSessionId],
   )
   const row = rows[0]
   if (!row) return null
-  return { title: row.title, pinned: row.pinned, pinnedAt: row.pinned_at === null ? null : Number(row.pinned_at) }
+  return {
+    title: row.title,
+    pinned: row.pinned,
+    pinnedAt: row.pinned_at === null ? null : Number(row.pinned_at),
+    modelId: row.model_id,
+  }
 }
 
 /** 批量取（列表合并用），一次查询 */
@@ -47,6 +59,22 @@ export async function getConversationMetaMap(
     })
   }
   return map
+}
+
+/** 会话模型写入（不存在则插入；不覆盖标题/置顶字段） */
+export async function upsertConversationModel(
+  pool: Pool,
+  principalId: string,
+  mossSessionId: string,
+  modelId: string,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO conversation_meta (principal_id, moss_session_id, model_id, updated_at)
+     VALUES ($1, $2, $3, now())
+     ON CONFLICT (principal_id, moss_session_id) DO UPDATE
+       SET model_id = $3, updated_at = now()`,
+    [principalId, mossSessionId, modelId],
+  )
 }
 
 /** 标题写入（不存在则插入；不覆盖置顶字段） */

--- a/apps/webui/src/server/features/conversations/conversationRoutes.ts
+++ b/apps/webui/src/server/features/conversations/conversationRoutes.ts
@@ -1,9 +1,9 @@
 import { Router, type NextFunction, type Response } from 'express'
 import { z, ZodError } from 'zod'
-import { getAccessToken } from '../auth/authService.js'
+import { getMossContext } from '../auth/authService.js'
 import { findPrincipalById, type Principal } from '../auth/principalRepository.js'
 import { requireSession, type AuthedRequest } from '../auth/sessionMiddleware.js'
-import { MossHttpError } from '@sudowork/moss-client'
+import { MossHttpError, type MossCallContext } from '@sudowork/moss-client'
 import {
   CreateConversationRequestSchema,
   ReorderPinnedRequestSchema,
@@ -42,9 +42,9 @@ export function createConversationRouter(deps: ConversationDeps): Router {
     return findPrincipalById(deps.pool, req.webSession!.principalId)
   }
 
-  /** 当前 Web Session 自己的 Moss access token（计划 3.2）。 */
-  async function resolveToken(req: AuthedRequest): Promise<string> {
-    return getAccessToken(deps.auth, req.webSession!)
+  /** 当前 Web Session 的 Moss 调用上下文（access token + 会话生效地址）。 */
+  async function resolveCtx(req: AuthedRequest): Promise<MossCallContext> {
+    return getMossContext(deps.auth, req.webSession!)
   }
 
   function convErrorHandler(err: unknown, res: Response, next: NextFunction): void {
@@ -79,8 +79,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
     void (async () => {
       const principal = await resolvePrincipal(req as AuthedRequest)
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
-      const token = await resolveToken(req as AuthedRequest)
-      res.status(200).json({ conversations: await listConversations(deps, principal, token) })
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json({ conversations: await listConversations(deps, principal, ctx) })
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
@@ -89,15 +89,15 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const principal = await resolvePrincipal(req as AuthedRequest)
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const input = CreateConversationRequestSchema.parse(req.body)
-      const token = await resolveToken(req as AuthedRequest)
-      res.status(201).json(await createConversation(deps, principal, input, token))
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(201).json(await createConversation(deps, principal, input, ctx))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
   router.get('/options', requireSession, (req, res, next) => {
     void (async () => {
-      const token = await resolveToken(req as AuthedRequest)
-      res.status(200).json(await getConversationOptions(deps, token))
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json(await getConversationOptions(deps, ctx))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
@@ -111,7 +111,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
         .max(512)
         .regex(/^\/uploads\/tenant-assistant-avatars\/[A-Za-z0-9][\w.-]*$/)
         .parse(req.query.path)
-      const asset = await proxyAgentAvatar(deps, path)
+      const ctx = await resolveCtx(req as AuthedRequest)
+      const asset = await proxyAgentAvatar(deps, ctx, path)
       res.set('Content-Type', asset.contentType ?? 'application/octet-stream')
       res.send(Buffer.from(asset.buffer))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
@@ -122,8 +123,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const principal = await resolvePrincipal(req as AuthedRequest)
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const id = z.string().min(1).parse(req.params.id)
-      const token = await resolveToken(req as AuthedRequest)
-      res.status(200).json(await getContext(deps, principal, id, token))
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json(await getContext(deps, principal, id, ctx))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
@@ -132,8 +133,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const principal = await resolvePrincipal(req as AuthedRequest)
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const id = z.string().min(1).parse(req.params.id)
-      const token = await resolveToken(req as AuthedRequest)
-      await terminateConversation(deps, principal, id, token)
+      const ctx = await resolveCtx(req as AuthedRequest)
+      await terminateConversation(deps, principal, id, ctx)
       res.status(200).json({ ok: true })
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
@@ -145,8 +146,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const id = z.string().min(1).parse(req.params.id)
       const path = typeof req.query.path === 'string' ? req.query.path : ''
       const search = typeof req.query.search === 'string' ? req.query.search : ''
-      const token = await resolveToken(req as AuthedRequest)
-      res.status(200).json(await getWorkspaceTree(deps, principal, id, path, token, search))
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json(await getWorkspaceTree(deps, principal, id, path, ctx, search))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
@@ -156,8 +157,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const id = z.string().min(1).parse(req.params.id)
       const path = z.string().min(1).parse(req.query.path)
-      const token = await resolveToken(req as AuthedRequest)
-      res.status(200).json(await getWorkspaceFile(deps, principal, id, path, token))
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json(await getWorkspaceFile(deps, principal, id, path, ctx))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
@@ -169,11 +170,11 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const body = z
         .object({ path: z.string().min(1).max(1024), content_base64: z.string().min(1) })
         .parse(req.body)
-      const token = await resolveToken(req as AuthedRequest)
+      const ctx = await resolveCtx(req as AuthedRequest)
       res
         .status(200)
         .json(
-        await uploadWorkspaceFile(deps, principal, id, body.path, body.content_base64, token),
+        await uploadWorkspaceFile(deps, principal, id, body.path, body.content_base64, ctx),
       )
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
@@ -184,8 +185,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const principal = await resolvePrincipal(req as AuthedRequest)
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const id = z.string().min(1).parse(req.params.id)
-      const token = await resolveToken(req as AuthedRequest)
-      const json = (await deps.moss.sessionSkillsAvailable(token, id)) as {
+      const ctx = await resolveCtx(req as AuthedRequest)
+      const json = (await deps.moss.sessionSkillsAvailable(ctx, id)) as {
         skills?: {
           name?: unknown
           displayName?: unknown
@@ -217,8 +218,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const principal = await resolvePrincipal(req as AuthedRequest)
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const id = z.string().min(1).parse(req.params.id)
-      const token = await resolveToken(req as AuthedRequest)
-      res.status(200).json(await getDeliverables(deps, principal, id, token))
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json(await getDeliverables(deps, principal, id, ctx))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
@@ -229,8 +230,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const id = z.string().min(1).parse(req.params.id)
       const body = UpdateConversationMetaRequestSchema.parse(req.body)
-      const token = await resolveToken(req as AuthedRequest)
-      await updateConversationMeta(deps, principal, id, token, body)
+      const ctx = await resolveCtx(req as AuthedRequest)
+      await updateConversationMeta(deps, principal, id, ctx, body)
       res.status(200).json({ ok: true })
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
@@ -252,8 +253,8 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const principal = await resolvePrincipal(req as AuthedRequest)
       if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
       const id = z.string().min(1).parse(req.params.id)
-      const token = await resolveToken(req as AuthedRequest)
-      await deleteConversation(deps, principal, id, token)
+      const ctx = await resolveCtx(req as AuthedRequest)
+      await deleteConversation(deps, principal, id, ctx)
       res.status(200).json({ ok: true })
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })

--- a/apps/webui/src/server/features/conversations/conversationRoutes.ts
+++ b/apps/webui/src/server/features/conversations/conversationRoutes.ts
@@ -21,6 +21,7 @@ import {
   getWorkspaceFile,
   getWorkspaceTree,
   listConversations,
+  proxyAgentAvatar,
   reorderPinnedConversations,
   terminateConversation,
   updateConversationMeta,
@@ -97,6 +98,22 @@ export function createConversationRouter(deps: ConversationDeps): Router {
     void (async () => {
       const token = await resolveToken(req as AuthedRequest)
       res.status(200).json(await getConversationOptions(deps, token))
+    })().catch((err: unknown) => convErrorHandler(err, res, next))
+  })
+
+  // tenant 头像同源代理：白名单仅放行 /uploads/tenant-assistant-avatars/<单层文件名>，防 SSRF/路径穿越。
+  // 单段 GET 路径，与 /options 并列，不与 DELETE /:id、两段 /:id/* 冲突。
+  router.get('/agent-avatar', requireSession, (req, res, next) => {
+    void (async () => {
+      const path = z
+        .string()
+        .min(1)
+        .max(512)
+        .regex(/^\/uploads\/tenant-assistant-avatars\/[A-Za-z0-9][\w.-]*$/)
+        .parse(req.query.path)
+      const asset = await proxyAgentAvatar(deps, path)
+      res.set('Content-Type', asset.contentType ?? 'application/octet-stream')
+      res.send(Buffer.from(asset.buffer))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 

--- a/apps/webui/src/server/features/conversations/conversationService.ts
+++ b/apps/webui/src/server/features/conversations/conversationService.ts
@@ -4,7 +4,7 @@ import type { AppConfig } from '../../config.js'
 import type { AuthDeps } from '../auth/authService.js'
 import type { Principal } from '../auth/principalRepository.js'
 import type { MossSessionPort } from '@sudowork/moss-client'
-import { type MossFetch, MossHttpError, MossNetworkError } from '@sudowork/moss-client'
+import { type MossAsset, type MossFetch, MossHttpError, MossNetworkError, mossFetchAsset } from '@sudowork/moss-client'
 import type {
   ConversationListItem,
   CreateConversationRequest,
@@ -41,6 +41,8 @@ export interface ConversationDeps {
   auth: AuthDeps
   moss: MossSessionPort
   mossFetch: MossFetch
+  /** 拉取 moss 静态资源（tenant 头像代理）；app.ts 注入，缺省用真实 mossFetchAsset */
+  mossFetchAsset?: typeof mossFetchAsset
   coordinator: ConversationCoordinator
   /** DELETE 会话时关闭该会话全部服务器 pty（app.ts 注入；测试可不传） */
   closeTerminals?: (conversationId: string) => void
@@ -264,8 +266,35 @@ export async function deleteConversation(
 
 export interface ConversationOptions {
   models: { id: string; name: string }[]
-  agents: { name: string; displayName: string; emoji: string; description: string }[]
+  agents: {
+    name: string
+    displayName: string
+    emoji: string
+    description: string
+    avatar: string
+    defaultInitPrompt: string
+    promptsI18n: { 'zh-CN': string[] }
+  }[]
   skills: { name: string; displayName: string; description: string; icon: string; emoji: string }[]
+}
+
+/** moss 智能体元数据字段命名不统一（camelCase / snake_case / 嵌 meta），统一取第一个非空字符串 */
+function pickString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === 'string' && value) return value
+  }
+  return ''
+}
+
+/** 从 moss agent 元数据抽取 zh-CN 案例提示词（兼容 promptsI18n / prompts_i18n / meta 嵌套） */
+function pickZhCnPrompts(sources: unknown[]): string[] {
+  for (const source of sources) {
+    if (source && typeof source === 'object' && !Array.isArray(source)) {
+      const zh = (source as { 'zh-CN'?: unknown })['zh-CN']
+      if (Array.isArray(zh)) return zh.filter((item): item is string => typeof item === 'string')
+    }
+  }
+  return []
 }
 
 export async function getConversationOptions(
@@ -294,12 +323,42 @@ export async function getConversationOptions(
   return {
     models: models.data.map((m) => ({ id: m.id, name: m.name ?? m.id })),
     agents: agents.map((a) => {
-      const extra = a as { displayName?: unknown; emoji?: unknown; description?: unknown }
+      const extra = a as {
+        displayName?: unknown
+        emoji?: unknown
+        description?: unknown
+        avatar?: unknown
+        defaultInitPrompt?: unknown
+        default_init_prompt?: unknown
+        promptsI18n?: unknown
+        prompts_i18n?: unknown
+        meta?: {
+          defaultInitPrompt?: unknown
+          default_init_prompt?: unknown
+          promptsI18n?: unknown
+          prompts_i18n?: unknown
+        }
+      }
       return {
         name: a.name,
         displayName: typeof extra.displayName === 'string' ? extra.displayName : a.name,
         emoji: typeof extra.emoji === 'string' ? extra.emoji : '',
         description: typeof extra.description === 'string' ? extra.description : '',
+        avatar: typeof extra.avatar === 'string' ? extra.avatar : '',
+        defaultInitPrompt: pickString(
+          extra.defaultInitPrompt,
+          extra.default_init_prompt,
+          extra.meta?.defaultInitPrompt,
+          extra.meta?.default_init_prompt,
+        ),
+        promptsI18n: {
+          'zh-CN': pickZhCnPrompts([
+            extra.promptsI18n,
+            extra.prompts_i18n,
+            extra.meta?.promptsI18n,
+            extra.meta?.prompts_i18n,
+          ]),
+        },
       }
     }),
     skills: skills.map((s) => {
@@ -313,6 +372,14 @@ export async function getConversationOptions(
       }
     }),
   }
+}
+
+/**
+ * tenant 头像同源代理：从 moss 拉取头像二进制交由 webui 转发（moss 静态资源，无需鉴权）。
+ * 调用方（conversationRoutes）已用 zod 白名单限制 path 仅 /uploads/tenant-assistant-avatars/<file>。
+ */
+export async function proxyAgentAvatar(deps: ConversationDeps, path: string): Promise<MossAsset> {
+  return (deps.mossFetchAsset ?? mossFetchAsset)(deps.config.moss.baseUrl, path)
 }
 
 // ---------- workspace（DTO 白名单：node 去 fullPath，计划 3.10） ----------

--- a/apps/webui/src/server/features/conversations/conversationService.ts
+++ b/apps/webui/src/server/features/conversations/conversationService.ts
@@ -3,7 +3,7 @@ import type { Pool } from 'pg'
 import type { AppConfig } from '../../config.js'
 import type { AuthDeps } from '../auth/authService.js'
 import type { Principal } from '../auth/principalRepository.js'
-import type { MossSessionPort } from '@sudowork/moss-client'
+import type { MossCallContext, MossSessionPort } from '@sudowork/moss-client'
 import { type MossAsset, type MossFetch, MossHttpError, MossNetworkError, mossFetchAsset } from '@sudowork/moss-client'
 import type {
   ConversationListItem,
@@ -58,9 +58,9 @@ const AvailableModelsSchema = z
 async function fetchVisibleNames(
   deps: ConversationDeps,
   path: '/api/v1/agents/installed' | '/api/v1/skills/installed',
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<Set<string>> {
-  const json = await deps.mossFetch(deps.config.moss.baseUrl, { method: 'GET', path, accessToken })
+  const json = await deps.mossFetch(ctx.baseUrl, { method: 'GET', path, accessToken: ctx.accessToken })
   const parsed = NameListSchema.parse(json)
   return new Set(parsed.map((item) => item.name))
 }
@@ -69,16 +69,16 @@ async function fetchVisibleNames(
 async function assertSelectionVisible(
   deps: ConversationDeps,
   input: CreateConversationRequest,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<void> {
   if (input.assistantName) {
-    const names = await fetchVisibleNames(deps, '/api/v1/agents/installed', accessToken)
+    const names = await fetchVisibleNames(deps, '/api/v1/agents/installed', ctx)
     if (!names.has(input.assistantName)) {
       throw new InvalidSelectionError('assistantName', input.assistantName)
     }
   }
   if (input.enabledSkills.length > 0) {
-    const names = await fetchVisibleNames(deps, '/api/v1/skills/installed', accessToken)
+    const names = await fetchVisibleNames(deps, '/api/v1/skills/installed', ctx)
     for (const skill of input.enabledSkills) {
       if (!names.has(skill)) {
         throw new InvalidSelectionError('enabledSkills', skill)
@@ -88,11 +88,11 @@ async function assertSelectionVisible(
 }
 
 /** 建会话选模型时：核验 modelId 在当前用户可用模型列表中（不接受浏览器自造）。 */
-async function assertModelAvailable(deps: ConversationDeps, modelId: string, accessToken: string): Promise<void> {
-  const json = await deps.mossFetch(deps.config.moss.baseUrl, {
+async function assertModelAvailable(deps: ConversationDeps, modelId: string, ctx: MossCallContext): Promise<void> {
+  const json = await deps.mossFetch(ctx.baseUrl, {
     method: 'GET',
     path: '/api/v1/models/available',
-    accessToken,
+    accessToken: ctx.accessToken,
   })
   const models = AvailableModelsSchema.parse(json)
   if (!models.data.some((model) => model.id === modelId)) {
@@ -103,9 +103,9 @@ async function assertModelAvailable(deps: ConversationDeps, modelId: string, acc
 export async function listConversations(
   deps: ConversationDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<ConversationListItem[]> {
-  const sessions = await mapMossErrors(() => deps.moss.list(accessToken))
+  const sessions = await mapMossErrors(() => deps.moss.list(ctx))
   // 强制过滤：即使 token 带 sessions:list:any 也只返回本人会话（计划 3.3）；
   // 并过滤 terminated（部署版实测 terminate 后 list 仍返回该会话，不过滤则用户视角「删除无效」）
   const visible = sessions.filter(
@@ -137,16 +137,16 @@ export async function createConversation(
   deps: ConversationDeps,
   principal: Principal,
   input: CreateConversationRequest,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<{ id: string }> {
-  await assertSelectionVisible(deps, input, accessToken)
+  await assertSelectionVisible(deps, input, ctx)
   // 模型：先校验可用（不通过则 400，不建会话）→ setUserModel（Moss 用户级），使新会话采用该模型
   if (input.modelId) {
-    await assertModelAvailable(deps, input.modelId, accessToken)
-    await mapMossErrors(() => deps.moss.setUserModel(accessToken, input.modelId!))
+    await assertModelAvailable(deps, input.modelId, ctx)
+    await mapMossErrors(() => deps.moss.setUserModel(ctx, input.modelId!))
   }
   const created = await mapMossErrors(() =>
-    deps.moss.create(accessToken, {
+    deps.moss.create(ctx, {
       assistantName: input.assistantName,
       enabledSkills: input.enabledSkills,
     }),
@@ -166,9 +166,9 @@ export async function requireOwnSession(
   deps: ConversationDeps,
   principal: Principal,
   sessionId: string,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<void> {
-  const session = await mapMossErrors(() => deps.moss.get(accessToken, sessionId))
+  const session = await mapMossErrors(() => deps.moss.get(ctx, sessionId))
   if (!session) throw new SessionNotFoundError()
   if (session.userId !== principal.mossUserId || session.orgId !== principal.orgId) {
     throw new SessionForbiddenError()
@@ -179,16 +179,16 @@ export async function getContext(
   deps: ConversationDeps,
   principal: Principal,
   sessionId: string,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<{ customTitle: string | null; title: string | null; modelId: string | null; messages: Record<string, unknown>[] }> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
+  await requireOwnSession(deps, principal, sessionId, ctx)
   const localMeta = async (): Promise<{ title: string | null; modelId: string | null }> => {
     const meta = await getConversationMeta(deps.pool, principal.id, sessionId)
     return { title: meta?.title ?? null, modelId: meta?.modelId ?? null }
   }
   let parsed: unknown
   try {
-    parsed = await deps.moss.context(accessToken, sessionId)
+    parsed = await deps.moss.context(ctx, sessionId)
   } catch (err) {
     if (err instanceof MossHttpError && err.status === 404) {
       // 空 transcript（新会话）上游返回 404
@@ -197,11 +197,11 @@ export async function getContext(
     }
     throw err
   }
-  const ctx = (parsed as { context?: { customTitle?: string; messages?: unknown[] } }).context
-  const messages = (ctx?.messages ?? []).map((raw) => sanitizeMessage(raw))
+  const mossContext = (parsed as { context?: { customTitle?: string; messages?: unknown[] } }).context
+  const messages = (mossContext?.messages ?? []).map((raw) => sanitizeMessage(raw))
   await generateTitleIfMissing(deps, principal, sessionId, messages)
   const meta = await localMeta()
-  return { customTitle: ctx?.customTitle ?? null, title: meta.title, modelId: meta.modelId, messages }
+  return { customTitle: mossContext?.customTitle ?? null, title: meta.title, modelId: meta.modelId, messages }
 }
 
 /**
@@ -252,10 +252,10 @@ export async function terminateConversation(
   deps: ConversationDeps,
   principal: Principal,
   sessionId: string,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<void> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
-  await mapMossErrors(() => deps.moss.terminate(accessToken, sessionId))
+  await requireOwnSession(deps, principal, sessionId, ctx)
+  await mapMossErrors(() => deps.moss.terminate(ctx, sessionId))
   await deps.coordinator.terminate(principal.id, sessionId)
 }
 
@@ -264,10 +264,10 @@ export async function updateConversationMeta(
   deps: ConversationDeps,
   principal: Principal,
   sessionId: string,
-  accessToken: string,
+  ctx: MossCallContext,
   update: { title?: string; pinned?: boolean },
 ): Promise<void> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
+  await requireOwnSession(deps, principal, sessionId, ctx)
   await updateConversationMetaRow(deps.pool, principal.id, sessionId, update)
 }
 
@@ -288,10 +288,10 @@ export async function deleteConversation(
   deps: ConversationDeps,
   principal: Principal,
   sessionId: string,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<void> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
-  await mapMossErrors(() => deps.moss.terminate(accessToken, sessionId))
+  await requireOwnSession(deps, principal, sessionId, ctx)
+  await mapMossErrors(() => deps.moss.terminate(ctx, sessionId))
   await deps.coordinator.terminate(principal.id, sessionId)
   await deleteConversationMetaRow(deps.pool, principal.id, sessionId)
   deps.closeTerminals?.(sessionId)
@@ -332,14 +332,14 @@ function pickZhCnPrompts(sources: unknown[]): string[] {
 
 export async function getConversationOptions(
   deps: ConversationDeps,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<ConversationOptions> {
-  const baseUrl = deps.config.moss.baseUrl
+  const baseUrl = ctx.baseUrl
   const [modelsJson, agentsJson, skillsJson] = await Promise.all(
     [
-      deps.mossFetch(baseUrl, { method: 'GET', path: '/api/v1/models/available', accessToken }),
-      deps.mossFetch(baseUrl, { method: 'GET', path: '/api/v1/agents/installed', accessToken }),
-      deps.mossFetch(baseUrl, { method: 'GET', path: '/api/v1/skills/installed', accessToken }),
+      deps.mossFetch(baseUrl, { method: 'GET', path: '/api/v1/models/available', accessToken: ctx.accessToken }),
+      deps.mossFetch(baseUrl, { method: 'GET', path: '/api/v1/agents/installed', accessToken: ctx.accessToken }),
+      deps.mossFetch(baseUrl, { method: 'GET', path: '/api/v1/skills/installed', accessToken: ctx.accessToken }),
     ].map((p) => mapMossErrors(() => p)),
   )
 
@@ -408,8 +408,9 @@ export async function getConversationOptions(
  * tenant 头像同源代理：从 moss 拉取头像二进制交由 webui 转发（moss 静态资源，无需鉴权）。
  * 调用方（conversationRoutes）已用 zod 白名单限制 path 仅 /uploads/tenant-assistant-avatars/<file>。
  */
-export async function proxyAgentAvatar(deps: ConversationDeps, path: string): Promise<MossAsset> {
-  return (deps.mossFetchAsset ?? mossFetchAsset)(deps.config.moss.baseUrl, path)
+export async function proxyAgentAvatar(deps: ConversationDeps, ctx: MossCallContext, path: string): Promise<MossAsset> {
+  // 用会话生效地址：自定义 moss 会话的 tenant 头像在其自定义 moss 上
+  return (deps.mossFetchAsset ?? mossFetchAsset)(ctx.baseUrl, path)
 }
 
 // ---------- workspace（DTO 白名单：node 去 fullPath，计划 3.10） ----------
@@ -419,11 +420,11 @@ export async function getWorkspaceTree(
   principal: Principal,
   sessionId: string,
   path: string,
-  accessToken: string,
+  ctx: MossCallContext,
   search = '',
 ): Promise<unknown> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
-  const tree = await mapMossErrors(() => deps.moss.workspaceTree(accessToken, sessionId, path, search))
+  await requireOwnSession(deps, principal, sessionId, ctx)
+  const tree = await mapMossErrors(() => deps.moss.workspaceTree(ctx, sessionId, path, search))
   return sanitizeWorkspaceNode(tree)
 }
 
@@ -442,10 +443,10 @@ export async function getWorkspaceFile(
   principal: Principal,
   sessionId: string,
   path: string,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<unknown> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
-  return mapMossErrors(() => deps.moss.workspaceFileGet(accessToken, sessionId, path))
+  await requireOwnSession(deps, principal, sessionId, ctx)
+  return mapMossErrors(() => deps.moss.workspaceFileGet(ctx, sessionId, path))
 }
 
 export async function uploadWorkspaceFile(
@@ -454,14 +455,14 @@ export async function uploadWorkspaceFile(
   sessionId: string,
   path: string,
   contentBase64: string,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<unknown> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
+  await requireOwnSession(deps, principal, sessionId, ctx)
   const decodedBytes = Math.floor((contentBase64.length * 3) / 4)
   if (decodedBytes > deps.config.upload.maxFileBytes) {
     throw new Error('FILE_TOO_LARGE')
   }
-  return mapMossErrors(() => deps.moss.workspaceFilePost(accessToken, sessionId, path, contentBase64))
+  return mapMossErrors(() => deps.moss.workspaceFilePost(ctx, sessionId, path, contentBase64))
 }
 
 function mapMossErrors<T>(fn: () => Promise<T>): Promise<T> {

--- a/apps/webui/src/server/features/conversations/conversationService.ts
+++ b/apps/webui/src/server/features/conversations/conversationService.ts
@@ -16,6 +16,7 @@ import {
   getConversationMetaMap,
   reorderPinnedConversations as reorderPinnedRows,
   updateConversationMeta as updateConversationMetaRow,
+  upsertConversationModel,
   upsertConversationTitle,
 } from './conversationMetaRepository.js'
 
@@ -30,7 +31,7 @@ export class SessionNotFoundError extends Error {}
 export class SessionForbiddenError extends Error {}
 export class MossUnavailableError extends Error {}
 export class InvalidSelectionError extends Error {
-  constructor(readonly field: 'assistantName' | 'enabledSkills', readonly value: string) {
+  constructor(readonly field: 'assistantName' | 'enabledSkills' | 'modelId', readonly value: string) {
     super(`${field} not in current visible list: ${value}`)
   }
 }
@@ -49,6 +50,10 @@ export interface ConversationDeps {
 }
 
 const NameListSchema = z.array(z.object({ name: z.string() }).passthrough())
+
+const AvailableModelsSchema = z
+  .object({ data: z.array(z.object({ id: z.string(), name: z.string().optional() }).passthrough()) })
+  .passthrough()
 
 async function fetchVisibleNames(
   deps: ConversationDeps,
@@ -79,6 +84,19 @@ async function assertSelectionVisible(
         throw new InvalidSelectionError('enabledSkills', skill)
       }
     }
+  }
+}
+
+/** 建会话选模型时：核验 modelId 在当前用户可用模型列表中（不接受浏览器自造）。 */
+async function assertModelAvailable(deps: ConversationDeps, modelId: string, accessToken: string): Promise<void> {
+  const json = await deps.mossFetch(deps.config.moss.baseUrl, {
+    method: 'GET',
+    path: '/api/v1/models/available',
+    accessToken,
+  })
+  const models = AvailableModelsSchema.parse(json)
+  if (!models.data.some((model) => model.id === modelId)) {
+    throw new InvalidSelectionError('modelId', modelId)
   }
 }
 
@@ -117,17 +135,28 @@ export async function listConversations(
 
 export async function createConversation(
   deps: ConversationDeps,
-  _principal: Principal,
+  principal: Principal,
   input: CreateConversationRequest,
   accessToken: string,
 ): Promise<{ id: string }> {
   await assertSelectionVisible(deps, input, accessToken)
+  // 模型：先校验可用（不通过则 400，不建会话）→ setUserModel（Moss 用户级），使新会话采用该模型
+  if (input.modelId) {
+    await assertModelAvailable(deps, input.modelId, accessToken)
+    await mapMossErrors(() => deps.moss.setUserModel(accessToken, input.modelId!))
+  }
   const created = await mapMossErrors(() =>
     deps.moss.create(accessToken, {
       assistantName: input.assistantName,
       enabledSkills: input.enabledSkills,
     }),
   )
+  // 本地记录会话所选模型（重开会话时回读显示）。吞错防孤儿：会话已在 Moss 建立，抛错会造孤儿会话
+  if (input.modelId) {
+    await upsertConversationModel(deps.pool, principal.id, created.sessionId, input.modelId).catch((err: unknown) => {
+      console.warn(`[conversations] persist modelId failed (session=${created.sessionId}): ${(err as Error).message}`)
+    })
+  }
   // ws_url 只留在服务端（协调器 resume 时使用）
   return { id: created.sessionId }
 }
@@ -151,24 +180,28 @@ export async function getContext(
   principal: Principal,
   sessionId: string,
   accessToken: string,
-): Promise<{ customTitle: string | null; title: string | null; messages: Record<string, unknown>[] }> {
+): Promise<{ customTitle: string | null; title: string | null; modelId: string | null; messages: Record<string, unknown>[] }> {
   await requireOwnSession(deps, principal, sessionId, accessToken)
-  const localTitle = async (): Promise<string | null> =>
-    (await getConversationMeta(deps.pool, principal.id, sessionId))?.title ?? null
+  const localMeta = async (): Promise<{ title: string | null; modelId: string | null }> => {
+    const meta = await getConversationMeta(deps.pool, principal.id, sessionId)
+    return { title: meta?.title ?? null, modelId: meta?.modelId ?? null }
+  }
   let parsed: unknown
   try {
     parsed = await deps.moss.context(accessToken, sessionId)
   } catch (err) {
     if (err instanceof MossHttpError && err.status === 404) {
       // 空 transcript（新会话）上游返回 404
-      return { customTitle: null, title: await localTitle(), messages: [] }
+      const meta = await localMeta()
+      return { customTitle: null, title: meta.title, modelId: meta.modelId, messages: [] }
     }
     throw err
   }
   const ctx = (parsed as { context?: { customTitle?: string; messages?: unknown[] } }).context
   const messages = (ctx?.messages ?? []).map((raw) => sanitizeMessage(raw))
   await generateTitleIfMissing(deps, principal, sessionId, messages)
-  return { customTitle: ctx?.customTitle ?? null, title: await localTitle(), messages }
+  const meta = await localMeta()
+  return { customTitle: ctx?.customTitle ?? null, title: meta.title, modelId: meta.modelId, messages }
 }
 
 /**
@@ -310,10 +343,7 @@ export async function getConversationOptions(
     ].map((p) => mapMossErrors(() => p)),
   )
 
-  const models = z
-    .object({ data: z.array(z.object({ id: z.string(), name: z.string().optional() }).passthrough()) })
-    .passthrough()
-    .parse(modelsJson)
+  const models = AvailableModelsSchema.parse(modelsJson)
   // 与智能体页"我的智能体"一致：过滤 moss 系统内置（isBuiltin），不作为会话可选项
   const agents = NameListSchema.parse(agentsJson).filter(
     (a) => (a as { isBuiltin?: unknown }).isBuiltin !== true,

--- a/apps/webui/src/server/features/conversations/deliverablesService.ts
+++ b/apps/webui/src/server/features/conversations/deliverablesService.ts
@@ -5,6 +5,7 @@
  * （input 是 JSON 字符串，兼容对象形态）取 .path → kind 映射（写入→create / 编辑→edit）
  * → timestamp 作 createdAt → size/mime 从 workspace tree 匹配补齐。
  */
+import type { MossCallContext } from '@sudowork/moss-client'
 import type { ConversationDeps } from './conversationService.js'
 import { requireOwnSession } from './conversationService.js'
 
@@ -75,13 +76,13 @@ export async function getDeliverables(
   deps: ConversationDeps,
   principal: Parameters<typeof requireOwnSession>[1],
   sessionId: string,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<{ items: DeliverableItem[] }> {
-  await requireOwnSession(deps, principal, sessionId, accessToken)
+  await requireOwnSession(deps, principal, sessionId, ctx)
 
   const [contextJson, treeJson] = await Promise.all([
-    deps.moss.context(accessToken, sessionId),
-    deps.moss.workspaceTree(accessToken, sessionId, '').catch(() => null),
+    deps.moss.context(ctx, sessionId),
+    deps.moss.workspaceTree(ctx, sessionId, '').catch(() => null),
   ])
 
   const files: { relativePath: string; size?: number }[] = []

--- a/apps/webui/src/server/features/conversations/lockRepository.ts
+++ b/apps/webui/src/server/features/conversations/lockRepository.ts
@@ -57,6 +57,23 @@ export async function releaseToIdle(
   )
 }
 
+/**
+ * set_model 抢占路径专用：仅当锁仍为本次设置的 running + 本 writer 时回收为 idle（保留 writer）。
+ * 带守卫（区别于 releaseToIdle）：与断线 markUncertain / REST terminate 交错时不误回收。返回是否回收。
+ */
+export async function releaseToIdleIfHeld(
+  pool: Pool,
+  input: { principalId: string; mossSessionId: string; webSessionId: string },
+): Promise<boolean> {
+  const { rowCount } = await pool.query(
+    `UPDATE conversation_locks SET state = 'idle', updated_at = now()
+     WHERE principal_id = $1 AND moss_session_id = $2
+       AND state = 'running' AND writer_web_session_id = $3`,
+    [input.principalId, input.mossSessionId, input.webSessionId],
+  )
+  return (rowCount ?? 0) > 0
+}
+
 /** writer 在 idle 断开：立即清空 writer（会话可被其他设备接管）。 */
 export async function clearWriterIfIdle(
   pool: Pool,

--- a/apps/webui/src/server/features/cron/cronRoutes.ts
+++ b/apps/webui/src/server/features/cron/cronRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, type NextFunction, type Response } from 'express'
 import { z, ZodError } from 'zod'
-import { getAccessToken } from '../auth/authService.js'
+import { getMossContext } from '../auth/authService.js'
+import type { MossCallContext } from '@sudowork/moss-client'
 import { findPrincipalById, type Principal } from '../auth/principalRepository.js'
 import { requireSession, type AuthedRequest } from '../auth/sessionMiddleware.js'
 import { MossHttpError } from '@sudowork/moss-client'
@@ -54,8 +55,8 @@ export function createCronRouter(deps: CronDeps): Router {
     return findPrincipalById(deps.pool, req.webSession!.principalId)
   }
 
-  async function token(req: AuthedRequest): Promise<string> {
-    return getAccessToken(deps.auth, req.webSession!)
+  async function token(req: AuthedRequest): Promise<MossCallContext> {
+    return getMossContext(deps.auth, req.webSession!)
   }
 
   function handle(err: unknown, res: Response, next: NextFunction): void {

--- a/apps/webui/src/server/features/cron/cronService.ts
+++ b/apps/webui/src/server/features/cron/cronService.ts
@@ -2,7 +2,7 @@ import type { AppConfig } from '../../config.js'
 import type { Pool } from 'pg'
 import type { AuthDeps } from '../auth/authService.js'
 import type { Principal } from '../auth/principalRepository.js'
-import type { MossCronPort } from '@sudowork/moss-client'
+import type { MossCallContext, MossCronPort } from '@sudowork/moss-client'
 import type { MossSessionPort } from '@sudowork/moss-client'
 import { MossHttpError, MossNetworkError } from '@sudowork/moss-client'
 
@@ -32,7 +32,7 @@ export interface CronDeps {
   cron: MossCronPort
   sessions: MossSessionPort
   /** 从 fresh agents/installed 列表取当前可见名字集合（由 routes 注入） */
-  fetchVisibleAgentNames: (accessToken: string) => Promise<Set<string>>
+  fetchVisibleAgentNames: (ctx: MossCallContext) => Promise<Set<string>>
 }
 
 function mapErr(err: unknown): Error {
@@ -61,9 +61,9 @@ async function run<T>(fn: () => Promise<T>): Promise<T> {
 async function visibleJobs(
   deps: CronDeps,
   _principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<Record<string, unknown>[]> {
-  const json = await run(() => deps.cron.list(accessToken))
+  const json = await run(() => deps.cron.list(ctx))
   return extractRows(json)
 }
 
@@ -81,19 +81,19 @@ function extractRows(json: unknown): Record<string, unknown>[] {
 async function requireVisibleJob(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   jobId: string,
 ): Promise<void> {
-  const jobs = await visibleJobs(deps, principal, accessToken)
+  const jobs = await visibleJobs(deps, principal, ctx)
   if (!jobs.some((j) => String(j.id) === jobId)) throw new NotFoundError()
 }
 
 export async function listJobs(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
 ): Promise<{ jobs: Record<string, unknown>[]; canCreate: boolean; canUseAdminList: boolean }> {
-  const jobs = await visibleJobs(deps, principal, accessToken)
+  const jobs = await visibleJobs(deps, principal, ctx)
   // canCreate 投影：默认乐观展示创建入口；被组织停用时由 CRON_DISABLED_BY_ORG 降级
   return { jobs, canCreate: true, canUseAdminList: false }
 }
@@ -112,7 +112,7 @@ export interface CronJobInput {
 async function buildMossBody(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   input: CronJobInput,
   opts: { requireFull: boolean },
 ): Promise<Record<string, unknown>> {
@@ -133,7 +133,7 @@ async function buildMossBody(
 
   if (input.boundSessionId !== undefined && input.boundSessionId !== null) {
     // 计划 Task 7：boundSessionId 归属校验（当前用户 + 同 org）
-    const session = await run(() => deps.sessions.get(accessToken, input.boundSessionId!))
+    const session = await run(() => deps.sessions.get(ctx, input.boundSessionId!))
     if (!session) throw new NotFoundError()
     if (session.userId !== principal.mossUserId || session.orgId !== principal.orgId) {
       throw new ForbiddenError()
@@ -158,73 +158,73 @@ async function buildMossBody(
 export async function createJob(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   input: CronJobInput & { name: string; schedule: NonNullable<CronJobInput['schedule']> },
 ): Promise<unknown> {
-  const body = await buildMossBody(deps, principal, accessToken, input, { requireFull: true })
-  return run(() => deps.cron.create(accessToken, body))
+  const body = await buildMossBody(deps, principal, ctx, input, { requireFull: true })
+  return run(() => deps.cron.create(ctx, body))
 }
 
 export async function getJob(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   jobId: string,
 ): Promise<unknown> {
-  await requireVisibleJob(deps, principal, accessToken, jobId)
-  return run(() => deps.cron.get(accessToken, jobId))
+  await requireVisibleJob(deps, principal, ctx, jobId)
+  return run(() => deps.cron.get(ctx, jobId))
 }
 
 export async function updateJob(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   jobId: string,
   input: CronJobInput,
 ): Promise<unknown> {
-  await requireVisibleJob(deps, principal, accessToken, jobId)
-  const body = await buildMossBody(deps, principal, accessToken, input, { requireFull: false })
-  return run(() => deps.cron.update(accessToken, jobId, body))
+  await requireVisibleJob(deps, principal, ctx, jobId)
+  const body = await buildMossBody(deps, principal, ctx, input, { requireFull: false })
+  return run(() => deps.cron.update(ctx, jobId, body))
 }
 
 export async function deleteJob(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   jobId: string,
 ): Promise<unknown> {
-  await requireVisibleJob(deps, principal, accessToken, jobId)
-  return run(() => deps.cron.remove(accessToken, jobId))
+  await requireVisibleJob(deps, principal, ctx, jobId)
+  return run(() => deps.cron.remove(ctx, jobId))
 }
 
 export async function triggerJob(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   jobId: string,
 ): Promise<unknown> {
   // 手动触发：点击者必须是绑定会话 owner（requireVisibleJob 已保证本人可见）
-  await requireVisibleJob(deps, principal, accessToken, jobId)
-  return run(() => deps.cron.trigger(accessToken, jobId))
+  await requireVisibleJob(deps, principal, ctx, jobId)
+  return run(() => deps.cron.trigger(ctx, jobId))
 }
 
 export async function listRuns(
   deps: CronDeps,
   principal: Principal,
-  accessToken: string,
+  ctx: MossCallContext,
   jobId: string,
   limit: number,
 ): Promise<unknown> {
-  await requireVisibleJob(deps, principal, accessToken, jobId)
-  return run(() => deps.cron.runs(accessToken, jobId, limit))
+  await requireVisibleJob(deps, principal, ctx, jobId)
+  return run(() => deps.cron.runs(ctx, jobId, limit))
 }
 
 /** 计划 Task 7：assistantName 必须来自当前 fresh 可见列表（不接收浏览器自造 name）。 */
 export async function assertAssistantName(
   deps: CronDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   assistantName: string,
 ): Promise<void> {
-  const names = await deps.fetchVisibleAgentNames(accessToken)
+  const names = await deps.fetchVisibleAgentNames(ctx)
   if (!names.has(assistantName)) throw new InvalidSelectionError(assistantName)
 }

--- a/apps/webui/src/server/features/mcp/mcpRoutes.ts
+++ b/apps/webui/src/server/features/mcp/mcpRoutes.ts
@@ -3,7 +3,8 @@ import { z, ZodError } from 'zod'
 import type { Pool } from 'pg'
 import type { AppConfig } from '../../config.js'
 import type { AuthDeps } from '../auth/authService.js'
-import { getAccessToken } from '../auth/authService.js'
+import { getMossContext } from '../auth/authService.js'
+import type { MossCallContext } from '@sudowork/moss-client'
 import { requireSession, type AuthedRequest } from '../auth/sessionMiddleware.js'
 import type { MossMcpPort } from '@sudowork/moss-client'
 import { MossHttpError, MossNetworkError } from '@sudowork/moss-client'
@@ -40,10 +41,10 @@ async function mapErr<T>(fn: () => Promise<T>): Promise<T> {
 /** 从 fresh 列表找 server 行；返回其 scope（own personal 判定依据）。 */
 async function findServerRow(
   deps: McpDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   id: string,
 ): Promise<Record<string, unknown> | null> {
-  const list = (await mapErr(() => deps.mcp.servers(accessToken))) as Record<string, unknown>[]
+  const list = (await mapErr(() => deps.mcp.servers(ctx))) as Record<string, unknown>[]
   if (!Array.isArray(list)) return null
   return list.find((row) => row && row.id === id) ?? null
 }
@@ -105,7 +106,7 @@ export function createMcpRouter(deps: McpDeps): Router {
     }
   }
 
-  const tk = (req: AuthedRequest) => getAccessToken(deps.auth, req.webSession!)
+  const tk = (req: AuthedRequest) => getMossContext(deps.auth, req.webSession!)
 
   router.get(
     '/servers',

--- a/apps/webui/src/server/features/settings/settingsRoutes.ts
+++ b/apps/webui/src/server/features/settings/settingsRoutes.ts
@@ -3,7 +3,7 @@ import { z, ZodError } from 'zod'
 import type { Pool } from 'pg'
 import type { AppConfig } from '../../config.js'
 import type { AuthDeps } from '../auth/authService.js'
-import { getAccessToken } from '../auth/authService.js'
+import { getMossContext } from '../auth/authService.js'
 import { requireSession, type AuthedRequest } from '../auth/sessionMiddleware.js'
 import type { MossMcpPort } from '@sudowork/moss-client'
 import { MossHttpError, MossNetworkError } from '@sudowork/moss-client'
@@ -66,7 +66,7 @@ export function createSettingsRouter(deps: SettingsDeps): Router {
     '/profile',
     requireSession,
     wrap(async (req) => {
-      const tk = await getAccessToken(deps.auth, req.webSession!)
+      const tk = await getMossContext(deps.auth, req.webSession!)
       try {
         return await deps.mcp.userProfile(tk)
       } catch (err) {
@@ -109,7 +109,7 @@ export function createSettingsRouter(deps: SettingsDeps): Router {
     '/about',
     requireSession,
     wrap(async (req) => {
-      const tk = await getAccessToken(deps.auth, req.webSession!)
+      const tk = await getMossContext(deps.auth, req.webSession!)
       let branding: Record<string, unknown>
       try {
         const config = (await deps.mcp.tenantConfig(tk)) as Record<string, unknown>

--- a/apps/webui/src/server/features/skills/skillRoutes.ts
+++ b/apps/webui/src/server/features/skills/skillRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, type NextFunction, type Response } from 'express'
 import { ZodError } from 'zod'
-import { getAccessToken } from '../auth/authService.js'
+import { getMossContext } from '../auth/authService.js'
+import type { MossCallContext } from '@sudowork/moss-client'
 import { requireSession, type AuthedRequest } from '../auth/sessionMiddleware.js'
 import { MossHttpError } from '@sudowork/moss-client'
 import {
@@ -37,8 +38,8 @@ import {
 export function createSkillRouter(deps: SkillDeps): Router {
   const router = Router()
 
-  async function token(req: AuthedRequest): Promise<string> {
-    return getAccessToken(deps.auth, req.webSession!)
+  async function token(req: AuthedRequest): Promise<MossCallContext> {
+    return getMossContext(deps.auth, req.webSession!)
   }
 
   function handle(err: unknown, res: Response, next: NextFunction): void {

--- a/apps/webui/src/server/features/skills/skillService.ts
+++ b/apps/webui/src/server/features/skills/skillService.ts
@@ -1,7 +1,7 @@
 import type { AppConfig } from '../../config.js'
 import type { Pool } from 'pg'
 import type { AuthDeps } from '../auth/authService.js'
-import type { MossSkillPort } from '@sudowork/moss-client'
+import type { MossCallContext, MossSkillPort } from '@sudowork/moss-client'
 import { MossHttpError, MossNetworkError } from '@sudowork/moss-client'
 
 /**
@@ -33,10 +33,10 @@ async function mapErr<T>(fn: () => Promise<T>): Promise<T> {
 
 export async function requireAnyScope(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   scopes: string[],
 ): Promise<void> {
-  const me = await mapErr(() => deps.auth.mossAuth.me(accessToken))
+  const me = await mapErr(() => deps.auth.mossAuth.me(ctx.accessToken, ctx.baseUrl))
   const owned: string[] = Array.isArray(me.scopes) ? me.scopes : []
   const isAdmin = me.role === 'admin' || me.role === 'super_admin' || me.isSuperAdmin === true
   if (isAdmin) return
@@ -49,8 +49,8 @@ interface InstalledItem {
   name?: unknown
 }
 
-async function installedNames(deps: SkillDeps, accessToken: string): Promise<Set<string>> {
-  const list = (await mapErr(() => deps.skills.installed(accessToken))) as InstalledItem[]
+async function installedNames(deps: SkillDeps, ctx: MossCallContext): Promise<Set<string>> {
+  const list = (await mapErr(() => deps.skills.installed(ctx))) as InstalledItem[]
   const names = new Set<string>()
   if (Array.isArray(list)) {
     for (const item of list) {
@@ -60,26 +60,26 @@ async function installedNames(deps: SkillDeps, accessToken: string): Promise<Set
   return names
 }
 
-async function requireVisibleSkill(deps: SkillDeps, accessToken: string, name: string): Promise<void> {
-  if (!(await installedNames(deps, accessToken)).has(name)) throw new NotFoundError()
+async function requireVisibleSkill(deps: SkillDeps, ctx: MossCallContext, name: string): Promise<void> {
+  if (!(await installedNames(deps, ctx)).has(name)) throw new NotFoundError()
 }
 
-export async function listInstalled(deps: SkillDeps, accessToken: string): Promise<unknown> {
-  return mapErr(() => deps.skills.installed(accessToken))
+export async function listInstalled(deps: SkillDeps, ctx: MossCallContext): Promise<unknown> {
+  return mapErr(() => deps.skills.installed(ctx))
 }
 
-export async function hubCategories(deps: SkillDeps, accessToken: string): Promise<unknown> {
-  return mapErr(() => deps.skills.hubCategories(accessToken))
+export async function hubCategories(deps: SkillDeps, ctx: MossCallContext): Promise<unknown> {
+  return mapErr(() => deps.skills.hubCategories(ctx))
 }
 
 export async function hubList(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   searchParams: Record<string, string>,
 ): Promise<unknown> {
   // moss 上游返回 { skills, next_cursor, has_more }（skillStore.ts fetchSkillHubSkills），
   // 与 installFromHub 的兼容读取一致，统一归一化为 items 供前端消费
-  const hub = (await mapErr(() => deps.skills.hubList(accessToken, searchParams))) as {
+  const hub = (await mapErr(() => deps.skills.hubList(ctx, searchParams))) as {
     items?: Record<string, unknown>[]
     skills?: Record<string, unknown>[]
     next_cursor?: unknown
@@ -92,80 +92,80 @@ export async function hubList(
   }
 }
 
-export async function hubDetail(deps: SkillDeps, accessToken: string, id: string): Promise<unknown> {
-  return mapErr(() => deps.skills.hubDetail(accessToken, id))
+export async function hubDetail(deps: SkillDeps, ctx: MossCallContext, id: string): Promise<unknown> {
+  return mapErr(() => deps.skills.hubDetail(ctx, id))
 }
 
-export async function syncStatus(deps: SkillDeps, accessToken: string): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  return mapErr(() => deps.skills.syncStatus(accessToken))
+export async function syncStatus(deps: SkillDeps, ctx: MossCallContext): Promise<unknown> {
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  return mapErr(() => deps.skills.syncStatus(ctx))
 }
 
-export async function tenantList(deps: SkillDeps, accessToken: string): Promise<unknown> {
-  return mapErr(() => deps.skills.tenantList(accessToken))
+export async function tenantList(deps: SkillDeps, ctx: MossCallContext): Promise<unknown> {
+  return mapErr(() => deps.skills.tenantList(ctx))
 }
 
 export async function installFromHub(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
+  await requireAnyScope(deps, ctx, ['admin:settings'])
   const hub = (await mapErr(() =>
-    deps.skills.hubList(accessToken, { limit: '100' }),
+    deps.skills.hubList(ctx, { limit: '100' }),
   )) as { items?: Record<string, unknown>[]; skills?: Record<string, unknown>[] }
   const items = hub?.items ?? hub?.skills ?? []
   const meta = items.find((it) => it && (it.name === name || it.id === name))
   if (!meta) throw new NotFoundError()
-  return mapErr(() => deps.skills.install(accessToken, { skillMeta: meta }))
+  return mapErr(() => deps.skills.install(ctx, { skillMeta: meta }))
 }
 
 export async function setEnabled(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
   enabled: boolean,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  await requireVisibleSkill(deps, accessToken, name)
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  await requireVisibleSkill(deps, ctx, name)
   // 基线请求体是单个对象；不传 sourcePath（WebUI 不透传浏览器路径）
-  return mapErr(() => deps.skills.setEnabled(accessToken, { skillName: name, enabled }))
+  return mapErr(() => deps.skills.setEnabled(ctx, { skillName: name, enabled }))
 }
 
 export async function uploadCustom(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   file: string,
 ): Promise<unknown> {
-  return mapErr(() => deps.skills.uploadCustom(accessToken, { file }))
+  return mapErr(() => deps.skills.uploadCustom(ctx, { file }))
 }
 
 export async function uninstall(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   name: string,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  await requireVisibleSkill(deps, accessToken, name)
-  return mapErr(() => deps.skills.uninstall(accessToken, { skillName: name }))
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  await requireVisibleSkill(deps, ctx, name)
+  return mapErr(() => deps.skills.uninstall(ctx, { skillName: name }))
 }
 
-export async function syncFromHub(deps: SkillDeps, accessToken: string): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings'])
-  return mapErr(() => deps.skills.syncFromHub(accessToken))
+export async function syncFromHub(deps: SkillDeps, ctx: MossCallContext): Promise<unknown> {
+  await requireAnyScope(deps, ctx, ['admin:settings'])
+  return mapErr(() => deps.skills.syncFromHub(ctx))
 }
 
 export async function tenantUpload(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  await requireAnyScope(deps, accessToken, ['admin:settings', 'store:tenant:write'])
-  return mapErr(() => deps.skills.tenantUpload(accessToken, body))
+  await requireAnyScope(deps, ctx, ['admin:settings', 'store:tenant:write'])
+  return mapErr(() => deps.skills.tenantUpload(ctx, body))
 }
 
-async function requireTenantVisible(deps: SkillDeps, accessToken: string, id: string): Promise<void> {
-  const list = (await mapErr(() => deps.skills.tenantList(accessToken))) as Record<string, unknown>[]
+async function requireTenantVisible(deps: SkillDeps, ctx: MossCallContext, id: string): Promise<void> {
+  const list = (await mapErr(() => deps.skills.tenantList(ctx))) as Record<string, unknown>[]
   const row = Array.isArray(list) ? list.find((it) => it && it.id === id) : undefined
   if (!row) throw new NotFoundError()
   if (row.can_manage === false) throw new ForbiddenError()
@@ -173,28 +173,28 @@ async function requireTenantVisible(deps: SkillDeps, accessToken: string, id: st
 
 export async function tenantUpdate(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   id: string,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  await requireTenantVisible(deps, accessToken, id)
-  return mapErr(() => deps.skills.tenantUpdate(accessToken, id, body))
+  await requireTenantVisible(deps, ctx, id)
+  return mapErr(() => deps.skills.tenantUpdate(ctx, id, body))
 }
 
-export async function tenantDelete(deps: SkillDeps, accessToken: string, id: string): Promise<unknown> {
-  await requireTenantVisible(deps, accessToken, id)
-  return mapErr(() => deps.skills.tenantDelete(accessToken, id))
+export async function tenantDelete(deps: SkillDeps, ctx: MossCallContext, id: string): Promise<unknown> {
+  await requireTenantVisible(deps, ctx, id)
+  return mapErr(() => deps.skills.tenantDelete(ctx, id))
 }
 
-export async function tenantDownload(deps: SkillDeps, accessToken: string, id: string): Promise<unknown> {
-  return mapErr(() => deps.skills.tenantDownload(accessToken, id))
+export async function tenantDownload(deps: SkillDeps, ctx: MossCallContext, id: string): Promise<unknown> {
+  return mapErr(() => deps.skills.tenantDownload(ctx, id))
 }
 
 export async function tenantPublish(
   deps: SkillDeps,
-  accessToken: string,
+  ctx: MossCallContext,
   sourceName: string,
 ): Promise<unknown> {
-  await requireVisibleSkill(deps, accessToken, sourceName)
-  return mapErr(() => deps.skills.tenantPublish(accessToken, { skillName: sourceName }))
+  await requireVisibleSkill(deps, ctx, sourceName)
+  return mapErr(() => deps.skills.tenantPublish(ctx, { skillName: sourceName }))
 }

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -16,7 +16,7 @@ const config = loadConfig()
 
 const app = createApp({ publicOrigin: config.publicOrigin })
 const pool: Pool = getPool(config.databaseUrl)
-const mossAuth = createMossAuthPort(mossRequest, config.moss.baseUrl)
+const mossAuth = createMossAuthPort(mossRequest)
 
 const handles = registerApiRoutes(app, { config, pool, mossAuth })
 

--- a/apps/webui/tests/contract/moss-agent-skill.test.ts
+++ b/apps/webui/tests/contract/moss-agent-skill.test.ts
@@ -4,14 +4,15 @@ import { createMossSkillPort } from '@sudowork/moss-client'
 
 const BASE = 'http://moss.test'
 const TK = 'tk'
+const CTX = { accessToken: TK, baseUrl: BASE }
 
 describe('MossAgentPort request shapes（修订版 3.9：agent-hub 前缀）', () => {
   test('hub endpoints use /api/v1/agent-hub/* prefix', async () => {
     const mock = vi.fn().mockResolvedValue({})
-    const port = createMossAgentPort(mock, BASE)
-    await port.hubCategories(TK)
-    await port.hubList(TK, { limit: '20' })
-    await port.hubDetail(TK, 'a1')
+    const port = createMossAgentPort(mock)
+    await port.hubCategories(CTX)
+    await port.hubList(CTX, { limit: '20' })
+    await port.hubDetail(CTX, 'a1')
     expect(mock).toHaveBeenNthCalledWith(1, BASE, {
       method: 'GET',
       path: '/api/v1/agent-hub/categories',
@@ -32,8 +33,8 @@ describe('MossAgentPort request shapes（修订版 3.9：agent-hub 前缀）', (
 
   test('rules uses installed/:name/rules (not tenant/:id/rules)', async () => {
     const mock = vi.fn().mockResolvedValue({ rules: 'x' })
-    const port = createMossAgentPort(mock, BASE)
-    await port.installedRules(TK, 'helper')
+    const port = createMossAgentPort(mock)
+    await port.installedRules(CTX, 'helper')
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'GET',
       path: '/api/v1/agents/installed/helper/rules',
@@ -43,8 +44,8 @@ describe('MossAgentPort request shapes（修订版 3.9：agent-hub 前缀）', (
 
   test('uninstall posts assistantName only (no client sourcePath)', async () => {
     const mock = vi.fn().mockResolvedValue({ ok: true })
-    const port = createMossAgentPort(mock, BASE)
-    await port.uninstall(TK, { assistantName: 'helper' })
+    const port = createMossAgentPort(mock)
+    await port.uninstall(CTX, { assistantName: 'helper' })
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'POST',
       path: '/api/v1/agents/uninstall',
@@ -55,13 +56,13 @@ describe('MossAgentPort request shapes（修订版 3.9：agent-hub 前缀）', (
 
   test('tenant endpoints', async () => {
     const mock = vi.fn().mockResolvedValue([])
-    const port = createMossAgentPort(mock, BASE)
-    await port.tenantList(TK)
-    await port.tenantCreate(TK, { name: 'n' })
-    await port.tenantUpdate(TK, 't1', { description: 'd' })
-    await port.tenantDelete(TK, 't1')
-    await port.tenantDownload(TK, 't1')
-    await port.tenantPublish(TK, { assistantName: 'helper' })
+    const port = createMossAgentPort(mock)
+    await port.tenantList(CTX)
+    await port.tenantCreate(CTX, { name: 'n' })
+    await port.tenantUpdate(CTX, 't1', { description: 'd' })
+    await port.tenantDelete(CTX, 't1')
+    await port.tenantDownload(CTX, 't1')
+    await port.tenantPublish(CTX, { assistantName: 'helper' })
     const paths = mock.mock.calls.map((c) => (c[1] as { method: string; path: string }).method + ' ' + (c[1] as { path: string }).path)
     expect(paths).toEqual([
       'GET /api/v1/agents/tenant',
@@ -77,10 +78,10 @@ describe('MossAgentPort request shapes（修订版 3.9：agent-hub 前缀）', (
 describe('MossSkillPort request shapes（修订版 3.9：skill-hub 前缀、enabled 单对象）', () => {
   test('hub endpoints use /api/v1/skill-hub/* prefix', async () => {
     const mock = vi.fn().mockResolvedValue({})
-    const port = createMossSkillPort(mock, BASE)
-    await port.hubCategories(TK)
-    await port.hubList(TK, {})
-    await port.hubDetail(TK, 's1')
+    const port = createMossSkillPort(mock)
+    await port.hubCategories(CTX)
+    await port.hubList(CTX, {})
+    await port.hubDetail(CTX, 's1')
     expect(mock).toHaveBeenNthCalledWith(1, BASE, {
       method: 'GET',
       path: '/api/v1/skill-hub/categories',
@@ -101,8 +102,8 @@ describe('MossSkillPort request shapes（修订版 3.9：skill-hub 前缀、enab
 
   test('enabled sends single {skillName, enabled} object（基线事实，非数组）', async () => {
     const mock = vi.fn().mockResolvedValue({ ok: true })
-    const port = createMossSkillPort(mock, BASE)
-    await port.setEnabled(TK, { skillName: 'pdf', enabled: true })
+    const port = createMossSkillPort(mock)
+    await port.setEnabled(CTX, { skillName: 'pdf', enabled: true })
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'PATCH',
       path: '/api/v1/skills/enabled',
@@ -113,8 +114,8 @@ describe('MossSkillPort request shapes（修订版 3.9：skill-hub 前缀、enab
 
   test('tenant upload uses /tenant/upload (not /tenant/create)', async () => {
     const mock = vi.fn().mockResolvedValue({})
-    const port = createMossSkillPort(mock, BASE)
-    await port.tenantUpload(TK, { archiveBase64: 'eA==' })
+    const port = createMossSkillPort(mock)
+    await port.tenantUpload(CTX, { archiveBase64: 'eA==' })
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'POST',
       path: '/api/v1/skills/tenant/upload',

--- a/apps/webui/tests/contract/moss-auth.test.ts
+++ b/apps/webui/tests/contract/moss-auth.test.ts
@@ -11,9 +11,9 @@ function okTokenSet() {
 describe('MossAuthPort request shapes (contract vs baseline)', () => {
   test('password login posts grant_type=password to /api/v1/auth/login', async () => {
     const mock = vi.fn().mockResolvedValue(okTokenSet())
-    const port = createMossAuthPort(mock, BASE)
+    const port = createMossAuthPort(mock)
 
-    const tokens = await port.loginWithPassword({ username: 'u1', password: 'p1' })
+    const tokens = await port.loginWithPassword({ username: 'u1', password: 'p1' }, BASE)
 
     expect(tokens.access_token).toBe('at-1')
     expect(mock).toHaveBeenCalledWith(
@@ -28,9 +28,9 @@ describe('MossAuthPort request shapes (contract vs baseline)', () => {
 
   test('api key login posts grant_type=api_key', async () => {
     const mock = vi.fn().mockResolvedValue(okTokenSet())
-    const port = createMossAuthPort(mock, BASE)
+    const port = createMossAuthPort(mock)
 
-    await port.loginWithApiKey('sk-xyz')
+    await port.loginWithApiKey('sk-xyz', BASE)
 
     expect(mock).toHaveBeenCalledWith(
       BASE,
@@ -44,9 +44,9 @@ describe('MossAuthPort request shapes (contract vs baseline)', () => {
 
   test('refresh posts grant_type=refresh_token to /api/v1/auth/token', async () => {
     const mock = vi.fn().mockResolvedValue(okTokenSet())
-    const port = createMossAuthPort(mock, BASE)
+    const port = createMossAuthPort(mock)
 
-    await port.refresh('rt-old')
+    await port.refresh('rt-old', BASE)
 
     expect(mock).toHaveBeenCalledWith(
       BASE,
@@ -65,9 +65,9 @@ describe('MossAuthPort request shapes (contract vs baseline)', () => {
       scopes: ['s'],
       role: 'user',
     })
-    const port = createMossAuthPort(mock, BASE)
+    const port = createMossAuthPort(mock)
 
-    const me = await port.me('at-9')
+    const me = await port.me('at-9', BASE)
     expect(me.user.id).toBe('u')
 
     expect(mock).toHaveBeenCalledWith(
@@ -78,8 +78,8 @@ describe('MossAuthPort request shapes (contract vs baseline)', () => {
 
   test('token set missing required fields is rejected', async () => {
     const mock = vi.fn().mockResolvedValue({ access_token: 'at' })
-    const port = createMossAuthPort(mock, BASE)
-    await expect(port.loginWithApiKey('sk')).rejects.toThrow()
+    const port = createMossAuthPort(mock)
+    await expect(port.loginWithApiKey('sk', BASE)).rejects.toThrow()
   })
 })
 

--- a/apps/webui/tests/contract/moss-cron.test.ts
+++ b/apps/webui/tests/contract/moss-cron.test.ts
@@ -3,18 +3,19 @@ import { createMossCronPort } from '@sudowork/moss-client'
 
 const BASE = 'http://moss.test'
 const TK = 'tk'
+const CTX = { accessToken: TK, baseUrl: BASE }
 
 describe('MossCronPort request shapes（修订版 3.9）', () => {
   test('CRUD/trigger/runs paths match baseline routes', async () => {
     const mock = vi.fn().mockResolvedValue({ jobs: [] })
-    const port = createMossCronPort(mock, BASE)
-    await port.list(TK)
-    await port.get(TK, 'j1')
-    await port.create(TK, { name: 'n', schedule: { kind: 'cron', value: '0 9 * * *' } })
-    await port.update(TK, 'j1', { enabled: false })
-    await port.remove(TK, 'j1')
-    await port.trigger(TK, 'j1')
-    await port.runs(TK, 'j1', 20)
+    const port = createMossCronPort(mock)
+    await port.list(CTX)
+    await port.get(CTX, 'j1')
+    await port.create(CTX, { name: 'n', schedule: { kind: 'cron', value: '0 9 * * *' } })
+    await port.update(CTX, 'j1', { enabled: false })
+    await port.remove(CTX, 'j1')
+    await port.trigger(CTX, 'j1')
+    await port.runs(CTX, 'j1', 20)
 
     const calls = mock.mock.calls.map(
       (c) =>
@@ -34,8 +35,8 @@ describe('MossCronPort request shapes（修订版 3.9）', () => {
 
   test('admin list uses /api/v1/admin/cron/jobs', async () => {
     const mock = vi.fn().mockResolvedValue({ data: [] })
-    const port = createMossCronPort(mock, BASE)
-    await port.adminList(TK)
+    const port = createMossCronPort(mock)
+    await port.adminList(CTX)
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'GET',
       path: '/api/v1/admin/cron/jobs',
@@ -45,14 +46,14 @@ describe('MossCronPort request shapes（修订版 3.9）', () => {
 
   test('schedule body uses value field (never expr)', async () => {
     const mock = vi.fn().mockResolvedValue({ ok: true })
-    const port = createMossCronPort(mock, BASE)
+    const port = createMossCronPort(mock)
     const body = {
       name: 'daily',
       schedule: { kind: 'every' as const, value: '30m', tz: 'Asia/Shanghai' },
       conversationMode: 'new' as const,
       assistantName: 'helper',
     }
-    await port.create(TK, body)
+    await port.create(CTX, body)
     const sent = mock.mock.calls[0]![1] as { body: Record<string, unknown> }
     expect(sent.body).toEqual(body)
     expect(JSON.stringify(sent.body)).not.toContain('expr')

--- a/apps/webui/tests/contract/moss-profile-mcp.test.ts
+++ b/apps/webui/tests/contract/moss-profile-mcp.test.ts
@@ -3,16 +3,17 @@ import { createMossMcpPort } from '@sudowork/moss-client'
 
 const BASE = 'http://moss.test'
 const TK = 'tk'
+const CTX = { accessToken: TK, baseUrl: BASE }
 
 describe('MossMcpPort request shapes（修订版 3.9）', () => {
   test('server/template/policy endpoints', async () => {
     const mock = vi.fn().mockResolvedValue([])
-    const port = createMossMcpPort(mock, BASE)
-    await port.servers(TK)
-    await port.templates(TK)
-    await port.policy(TK)
-    await port.userProfile(TK)
-    await port.tenantConfig(TK)
+    const port = createMossMcpPort(mock)
+    await port.servers(CTX)
+    await port.templates(CTX)
+    await port.policy(CTX)
+    await port.userProfile(CTX)
+    await port.tenantConfig(CTX)
     const paths = mock.mock.calls.map((c) => (c[1] as { path: string }).path)
     expect(paths).toEqual([
       '/api/v1/me/mcp-servers',
@@ -25,8 +26,8 @@ describe('MossMcpPort request shapes（修订版 3.9）', () => {
 
   test('template install sends config_values/auth_credentials/display_name precisely', async () => {
     const mock = vi.fn().mockResolvedValue({})
-    const port = createMossMcpPort(mock, BASE)
-    await port.installTemplate(TK, 'tpl-1', {
+    const port = createMossMcpPort(mock)
+    await port.installTemplate(CTX, 'tpl-1', {
       config_values: { url: 'https://x' },
       auth_credentials: { token: 'secret' },
       display_name: '我的 MCP',
@@ -45,14 +46,14 @@ describe('MossMcpPort request shapes（修订版 3.9）', () => {
 
   test('enable/disable are PUT; test/user-config/patch/delete paths', async () => {
     const mock = vi.fn().mockResolvedValue({})
-    const port = createMossMcpPort(mock, BASE)
-    await port.setEnabled(TK, 's1', true)
-    await port.setEnabled(TK, 's1', false)
-    await port.test(TK, 's1')
-    await port.getUserConfig(TK, 's1')
-    await port.putUserConfig(TK, 's1', { config_values: { a: '1' } })
-    await port.updateServer(TK, 's1', { display_name: 'x' })
-    await port.deleteServer(TK, 's1')
+    const port = createMossMcpPort(mock)
+    await port.setEnabled(CTX, 's1', true)
+    await port.setEnabled(CTX, 's1', false)
+    await port.test(CTX, 's1')
+    await port.getUserConfig(CTX, 's1')
+    await port.putUserConfig(CTX, 's1', { config_values: { a: '1' } })
+    await port.updateServer(CTX, 's1', { display_name: 'x' })
+    await port.deleteServer(CTX, 's1')
     const calls = mock.mock.calls.map((c) => c[1] as { method: string; path: string })
     expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
       'PUT /api/v1/me/mcp-servers/s1/enable',

--- a/apps/webui/tests/contract/moss-session.test.ts
+++ b/apps/webui/tests/contract/moss-session.test.ts
@@ -35,6 +35,18 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
     })
   })
 
+  test('setUserModel puts /api/v1/users/me/model with { modelId }', async () => {
+    const mock = vi.fn().mockResolvedValue({ data: { modelId: 'gpt-4', updatedAt: 1 } })
+    const port = createMossSessionPort(mock, BASE)
+    await port.setUserModel('tk', 'gpt-4')
+    expect(mock).toHaveBeenCalledWith(BASE, {
+      method: 'PUT',
+      path: '/api/v1/users/me/model',
+      accessToken: 'tk',
+      body: { modelId: 'gpt-4' },
+    })
+  })
+
   test('context/resume/terminate/workspace paths match baseline routes', async () => {
     const mock = vi.fn().mockImplementation((_base: string, req: { method: string; path: string }) =>
       Promise.resolve(

--- a/apps/webui/tests/contract/moss-session.test.ts
+++ b/apps/webui/tests/contract/moss-session.test.ts
@@ -9,12 +9,13 @@ import {
 } from '@sudowork/moss-client'
 
 const BASE = 'http://moss.test'
+const CTX = { accessToken: 'tk', baseUrl: BASE }
 
 describe('MossSessionPort request shapes (contract vs baseline)', () => {
   test('list calls GET /api/v1/sessions', async () => {
     const mock = vi.fn().mockResolvedValue({ sessions: [] })
-    const port = createMossSessionPort(mock, BASE)
-    await port.list('tk')
+    const port = createMossSessionPort(mock)
+    await port.list(CTX)
     expect(mock).toHaveBeenCalledWith(BASE, { method: 'GET', path: '/api/v1/sessions', accessToken: 'tk' })
   })
 
@@ -24,8 +25,8 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
       ws_url: 'ws://moss.test/ws/sessions/s1',
       work_dir: '/home/x',
     })
-    const port = createMossSessionPort(mock, BASE)
-    const created = await port.create('tk', { assistantName: 'helper', enabledSkills: ['a', 'b'] })
+    const port = createMossSessionPort(mock)
+    const created = await port.create(CTX, { assistantName: 'helper', enabledSkills: ['a', 'b'] })
     expect(created).toEqual({ sessionId: 's1', wsUrl: 'ws://moss.test/ws/sessions/s1' })
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'POST',
@@ -37,8 +38,8 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
 
   test('setUserModel puts /api/v1/users/me/model with { modelId }', async () => {
     const mock = vi.fn().mockResolvedValue({ data: { modelId: 'gpt-4', updatedAt: 1 } })
-    const port = createMossSessionPort(mock, BASE)
-    await port.setUserModel('tk', 'gpt-4')
+    const port = createMossSessionPort(mock)
+    await port.setUserModel(CTX, 'gpt-4')
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'PUT',
       path: '/api/v1/users/me/model',
@@ -59,30 +60,30 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
               : { ok: true },
       ),
     )
-    const port = createMossSessionPort(mock, BASE)
+    const port = createMossSessionPort(mock)
 
-    await port.context('tk', 's1')
+    await port.context(CTX, 's1')
     expect(mock).toHaveBeenLastCalledWith(BASE, {
       method: 'GET',
       path: '/api/v1/sessions/s1/context',
       accessToken: 'tk',
     })
 
-    await port.resume('tk', 's1')
+    await port.resume(CTX, 's1')
     expect(mock).toHaveBeenLastCalledWith(BASE, {
       method: 'POST',
       path: '/api/v1/sessions/s1/resume',
       accessToken: 'tk',
     })
 
-    await port.terminate('tk', 's1')
+    await port.terminate(CTX, 's1')
     expect(mock).toHaveBeenLastCalledWith(BASE, {
       method: 'POST',
       path: '/api/v1/sessions/s1/terminate',
       accessToken: 'tk',
     })
 
-    await port.workspaceTree('tk', 's1', '')
+    await port.workspaceTree(CTX, 's1', '')
     expect(mock).toHaveBeenLastCalledWith(BASE, {
       method: 'GET',
       path: '/api/v1/sessions/s1/workspace/tree',
@@ -93,8 +94,8 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
 
   test('session ids are uri-encoded once', async () => {
     const mock = vi.fn().mockResolvedValue({ ok: true })
-    const port = createMossSessionPort(mock, BASE)
-    await port.context('tk', 'id with space/slash')
+    const port = createMossSessionPort(mock)
+    await port.context(CTX, 'id with space/slash')
     expect(mock).toHaveBeenCalledWith(BASE, {
       method: 'GET',
       path: '/api/v1/sessions/id%20with%20space%2Fslash/context',

--- a/apps/webui/tests/integration/agent-skill-idor.test.ts
+++ b/apps/webui/tests/integration/agent-skill-idor.test.ts
@@ -81,7 +81,7 @@ function createFakeAgents(): MossAgentPort {
       return { id, name: 'hub-agent' }
     },
     async installed(tk) {
-      return installedByToken[tk] ?? []
+      return installedByToken[tk.accessToken] ?? []
     },
     async install() {
       return { ok: true }
@@ -154,7 +154,7 @@ function createFakeSkills(): MossSkillPort {
       return { id, name: 'hub-skill' }
     },
     async installed(tk) {
-      return installedByToken[tk] ?? []
+      return installedByToken[tk.accessToken] ?? []
     },
     async install() {
       return { ok: true }

--- a/apps/webui/tests/integration/conversation-stream.test.ts
+++ b/apps/webui/tests/integration/conversation-stream.test.ts
@@ -186,6 +186,7 @@ describe('conversation stream (browser WS ⇄ coordinator ⇄ upstream moss WS)'
       async create(_input) {
         return { sessionId: 'new', wsUrl: '' }
       },
+      async setUserModel() {},
       async context() {
         return { context: { messages: [] } }
       },

--- a/apps/webui/tests/integration/conversations.test.ts
+++ b/apps/webui/tests/integration/conversations.test.ts
@@ -50,6 +50,7 @@ function createFakeMossSession(): MossSessionPort {
     async create(_accessToken, input) {
       return { sessionId: `created-${input.assistantName}`, wsUrl: 'ws://moss.test/ws/sessions/x' }
     },
+    async setUserModel() {},
     async context(_tk, sessionId) {
       if (sessionId === 'sess-empty') throw new MossHttpError(404, '', '')
       return {

--- a/apps/webui/tests/integration/cron-idor.test.ts
+++ b/apps/webui/tests/integration/cron-idor.test.ts
@@ -120,6 +120,7 @@ function createFakeSessions(): MossSessionPort {
     async create() {
       return { sessionId: 'x', wsUrl: '' }
     },
+    async setUserModel() {},
     async context() {
       return { context: { messages: [] } }
     },

--- a/apps/webui/tests/integration/cron-idor.test.ts
+++ b/apps/webui/tests/integration/cron-idor.test.ts
@@ -63,7 +63,7 @@ function createFakeCron(): MossCronPort {
   const store = new Map<string, Record<string, unknown>>()
   return {
     async list(tk) {
-      return { jobs: JOBS[tk] ?? [] }
+      return { jobs: JOBS[tk.accessToken] ?? [] }
     },
     async adminList() {
       return { jobs: [...JOBS['at-a']!, ...JOBS['at-b']!] }

--- a/apps/webui/tests/unit/client/LoginPage.test.tsx
+++ b/apps/webui/tests/unit/client/LoginPage.test.tsx
@@ -27,6 +27,7 @@ describe('LoginPage', () => {
   beforeEach(() => {
     loginPasswordMock.mockReset()
     loginApiKeyMock.mockReset()
+    localStorage.clear()
   })
 
   test('renders password fields by default; apiKey field after switching', () => {
@@ -65,7 +66,42 @@ describe('LoginPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '登录' }))
 
     await waitFor(() => expect(onSuccess).toHaveBeenCalledWith({ ok: true }))
-    expect(loginApiKeyMock).toHaveBeenCalledWith('moss_sk_x')
+    expect(loginApiKeyMock).toHaveBeenCalledWith('moss_sk_x', undefined)
+  })
+
+  test('custom moss url: collapsed by default; expand + valid url passes mossBaseUrl and persists', async () => {
+    loginPasswordMock.mockResolvedValue({ ok: true })
+    render(<LoginPage />)
+
+    // 默认折叠：只见 toggle，无地址输入框
+    expect(screen.queryByLabelText('Moss 服务器地址')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: '使用自定义服务器地址' }))
+
+    fireEvent.change(screen.getByLabelText('用户名'), { target: { value: 'u' } })
+    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'p' } })
+    fireEvent.change(screen.getByLabelText('Moss 服务器地址'), { target: { value: 'https://custom.moss:9443' } })
+    fireEvent.click(screen.getByRole('button', { name: '登录' }))
+
+    await waitFor(() =>
+      expect(loginPasswordMock).toHaveBeenCalledWith({
+        username: 'u',
+        password: 'p',
+        mossBaseUrl: 'https://custom.moss:9443',
+      }),
+    )
+    expect(localStorage.getItem('login.mossBaseUrl')).toBe('https://custom.moss:9443')
+  })
+
+  test('custom moss url: invalid url blocks submit with an error', async () => {
+    render(<LoginPage />)
+    fireEvent.click(screen.getByRole('button', { name: '使用自定义服务器地址' }))
+    fireEvent.change(screen.getByLabelText('用户名'), { target: { value: 'u' } })
+    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'p' } })
+    fireEvent.change(screen.getByLabelText('Moss 服务器地址'), { target: { value: 'ftp://bad' } })
+    fireEvent.click(screen.getByRole('button', { name: '登录' }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
+    expect(loginPasswordMock).not.toHaveBeenCalled()
   })
 
   test('shows a friendly message for INVALID_CREDENTIALS', async () => {

--- a/apps/webui/tests/unit/client/agentAvatar.test.ts
+++ b/apps/webui/tests/unit/client/agentAvatar.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+import {
+  AGENT_AVATAR_PROXY_PATH,
+  resolveAgentAvatar,
+} from '@client/components/agentAvatar'
+
+describe('resolveAgentAvatar', () => {
+  test('空/null/undefined 返回 null', () => {
+    expect(resolveAgentAvatar('')).toBeNull()
+    expect(resolveAgentAvatar('   ')).toBeNull()
+    expect(resolveAgentAvatar(null)).toBeNull()
+    expect(resolveAgentAvatar(undefined)).toBeNull()
+  })
+
+  test('绝对 URL（hub COS）跨源直连，原样返回', () => {
+    const url = 'https://sudowork-hub.example.com/a/b.png'
+    expect(resolveAgentAvatar(url)).toEqual({ kind: 'image', value: url })
+  })
+
+  test('data URI 原样返回为 image', () => {
+    const uri = 'data:image/png;base64,AAAA'
+    expect(resolveAgentAvatar(uri)).toEqual({ kind: 'image', value: uri })
+  })
+
+  test('emoji（含 ZWJ 序列）识别为 emoji', () => {
+    expect(resolveAgentAvatar('🤖')).toEqual({ kind: 'emoji', value: '🤖' })
+    expect(resolveAgentAvatar('👨‍💻')).toEqual({ kind: 'emoji', value: '👨‍💻' })
+  })
+
+  test('tenant 相对路径拼同源代理 URL（path 经 encodeURIComponent）', () => {
+    const path = '/uploads/tenant-assistant-avatars/abc-1.png'
+    expect(resolveAgentAvatar(path)).toEqual({
+      kind: 'image',
+      value: `${AGENT_AVATAR_PROXY_PATH}?path=${encodeURIComponent(path)}`,
+    })
+  })
+
+  test('其他相对路径 / blob 不生成代理，返回 null 交兜底', () => {
+    expect(resolveAgentAvatar('/other/path.png')).toBeNull()
+    expect(resolveAgentAvatar('blob:xxx')).toBeNull()
+  })
+})

--- a/apps/webui/tests/unit/client/conversations.test.tsx
+++ b/apps/webui/tests/unit/client/conversations.test.tsx
@@ -134,8 +134,17 @@ vi.mock('@client/features/conversations/conversationApi', () => ({
   getConversationOptions: vi.fn().mockResolvedValue({
     models: [{ id: 'm1', name: 'M1' }],
     agents: [
-      { name: 'helper', displayName: '帮助助手', emoji: '🤖', description: '帮你干活' },
-      { name: 'writer', displayName: '写作助手', emoji: '', description: '' },
+      { name: 'helper', displayName: '帮助助手', emoji: '🤖', description: '帮你干活', avatar: '', defaultInitPrompt: '', promptsI18n: { 'zh-CN': [] } },
+      { name: 'writer', displayName: '写作助手', emoji: '', description: '', avatar: '', defaultInitPrompt: '', promptsI18n: { 'zh-CN': [] } },
+      {
+        name: 'guide',
+        displayName: '上手向导',
+        emoji: '🧭',
+        description: '带你快速上手',
+        avatar: '',
+        defaultInitPrompt: '请帮我从零开始',
+        promptsI18n: { 'zh-CN': ['案例一：生成周报', '案例二：整理表格'] },
+      },
     ],
     skills: [{ name: 'pdf' }, { name: 'search' }],
   }),
@@ -180,9 +189,9 @@ describe('NewConversationPage', () => {
 
     await waitFor(() => expect(screen.getByTestId('assistant-chip-helper')).toBeTruthy(), { timeout: 5000 })
     fireEvent.click(screen.getByTestId('assistant-chip-helper'))
-    // 选中态视图：返回箭头 + 名称 + 描述卡（名称与 chip 同文本，用 getAllByText 断言出现两处）
-    await waitFor(() => expect(screen.getAllByText('帮助助手').length).toBeGreaterThanOrEqual(2), { timeout: 5000 })
-    expect(screen.getByText('帮你干活')).toBeTruthy()
+    // 选中后 chip 列表隐藏（helper 无案例提示词，底部整块不渲染），名称仅出现在选中态视图
+    await waitFor(() => expect(screen.getByText('帮你干活')).toBeTruthy(), { timeout: 5000 })
+    expect(screen.getByText('帮助助手')).toBeTruthy()
     expect(screen.getByLabelText('消息输入框').getAttribute('placeholder')).toMatch(/^帮助助手, /)
     fireEvent.change(screen.getByLabelText('消息输入框'), { target: { value: '帮我' } })
     fireEvent.click(screen.getByRole('button', { name: '发送' }))
@@ -192,5 +201,25 @@ describe('NewConversationPage', () => {
       assistantName: 'helper',
       enabledSkills: [],
     })
+  })
+
+  test('selecting an agent with prompts prefills input and renders clickable examples', async () => {
+    render(
+      <MemoryRouter initialEntries={['/guid']}>
+        <NewConversationPage />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('assistant-chip-guide')).toBeTruthy(), { timeout: 5000 })
+    fireEvent.click(screen.getByTestId('assistant-chip-guide'))
+
+    // 行为A：defaultInitPrompt 预填输入框
+    const box = (await waitFor(() => screen.getByLabelText('消息输入框'), { timeout: 5000 })) as HTMLTextAreaElement
+    await waitFor(() => expect(box.value).toBe('请帮我从零开始'), { timeout: 5000 })
+
+    // 行为A：promptsI18n['zh-CN'] 案例可点击，点击写入输入框
+    expect(screen.getByTestId('agent-example-prompts')).toBeTruthy()
+    fireEvent.click(screen.getByText('案例二：整理表格'))
+    expect(box.value).toBe('案例二：整理表格')
   })
 })

--- a/apps/webui/tests/unit/client/conversations.test.tsx
+++ b/apps/webui/tests/unit/client/conversations.test.tsx
@@ -76,6 +76,36 @@ describe('reduceStreamEvent（上游事件聚合）', () => {
     state = reduceStreamEvent(state, { kind: 'error', code: 'CONVERSATION_BUSY' })
     expect(state.lastError).toBe('CONVERSATION_BUSY')
   })
+
+  test('error with pending model switch + whitelist code sets modelSwitchError, clears pending', () => {
+    const pending: ConversationStreamState = { ...initialStreamState, modelSwitchPending: 'gpt-4' }
+    const next = reduceStreamEvent(pending, { kind: 'error', code: 'CONVERSATION_BUSY' })
+    expect(next.modelSwitchError).toBe('CONVERSATION_BUSY')
+    expect(next.modelSwitchPending).toBeNull()
+  })
+
+  test('error without pending switch does not set modelSwitchError', () => {
+    const next = reduceStreamEvent(initialStreamState, { kind: 'error', code: 'CONVERSATION_BUSY' })
+    expect(next.modelSwitchError).toBeNull()
+    expect(next.lastError).toBe('CONVERSATION_BUSY')
+  })
+
+  test('model_changed confirms pending switch: clears pending/error, updates currentModel, drops hydrated', () => {
+    const pending: ConversationStreamState = {
+      ...initialStreamState,
+      modelSwitchPending: 'gpt-4',
+      modelSwitchError: 'X',
+      hydratedModel: 'seed',
+    }
+    const next = reduceStreamEvent(pending, {
+      kind: 'upstream',
+      event: { type: 'system', subtype: 'model_changed', model: 'proxy/gpt-4' },
+    })
+    expect(next.currentModel).toBe('proxy/gpt-4')
+    expect(next.modelSwitchPending).toBeNull()
+    expect(next.modelSwitchError).toBeNull()
+    expect(next.hydratedModel).toBeNull()
+  })
 })
 
 describe('useConversationSocket 切换会话重置（防消息泄漏）', () => {
@@ -105,6 +135,26 @@ describe('useConversationSocket 切换会话重置（防消息泄漏）', () => 
       expect(result.current.state.messages).toHaveLength(0)
       expect(result.current.state.lockState).toBeNull()
       expect(result.current.state.isWriter).toBe(false)
+    } finally {
+      globalThis.WebSocket = original
+    }
+  })
+
+  test('hydrateModel seeds hydratedModel; setModel while socket not open reports UPSTREAM_NOT_CONNECTED', () => {
+    const original = globalThis.WebSocket
+    globalThis.WebSocket = StubWebSocket as unknown as typeof WebSocket
+    try {
+      const { result } = renderHook(({ id }: { id: string }) => useConversationSocket(id), {
+        initialProps: { id: 'conv-a' },
+      })
+
+      act(() => result.current.hydrateModel('gpt-4'))
+      expect(result.current.state.hydratedModel).toBe('gpt-4')
+
+      // StubWebSocket.readyState=0（非 OPEN）→ setModel 立即置错，不进入 pending
+      act(() => result.current.setModel('gpt-5'))
+      expect(result.current.state.modelSwitchError).toBe('UPSTREAM_NOT_CONNECTED')
+      expect(result.current.state.modelSwitchPending).toBeNull()
     } finally {
       globalThis.WebSocket = original
     }

--- a/apps/webui/tests/unit/client/conversations.test.tsx
+++ b/apps/webui/tests/unit/client/conversations.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, test, vi } from 'vitest'
 import {
   initialStreamState,
   reduceStreamEvent,
+  useConversationSocket,
   type ConversationStreamState,
 } from '@client/features/conversations/useConversationSocket'
 import { SendBox } from '@client/features/conversations/SendBox'
@@ -74,6 +75,39 @@ describe('reduceStreamEvent（上游事件聚合）', () => {
     expect(state.isWriter).toBe(true)
     state = reduceStreamEvent(state, { kind: 'error', code: 'CONVERSATION_BUSY' })
     expect(state.lastError).toBe('CONVERSATION_BUSY')
+  })
+})
+
+describe('useConversationSocket 切换会话重置（防消息泄漏）', () => {
+  // 极简 WebSocket 桩：hook 的连接 effect 需要构造 WebSocket，但本用例只验证切换重置、不依赖 WS 消息
+  class StubWebSocket {
+    onopen: (() => void) | null = null
+    onclose: (() => void) | null = null
+    onerror: (() => void) | null = null
+    onmessage: ((ev: { data: string }) => void) | null = null
+    readyState = 0
+    send(): void {}
+    close(): void {}
+  }
+
+  test('切换 conversationId 后，上一会话的本地消息与控制态不残留', () => {
+    const original = globalThis.WebSocket
+    globalThis.WebSocket = StubWebSocket as unknown as typeof WebSocket
+    try {
+      const { result, rerender } = renderHook(({ id }: { id: string }) => useConversationSocket(id), {
+        initialProps: { id: 'conv-a' },
+      })
+
+      act(() => result.current.appendLocalUser('会话A的本地消息'))
+      expect(result.current.state.messages).toHaveLength(1)
+
+      rerender({ id: 'conv-b' })
+      expect(result.current.state.messages).toHaveLength(0)
+      expect(result.current.state.lockState).toBeNull()
+      expect(result.current.state.isWriter).toBe(false)
+    } finally {
+      globalThis.WebSocket = original
+    }
   })
 })
 

--- a/apps/webui/tests/unit/server/customMossUrl.test.ts
+++ b/apps/webui/tests/unit/server/customMossUrl.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { deriveWsBaseUrl } from '@sudowork/moss-client'
+import type { AppConfig } from '@server/config'
+import { resolveLoginMoss } from '@server/features/auth/authService'
+
+const config = { moss: { baseUrl: 'https://moss.default.com' } } as AppConfig
+
+describe('resolveLoginMoss（登录期 moss 地址归一化）', () => {
+  test('无自定义地址 → 配置默认，身份地址为 null', () => {
+    expect(resolveLoginMoss(config)).toEqual({ baseUrl: 'https://moss.default.com', identityBaseUrl: null })
+  })
+
+  test('自定义地址与配置同 origin → 视为未自定义，身份地址为 null', () => {
+    expect(resolveLoginMoss(config, 'https://moss.default.com/')).toEqual({
+      baseUrl: 'https://moss.default.com',
+      identityBaseUrl: null,
+    })
+  })
+
+  test('自定义地址异 origin → 归一为 origin，身份地址非 null', () => {
+    expect(resolveLoginMoss(config, 'https://custom.moss.com:8443/x')).toEqual({
+      baseUrl: 'https://custom.moss.com:8443',
+      identityBaseUrl: 'https://custom.moss.com:8443',
+    })
+  })
+})
+
+describe('deriveWsBaseUrl（http→ws / https→wss）', () => {
+  test('http 推导 ws', () => {
+    expect(deriveWsBaseUrl('http://moss.test:1/')).toBe('ws://moss.test:1/')
+  })
+  test('https 推导 wss', () => {
+    expect(deriveWsBaseUrl('https://moss.test')).toBe('wss://moss.test')
+  })
+})

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -34,14 +34,19 @@ export const MossMeSchema = z.object({
 })
 export type MossMe = z.infer<typeof MossMeSchema>
 
+/** 自定义 Moss 服务器地址（可选）：仅 http(s) 完整 URL，登录时该会话所有 moss 调用走此地址 */
+const MossBaseUrlSchema = z.string().trim().url().regex(/^https?:\/\//i).max(2048).optional()
+
 export const LoginPasswordRequestSchema = z.object({
   username: z.string().trim().min(1).max(255),
   password: z.string().min(1).max(1024),
+  mossBaseUrl: MossBaseUrlSchema,
 })
 export type LoginPasswordRequest = z.infer<typeof LoginPasswordRequestSchema>
 
 export const LoginApiKeyRequestSchema = z.object({
   apiKey: z.string().trim().min(1).max(512),
+  mossBaseUrl: MossBaseUrlSchema,
 })
 export type LoginApiKeyRequest = z.infer<typeof LoginApiKeyRequestSchema>
 

--- a/packages/contracts/src/conversations.ts
+++ b/packages/contracts/src/conversations.ts
@@ -89,6 +89,8 @@ export const CreateConversationRequestSchema = z.object({
   /** 空串 = 不指定智能体，由 Moss 走默认（部署版实测空 assistant_name 创建 200） */
   assistantName: z.string().trim().max(255),
   enabledSkills: z.array(z.string().min(1).max(255)).max(50).default([]),
+  /** 建会话时所选模型（可选）；服务端校验可用后 setUserModel + 本地持久化 */
+  modelId: z.string().trim().min(1).max(255).optional(),
 })
 export type CreateConversationRequest = z.infer<typeof CreateConversationRequestSchema>
 
@@ -125,6 +127,8 @@ export const ConversationContextDtoSchema = z.object({
   customTitle: z.string().nullable(),
   /** webui 本地标题（conversation_meta.title，与列表接口同源；Moss 上游无标题概念） */
   title: z.string().nullable(),
+  /** webui 本地记录的会话模型（conversation_meta.model_id；未指定过为 null），用于重开回读显示 */
+  modelId: z.string().nullable(),
   messages: z.array(z.record(z.string(), z.unknown())),
 })
 export type ConversationContextDto = z.infer<typeof ConversationContextDtoSchema>

--- a/packages/moss-client/src/MossAgentClient.ts
+++ b/packages/moss-client/src/MossAgentClient.ts
@@ -1,75 +1,110 @@
-import { type MossFetch } from './MossHttpClient.js'
+import { type MossCallContext, type MossFetch } from './MossHttpClient.js'
 
 /**
  * Moss Agent 端口（计划 3.9 修订版映射）：
  * Hub 前缀为 /api/v1/agent-hub/*；installed 无独立 enabled 接口；
  * rules 是 /api/v1/agents/installed/:name/rules（admin:settings）。
- * 所有方法由调用方传入该 Web Session 自己的 access token。
+ * 每次调用传入 MossCallContext（access token + 会话生效的 moss 地址）。
  */
 
 export interface MossAgentPort {
-  hubCategories(accessToken: string): Promise<unknown>
-  hubList(accessToken: string, searchParams: Record<string, string>): Promise<unknown>
-  hubDetail(accessToken: string, id: string): Promise<unknown>
-  installed(accessToken: string): Promise<unknown>
-  install(accessToken: string, body: unknown): Promise<unknown>
-  create(accessToken: string, body: unknown): Promise<unknown>
-  uploadCustom(accessToken: string, body: { file: string }): Promise<unknown>
-  updateMeta(accessToken: string, body: unknown): Promise<unknown>
-  uninstall(accessToken: string, body: unknown): Promise<unknown>
-  syncFromHub(accessToken: string): Promise<unknown>
-  syncStatus(accessToken: string): Promise<unknown>
-  installedRules(accessToken: string, assistantName: string): Promise<unknown>
-  tenantList(accessToken: string): Promise<unknown>
-  tenantCreate(accessToken: string, body: unknown): Promise<unknown>
-  tenantUpdate(accessToken: string, id: string, body: unknown): Promise<unknown>
-  tenantDelete(accessToken: string, id: string): Promise<unknown>
-  tenantDownload(accessToken: string, id: string): Promise<unknown>
-  tenantPublish(accessToken: string, body: unknown): Promise<unknown>
+  hubCategories(ctx: MossCallContext): Promise<unknown>
+  hubList(ctx: MossCallContext, searchParams: Record<string, string>): Promise<unknown>
+  hubDetail(ctx: MossCallContext, id: string): Promise<unknown>
+  installed(ctx: MossCallContext): Promise<unknown>
+  install(ctx: MossCallContext, body: unknown): Promise<unknown>
+  create(ctx: MossCallContext, body: unknown): Promise<unknown>
+  uploadCustom(ctx: MossCallContext, body: { file: string }): Promise<unknown>
+  updateMeta(ctx: MossCallContext, body: unknown): Promise<unknown>
+  uninstall(ctx: MossCallContext, body: unknown): Promise<unknown>
+  syncFromHub(ctx: MossCallContext): Promise<unknown>
+  syncStatus(ctx: MossCallContext): Promise<unknown>
+  installedRules(ctx: MossCallContext, assistantName: string): Promise<unknown>
+  tenantList(ctx: MossCallContext): Promise<unknown>
+  tenantCreate(ctx: MossCallContext, body: unknown): Promise<unknown>
+  tenantUpdate(ctx: MossCallContext, id: string, body: unknown): Promise<unknown>
+  tenantDelete(ctx: MossCallContext, id: string): Promise<unknown>
+  tenantDownload(ctx: MossCallContext, id: string): Promise<unknown>
+  tenantPublish(ctx: MossCallContext, body: unknown): Promise<unknown>
 }
 
 function seg(value: string): string {
   return encodeURIComponent(value)
 }
 
-export function createMossAgentPort(mossFetch: MossFetch, baseUrl: string): MossAgentPort {
+export function createMossAgentPort(mossFetch: MossFetch): MossAgentPort {
   return {
-    hubCategories: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/agent-hub/categories', accessToken: tk }),
-    hubList: (tk, searchParams) =>
-      mossFetch(baseUrl, { method: 'GET', path: '/api/v1/agent-hub/assistants/cursor', accessToken: tk, searchParams }),
-    hubDetail: (tk, id) =>
-      mossFetch(baseUrl, { method: 'GET', path: `/api/v1/agent-hub/assistants/${seg(id)}`, accessToken: tk }),
-    installed: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/agents/installed', accessToken: tk }),
-    install: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/agents/install', accessToken: tk, body }),
-    create: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/agents/create', accessToken: tk, body }),
-    uploadCustom: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/agents/custom', accessToken: tk, body }),
-    updateMeta: (tk, body) =>
-      mossFetch(baseUrl, { method: 'PATCH', path: '/api/v1/agents/meta', accessToken: tk, body }),
-    uninstall: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/agents/uninstall', accessToken: tk, body }),
-    syncFromHub: (tk) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/agents/sync-from-hub', accessToken: tk }),
-    syncStatus: (tk) =>
-      mossFetch(baseUrl, { method: 'GET', path: '/api/v1/agents/sync-status', accessToken: tk }),
-    installedRules: (tk, assistantName) =>
-      mossFetch(baseUrl, {
+    hubCategories: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/agent-hub/categories', accessToken: ctx.accessToken }),
+    hubList: (ctx, searchParams) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'GET',
+        path: '/api/v1/agent-hub/assistants/cursor',
+        accessToken: ctx.accessToken,
+        searchParams,
+      }),
+    hubDetail: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'GET',
+        path: `/api/v1/agent-hub/assistants/${seg(id)}`,
+        accessToken: ctx.accessToken,
+      }),
+    installed: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/agents/installed', accessToken: ctx.accessToken }),
+    install: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/agents/install', accessToken: ctx.accessToken, body }),
+    create: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/agents/create', accessToken: ctx.accessToken, body }),
+    uploadCustom: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/agents/custom', accessToken: ctx.accessToken, body }),
+    updateMeta: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'PATCH', path: '/api/v1/agents/meta', accessToken: ctx.accessToken, body }),
+    uninstall: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/agents/uninstall', accessToken: ctx.accessToken, body }),
+    syncFromHub: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/agents/sync-from-hub', accessToken: ctx.accessToken }),
+    syncStatus: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/agents/sync-status', accessToken: ctx.accessToken }),
+    installedRules: (ctx, assistantName) =>
+      mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/agents/installed/${seg(assistantName)}/rules`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
       }),
-    tenantList: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/agents/tenant', accessToken: tk }),
-    tenantCreate: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/agents/tenant/create', accessToken: tk, body }),
-    tenantUpdate: (tk, id, body) =>
-      mossFetch(baseUrl, { method: 'PATCH', path: `/api/v1/agents/tenant/${seg(id)}`, accessToken: tk, body }),
-    tenantDelete: (tk, id) =>
-      mossFetch(baseUrl, { method: 'DELETE', path: `/api/v1/agents/tenant/${seg(id)}`, accessToken: tk }),
-    tenantDownload: (tk, id) =>
-      mossFetch(baseUrl, { method: 'GET', path: `/api/v1/agents/tenant/${seg(id)}/download`, accessToken: tk }),
-    tenantPublish: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/agents/tenant/publish', accessToken: tk, body }),
+    tenantList: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/agents/tenant', accessToken: ctx.accessToken }),
+    tenantCreate: (ctx, body) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'POST',
+        path: '/api/v1/agents/tenant/create',
+        accessToken: ctx.accessToken,
+        body,
+      }),
+    tenantUpdate: (ctx, id, body) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'PATCH',
+        path: `/api/v1/agents/tenant/${seg(id)}`,
+        accessToken: ctx.accessToken,
+        body,
+      }),
+    tenantDelete: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'DELETE',
+        path: `/api/v1/agents/tenant/${seg(id)}`,
+        accessToken: ctx.accessToken,
+      }),
+    tenantDownload: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'GET',
+        path: `/api/v1/agents/tenant/${seg(id)}/download`,
+        accessToken: ctx.accessToken,
+      }),
+    tenantPublish: (ctx, body) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'POST',
+        path: '/api/v1/agents/tenant/publish',
+        accessToken: ctx.accessToken,
+        body,
+      }),
   }
 }

--- a/packages/moss-client/src/MossAuthClient.ts
+++ b/packages/moss-client/src/MossAuthClient.ts
@@ -12,18 +12,19 @@ import { type MossFetch } from './MossHttpClient.js'
  * - POST /api/v1/auth/token（grant_type=refresh_token）
  * - GET  /api/v1/auth/me
  * 端口接口化，便于契约测试与集成测试注入桩实现。
+ * 每个方法尾部传入 baseUrl（登录期无 session，地址由 resolveLoginMoss 决定；登录后取 session 地址）。
  */
 
 export interface MossAuthPort {
-  loginWithPassword(input: { username: string; password: string }): Promise<MossTokenSet>
-  loginWithApiKey(apiKey: string): Promise<MossTokenSet>
-  refresh(refreshToken: string): Promise<MossTokenSet>
-  me(accessToken: string): Promise<MossMe>
+  loginWithPassword(input: { username: string; password: string }, baseUrl: string): Promise<MossTokenSet>
+  loginWithApiKey(apiKey: string, baseUrl: string): Promise<MossTokenSet>
+  refresh(refreshToken: string, baseUrl: string): Promise<MossTokenSet>
+  me(accessToken: string, baseUrl: string): Promise<MossMe>
 }
 
-export function createMossAuthPort(mossFetch: MossFetch, baseUrl: string): MossAuthPort {
+export function createMossAuthPort(mossFetch: MossFetch): MossAuthPort {
   return {
-    async loginWithPassword(input) {
+    async loginWithPassword(input, baseUrl) {
       const json = await mossFetch(baseUrl, {
         method: 'POST',
         path: '/api/v1/auth/login',
@@ -31,7 +32,7 @@ export function createMossAuthPort(mossFetch: MossFetch, baseUrl: string): MossA
       })
       return MossTokenSetSchema.parse(json)
     },
-    async loginWithApiKey(apiKey) {
+    async loginWithApiKey(apiKey, baseUrl) {
       const json = await mossFetch(baseUrl, {
         method: 'POST',
         path: '/api/v1/auth/login',
@@ -39,7 +40,7 @@ export function createMossAuthPort(mossFetch: MossFetch, baseUrl: string): MossA
       })
       return MossTokenSetSchema.parse(json)
     },
-    async refresh(refreshToken) {
+    async refresh(refreshToken, baseUrl) {
       const json = await mossFetch(baseUrl, {
         method: 'POST',
         path: '/api/v1/auth/token',
@@ -47,7 +48,7 @@ export function createMossAuthPort(mossFetch: MossFetch, baseUrl: string): MossA
       })
       return MossTokenSetSchema.parse(json)
     },
-    async me(accessToken) {
+    async me(accessToken, baseUrl) {
       const json = await mossFetch(baseUrl, {
         method: 'GET',
         path: '/api/v1/auth/me',

--- a/packages/moss-client/src/MossCronClient.ts
+++ b/packages/moss-client/src/MossCronClient.ts
@@ -1,56 +1,57 @@
-import { type MossFetch } from './MossHttpClient.js'
+import { type MossCallContext, type MossFetch } from './MossHttpClient.js'
 
 /**
  * Moss Cron 端口（计划 3.9 修订版）：
  * - 普通列表 GET /api/v1/cron/jobs；admin:cron/cron:list:any → GET /api/v1/admin/cron/jobs
  * - schedule DTO：{kind:'at'|'every'|'cron', value, tz?, description?}（无 expr 字段）
  * - 引用仅 assistantId/assistantName（基线无 skill 字段）
+ * 每次调用传入 MossCallContext（access token + 会话生效的 moss 地址）。
  */
 
 export interface MossCronPort {
-  list(accessToken: string): Promise<unknown>
-  adminList(accessToken: string): Promise<unknown>
-  get(accessToken: string, id: string): Promise<unknown>
-  create(accessToken: string, body: unknown): Promise<unknown>
-  update(accessToken: string, id: string, body: unknown): Promise<unknown>
-  remove(accessToken: string, id: string): Promise<unknown>
-  trigger(accessToken: string, id: string): Promise<unknown>
-  runs(accessToken: string, id: string, limit: number): Promise<unknown>
+  list(ctx: MossCallContext): Promise<unknown>
+  adminList(ctx: MossCallContext): Promise<unknown>
+  get(ctx: MossCallContext, id: string): Promise<unknown>
+  create(ctx: MossCallContext, body: unknown): Promise<unknown>
+  update(ctx: MossCallContext, id: string, body: unknown): Promise<unknown>
+  remove(ctx: MossCallContext, id: string): Promise<unknown>
+  trigger(ctx: MossCallContext, id: string): Promise<unknown>
+  runs(ctx: MossCallContext, id: string, limit: number): Promise<unknown>
 }
 
 function seg(value: string): string {
   return encodeURIComponent(value)
 }
 
-export function createMossCronPort(mossFetch: MossFetch, baseUrl: string): MossCronPort {
+export function createMossCronPort(mossFetch: MossFetch): MossCronPort {
   return {
-    list: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/cron/jobs', accessToken: tk }),
-    adminList: (tk) =>
-      mossFetch(baseUrl, { method: 'GET', path: '/api/v1/admin/cron/jobs', accessToken: tk }),
-    get: (tk, id) =>
-      mossFetch(baseUrl, { method: 'GET', path: `/api/v1/cron/jobs/${seg(id)}`, accessToken: tk }),
-    create: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/cron/jobs', accessToken: tk, body }),
-    update: (tk, id, body) =>
-      mossFetch(baseUrl, {
+    list: (ctx) => mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/cron/jobs', accessToken: ctx.accessToken }),
+    adminList: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/admin/cron/jobs', accessToken: ctx.accessToken }),
+    get: (ctx, id) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: `/api/v1/cron/jobs/${seg(id)}`, accessToken: ctx.accessToken }),
+    create: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/cron/jobs', accessToken: ctx.accessToken, body }),
+    update: (ctx, id, body) =>
+      mossFetch(ctx.baseUrl, {
         method: 'PATCH',
         path: `/api/v1/cron/jobs/${seg(id)}`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
         body,
       }),
-    remove: (tk, id) =>
-      mossFetch(baseUrl, { method: 'DELETE', path: `/api/v1/cron/jobs/${seg(id)}`, accessToken: tk }),
-    trigger: (tk, id) =>
-      mossFetch(baseUrl, {
+    remove: (ctx, id) =>
+      mossFetch(ctx.baseUrl, { method: 'DELETE', path: `/api/v1/cron/jobs/${seg(id)}`, accessToken: ctx.accessToken }),
+    trigger: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
         method: 'POST',
         path: `/api/v1/cron/jobs/${seg(id)}/trigger`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
       }),
-    runs: (tk, id, limit) =>
-      mossFetch(baseUrl, {
+    runs: (ctx, id, limit) =>
+      mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/cron/jobs/${seg(id)}/runs`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
         searchParams: { limit: String(limit) },
       }),
   }

--- a/packages/moss-client/src/MossHttpClient.ts
+++ b/packages/moss-client/src/MossHttpClient.ts
@@ -87,3 +87,35 @@ export async function mossRequest(
     clearTimeout(timer)
   }
 }
+
+export interface MossAsset {
+  buffer: ArrayBuffer
+  contentType: string | null
+}
+
+/**
+ * 拉取 moss 静态二进制资源（如 tenant 头像）。与 mossRequest 不同：不解析 JSON、返回原始字节 +
+ * Content-Type，供 webui 同源代理转发。非 2xx 抛 MossHttpError（不读 body），不可达抛 MossNetworkError。
+ */
+export async function mossFetchAsset(
+  baseUrl: string,
+  path: string,
+  timeoutMs = DEFAULT_MOSS_TIMEOUT_MS,
+): Promise<MossAsset> {
+  const url = new URL(path, baseUrl)
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { method: 'GET', signal: controller.signal })
+    if (!res.ok) {
+      throw new MossHttpError(res.status, '', path)
+    }
+    const buffer = await res.arrayBuffer()
+    return { buffer, contentType: res.headers.get('content-type') }
+  } catch (err) {
+    if (err instanceof MossHttpError) throw err
+    throw new MossNetworkError(path, err)
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/moss-client/src/MossHttpClient.ts
+++ b/packages/moss-client/src/MossHttpClient.ts
@@ -38,6 +38,15 @@ export interface MossRequest {
 
 export type MossFetch = (baseUrl: string, req: MossRequest, timeoutMs?: number) => Promise<unknown>
 
+/**
+ * 每次 moss 调用的上下文：access token + 该会话生效的 moss 地址。
+ * 支持登录页自定义 Moss 地址——地址随 token 逐调用同链路传递，而非烘焙进端口构造。
+ */
+export interface MossCallContext {
+  accessToken: string
+  baseUrl: string
+}
+
 export const DEFAULT_MOSS_TIMEOUT_MS = 15_000
 
 export async function mossRequest(

--- a/packages/moss-client/src/MossMcpClient.ts
+++ b/packages/moss-client/src/MossMcpClient.ts
@@ -1,93 +1,103 @@
-import { type MossFetch } from './MossHttpClient.js'
+import { type MossCallContext, type MossFetch } from './MossHttpClient.js'
 
 /**
  * Moss MCP 端口（计划 3.9 修订版）：
  * - own personal 判定：响应无 owner 字段，用 scope === 'user'（服务端 SQL 保证本人）
  * - 列表仅含 status === 'enabled' 的服务器（pending/error 个人 MCP 不出现）
  * - template install 精确发送 config_values / auth_credentials / display_name
+ * 每次调用传入 MossCallContext（access token + 会话生效的 moss 地址）。
  */
 
 export interface MossMcpPort {
-  servers(accessToken: string): Promise<unknown>
-  templates(accessToken: string): Promise<unknown>
+  servers(ctx: MossCallContext): Promise<unknown>
+  templates(ctx: MossCallContext): Promise<unknown>
   installTemplate(
-    accessToken: string,
+    ctx: MossCallContext,
     templateId: string,
     body: { config_values?: Record<string, string>; auth_credentials?: Record<string, string>; display_name?: string },
   ): Promise<unknown>
-  installJson(accessToken: string, body: { json_config: string; name?: string }): Promise<unknown>
-  createServer(accessToken: string, body: unknown): Promise<unknown>
-  setEnabled(accessToken: string, id: string, enabled: boolean): Promise<unknown>
-  test(accessToken: string, id: string): Promise<unknown>
-  getUserConfig(accessToken: string, id: string): Promise<unknown>
-  putUserConfig(accessToken: string, id: string, body: { config_values: Record<string, string> }): Promise<unknown>
-  updateServer(accessToken: string, id: string, body: unknown): Promise<unknown>
-  deleteServer(accessToken: string, id: string): Promise<unknown>
-  policy(accessToken: string): Promise<unknown>
-  userProfile(accessToken: string): Promise<unknown>
-  tenantConfig(accessToken: string): Promise<unknown>
+  installJson(ctx: MossCallContext, body: { json_config: string; name?: string }): Promise<unknown>
+  createServer(ctx: MossCallContext, body: unknown): Promise<unknown>
+  setEnabled(ctx: MossCallContext, id: string, enabled: boolean): Promise<unknown>
+  test(ctx: MossCallContext, id: string): Promise<unknown>
+  getUserConfig(ctx: MossCallContext, id: string): Promise<unknown>
+  putUserConfig(ctx: MossCallContext, id: string, body: { config_values: Record<string, string> }): Promise<unknown>
+  updateServer(ctx: MossCallContext, id: string, body: unknown): Promise<unknown>
+  deleteServer(ctx: MossCallContext, id: string): Promise<unknown>
+  policy(ctx: MossCallContext): Promise<unknown>
+  userProfile(ctx: MossCallContext): Promise<unknown>
+  tenantConfig(ctx: MossCallContext): Promise<unknown>
 }
 
 function seg(value: string): string {
   return encodeURIComponent(value)
 }
 
-export function createMossMcpPort(mossFetch: MossFetch, baseUrl: string): MossMcpPort {
+export function createMossMcpPort(mossFetch: MossFetch): MossMcpPort {
   return {
-    servers: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/me/mcp-servers', accessToken: tk }),
-    templates: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/me/mcp-templates', accessToken: tk }),
-    installTemplate: (tk, templateId, body) =>
-      mossFetch(baseUrl, {
+    servers: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/me/mcp-servers', accessToken: ctx.accessToken }),
+    templates: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/me/mcp-templates', accessToken: ctx.accessToken }),
+    installTemplate: (ctx, templateId, body) =>
+      mossFetch(ctx.baseUrl, {
         method: 'POST',
         path: `/api/v1/me/mcp-templates/${seg(templateId)}/install`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
         body,
       }),
-    installJson: (tk, body) =>
-      mossFetch(baseUrl, {
+    installJson: (ctx, body) =>
+      mossFetch(ctx.baseUrl, {
         method: 'POST',
         path: '/api/v1/me/mcp-servers/install-json',
-        accessToken: tk,
+        accessToken: ctx.accessToken,
         body,
       }),
-    createServer: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/me/mcp-servers', accessToken: tk, body }),
-    setEnabled: (tk, id, enabled) =>
-      mossFetch(baseUrl, {
+    createServer: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/me/mcp-servers', accessToken: ctx.accessToken, body }),
+    setEnabled: (ctx, id, enabled) =>
+      mossFetch(ctx.baseUrl, {
         method: 'PUT',
         path: `/api/v1/me/mcp-servers/${seg(id)}/${enabled ? 'enable' : 'disable'}`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
       }),
-    test: (tk, id) =>
-      mossFetch(baseUrl, { method: 'POST', path: `/api/v1/me/mcp-servers/${seg(id)}/test`, accessToken: tk }),
-    getUserConfig: (tk, id) =>
-      mossFetch(baseUrl, {
+    test: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'POST',
+        path: `/api/v1/me/mcp-servers/${seg(id)}/test`,
+        accessToken: ctx.accessToken,
+      }),
+    getUserConfig: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/me/mcp-servers/${seg(id)}/user-config`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
       }),
-    putUserConfig: (tk, id, body) =>
-      mossFetch(baseUrl, {
+    putUserConfig: (ctx, id, body) =>
+      mossFetch(ctx.baseUrl, {
         method: 'PUT',
         path: `/api/v1/me/mcp-servers/${seg(id)}/user-config`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
         body,
       }),
-    updateServer: (tk, id, body) =>
-      mossFetch(baseUrl, {
+    updateServer: (ctx, id, body) =>
+      mossFetch(ctx.baseUrl, {
         method: 'PATCH',
         path: `/api/v1/me/mcp-servers/${seg(id)}`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
         body,
       }),
-    deleteServer: (tk, id) =>
-      mossFetch(baseUrl, {
+    deleteServer: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
         method: 'DELETE',
         path: `/api/v1/me/mcp-servers/${seg(id)}`,
-        accessToken: tk,
+        accessToken: ctx.accessToken,
       }),
-    policy: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/tenant/mcp-policy', accessToken: tk }),
-    userProfile: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/user/profile', accessToken: tk }),
-    tenantConfig: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/tenant/config', accessToken: tk }),
+    policy: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/tenant/mcp-policy', accessToken: ctx.accessToken }),
+    userProfile: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/user/profile', accessToken: ctx.accessToken }),
+    tenantConfig: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/tenant/config', accessToken: ctx.accessToken }),
   }
 }

--- a/packages/moss-client/src/MossSessionClient.ts
+++ b/packages/moss-client/src/MossSessionClient.ts
@@ -24,6 +24,8 @@ export interface MossSessionPort {
     accessToken: string,
     input: { assistantName: string; enabledSkills: string[] },
   ): Promise<{ sessionId: string; wsUrl: string }>
+  /** 用户级模型偏好（Moss 无会话级模型接口，PUT /api/v1/users/me/model）；建会话前设置使新会话采用该模型 */
+  setUserModel(accessToken: string, modelId: string): Promise<void>
   context(accessToken: string, sessionId: string): Promise<unknown>
   resume(accessToken: string, sessionId: string): Promise<{ session: MossSessionSummary; wsUrl: string }>
   terminate(accessToken: string, sessionId: string): Promise<void>
@@ -74,6 +76,16 @@ export function createMossSessionPort(mossFetch: MossFetch, baseUrl: string): Mo
       })
       const parsed = MossCreateSessionResponseSchema.parse(json)
       return { sessionId: parsed.session_id, wsUrl: parsed.ws_url }
+    },
+
+    async setUserModel(accessToken, modelId) {
+      // body 键名与桌面端 MossSessionApi.setUserModelPreference 一致（camelCase modelId）
+      await mossFetch(baseUrl, {
+        method: 'PUT',
+        path: '/api/v1/users/me/model',
+        accessToken,
+        body: { modelId },
+      })
     },
 
     async context(accessToken, sessionId) {

--- a/packages/moss-client/src/MossSessionClient.ts
+++ b/packages/moss-client/src/MossSessionClient.ts
@@ -8,32 +8,32 @@ import {
   MossWorkspaceNodeSchema,
   type MossSessionSummary,
 } from '@sudowork/contracts/conversations'
-import { type MossFetch } from './MossHttpClient.js'
+import { type MossCallContext, type MossFetch } from './MossHttpClient.js'
 
 /**
  * Moss Session REST 端口（计划 Task 5）：
  * list/create/get/context/resume/terminate + workspace tree/file。
  * 不实现 PATCH/DELETE（基线不存在，计划 1.3）。
+ * 每次调用传入 MossCallContext（access token + 会话生效的 moss 地址），支持登录页自定义地址。
  */
 
 export interface MossSessionPort {
-  /** 计划 3.2：每次请求由调用方传入该 Web Session 自己的 access token。 */
-  list(accessToken: string): Promise<MossSessionSummary[]>
-  get(accessToken: string, sessionId: string): Promise<MossSessionSummary | null>
+  list(ctx: MossCallContext): Promise<MossSessionSummary[]>
+  get(ctx: MossCallContext, sessionId: string): Promise<MossSessionSummary | null>
   create(
-    accessToken: string,
+    ctx: MossCallContext,
     input: { assistantName: string; enabledSkills: string[] },
   ): Promise<{ sessionId: string; wsUrl: string }>
   /** 用户级模型偏好（Moss 无会话级模型接口，PUT /api/v1/users/me/model）；建会话前设置使新会话采用该模型 */
-  setUserModel(accessToken: string, modelId: string): Promise<void>
-  context(accessToken: string, sessionId: string): Promise<unknown>
-  resume(accessToken: string, sessionId: string): Promise<{ session: MossSessionSummary; wsUrl: string }>
-  terminate(accessToken: string, sessionId: string): Promise<void>
-  workspaceTree(accessToken: string, sessionId: string, path: string, search?: string): Promise<unknown>
-  workspaceFileGet(accessToken: string, sessionId: string, path: string): Promise<unknown>
-  workspaceFilePost(accessToken: string, sessionId: string, path: string, contentBase64: string): Promise<unknown>
+  setUserModel(ctx: MossCallContext, modelId: string): Promise<void>
+  context(ctx: MossCallContext, sessionId: string): Promise<unknown>
+  resume(ctx: MossCallContext, sessionId: string): Promise<{ session: MossSessionSummary; wsUrl: string }>
+  terminate(ctx: MossCallContext, sessionId: string): Promise<void>
+  workspaceTree(ctx: MossCallContext, sessionId: string, path: string, search?: string): Promise<unknown>
+  workspaceFileGet(ctx: MossCallContext, sessionId: string, path: string): Promise<unknown>
+  workspaceFilePost(ctx: MossCallContext, sessionId: string, path: string, contentBase64: string): Promise<unknown>
   /** 会话级可用技能（部署版实测 GET /api/v1/sessions/:id/skills/available 200） */
-  sessionSkillsAvailable(accessToken: string, sessionId: string): Promise<unknown>
+  sessionSkillsAvailable(ctx: MossCallContext, sessionId: string): Promise<unknown>
 }
 
 function encodeSegment(value: string): string {
@@ -45,30 +45,30 @@ function safeParse<T extends z.ZodTypeAny>(schema: T, json: unknown): z.infer<T>
   return parsed.success ? parsed.data : null
 }
 
-export function createMossSessionPort(mossFetch: MossFetch, baseUrl: string): MossSessionPort {
+export function createMossSessionPort(mossFetch: MossFetch): MossSessionPort {
   return {
-    async list(accessToken) {
-      const json = await mossFetch(baseUrl, { method: 'GET', path: '/api/v1/sessions', accessToken })
+    async list(ctx) {
+      const json = await mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/sessions', accessToken: ctx.accessToken })
       const parsed = MossSessionListResponseSchema.parse(json)
       return parsed.sessions
     },
 
-    async get(accessToken, sessionId) {
-      const json = await mossFetch(baseUrl, {
+    async get(ctx, sessionId) {
+      const json = await mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}`,
-        accessToken,
+        accessToken: ctx.accessToken,
       })
       // 上游单会话响应为 { session: <summary>, ... } 包装
       const wrapped = safeParse(z.object({ session: MossSessionSummarySchema }), json)
       return wrapped?.session ?? null
     },
 
-    async create(accessToken, input) {
-      const json = await mossFetch(baseUrl, {
+    async create(ctx, input) {
+      const json = await mossFetch(ctx.baseUrl, {
         method: 'POST',
         path: '/api/v1/sessions',
-        accessToken,
+        accessToken: ctx.accessToken,
         body: {
           assistant_name: input.assistantName,
           enabled_skills: input.enabledSkills,
@@ -78,80 +78,80 @@ export function createMossSessionPort(mossFetch: MossFetch, baseUrl: string): Mo
       return { sessionId: parsed.session_id, wsUrl: parsed.ws_url }
     },
 
-    async setUserModel(accessToken, modelId) {
+    async setUserModel(ctx, modelId) {
       // body 键名与桌面端 MossSessionApi.setUserModelPreference 一致（camelCase modelId）
-      await mossFetch(baseUrl, {
+      await mossFetch(ctx.baseUrl, {
         method: 'PUT',
         path: '/api/v1/users/me/model',
-        accessToken,
+        accessToken: ctx.accessToken,
         body: { modelId },
       })
     },
 
-    async context(accessToken, sessionId) {
-      const json = await mossFetch(baseUrl, {
+    async context(ctx, sessionId) {
+      const json = await mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}/context`,
-        accessToken,
+        accessToken: ctx.accessToken,
       })
       return MossContextResponseSchema.parse(json)
     },
 
-    async resume(accessToken, sessionId) {
-      const json = await mossFetch(baseUrl, {
+    async resume(ctx, sessionId) {
+      const json = await mossFetch(ctx.baseUrl, {
         method: 'POST',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}/resume`,
-        accessToken,
+        accessToken: ctx.accessToken,
       })
       const parsed = MossResumeResponseSchema.parse(json)
       return { session: parsed.session, wsUrl: parsed.ws_url }
     },
 
-    async terminate(accessToken, sessionId) {
-      await mossFetch(baseUrl, {
+    async terminate(ctx, sessionId) {
+      await mossFetch(ctx.baseUrl, {
         method: 'POST',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}/terminate`,
-        accessToken,
+        accessToken: ctx.accessToken,
       })
     },
 
-    async workspaceTree(accessToken, sessionId, path, search = '') {
+    async workspaceTree(ctx, sessionId, path, search = '') {
       const searchParams: Record<string, string> = {}
       if (path) searchParams.path = path
       if (search) searchParams.search = search
-      const json = await mossFetch(baseUrl, {
+      const json = await mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}/workspace/tree`,
-        accessToken,
+        accessToken: ctx.accessToken,
         searchParams,
       })
       const treeSchema = z.object({ root: MossWorkspaceNodeSchema })
       return safeParse(treeSchema, json)?.root ?? null
     },
 
-    async workspaceFileGet(accessToken, sessionId, path) {
-      return mossFetch(baseUrl, {
+    async workspaceFileGet(ctx, sessionId, path) {
+      return mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}/workspace/file`,
-        accessToken,
+        accessToken: ctx.accessToken,
         searchParams: { path },
       })
     },
 
-    async workspaceFilePost(accessToken, sessionId, path, contentBase64) {
-      return mossFetch(baseUrl, {
+    async workspaceFilePost(ctx, sessionId, path, contentBase64) {
+      return mossFetch(ctx.baseUrl, {
         method: 'POST',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}/workspace/file`,
-        accessToken,
+        accessToken: ctx.accessToken,
         body: { path, content_base64: contentBase64 },
       })
     },
 
-    async sessionSkillsAvailable(accessToken, sessionId) {
-      return mossFetch(baseUrl, {
+    async sessionSkillsAvailable(ctx, sessionId) {
+      return mossFetch(ctx.baseUrl, {
         method: 'GET',
         path: `/api/v1/sessions/${encodeSegment(sessionId)}/skills/available`,
-        accessToken,
+        accessToken: ctx.accessToken,
       })
     },
   }

--- a/packages/moss-client/src/MossSkillClient.ts
+++ b/packages/moss-client/src/MossSkillClient.ts
@@ -1,63 +1,99 @@
-import { type MossFetch } from './MossHttpClient.js'
+import { type MossCallContext, type MossFetch } from './MossHttpClient.js'
 
 /**
  * Moss Skill 端口（计划 3.9 修订版映射）：
  * Hub 前缀为 /api/v1/skill-hub/*；enabled 请求体是单个 {skillName, enabled, sourcePath?}。
+ * 每次调用传入 MossCallContext（access token + 会话生效的 moss 地址）。
  */
 
 export interface MossSkillPort {
-  hubCategories(accessToken: string): Promise<unknown>
-  hubList(accessToken: string, searchParams: Record<string, string>): Promise<unknown>
-  hubDetail(accessToken: string, id: string): Promise<unknown>
-  installed(accessToken: string): Promise<unknown>
-  install(accessToken: string, body: unknown): Promise<unknown>
-  setEnabled(accessToken: string, body: { skillName: string; enabled: boolean }): Promise<unknown>
-  uploadCustom(accessToken: string, body: { file: string }): Promise<unknown>
-  uninstall(accessToken: string, body: unknown): Promise<unknown>
-  syncFromHub(accessToken: string): Promise<unknown>
-  syncStatus(accessToken: string): Promise<unknown>
-  tenantList(accessToken: string): Promise<unknown>
-  tenantUpload(accessToken: string, body: unknown): Promise<unknown>
-  tenantUpdate(accessToken: string, id: string, body: unknown): Promise<unknown>
-  tenantDelete(accessToken: string, id: string): Promise<unknown>
-  tenantDownload(accessToken: string, id: string): Promise<unknown>
-  tenantPublish(accessToken: string, body: unknown): Promise<unknown>
+  hubCategories(ctx: MossCallContext): Promise<unknown>
+  hubList(ctx: MossCallContext, searchParams: Record<string, string>): Promise<unknown>
+  hubDetail(ctx: MossCallContext, id: string): Promise<unknown>
+  installed(ctx: MossCallContext): Promise<unknown>
+  install(ctx: MossCallContext, body: unknown): Promise<unknown>
+  setEnabled(ctx: MossCallContext, body: { skillName: string; enabled: boolean }): Promise<unknown>
+  uploadCustom(ctx: MossCallContext, body: { file: string }): Promise<unknown>
+  uninstall(ctx: MossCallContext, body: unknown): Promise<unknown>
+  syncFromHub(ctx: MossCallContext): Promise<unknown>
+  syncStatus(ctx: MossCallContext): Promise<unknown>
+  tenantList(ctx: MossCallContext): Promise<unknown>
+  tenantUpload(ctx: MossCallContext, body: unknown): Promise<unknown>
+  tenantUpdate(ctx: MossCallContext, id: string, body: unknown): Promise<unknown>
+  tenantDelete(ctx: MossCallContext, id: string): Promise<unknown>
+  tenantDownload(ctx: MossCallContext, id: string): Promise<unknown>
+  tenantPublish(ctx: MossCallContext, body: unknown): Promise<unknown>
 }
 
 function seg(value: string): string {
   return encodeURIComponent(value)
 }
 
-export function createMossSkillPort(mossFetch: MossFetch, baseUrl: string): MossSkillPort {
+export function createMossSkillPort(mossFetch: MossFetch): MossSkillPort {
   return {
-    hubCategories: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/skill-hub/categories', accessToken: tk }),
-    hubList: (tk, searchParams) =>
-      mossFetch(baseUrl, { method: 'GET', path: '/api/v1/skill-hub/skills/cursor', accessToken: tk, searchParams }),
-    hubDetail: (tk, id) =>
-      mossFetch(baseUrl, { method: 'GET', path: `/api/v1/skill-hub/skills/${seg(id)}`, accessToken: tk }),
-    installed: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/skills/installed', accessToken: tk }),
-    install: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/skills/install', accessToken: tk, body }),
-    setEnabled: (tk, body) =>
-      mossFetch(baseUrl, { method: 'PATCH', path: '/api/v1/skills/enabled', accessToken: tk, body }),
-    uploadCustom: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/skills/custom', accessToken: tk, body }),
-    uninstall: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/skills/uninstall', accessToken: tk, body }),
-    syncFromHub: (tk) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/skills/sync-from-hub', accessToken: tk }),
-    syncStatus: (tk) =>
-      mossFetch(baseUrl, { method: 'GET', path: '/api/v1/skills/sync-status', accessToken: tk }),
-    tenantList: (tk) => mossFetch(baseUrl, { method: 'GET', path: '/api/v1/skills/tenant', accessToken: tk }),
-    tenantUpload: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/skills/tenant/upload', accessToken: tk, body }),
-    tenantUpdate: (tk, id, body) =>
-      mossFetch(baseUrl, { method: 'PATCH', path: `/api/v1/skills/tenant/${seg(id)}`, accessToken: tk, body }),
-    tenantDelete: (tk, id) =>
-      mossFetch(baseUrl, { method: 'DELETE', path: `/api/v1/skills/tenant/${seg(id)}`, accessToken: tk }),
-    tenantDownload: (tk, id) =>
-      mossFetch(baseUrl, { method: 'GET', path: `/api/v1/skills/tenant/${seg(id)}/download`, accessToken: tk }),
-    tenantPublish: (tk, body) =>
-      mossFetch(baseUrl, { method: 'POST', path: '/api/v1/skills/tenant/publish', accessToken: tk, body }),
+    hubCategories: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/skill-hub/categories', accessToken: ctx.accessToken }),
+    hubList: (ctx, searchParams) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'GET',
+        path: '/api/v1/skill-hub/skills/cursor',
+        accessToken: ctx.accessToken,
+        searchParams,
+      }),
+    hubDetail: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'GET',
+        path: `/api/v1/skill-hub/skills/${seg(id)}`,
+        accessToken: ctx.accessToken,
+      }),
+    installed: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/skills/installed', accessToken: ctx.accessToken }),
+    install: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/skills/install', accessToken: ctx.accessToken, body }),
+    setEnabled: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'PATCH', path: '/api/v1/skills/enabled', accessToken: ctx.accessToken, body }),
+    uploadCustom: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/skills/custom', accessToken: ctx.accessToken, body }),
+    uninstall: (ctx, body) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/skills/uninstall', accessToken: ctx.accessToken, body }),
+    syncFromHub: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'POST', path: '/api/v1/skills/sync-from-hub', accessToken: ctx.accessToken }),
+    syncStatus: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/skills/sync-status', accessToken: ctx.accessToken }),
+    tenantList: (ctx) =>
+      mossFetch(ctx.baseUrl, { method: 'GET', path: '/api/v1/skills/tenant', accessToken: ctx.accessToken }),
+    tenantUpload: (ctx, body) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'POST',
+        path: '/api/v1/skills/tenant/upload',
+        accessToken: ctx.accessToken,
+        body,
+      }),
+    tenantUpdate: (ctx, id, body) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'PATCH',
+        path: `/api/v1/skills/tenant/${seg(id)}`,
+        accessToken: ctx.accessToken,
+        body,
+      }),
+    tenantDelete: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'DELETE',
+        path: `/api/v1/skills/tenant/${seg(id)}`,
+        accessToken: ctx.accessToken,
+      }),
+    tenantDownload: (ctx, id) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'GET',
+        path: `/api/v1/skills/tenant/${seg(id)}/download`,
+        accessToken: ctx.accessToken,
+      }),
+    tenantPublish: (ctx, body) =>
+      mossFetch(ctx.baseUrl, {
+        method: 'POST',
+        path: '/api/v1/skills/tenant/publish',
+        accessToken: ctx.accessToken,
+        body,
+      }),
   }
 }

--- a/packages/moss-client/src/MossWebSocket.ts
+++ b/packages/moss-client/src/MossWebSocket.ts
@@ -11,6 +11,11 @@ import WebSocket from 'ws'
 
 export class MossWsValidationError extends Error {}
 
+/** 由会话生效的 http(s) moss 地址推导同 host 的 ws 地址（http→ws、https→wss）。 */
+export function deriveWsBaseUrl(httpBaseUrl: string): string {
+  return httpBaseUrl.replace(/^http/i, 'ws')
+}
+
 export function validateMossWsUrl(
   wsUrl: string,
   expectedSessionId: string,


### PR DESCRIPTION
从独立仓库 `sudowork-webui` 迁移 4 个特性到 monorepo `apps/webui`，全部落到重构后的分层（`@sudowork/moss-client`、`@sudowork/contracts` 等），非代码复刻。

## 特性
- **fix(webui): 会话切换消息泄漏修复** — `useConversationSocket` 改用 `useLayoutEffect` 并在切换 `conversationId` 时整体重置流状态，避免上一会话消息渲染到新会话底部。
- **feat(webui): 头像代理 + 问候语预填** — 新增共享 `resolveAgentAvatar`，tenant 头像走同源 `GET /api/conversations/agent-avatar` 代理（`mossFetchAsset`）；选中 agent 时用 `defaultInitPrompt` 预填、渲染 zh-CN 案例提示词（容错读取，字段缺失时优雅空操作）。CSP 沿用现有白名单，未放开。
- **feat(webui): 会话模型持久化与切换** — migration 003 增 `model_id`；建会话校验模型 + `setUserModel` + 落库，重开回读 hydrate；会话内切模型走 idle 抢占 + 守卫回收，含 pending/error/超时反馈。
- **feat(webui): 登录页自定义 Moss 地址** — 逐调用透传 `MossCallContext`（token + 会话地址）替代端口烘焙 baseUrl；migration 004 以 `(地址, org, user)` 为身份键；登录页折叠输入（http(s) 校验 + localStorage 记忆）。桌面端不受端口重构影响。

## 验证
- server + client `tsc --noEmit` 干净（仅既有 shared-renderer/@office-ai 报错，与本 PR 无关）。
- 单测/契约测试通过（唯一失败为既有 `buildUserMessage` 顺序测试，非本 PR 改动）。
- migration 003/004 已在本地 PG 成功应用；改动文件 eslint 全绿。

## 说明
- 迁移同步更新了被端口 ctx 化 / `setUserModel` 波及的 contract、integration、unit 测试（不改则 tsc/CI 红）。
- 头像问候语（行为A）依赖 moss `/api/v1/agents/installed` 是否返回 `defaultInitPrompt`/`promptsI18n`，需在可达 moss 上实测确认真实生效。
