### PR TITLE
fix(webui): show new conversation instantly with correct title

### DIFF
--- a/apps/webui/src/client/features/conversations/NewConversationPage.tsx
+++ b/apps/webui/src/client/features/conversations/NewConversationPage.tsx
@@ -6,13 +6,13 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { Button, Dropdown, Input, Menu, Message, Popover, Tag } from '@arco-design/web-react'
 import type { RefTextAreaType } from '@arco-design/web-react/es/Input/textarea'
 import { ArrowUp, AtSign, Bot, Brain, Plus, Zap } from 'lucide-react'
 import { ApiError } from '../auth/authApi'
 import { resolveAgentAvatar } from '@client/components/agentAvatar'
-import { createConversation, getConversationOptions } from './conversationApi'
+import { createConversation, getConversationOptions, updateConversationMeta } from './conversationApi'
 import { AgentSelectedView, type SelectedAgentInfo } from './AgentSelectedView'
 import { SkillSelectorMenu } from './SkillSelectorMenu'
 import { stripAtQuery, useSkillSelector } from './useSkillSelector'
@@ -102,8 +102,16 @@ const FOCUS_RING = {
   dark: { border: '#4D4B87', shadow: '0 2px 20px rgba(77,75,135,.45)' },
 }
 
+/** 从首条用户输入派生会话标题（与服务端 generateTitleIfMissing 同规则：剥 <think> → 首行 → 前 50 字）。 */
+function deriveConversationTitle(text: string): string {
+  const stripped = text.replace(/<think>[\s\S]*?<\/think>/g, '').trim()
+  const firstLine = stripped.split('\n')[0] ?? ''
+  return firstLine.slice(0, 50).trim()
+}
+
 export function NewConversationPage(): React.ReactElement {
   const navigate = useNavigate()
+  const { mutate } = useSWRConfig()
   const { data: options } = useSWR('conversation-options', getConversationOptions)
 
   const [selectedAgent, setSelectedAgent] = useState<SelectedAgentInfo | null>(null)
@@ -159,6 +167,19 @@ export function NewConversationPage(): React.ReactElement {
         enabledSkills: selectedSkills,
         ...(selectedModel ? { modelId: selectedModel } : {}),
       })
+      // 建成即派生标题写库并失效侧栏，使新会话立即出现且直接显示正确标题（否则要等 30s 轮询、
+      // 且标题要等服务端 turn 结束后才生成）；只在写库后失效一次，避免先占位再变正确。
+      const title = deriveConversationTitle(input.trim())
+      const revalidate = (): void => {
+        void mutate('conversations')
+      }
+      if (title) {
+        void updateConversationMeta(created.id, { title })
+          .catch(() => {})
+          .finally(revalidate)
+      } else {
+        revalidate()
+      }
       void navigate(`/conversation/${created.id}`, {
         state: { initialMessage: input.trim(), initialImages: images, initialModel: selectedModel || undefined },
       })

--- a/apps/webui/src/server/features/conversations/conversationMetaRepository.ts
+++ b/apps/webui/src/server/features/conversations/conversationMetaRepository.ts
@@ -105,10 +105,15 @@ export async function updateConversationMeta(
   mossSessionId: string,
   update: MetaUpdate,
 ): Promise<void> {
-  const sets: string[] = ['updated_at = now()']
+  // INSERT 列须随 title 动态补齐：行不存在时走 INSERT，若 title 不进列则新行标题恒为 NULL
+  const insertCols = ['principal_id', 'moss_session_id', 'updated_at']
+  const insertVals = ['$1', '$2', 'now()']
   const params: unknown[] = [principalId, mossSessionId]
+  const sets: string[] = ['updated_at = now()']
   if (update.title !== undefined) {
     params.push(update.title)
+    insertCols.push('title')
+    insertVals.push(`$${params.length}`)
     sets.push(`title = $${params.length}`)
   }
   if (update.pinned !== undefined) {
@@ -118,8 +123,8 @@ export async function updateConversationMeta(
     else sets.push('pinned_at = NULL')
   }
   await pool.query(
-    `INSERT INTO conversation_meta (principal_id, moss_session_id, updated_at)
-     VALUES ($1, $2, now())
+    `INSERT INTO conversation_meta (${insertCols.join(', ')})
+     VALUES (${insertVals.join(', ')})
      ON CONFLICT (principal_id, moss_session_id) DO UPDATE SET ${sets.join(', ')}`,
     params,
   )

--- a/apps/webui/tests/integration/conversations.test.ts
+++ b/apps/webui/tests/integration/conversations.test.ts
@@ -263,6 +263,23 @@ describe('conversation REST (real PostgreSQL + fake moss)', () => {
     expect(Array.isArray(res.body.models)).toBe(true)
   })
 
+  test('PATCH meta writes title even when no meta row exists yet', async () => {
+    const app = await buildApp()
+    // sess-a1 从未写过 meta 行（未选模型的新建会话场景）：PATCH title 须建行写入而非静默丢失
+    const patched = await request(app)
+      .patch('/api/conversations/sess-a1/meta')
+      .set('Cookie', cookieA)
+      .set('Origin', testConfig.publicOrigin)
+      .send({ title: 'hello world' })
+    expect(patched.status).toBe(200)
+    expect(patched.body).toEqual({ ok: true })
+
+    const list = await request(app).get('/api/conversations').set('Cookie', cookieA)
+    expect(list.status).toBe(200)
+    const a1 = (list.body.conversations as { id: string; title: string | null }[]).find((c) => c.id === 'sess-a1')!
+    expect(a1.title).toBe('hello world')
+  })
+
   test('unauthenticated requests are rejected', async () => {
     const app = await buildApp()
     expect((await request(app).get('/api/conversations')).status).toBe(401)


### PR DESCRIPTION
On new-conversation send, derive the title from the first input line and
persist it via PATCH /meta, then invalidate the sidebar 'conversations'
SWR key so the conversation appears immediately with the correct name
instead of waiting up to 30s for polling and showing the '会话' placeholder.

Also fix conversationMetaRepository.updateConversationMeta whose INSERT
branch omitted the title column, so title was silently dropped when the
meta row did not exist yet (e.g. new conversation without a selected
model). Add an integration test covering that path.
