### PR TITLE
feat(webui): complete web full-chat productization (G1-G5)

### DIFF
--- a/apps/desktop/src/agent/remote/MossWsConnection.ts
+++ b/apps/desktop/src/agent/remote/MossWsConnection.ts
@@ -391,53 +391,12 @@ export class MossWsConnection {
 
     if (msg.type === 'user') return;
 
-    if (msg.type === 'tool_progress') {
-      this.callbacks.onMessage({
-        type: 'acp_tool_call',
-        msg_id: msg.tool_use_id || uuid(36),
-        conversation_id: '',
-        data: {
-          sessionId: this.sessionId || '',
-          update: {
-            sessionUpdate: 'tool_call_update',
-            toolCallId: msg.tool_use_id || uuid(36),
-            status: 'in_progress',
-            content: [{ type: 'content', content: { type: 'text', text: `Executing... (${msg.elapsed_time_seconds}s)` } }],
-          },
-        },
-      });
-      return;
-    }
-
-    if (msg.type === 'tool_use_summary') {
-      this.callbacks.onMessage({
-        type: 'content',
-        msg_id: msg.uuid || uuid(36),
-        conversation_id: '',
-        data: `[Tool Summary] ${msg.summary}`,
-      });
-      return;
-    }
-
-    if (msg.type === 'streamlined_text') {
-      if (msg.text && msg.text.trim()) {
-        this.callbacks.onMessage({
-          type: 'content',
-          msg_id: msg.uuid || uuid(36),
-          conversation_id: '',
-          data: msg.text,
-        });
+    // Stateless frame mapping (tool_progress / tool_use_summary / streamlined_*)
+    // is owned by the shared @sudowork/common/mossResponse mapper (DRY with web).
+    if (msg.type === 'tool_progress' || msg.type === 'tool_use_summary' || msg.type === 'streamlined_text' || msg.type === 'streamlined_tool_use_summary') {
+      for (const m of mossFrameToResponses(msg, { sessionId: this.sessionId || '', nextMsgId: () => uuid(36) })) {
+        this.callbacks.onMessage(m);
       }
-      return;
-    }
-
-    if (msg.type === 'streamlined_tool_use_summary') {
-      this.callbacks.onMessage({
-        type: 'content',
-        msg_id: msg.uuid || uuid(36),
-        conversation_id: '',
-        data: `[Tool Summary] ${msg.tool_summary}`,
-      });
       return;
     }
 

--- a/apps/desktop/src/process/task/RemoteAgent.ts
+++ b/apps/desktop/src/process/task/RemoteAgent.ts
@@ -8,6 +8,7 @@ import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import type { IResponseMessage } from '@sudowork/host-bridge/ipcBridge';
 import type { AcpQuestionAnswerItem, TMessage } from '@sudowork/common/chatLib';
+import { mossControlRequestToConfirmation } from '@sudowork/common/mossResponse';
 import type { TChatConversation } from '@sudowork/common/storage';
 import { isRemoteContainerPath } from '@sudowork/common/utils/workspaceSkillSync';
 import { MossWsConnection, type MossWsConnectionConfig, type MossWsCallbacks } from '@/agent/remote/MossWsConnection';
@@ -1398,20 +1399,7 @@ class RemoteAgent extends BaseAgent<RemoteAgentData> {
     // wait for the user. Without this, a long-thought permission dialog could
     // outlive the idle detach window.
     this.cancelIdleDetachTimer();
-    this.addConfirmation({
-      id: requestId,
-      callId: requestId,
-      title: req.title || req.tool_name || 'Permission Required',
-      description: JSON.stringify(req.rawInput || req.input || {}),
-      options: req.options?.map((opt: any) => ({
-        label: opt.name || opt,
-        value: opt.optionId || opt,
-      })) || [
-        { label: 'Allow', value: 'allow_once' },
-        { label: 'Always Allow', value: 'allow_always' },
-        { label: 'Reject', value: 'reject_once' },
-      ],
-    });
+    this.addConfirmation(mossControlRequestToConfirmation(req, requestId));
   }
 
   private emitQuestionAnswered(msgId: string, answers: AcpQuestionResponseAnswer[]): void {

--- a/apps/desktop/tests/unit/mossResponseMapping.test.ts
+++ b/apps/desktop/tests/unit/mossResponseMapping.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractTextFromContent, isUserAbortError, mossFrameToResponses, type MossResponseCtx } from '@sudowork/common/mossResponse';
+import { extractTextFromContent, isUserAbortError, mossControlRequestToConfirmation, mossFrameToResponses, type MossResponseCtx } from '@sudowork/common/mossResponse';
 
 // Deterministic ctx so assertions can pin msg_id fallbacks.
 let counter = 0;
@@ -22,7 +22,6 @@ describe('mossFrameToResponses', () => {
 
   it('returns [] for unknown / caller-owned frame types and non-objects', () => {
     expect(mossFrameToResponses({ type: 'user' }, makeCtx())).toEqual([]);
-    expect(mossFrameToResponses({ type: 'tool_progress' }, makeCtx())).toEqual([]);
     expect(mossFrameToResponses(null, makeCtx())).toEqual([]);
     expect(mossFrameToResponses('nope' as unknown as object, makeCtx())).toEqual([]);
   });
@@ -70,6 +69,13 @@ describe('mossFrameToResponses', () => {
       const out = mossFrameToResponses({ type: 'tool_use', name: 'AskUserQuestion', tool_use_id: 'tu-1', _request_id: 'req-9', input: { question: 'Pick one', description: 'why', options: ['a', 'b', 3] } }, makeCtx());
       expect(out).toHaveLength(1);
       expect(out[0]).toMatchObject({ type: 'acp_question', msg_id: 'tu-1', data: { question: 'Pick one', intro: 'why', options: ['a', 'b'], answered: false, _request_id: 'req-9' } });
+      // conversationId defaults to '' (desktop callers don't pass ctx.conversationId)
+      expect(out[0].data).toMatchObject({ conversationId: '' });
+    });
+
+    it('stamps the acp_question conversationId from ctx.conversationId (web passes sessionId)', () => {
+      const out = mossFrameToResponses({ type: 'tool_use', name: 'AskUserQuestion', tool_use_id: 'tu-q', input: { question: 'Q?' } }, makeCtx({ conversationId: 'conv-9' }));
+      expect(out[0].data).toMatchObject({ conversationId: 'conv-9' });
     });
 
     it('maps a completed tool_use to a tool_call_update', () => {
@@ -121,6 +127,38 @@ describe('mossFrameToResponses', () => {
     });
   });
 
+  describe('tool_progress / summaries / streamlined', () => {
+    it('maps tool_progress to an in_progress tool_call_update with elapsed time', () => {
+      const out = mossFrameToResponses({ type: 'tool_progress', tool_use_id: 'tp-1', elapsed_time_seconds: 4 }, makeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({
+        type: 'acp_tool_call',
+        msg_id: 'tp-1',
+        data: { sessionId: 'sess-1', update: { sessionUpdate: 'tool_call_update', toolCallId: 'tp-1', status: 'in_progress', content: [{ type: 'content', content: { type: 'text', text: 'Executing... (4s)' } }] } },
+      });
+    });
+
+    it('maps tool_use_summary to a [Tool Summary] content message', () => {
+      const out = mossFrameToResponses({ type: 'tool_use_summary', uuid: 'sum-1', summary: 'ran 3 tests' }, makeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({ type: 'content', msg_id: 'sum-1', data: '[Tool Summary] ran 3 tests' });
+    });
+
+    it('maps streamlined_text to content and drops blank text', () => {
+      const out = mossFrameToResponses({ type: 'streamlined_text', uuid: 'st-1', text: 'streaming chunk' }, makeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({ type: 'content', msg_id: 'st-1', data: 'streaming chunk' });
+
+      expect(mossFrameToResponses({ type: 'streamlined_text', uuid: 'st-2', text: '   ' }, makeCtx())).toEqual([]);
+    });
+
+    it('maps streamlined_tool_use_summary to a [Tool Summary] content message', () => {
+      const out = mossFrameToResponses({ type: 'streamlined_tool_use_summary', uuid: 'sts-1', tool_summary: 'edited file.ts' }, makeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({ type: 'content', msg_id: 'sts-1', data: '[Tool Summary] edited file.ts' });
+    });
+  });
+
   it('stamps conversation_id from ctx (default "") and prefers frame.uuid for msg_id', () => {
     const withUuid = mossFrameToResponses({ type: 'result', uuid: 'u-1', subtype: 'success' }, makeCtx());
     expect(withUuid[0].msg_id).toBe('u-1');
@@ -145,5 +183,48 @@ describe('shared helpers', () => {
     expect(extractTextFromContent('raw')).toBe('raw');
     expect(extractTextFromContent([{ type: 'text', text: 'a' }, { type: 'image' }, { type: 'text', text: 'b' }])).toBe('ab');
     expect(extractTextFromContent({ nope: true })).toBe('');
+  });
+});
+
+describe('mossControlRequestToConfirmation', () => {
+  it('maps a control_request payload with options onto IConfirmation', () => {
+    const confirmation = mossControlRequestToConfirmation(
+      {
+        title: 'Run command',
+        rawInput: { cmd: 'ls' },
+        options: [
+          { name: 'Allow', optionId: 'allow_once' },
+          { name: 'Reject', optionId: 'reject_once' },
+        ],
+      },
+      'req-1'
+    );
+    expect(confirmation).toEqual({
+      id: 'req-1',
+      callId: 'req-1',
+      title: 'Run command',
+      description: '{"cmd":"ls"}',
+      options: [
+        { label: 'Allow', value: 'allow_once' },
+        { label: 'Reject', value: 'reject_once' },
+      ],
+    });
+  });
+
+  it('falls back to tool_name title, stringified input and default options', () => {
+    const confirmation = mossControlRequestToConfirmation({ tool_name: 'Bash', input: { cmd: 'pwd' } }, 'req-2');
+    expect(confirmation.title).toBe('Bash');
+    expect(confirmation.description).toBe('{"cmd":"pwd"}');
+    expect(confirmation.options).toEqual([
+      { label: 'Allow', value: 'allow_once' },
+      { label: 'Always Allow', value: 'allow_always' },
+      { label: 'Reject', value: 'reject_once' },
+    ]);
+  });
+
+  it('stringifies empty input as {} and keeps the default title', () => {
+    const confirmation = mossControlRequestToConfirmation({}, 'req-3');
+    expect(confirmation.title).toBe('Permission Required');
+    expect(confirmation.description).toBe('{}');
   });
 });

--- a/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
+++ b/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
@@ -31,9 +31,14 @@ import { bridge } from '@office-ai/platform'
 // Canonical wire shape — one definition shared with the renderer + main, not a
 // parallel copy.
 import type { IBridgeResponse } from '@sudowork/host-bridge/ipcBridge'
+import type { IConfirmation } from '@sudowork/common/chatLib'
 // The moss-frame → IResponseMessage mapping is the SAME implementation the desktop
 // MossWsConnection uses (shared leaf module, full stateless-frame coverage).
-import { mossFrameToResponses } from '@sudowork/common/mossResponse'
+import {
+  isUserAbortError,
+  mossControlRequestToConfirmation,
+  mossFrameToResponses,
+} from '@sudowork/common/mossResponse'
 
 interface BridgeEmitter {
   emit: (name: string, data: unknown) => void
@@ -166,6 +171,21 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 
 const openStreams = new Map<string, WebSocket>()
 
+// Per-session interactive state (browser memory, mirrors the desktop main-process
+// maps; cleared with the session WS on close).
+// - pending permission prompts shown through the renderer's confirmation UI
+const pendingConfirmations = new Map<string, IConfirmation[]>()
+// - pending AskUserQuestion cards keyed by toolCallId AND responseToolCallId
+//   (mirrors desktop RemoteAgent.pendingQuestions double-keying)
+const pendingQuestions = new Map<
+  string,
+  Map<string, { msgId: string; responseToolUseId?: string; toolCallId: string }>
+>()
+// - sessions whose last result was a user abort: trailing assistant frames are
+//   suppressed until the user sends again (desktop models this as the connection
+//   lifecycle; here the reset point is the next outbound send)
+const abortedSessions = new Set<string>()
+
 let __mid = 0
 function nextMsgId(): string {
   __mid += 1
@@ -194,11 +214,72 @@ function ensureSessionStream(sessionId: string): WebSocket | null {
     // `event` is an anthropic-style moss message. The renderer expects
     // IResponseMessage, so translate (mirrors the desktop MossWsConnection).
     if (frame && frame.kind === 'upstream' && frame.event) {
-      for (const msg of mossFrameToResponses(frame.event, {
+      // moss frame shapes are open-ended; narrow to the fields the branches below touch
+      const event = frame.event as {
+        type?: string
+        request?: unknown
+        request_id?: string
+      }
+
+      // Permission prompt → renderer confirmation card (mirrors desktop
+      // RemoteAgent.handlePermissionRequest via the shared converter).
+      if (event.type === 'control_request' && typeof event.request_id === 'string') {
+        const confirmation: IConfirmation & { conversation_id: string } = {
+          ...mossControlRequestToConfirmation(event.request, event.request_id),
+          conversation_id: sessionId,
+        }
+        const list = pendingConfirmations.get(sessionId) ?? []
+        list.push(confirmation)
+        pendingConfirmations.set(sessionId, list)
+        emitterRef?.emit('confirmation.add', confirmation)
+        return
+      }
+
+      // User-abort tracking: suppress trailing assistant frames until the next send.
+      if (event.type === 'result' && isUserAbortError(event)) {
+        abortedSessions.add(sessionId)
+      }
+      if (event.type === 'assistant' && abortedSessions.has(sessionId)) {
+        return
+      }
+
+      for (const msg of mossFrameToResponses(event, {
         sessionId,
         conversationId: sessionId,
         nextMsgId,
       })) {
+        // Register pending question cards under BOTH ids (mirrors desktop
+        // RemoteAgent.pendingQuestions double-keying) so the answer handler can
+        // resolve the original msg_id for the "answered" update.
+        if (msg.type === 'acp_question') {
+          const data = msg.data as { toolCallId?: string; responseToolCallId?: string }
+          if (data?.toolCallId) {
+            const pending = {
+              msgId: msg.msg_id,
+              responseToolUseId: data.responseToolCallId,
+              toolCallId: data.toolCallId,
+            }
+            const map =
+              pendingQuestions.get(sessionId) ??
+              new Map<string, { msgId: string; responseToolUseId?: string; toolCallId: string }>()
+            map.set(data.toolCallId, pending)
+            if (data.responseToolCallId) map.set(data.responseToolCallId, pending)
+            pendingQuestions.set(sessionId, map)
+          }
+        }
+        // The upstream acp_model_info only carries the current model (empty
+        // availableModels); merge the cached list so a model_changed confirmation
+        // does not flip the selector back to read-only.
+        if (msg.type === 'acp_model_info' && cachedModels && cachedModels.length > 0) {
+          const modelInfoData = msg.data as { availableModels?: unknown[] } | undefined
+          if (!modelInfoData?.availableModels?.length) {
+            msg.data = {
+              ...modelInfoData,
+              availableModels: cachedModels,
+              canSwitch: cachedModels.length > 1,
+            }
+          }
+        }
         emitterRef?.emit('chat.response.stream', msg)
         emitterRef?.emit('moss.response-stream', msg)
       }
@@ -211,7 +292,12 @@ function ensureSessionStream(sessionId: string): WebSocket | null {
       })
     }
   })
-  ws.addEventListener('close', () => openStreams.delete(sessionId))
+  ws.addEventListener('close', () => {
+    openStreams.delete(sessionId)
+    pendingConfirmations.delete(sessionId)
+    pendingQuestions.delete(sessionId)
+    abortedSessions.delete(sessionId)
+  })
   ws.addEventListener('error', () => {
     try {
       ws.close()
@@ -251,6 +337,52 @@ function extractText(req: AnyReq): string {
     return req.content.map((p: AnyReq) => (typeof p?.text === 'string' ? p.text : '')).join('')
   }
   return ''
+}
+
+// ---------------------------------------------------------------------------
+// Model surface for the renderer's AcpModelSelector (web conversations project
+// backend 'scode', so the selector's standard path consumes these channels).
+// The upstream acp_model_info stream only carries the CURRENT model (empty list),
+// so this side owns the available-models cache and merges it into stream frames
+// to keep the selector switchable after a model_changed confirmation.
+// ---------------------------------------------------------------------------
+
+let cachedModels: Array<{ id: string; label: string }> | null = null
+
+async function fetchAvailableModels(): Promise<Array<{ id: string; label: string }>> {
+  const opts = await apiFetch<{ models: { id: string; name: string }[] }>(
+    '/api/conversations/options',
+  )
+  const models = opts.models.map((m) => ({ id: m.id, label: m.name || m.id }))
+  cachedModels = models
+  return models
+}
+
+/** Current model with a three-level fallback mirroring the renderer's fetchMossModelInfo:
+ *  conversation model → user preference → first available. */
+async function resolveCurrentModelId(sessionId?: string): Promise<string> {
+  if (sessionId) {
+    const conv = await apiFetch<{ modelId: string | null }>(
+      `/api/conversations/${encodeURIComponent(sessionId)}/model`,
+    ).catch(() => null)
+    if (conv?.modelId) return conv.modelId
+  }
+  const user = await apiFetch<{ modelId: string | null }>('/api/conversations/user-model').catch(
+    () => null,
+  )
+  if (user?.modelId) return user.modelId
+  return cachedModels?.[0]?.id ?? ''
+}
+
+function makeModelInfo(models: Array<{ id: string; label: string }>, currentModelId: string) {
+  const match = models.find((m) => m.id === currentModelId)
+  return {
+    source: 'models',
+    currentModelId,
+    currentModelLabel: match?.label || currentModelId,
+    canSwitch: models.length > 1,
+    availableModels: models,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -339,7 +471,15 @@ const handlers: Record<string, (req: AnyReq) => Promise<unknown>> = {
   },
   'get-conversation': async (req) => {
     const found = (await listConversations()).find((c) => c.id === req?.id)
-    return found ? toChatConversation(found) : undefined
+    if (!found) return undefined
+    const conv = toChatConversation(found)
+    // 会话模型回读：conversation_meta.model_id（renderer 以 extra.currentModelId 作 initialModelId）
+    const model = await apiFetch<{ modelId: string | null }>(
+      `/api/conversations/${encodeURIComponent(String(req?.id ?? ''))}/model`,
+    ).catch(() => null)
+    if (model?.modelId)
+      conv.extra = { ...(conv.extra as Record<string, unknown>), currentModelId: model.modelId }
+    return conv
   },
   'database.get-conversation-messages': async (req) => {
     const id = String(req?.conversation_id ?? '')
@@ -436,20 +576,31 @@ const handlers: Record<string, (req: AnyReq) => Promise<unknown>> = {
     )
     return ok(opts.models.map((m) => ({ id: m.id, name: m.name, ratio: 1 })))
   },
-  'moss.get-user-model': async () => ok(null),
-  'moss.set-user-model': async (req) =>
-    ok({ modelId: String(req?.modelId ?? ''), updatedAt: Date.now() }),
+  'moss.get-user-model': async () => {
+    const data = await apiFetch<{ modelId: string | null }>('/api/conversations/user-model')
+    return ok(data ?? { modelId: null })
+  },
+  'moss.set-user-model': async (req) => {
+    const modelId = String(req?.modelId ?? '')
+    await apiFetch('/api/conversations/user-model', {
+      method: 'PUT',
+      body: JSON.stringify({ modelId }),
+    })
+    return ok({ modelId, updatedAt: Date.now() })
+  },
 
   // --- chat send / control (over the session WS) ---
   'chat.send.message': async (req) => {
     const sessionId = String(req?.conversation_id ?? req?.sessionId ?? '')
     if (!sessionId) return fail('NO_SESSION')
+    abortedSessions.delete(sessionId)
     sendOverStream(sessionId, { kind: 'send', text: extractText(req) })
     return ok()
   },
   'moss.send-message': async (req) => {
     const sessionId = String(req?.sessionId ?? '')
     if (!sessionId) return fail('NO_SESSION')
+    abortedSessions.delete(sessionId)
     sendOverStream(sessionId, { kind: 'send', text: String(req?.content ?? '') })
     return ok()
   },
@@ -469,6 +620,108 @@ const handlers: Record<string, (req: AnyReq) => Promise<unknown>> = {
     return ok()
   },
 
+  // --- in-session model switch (renderer AcpModelSelector, non-remote-agent branch) ---
+  'acp.set-model': async (req) => {
+    const sessionId = String(req?.conversationId ?? '')
+    const modelId = String(req?.modelId ?? '')
+    if (!sessionId || !modelId) return fail('Invalid conversationId or modelId')
+    if (!sendOverStream(sessionId, { kind: 'set_model', modelId })) return fail('NO_SESSION')
+    return ok()
+  },
+
+  // --- AskUserQuestion answer loop (server already forwards answer_question) ---
+  'acp.answer-question': async (req) => {
+    const sessionId = String(req?.conversationId ?? '')
+    if (!sessionId || typeof sessionId !== 'string') return fail('Invalid conversationId')
+    const toolCallId = String(req?.toolCallId ?? '')
+    if (!toolCallId) return fail('Invalid toolCallId')
+    const answers = Array.isArray(req?.answers) ? req.answers : []
+    if (answers.length === 0) return fail('answers must be a non-empty array')
+    const text = answers
+      .map((a: { value?: unknown }) => (typeof a?.value === 'string' ? a.value : ''))
+      .filter(Boolean)
+      .join('\n')
+    if (!text) return fail('answers must contain non-empty values')
+    if (!sendOverStream(sessionId, { kind: 'answer_question', parentToolUseId: toolCallId, text }))
+      return fail('NO_SESSION')
+    abortedSessions.delete(sessionId)
+
+    // Flip the pending card to answered (mirrors desktop emitQuestionAnswered).
+    // Without a registration (e.g. after a page refresh) the answer is still sent;
+    // there is just no local card to update.
+    const pending = pendingQuestions.get(sessionId)?.get(toolCallId)
+    if (pending) {
+      const map = pendingQuestions.get(sessionId)!
+      map.delete(pending.toolCallId)
+      if (pending.responseToolUseId) map.delete(pending.responseToolUseId)
+      const answerItems = answers.map(
+        (a: { id?: unknown; value?: unknown; label?: unknown }, index: number) => ({
+          id: typeof a?.id === 'string' ? a.id : String(index + 1),
+          index: index + 1,
+          submissionValue: typeof a?.value === 'string' ? a.value : '',
+          displayValue:
+            (typeof a?.label === 'string' && a.label) ||
+            (typeof a?.value === 'string' && a.value) ||
+            '',
+          skipped: a?.value === '[skipped]',
+        }),
+      )
+      const selectedAnswer = answerItems
+        .map((a) => `${a.index}. ${a.skipped ? '[skipped]' : a.displayValue}`)
+        .join('\n')
+      const answered = {
+        type: 'acp_question',
+        msg_id: pending.msgId,
+        conversation_id: sessionId,
+        data: { answered: true, selectedAnswer, answerItems },
+      }
+      emitterRef?.emit('chat.response.stream', answered)
+      emitterRef?.emit('moss.response-stream', answered)
+    }
+    return ok()
+  },
+
+  // --- permission approval loop (renderer confirmation card) ---
+  'confirmation.confirm': async (req) => {
+    const sessionId = String(req?.conversation_id ?? '')
+    if (
+      !sendOverStream(sessionId, {
+        kind: 'control_response',
+        requestId: String(req?.callId ?? ''),
+        optionId: String(req?.data ?? ''),
+      })
+    ) {
+      return fail('NO_SESSION')
+    }
+    const list = pendingConfirmations.get(sessionId)
+    if (list)
+      pendingConfirmations.set(
+        sessionId,
+        list.filter((c) => c.id !== req?.msg_id),
+      )
+    emitterRef?.emit('confirmation.remove', {
+      conversation_id: sessionId,
+      id: String(req?.msg_id ?? ''),
+    })
+    return ok()
+  },
+
+  // --- model surface for the renderer's AcpModelSelector (scode projection path) ---
+  'acp.get-model-info': async (req) => {
+    const models = await fetchAvailableModels()
+    if (models.length === 0) return ok({ modelInfo: null })
+    const currentModelId = await resolveCurrentModelId(String(req?.conversationId ?? ''))
+    return ok({ modelInfo: makeModelInfo(models, currentModelId) })
+  },
+
+  'scode.refresh-models': async () => {
+    const models = await fetchAvailableModels()
+    const currentModelId = await resolveCurrentModelId()
+    // data is checked by the renderer (result.success && result.data) — must be a
+    // real AcpModelInfo, never a bare ok().
+    return ok({ modelInfo: makeModelInfo(models, currentModelId) })
+  },
+
   // --- misc surfaces the enterprise chat page touches early ---
   'conversation.get-slash-commands': async () => ok({ commands: [] }),
 
@@ -480,7 +733,8 @@ const handlers: Record<string, (req: AnyReq) => Promise<unknown>> = {
   'cron.list-jobs-by-conversation': async () => [],
   // The conversation view loads these on open; they return RAW arrays, so the
   // default-reject object breaks array consumers ("data is not iterable").
-  'confirmation.list': async () => [],
+  'confirmation.list': async (req) =>
+    pendingConfirmations.get(String(req?.conversation_id ?? '')) ?? [],
   'approval.check': async () => false,
   'acp.get-mode': async () => ok({ mode: 'default', initialized: true }),
   'conversation.flush-pending-messages': async () => undefined,

--- a/apps/webui/src/server/features/conversations/ConversationCoordinator.ts
+++ b/apps/webui/src/server/features/conversations/ConversationCoordinator.ts
@@ -9,6 +9,7 @@ import { MossHttpError, MossNetworkError, deriveWsBaseUrl } from '@sudowork/moss
 import {
   MossUpstreamSocket,
   buildAnswerQuestionMessage,
+  buildControlResponseMessage,
   buildInterruptMessage,
   buildSetModelMessage,
   buildUserMessage,
@@ -371,6 +372,21 @@ export class ConversationCoordinator {
             }
           }
         }
+      }
+
+      if (msg.kind === 'control_response') {
+        // 权限审批回批：转发上游。WS 连接已按 (principalId, mossSessionId) 隔离，回批者必为
+        // 会话拥有者；审批可能跨越写锁的 uncertain 边界，故不做 writer 锁校验。审批请求来自
+        // 当前活跃的上游连接（活着才有请求）——不 ensureUpstream 重建（非 writer 连接会被
+        // UPSTREAM_OWNER_MISMATCH 拒绝，且失联的请求本就无需回批）。
+        if (
+          !entry.upstream ||
+          entry.upstream.isClosed ||
+          !entry.upstream.send(buildControlResponseMessage(msg.requestId, msg.optionId))
+        ) {
+          this.sendTo(conn.ws, { kind: 'error', code: 'UPSTREAM_NOT_CONNECTED' })
+        }
+        return
       }
 
       if (msg.kind === 'stop') {

--- a/apps/webui/src/server/features/conversations/conversationRoutes.ts
+++ b/apps/webui/src/server/features/conversations/conversationRoutes.ts
@@ -7,6 +7,7 @@ import { MossHttpError, type MossCallContext } from '@sudowork/moss-client'
 import {
   CreateConversationRequestSchema,
   ReorderPinnedRequestSchema,
+  SetUserModelRequestSchema,
   UpdateConversationMetaRequestSchema,
 } from '@sudowork/contracts/conversations'
 import {
@@ -16,13 +17,16 @@ import {
   SessionNotFoundError,
   createConversation,
   deleteConversation,
-  getContext,
+  getConversationModel,
   getConversationOptions,
+  getUserModel,
+  getContext,
   getWorkspaceFile,
   getWorkspaceTree,
   listConversations,
   proxyAgentAvatar,
   reorderPinnedConversations,
+  setUserModel,
   terminateConversation,
   updateConversationMeta,
   uploadWorkspaceFile,
@@ -104,6 +108,23 @@ export function createConversationRouter(deps: ConversationDeps): Router {
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 
+  // 用户级模型偏好（shared-renderer 的 moss.get/set-user-model 通道代理；单段路径先于 /:id/* 注册）
+  router.get('/user-model', requireSession, (req, res, next) => {
+    void (async () => {
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json(await getUserModel(deps, ctx))
+    })().catch((err: unknown) => convErrorHandler(err, res, next))
+  })
+
+  router.put('/user-model', requireSession, (req, res, next) => {
+    void (async () => {
+      const input = SetUserModelRequestSchema.parse(req.body)
+      const ctx = await resolveCtx(req as AuthedRequest)
+      await setUserModel(deps, input.modelId, ctx)
+      res.status(200).json({ modelId: input.modelId })
+    })().catch((err: unknown) => convErrorHandler(err, res, next))
+  })
+
   // tenant 头像同源代理：白名单仅放行 /uploads/tenant-assistant-avatars/<单层文件名>，防 SSRF/路径穿越。
   // 单段 GET 路径，与 /options 并列，不与 DELETE /:id、两段 /:id/* 冲突。
   router.get('/agent-avatar', requireSession, (req, res, next) => {
@@ -128,6 +149,17 @@ export function createConversationRouter(deps: ConversationDeps): Router {
       const id = z.string().min(1).parse(req.params.id)
       const ctx = await resolveCtx(req as AuthedRequest)
       res.status(200).json(await getContext(deps, principal, id, ctx))
+    })().catch((err: unknown) => convErrorHandler(err, res, next))
+  })
+
+  // 会话级模型回读（conversation_meta.model_id，本地读；避免为取 modelId 拉取完整 context）
+  router.get('/:id/model', requireSession, (req, res, next) => {
+    void (async () => {
+      const principal = await resolvePrincipal(req as AuthedRequest)
+      if (!principal) return void res.status(401).json({ error: 'SESSION_REQUIRED' })
+      const id = z.string().min(1).parse(req.params.id)
+      const ctx = await resolveCtx(req as AuthedRequest)
+      res.status(200).json(await getConversationModel(deps, principal, id, ctx))
     })().catch((err: unknown) => convErrorHandler(err, res, next))
   })
 

--- a/apps/webui/src/server/features/conversations/conversationService.ts
+++ b/apps/webui/src/server/features/conversations/conversationService.ts
@@ -13,7 +13,9 @@ import {
 } from '@sudowork/moss-client'
 import type {
   ConversationListItem,
+  ConversationModelResponse,
   CreateConversationRequest,
+  UserModelResponse,
 } from '@sudowork/contracts/conversations'
 import type { ConversationCoordinator } from './ConversationCoordinator.js'
 import {
@@ -198,6 +200,41 @@ export async function requireOwnSession(
   if (session.userId !== principal.mossUserId || session.orgId !== principal.orgId) {
     throw new SessionForbiddenError()
   }
+}
+
+/** 用户级模型偏好读取；上游无该端点（404）/未设偏好 → null（renderer 侧三级 fallback 已兜底）。 */
+export async function getUserModel(
+  deps: ConversationDeps,
+  ctx: MossCallContext,
+): Promise<UserModelResponse> {
+  try {
+    return { modelId: await deps.moss.getUserModel(ctx) }
+  } catch (err) {
+    if (err instanceof MossHttpError || err instanceof MossNetworkError) return { modelId: null }
+    throw err
+  }
+}
+
+/** 用户级模型偏好写入；先校验可用（不接受浏览器自造 modelId，对齐建会话路径）。 */
+export async function setUserModel(
+  deps: ConversationDeps,
+  modelId: string,
+  ctx: MossCallContext,
+): Promise<void> {
+  await assertModelAvailable(deps, modelId, ctx)
+  await mapMossErrors(() => deps.moss.setUserModel(ctx, modelId))
+}
+
+/** 会话级模型回读（conversation_meta.model_id，本地读）；归属校验与 /context 同模式防 IDOR。 */
+export async function getConversationModel(
+  deps: ConversationDeps,
+  principal: Principal,
+  sessionId: string,
+  ctx: MossCallContext,
+): Promise<ConversationModelResponse> {
+  await requireOwnSession(deps, principal, sessionId, ctx)
+  const meta = await getConversationMeta(deps.pool, principal.id, sessionId)
+  return { modelId: meta?.modelId ?? null }
 }
 
 export async function getContext(

--- a/apps/webui/tests/contract/moss-session.test.ts
+++ b/apps/webui/tests/contract/moss-session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { createMossSessionPort } from '@sudowork/moss-client'
 import {
   buildAnswerQuestionMessage,
+  buildControlResponseMessage,
   buildSetModelMessage,
   buildUserMessage,
   validateMossWsUrl,
@@ -23,7 +24,7 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
     })
   })
 
-  test('create posts assistant_name + enabled_skills, never cwd/runtime', async () => {
+  test('create posts assistant_name + enabled_skills + explicit skip_permissions=false, never cwd/runtime', async () => {
     const mock = vi.fn().mockResolvedValue({
       session_id: 's1',
       ws_url: 'ws://moss.test/ws/sessions/s1',
@@ -36,7 +37,11 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
       method: 'POST',
       path: '/api/v1/sessions',
       accessToken: 'tk',
-      body: { assistant_name: 'helper', enabled_skills: ['a', 'b'] },
+      body: {
+        assistant_name: 'helper',
+        enabled_skills: ['a', 'b'],
+        dangerously_skip_permissions: false,
+      },
     })
   })
 
@@ -50,6 +55,23 @@ describe('MossSessionPort request shapes (contract vs baseline)', () => {
       accessToken: 'tk',
       body: { modelId: 'gpt-4' },
     })
+  })
+
+  test('getUserModel gets /api/v1/users/me/model and reads modelId (camel/snake compatible)', async () => {
+    const mock = vi.fn().mockResolvedValue({ modelId: 'gpt-4' })
+    const port = createMossSessionPort(mock)
+    await expect(port.getUserModel(CTX)).resolves.toBe('gpt-4')
+    expect(mock).toHaveBeenCalledWith(BASE, {
+      method: 'GET',
+      path: '/api/v1/users/me/model',
+      accessToken: 'tk',
+    })
+
+    const snakeMock = vi.fn().mockResolvedValue({ model_id: 'claude-x' })
+    await expect(createMossSessionPort(snakeMock).getUserModel(CTX)).resolves.toBe('claude-x')
+
+    const unsetMock = vi.fn().mockResolvedValue({})
+    await expect(createMossSessionPort(unsetMock).getUserModel(CTX)).resolves.toBeNull()
   })
 
   test('context/resume/terminate/workspace paths match baseline routes', async () => {
@@ -182,5 +204,17 @@ describe('protocol builders (browser message -> moss acp wire format)', () => {
       request: { subtype: 'set_model', model_id: 'gpt-x' },
     })
     expect(typeof msg.request_id).toBe('string')
+  })
+
+  test('buildControlResponseMessage mirrors the desktop permission-answer shape', () => {
+    const msg = buildControlResponseMessage('req-1', 'allow_once')
+    expect(msg).toEqual({
+      type: 'control_response',
+      response: {
+        subtype: 'success',
+        request_id: 'req-1',
+        response: { behavior: 'allow_once' },
+      },
+    })
   })
 })

--- a/apps/webui/tests/integration/conversation-stream.test.ts
+++ b/apps/webui/tests/integration/conversation-stream.test.ts
@@ -105,23 +105,6 @@ describe('conversation stream (browser WS ⇄ coordinator ⇄ upstream moss WS)'
       username: 'user_a',
     })
 
-    const mkCookie = async (accessToken: string): Promise<string> => {
-      const token = generateSessionToken()
-      await createWebSession(pool, {
-        principalId: principal.id,
-        tokenDigest: digestToken(token, HMAC_KEY),
-        encrypted: encryptToken(
-          JSON.stringify({ accessToken, refreshToken: 'rt', expiresAt: Date.now() + 3600_000 }),
-          AES_KEY,
-        ),
-        accessExpiresAt: new Date(Date.now() + 3600_000),
-        expiresAt: new Date(Date.now() + 86400_000),
-      })
-      return `sudowork_session=${token}`
-    }
-    cookie1 = await mkCookie('at-stream')
-    cookie2 = await mkCookie('at-stream-2')
-
     // ---- fake upstream moss WS ----
     const upstreamWss = new WebSocketServer({ noServer: true })
     upstreamServer = createServer()
@@ -158,6 +141,27 @@ describe('conversation stream (browser WS ⇄ coordinator ⇄ upstream moss WS)'
       })
     })
     upstreamPort = await listen(upstreamServer)
+
+    // cookies 在上游端口确定后创建（mossBaseUrl 需指向 fake 上游的实际 host）
+    const mkCookie = async (accessToken: string): Promise<string> => {
+      const token = generateSessionToken()
+      await createWebSession(pool, {
+        principalId: principal.id,
+        tokenDigest: digestToken(token, HMAC_KEY),
+        encrypted: encryptToken(
+          JSON.stringify({ accessToken, refreshToken: 'rt', expiresAt: Date.now() + 3600_000 }),
+          AES_KEY,
+        ),
+        accessExpiresAt: new Date(Date.now() + 3600_000),
+        expiresAt: new Date(Date.now() + 86400_000),
+        // WS 校验基准用会话生效地址（deriveWsBaseUrl(ctx.baseUrl)）：
+        // 指向 fake 上游的实际 host，否则 resume 返回的 wsUrl 过不了 validateMossWsUrl
+        mossBaseUrl: `http://127.0.0.1:${upstreamPort}`,
+      })
+      return `sudowork_session=${token}`
+    }
+    cookie1 = await mkCookie('at-stream')
+    cookie2 = await mkCookie('at-stream-2')
 
     // ---- WebUI app ----
     const testConfig: AppConfig = {
@@ -199,6 +203,9 @@ describe('conversation stream (browser WS ⇄ coordinator ⇄ upstream moss WS)'
         return { sessionId: 'new', wsUrl: '' }
       },
       async setUserModel() {},
+      async getUserModel() {
+        return null
+      },
       async context() {
         return { context: { messages: [] } }
       },
@@ -355,6 +362,56 @@ describe('conversation stream (browser WS ⇄ coordinator ⇄ upstream moss WS)'
       ws2.close()
       upstreamMode = 'auto'
       // 结束后清锁，避免 running 断线给后续用例留下 uncertain 残留
+      await request(app)
+        .post(`/api/conversations/${SID}/terminate`)
+        .set('Cookie', cookie1)
+        .set('Origin', 'http://localhost:5273')
+      await sleep(150)
+    }
+  }, 20_000)
+
+  test('control_response (permission answer) forwards to upstream; no writer lock required', async () => {
+    // 前置：清掉历史残留锁，保证起点 idle
+    await request(app)
+      .post(`/api/conversations/${SID}/terminate`)
+      .set('Cookie', cookie1)
+      .set('Origin', 'http://localhost:5273')
+    await sleep(150)
+
+    upstreamMode = 'hold'
+    const ws1 = await browserWs(cookie1)
+    const ws2 = await browserWs(cookie2)
+    const c1 = collector(ws1)
+    try {
+      await c1.waitFor((e) => e.kind === 'lock')
+      // ws1 成为 writer 并 running；ws2 为非 writer 观察者
+      ws1.send(JSON.stringify({ kind: 'send', text: 'needs approval', images: [] }))
+      await c1.waitFor((e) => e.kind === 'lock' && e.state === 'running')
+
+      // 审批回批不做 writer 校验（回批者必为会话拥有者；审批可能跨越锁边界）——
+      // 非 writer 的 ws2 发 control_response 也能转发；上游收到与桌面端
+      // respondToPermissionRequest 同形状的帧
+      const before = upstreamReceived.length
+      ws2.send(
+        JSON.stringify({ kind: 'control_response', requestId: 'perm-1', optionId: 'allow_once' }),
+      )
+      await sleep(300)
+      const frames = upstreamReceived
+        .slice(before)
+        .filter((e) => (e as { type?: string }).type === 'control_response')
+      expect(frames.length).toBe(1)
+      expect(frames[0]).toEqual({
+        type: 'control_response',
+        response: {
+          subtype: 'success',
+          request_id: 'perm-1',
+          response: { behavior: 'allow_once' },
+        },
+      })
+    } finally {
+      ws1.close()
+      ws2.close()
+      upstreamMode = 'auto'
       await request(app)
         .post(`/api/conversations/${SID}/terminate`)
         .set('Cookie', cookie1)

--- a/apps/webui/tests/integration/conversations.test.ts
+++ b/apps/webui/tests/integration/conversations.test.ts
@@ -8,6 +8,7 @@ import type { MossAuthPort } from '@sudowork/moss-client'
 import type { MossSessionPort } from '@sudowork/moss-client'
 import { MossHttpError } from '@sudowork/moss-client'
 import { ConversationCoordinator } from '@server/features/conversations/ConversationCoordinator'
+import { upsertConversationModel } from '@server/features/conversations/conversationMetaRepository'
 import { upsertPrincipal, type Principal } from '@server/features/auth/principalRepository'
 import { createWebSession } from '@server/features/auth/sessionRepository'
 import { digestToken, generateSessionToken } from '@server/security/sessionToken'
@@ -71,6 +72,10 @@ const SESSIONS = [
   },
 ]
 
+/** user-model 读桩：默认模拟上游无该端点（404 → service 兜底 null）。 */
+let fakeUserModelId: string | null = null
+let fakeUserModelError: unknown = new MossHttpError(404, '', '')
+
 function createFakeMossSession(): MossSessionPort {
   return {
     async list() {
@@ -83,6 +88,10 @@ function createFakeMossSession(): MossSessionPort {
       return { sessionId: `created-${input.assistantName}`, wsUrl: 'ws://moss.test/ws/sessions/x' }
     },
     async setUserModel() {},
+    async getUserModel() {
+      if (fakeUserModelError) throw fakeUserModelError
+      return fakeUserModelId
+    },
     async context(_tk, sessionId) {
       if (sessionId === 'sess-empty') throw new MossHttpError(404, '', '')
       return {
@@ -309,6 +318,68 @@ describe('conversation REST (real PostgreSQL + fake moss)', () => {
       .set('Cookie', cookieB)
       .set('Origin', testConfig.publicOrigin)
     expect(cross.status).toBe(403)
+  })
+
+  test('GET /user-model falls back to null on upstream 404 and proxies the preference', async () => {
+    const app = await buildApp()
+    // 默认桩抛 404（上游无该端点）→ 读不阻塞 UI，返回 null
+    const unset = await request(app).get('/api/conversations/user-model').set('Cookie', cookieA)
+    expect(unset.status).toBe(200)
+    expect(unset.body).toEqual({ modelId: null })
+
+    fakeUserModelError = null
+    fakeUserModelId = 'm1'
+    try {
+      const set = await request(app).get('/api/conversations/user-model').set('Cookie', cookieA)
+      expect(set.status).toBe(200)
+      expect(set.body).toEqual({ modelId: 'm1' })
+    } finally {
+      fakeUserModelError = new MossHttpError(404, '', '')
+      fakeUserModelId = null
+    }
+  })
+
+  test('PUT /user-model validates modelId against available models', async () => {
+    const app = await buildApp()
+    const ok = await request(app)
+      .put('/api/conversations/user-model')
+      .set('Cookie', cookieA)
+      .set('Origin', testConfig.publicOrigin)
+      .send({ modelId: 'm1' })
+    expect(ok.status).toBe(200)
+    expect(ok.body).toEqual({ modelId: 'm1' })
+
+    // 浏览器自造 modelId → 400（对齐建会话路径的 assertModelAvailable）
+    const ghost = await request(app)
+      .put('/api/conversations/user-model')
+      .set('Cookie', cookieA)
+      .set('Origin', testConfig.publicOrigin)
+      .send({ modelId: 'ghost' })
+    expect(ghost.status).toBe(400)
+    expect(ghost.body.error).toBe('SELECTION_NOT_AVAILABLE')
+    expect(ghost.body.field).toBe('modelId')
+  })
+
+  test('GET /:id/model reads conversation_meta with ownership (403/404/missing)', async () => {
+    const app = await buildApp()
+    // 直接为既有会话落 conversation_meta.model_id（fake 桩的 get 只认 SESSIONS，
+    // 动态创建的 id 过不了 requireOwnSession，故用 repository 写入而非 POST 创建）
+    await upsertConversationModel(pool, principalA.id, 'sess-a2', 'm1')
+
+    const hit = await request(app).get('/api/conversations/sess-a2/model').set('Cookie', cookieA)
+    expect(hit.status).toBe(200)
+    expect(hit.body).toEqual({ modelId: 'm1' })
+
+    // 未落模型的会话 → null；他人会话 → 403；不存在 → 404
+    const missing = await request(app)
+      .get('/api/conversations/sess-a1/model')
+      .set('Cookie', cookieA)
+    expect(missing.status).toBe(200)
+    expect(missing.body).toEqual({ modelId: null })
+    const cross = await request(app).get('/api/conversations/sess-a2/model').set('Cookie', cookieB)
+    expect(cross.status).toBe(403)
+    const notFound = await request(app).get('/api/conversations/nope/model').set('Cookie', cookieA)
+    expect(notFound.status).toBe(404)
   })
 
   test('workspace tree strips fullPath from nodes', async () => {

--- a/apps/webui/tests/integration/cron-idor.test.ts
+++ b/apps/webui/tests/integration/cron-idor.test.ts
@@ -139,6 +139,9 @@ function createFakeSessions(): MossSessionPort {
       return { sessionId: 'x', wsUrl: '' }
     },
     async setUserModel() {},
+    async getUserModel() {
+      return null
+    },
     async context() {
       return { context: { messages: [] } }
     },

--- a/packages/common/src/mossResponse.ts
+++ b/packages/common/src/mossResponse.ts
@@ -13,14 +13,17 @@
  * no app / `@sudowork/host-bridge` / node / electron / `@/` runtime dependency, so
  * it builds cleanly under `bun run build:packages`.
  *
- * Scope is the STATELESS frame types (result / system / tool_use / assistant). The
- * stateful / effectful frames (`hello` session capture, `control_response`
- * interrupt confirmation, `control_request` permission prompt) and the
- * unparseable-line text fallback are the CALLER's responsibility — `hello`,
- * `control_response` and `control_request` return `[]` here on purpose.
+ * Scope is the STATELESS frame types (result / system / tool_use / assistant /
+ * tool_progress / tool_use_summary / streamlined_*). The stateful / effectful
+ * frames (`hello` session capture, `control_response` interrupt confirmation,
+ * `control_request` permission prompt) and the unparseable-line text fallback
+ * are the CALLER's responsibility — `hello`, `control_response` and
+ * `control_request` return `[]` here on purpose. `control_request` still has a
+ * shared pure HELPER (`mossControlRequestToConfirmation`) converting its
+ * request payload into an `IConfirmation`; routing/effect stays caller-side.
  */
 
-import type { IResponseMessage } from './chatTypes.js';
+import type { IConfirmation, IResponseMessage } from './chatTypes.js';
 
 export interface MossResponseCtx {
   /** moss session id, stamped onto emitted `acp_tool_call` updates as `sessionId`. */
@@ -159,7 +162,7 @@ export function mossFrameToResponses(frame: any, ctx: MossResponseCtx): IRespons
           question: question || description || 'Question',
           intro: description,
           options,
-          conversationId: '',
+          conversationId: ctx.conversationId ?? '',
           toolCallId: toolUseId,
           responseToolCallId: responseToolUseId,
           answered: false,
@@ -278,7 +281,82 @@ export function mossFrameToResponses(frame: any, ctx: MossResponseCtx): IRespons
     return out;
   }
 
-  // Any other frame type (user / tool_progress / streamlined_* / stream_event /
-  // unknown / plain-text fallback) is handled by the caller.
+  if (frame.type === 'tool_progress') {
+    out.push({
+      type: 'acp_tool_call',
+      msg_id: frame.tool_use_id || ctx.nextMsgId(),
+      conversation_id: conversationId,
+      data: {
+        sessionId: ctx.sessionId,
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: frame.tool_use_id || ctx.nextMsgId(),
+          status: 'in_progress',
+          content: [{ type: 'content', content: { type: 'text', text: `Executing... (${frame.elapsed_time_seconds}s)` } }],
+        },
+      },
+    });
+    return out;
+  }
+
+  if (frame.type === 'tool_use_summary') {
+    out.push({
+      type: 'content',
+      msg_id: frame.uuid || ctx.nextMsgId(),
+      conversation_id: conversationId,
+      data: `[Tool Summary] ${frame.summary}`,
+    });
+    return out;
+  }
+
+  if (frame.type === 'streamlined_text') {
+    if (frame.text && frame.text.trim()) {
+      out.push({
+        type: 'content',
+        msg_id: frame.uuid || ctx.nextMsgId(),
+        conversation_id: conversationId,
+        data: frame.text,
+      });
+    }
+    return out;
+  }
+
+  if (frame.type === 'streamlined_tool_use_summary') {
+    out.push({
+      type: 'content',
+      msg_id: frame.uuid || ctx.nextMsgId(),
+      conversation_id: conversationId,
+      data: `[Tool Summary] ${frame.tool_summary}`,
+    });
+    return out;
+  }
+
+  // Any other frame type (user / stream_event / rate_limit_event / auth_status /
+  // prompt_suggestion / unknown / plain-text fallback) is handled by the caller.
   return out;
+}
+
+/**
+ * Convert a moss `control_request` permission prompt into the shared
+ * `IConfirmation` shape. Faithfully mirrors the desktop `RemoteAgent
+ * .handlePermissionRequest` mapping (title/description/options + the
+ * allow_once/allow_always/reject_once fallback). Routing the confirmation to
+ * the UI and answering it back over the WS stay caller-side.
+ */
+export function mossControlRequestToConfirmation(request: any, requestId: string): IConfirmation {
+  return {
+    id: requestId,
+    callId: requestId,
+    title: request.title || request.tool_name || 'Permission Required',
+    description: JSON.stringify(request.rawInput || request.input || {}),
+    options:
+      request.options?.map((opt: any) => ({
+        label: opt.name || opt,
+        value: opt.optionId || opt,
+      })) || [
+        { label: 'Allow', value: 'allow_once' },
+        { label: 'Always Allow', value: 'allow_always' },
+        { label: 'Reject', value: 'reject_once' },
+      ],
+  };
 }

--- a/packages/contracts/src/conversations.ts
+++ b/packages/contracts/src/conversations.ts
@@ -94,6 +94,24 @@ export const CreateConversationRequestSchema = z.object({
 })
 export type CreateConversationRequest = z.infer<typeof CreateConversationRequestSchema>
 
+/** 用户级模型偏好（Moss 用户偏好 GET/PUT /api/v1/users/me/model 的 webui 代理 DTO） */
+export const SetUserModelRequestSchema = z.object({
+  modelId: z.string().trim().min(1).max(255),
+})
+export type SetUserModelRequest = z.infer<typeof SetUserModelRequestSchema>
+
+export const UserModelResponseSchema = z.object({
+  /** 未设偏好 / 上游不可用时为 null */
+  modelId: z.string().nullable(),
+})
+export type UserModelResponse = z.infer<typeof UserModelResponseSchema>
+
+/** 会话级模型回读（conversation_meta.model_id；未指定过为 null） */
+export const ConversationModelResponseSchema = z.object({
+  modelId: z.string().nullable(),
+})
+export type ConversationModelResponse = z.infer<typeof ConversationModelResponseSchema>
+
 export const ConversationListItemSchema = z.object({
   id: z.string(),
   status: z.string(),
@@ -161,6 +179,12 @@ export const ClientOutboundMessageSchema = z.discriminatedUnion('kind', [
     modelId: z.string().min(1).max(255),
   }),
   z.object({
+    /** 权限审批回批（转发上游 control_response；requestId/optionId 对应 request_id/behavior） */
+    kind: z.literal('control_response'),
+    requestId: z.string().min(1).max(255),
+    optionId: z.string().min(1).max(255),
+  }),
+  z.object({
     /** 停止当前回复（转发上游 control_request interrupt） */
     kind: z.literal('stop'),
   }),
@@ -184,4 +208,10 @@ export const UPSTREAM_EVENT_TYPES = new Set([
   'result',
   'system',
   'thinking', // 当前上游不发射；保留兼容位，未来上游支持即生效
+  // full-chat 产品化：权限审批（renderer 的 confirmation UI 消费）与工具进度/摘要/流式文本
+  'control_request',
+  'tool_progress',
+  'tool_use_summary',
+  'streamlined_text',
+  'streamlined_tool_use_summary',
 ])

--- a/packages/moss-client/src/MossSessionClient.ts
+++ b/packages/moss-client/src/MossSessionClient.ts
@@ -26,6 +26,8 @@ export interface MossSessionPort {
   ): Promise<{ sessionId: string; wsUrl: string }>
   /** 用户级模型偏好（Moss 无会话级模型接口，PUT /api/v1/users/me/model）；建会话前设置使新会话采用该模型 */
   setUserModel(ctx: MossCallContext, modelId: string): Promise<void>
+  /** 用户级模型偏好读取（GET /api/v1/users/me/model）；未设偏好时 null。上游无该端点等错误由调用方 catch */
+  getUserModel(ctx: MossCallContext): Promise<string | null>
   context(ctx: MossCallContext, sessionId: string): Promise<unknown>
   resume(ctx: MossCallContext, sessionId: string): Promise<{ session: MossSessionSummary; wsUrl: string }>
   terminate(ctx: MossCallContext, sessionId: string): Promise<void>
@@ -72,6 +74,9 @@ export function createMossSessionPort(mossFetch: MossFetch): MossSessionPort {
         body: {
           assistant_name: input.assistantName,
           enabled_skills: input.enabledSkills,
+          // 对齐桌面端 MossWsConnection 默认（false）：工具执行走 control_request 审批，
+          // 而非跳过权限。moss 服务端缺省值不可考，显式传递以确定行为。
+          dangerously_skip_permissions: false,
         },
       })
       const parsed = MossCreateSessionResponseSchema.parse(json)
@@ -86,6 +91,17 @@ export function createMossSessionPort(mossFetch: MossFetch): MossSessionPort {
         accessToken: ctx.accessToken,
         body: { modelId },
       })
+    },
+
+    async getUserModel(ctx) {
+      const json = await mossFetch(ctx.baseUrl, {
+        method: 'GET',
+        path: '/api/v1/users/me/model',
+        accessToken: ctx.accessToken,
+      })
+      // 上游响应形状未在仓库内可考（camelCase 与 snake_case 兼容读取），未设偏好返回 null
+      const parsed = safeParse(z.object({ modelId: z.string().nullable().optional(), model_id: z.string().nullable().optional() }).passthrough(), json)
+      return parsed?.modelId ?? parsed?.model_id ?? null
     },
 
     async context(ctx, sessionId) {

--- a/packages/moss-client/src/MossWebSocket.ts
+++ b/packages/moss-client/src/MossWebSocket.ts
@@ -214,3 +214,15 @@ export function buildInterruptMessage(requestId?: string): Record<string, unknow
     request: { subtype: 'interrupt' },
   }
 }
+
+/** 权限审批回批（与桌面端 MossWsConnection.respondToPermissionRequest 的消息形状一致） */
+export function buildControlResponseMessage(requestId: string, optionId: string): Record<string, unknown> {
+  return {
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: requestId,
+      response: { behavior: optionId },
+    },
+  }
+}


### PR DESCRIPTION
Finish the web full-chat gaps left after #1100, bringing the
shared-renderer path to feature parity with the desktop moss flow:

- shared mapping (@sudowork/common/mossResponse): add the 4 stateless
  frames (tool_progress / tool_use_summary / streamlined_text /
  streamlined_tool_use_summary), add mossControlRequestToConfirmation,
  and stamp the acp_question conversationId from ctx (desktop callers
  pass none, so their behavior is unchanged)
- desktop: drop the now-duplicated inline frame branches and the inline
  permission-request mapping in favor of the shared module (DRY)
- server: whitelist the 5 new upstream frames, forward control_response
  approval answers upstream (no writer-lock check), add GET/PUT
  /api/conversations/user-model and the lightweight GET /:id/model
  (local conversation_meta read), and moss-client gains getUserModel
  plus an explicit dangerously_skip_permissions=false on create
- mossAdapter: per-session pending confirmations/questions and abort
  suppression; control_request renders the renderer confirmation card;
  acp.answer-question / acp.set-model / confirmation.* / user-model
  handlers; acp.get-model-info synthesizes a switchable AcpModelInfo
  (options + 3-level current-model fallback) so the scode-projection
  selector becomes usable, scode.refresh-models returns real data, and
  get-conversation reads back conversation_meta model
- tests: mapping cases for the new frames/converter, contract updates
  for create body + getUserModel + buildControlResponseMessage,
  integration coverage for user-model REST, :id/model and
  control_response forwarding; fake session ports gain getUserModel
