### PR TITLE
ci(ffmpeg): fix mirror workflow for monorepo move + re-pin to a current BtbN build

### DIFF
--- a/.github/workflows/mirror-ffmpeg-to-cos.yml
+++ b/.github/workflows/mirror-ffmpeg-to-cos.yml
@@ -27,6 +27,11 @@ jobs:
   mirror:
     name: Mirror pinned FFmpeg to runtime COS
     runs-on: ubuntu-latest
+    # The ffmpeg tooling lives in the desktop workspace after the monorepo move,
+    # so every `run:` step resolves scripts/ src/shared/ resources/ from there.
+    defaults:
+      run:
+        working-directory: apps/desktop
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -37,11 +42,16 @@ jobs:
           node-version: '24'
 
       - name: Install deps (tar, yauzl for download-ffmpeg.js)
-        # download-ffmpeg.js only needs these two pure-JS libs — install just
-        # them (no --save, no native builds, no lockfile coupling).
-        run: npm install --no-save tar yauzl
+        # download-ffmpeg.js only needs these two pure-JS libs. Install them into
+        # an ISOLATED prefix (not the workspace) so npm doesn't try to resolve the
+        # monorepo's heavy workspace deps; the download step reaches them via
+        # NODE_PATH. (No --save, no native builds, no lockfile coupling.)
+        working-directory: ${{ runner.temp }}
+        run: npm install --no-save --prefix "${{ runner.temp }}/ffdeps" tar yauzl
 
       - name: Download + repack all pinned platforms
+        env:
+          NODE_PATH: ${{ runner.temp }}/ffdeps/node_modules
         run: |
           set -euo pipefail
           # download-ffmpeg.js runs on any OS — it just fetches the BtbN archive

--- a/apps/desktop/src/shared/ffmpeg-runtime.json
+++ b/apps/desktop/src/shared/ffmpeg-runtime.json
@@ -1,8 +1,8 @@
 {
   "_doc": "Pinned FFmpeg runtime — SSOT for scripts/download-ffmpeg.js (build-time bundling) and FfmpegRuntimeService (runtime extraction). Source: BtbN/FFmpeg-Builds GPL static builds (libx264 + libass, so `ffmpeg -vf subtitles=` subtitle burning works). 'tag' is an IMMUTABLE dated autobuild release (never 'latest', which rolls); 'version' is the git-describe shared by every asset name in that release; 'releaseSuffix' selects the FFmpeg release-branch build (n9.0) over the master snapshot. Per-platform 'sha256' is the SHA256 of the DOWNLOADED archive (BtbN's GitHub-published asset digest), verified after download — a mismatch aborts the build. To bump: pick a newer autobuild-* tag, set tag/version/releaseSuffix, and refresh every sha256 in one commit via `gh api repos/BtbN/FFmpeg-Builds/releases/tags/<tag> --jq '.assets[] | \"\\(.name) \\(.digest)\"'`. macOS: BtbN ships no macOS build — add an evermeet/osxexperts source before shipping mac (the script skips unconfigured platforms).",
 
-  "tag": "autobuild-2026-08-17-13-05",
-  "version": "n9.0.1-4-gb3ef323dd2",
+  "tag": "autobuild-2026-09-05-13-10",
+  "version": "n9.0.1-26-g5c8e7e2433",
   "releaseSuffix": "9.0",
 
   "_cos_doc": "Runtime download source. FfmpegRuntimeService downloads <cos.baseUrl>/ffmpeg/<tag>/ffmpeg-<key>.tar.gz on demand (China-reachable) when an ffmpeg-needing skill is installed, and verifies it against cos.sha256[key] (the SHA256 of the flat tar.gz produced+uploaded by .github/workflows/mirror-ffmpeg-to-cos.yml). IMPORTANT: node-tar's repack is NOT byte-reproducible, so EVERY mirror run re-uploads ALL platforms with fresh SHA256s — after ANY mirror run, replace EVERY entry below with the values the workflow printed, not just the one you bumped.",
@@ -20,10 +20,10 @@
 
   "_darwin_doc": "macOS: BtbN ships no macOS build, so darwin uses martin-riedl.de static release builds (same FFmpeg 9.0.1, --enable-gpl --enable-libass --enable-libx264). Unlike BtbN, ffmpeg and ffprobe are SEPARATE zips at immutable per-arch build-id URLs, so darwin entries carry explicit {url,sha256} per binary (verified against the source's .sha256 sidecar) instead of the derived-name/single-archive BtbN shape. To bump: pick a new release build id from https://ffmpeg.martin-riedl.de (macos/arm64 + macos/amd64, MATCH the versions) and refresh url+sha256.",
   "platforms": {
-    "win32-x64": { "btbn": "win64", "archive": "zip", "sha256": "ae937d5807fa7a281a0b9fbbfe976bfe60423a75c0892c0e6dcd266f37de43d5" },
-    "win32-arm64": { "btbn": "winarm64", "archive": "zip", "sha256": "ee488b5d138bc24557203b4b81a6a5895ef9b9a3f3b906c9669de2c6b07f63ef" },
-    "linux-x64": { "btbn": "linux64", "archive": "tar.xz", "sha256": "25557a63e38bbf2c03c27b647a40e3d1eaad391b6f0adfce501d62665b7c443c" },
-    "linux-arm64": { "btbn": "linuxarm64", "archive": "tar.xz", "sha256": "d6b7e2952b324b4f8f04d828778ca393668a34b00abd1a445000fbf97ba3e350" },
+    "win32-x64": { "btbn": "win64", "archive": "zip", "sha256": "a8ebbaf7a99185f5abc3a2d3a657521c38d7966f06b70468d7ab29a67fe8654f" },
+    "win32-arm64": { "btbn": "winarm64", "archive": "zip", "sha256": "4a14bf1cd415688667431b778432bf38d6ecca174e02cb0d08f21b331c8bd31a" },
+    "linux-x64": { "btbn": "linux64", "archive": "tar.xz", "sha256": "6b57f1c690481da960221afa3659c94532ceded9cb1eb633db853107769ba72a" },
+    "linux-arm64": { "btbn": "linuxarm64", "archive": "tar.xz", "sha256": "01b134fcdbf83d63814f483f30ead2102dec17fc560a54dd68acc585948b77c9" },
     "darwin-arm64": {
       "source": "martin-riedl",
       "archive": "zip",

--- a/apps/desktop/src/shared/ffmpeg-runtime.json
+++ b/apps/desktop/src/shared/ffmpeg-runtime.json
@@ -9,12 +9,12 @@
   "cos": {
     "baseUrl": "https://sudowork-runtime-1309794936.cos.ap-beijing.myqcloud.com",
     "sha256": {
-      "win32-x64": "10085a07553767019a9d3d198f4fb7487dd9c3c1cfd9029008b16cf0464d1af6",
-      "win32-arm64": "a04d6d587c613408b7b1678e7ad00295edacab1ab8db4cb6971139782f5dbae9",
-      "linux-x64": "a31668e1fbb9df98ec2ba7e77a42064e3da5095f3aca7ec9cd2534adeb3c27bf",
-      "linux-arm64": "4771b40691cf6cdb4c4a589d64cff6d5f24d9c806d379f9f46fe2f30a027d480",
-      "darwin-x64": "d6ed0741dd4d231da40c0ae7c698c0b184b2dcb39abae1921930e7911fe3c6b1",
-      "darwin-arm64": "6df2b84c0b32853c11da6aee66d72aafdab13a6eb528337c7f594550bc4469fb"
+      "win32-x64": "730264bebacaeb872108d5683197f6cd20e120472731f3cf3f3e6240696c6fb0",
+      "win32-arm64": "f77ac3364cb13bbcfc39f3f718d437480672a0b27f4d9b96b3142ebbe32fc9c1",
+      "linux-x64": "7a5a2ebcdf7d896e2960a995d3a0089970acad3cc269a721dc8ca856a5c8c83b",
+      "linux-arm64": "0b9f4d2175540f9f16705e7041c7f5a758ab106762388a9a96c4af3e008cf6f2",
+      "darwin-x64": "09152ccd2558fa34662682ee50010f924784a211b2bae3b8bffe300f7cfd3c03",
+      "darwin-arm64": "e1414711b6399d0852493538e5f8b476044bc45dbd46973913f7a60b0e7f68ea"
     }
   },
 


### PR DESCRIPTION
## Why

The monorepo migration moved the ffmpeg tooling into `apps/desktop/`, but the
FFmpeg→COS mirror workflow still ran `scripts/download-ffmpeg.js` and read
`src/shared/ffmpeg-runtime.json` from the repo root — so a re-mirror (needed on
any ffmpeg pin bump) would fail. Verifying that also surfaced that BtbN had
pruned the pinned dated autobuild, so the mirror could no longer re-fetch the
source at all.

Client provisioning was never affected (FfmpegRuntimeService downloads the
mirrored tar.gz from COS, not from BtbN) — this only concerned the mirror.

## What

- **Mirror workflow paths** — run its steps from `apps/desktop`
  (`working-directory`) so `scripts/ src/shared/ resources/` resolve there, and
  install `tar`+`yauzl` into an isolated prefix reached via `NODE_PATH` so npm
  doesn't pull the monorepo's heavy workspace deps.
- **Re-pin** — BtbN prunes old dated autobuilds, so `autobuild-2026-08-17-13-05`
  (n9.0.1-4) is gone. Re-pin win/linux to `autobuild-2026-09-05-13-10`
  (n9.0.1-26, same 9.0 branch). darwin stays on martin-riedl 9.0.1 — its
  build-id URLs are immutable and still valid (verified against the source
  sidecar), which is exactly why it's the more durable source.
- **Refresh cos.sha256** — all 6 from the mirror run for the new tag.

## Verified (end-to-end)

- The mirror workflow **ran green** on this branch: resolved all `apps/desktop`
  paths, installed tar/yauzl via NODE_PATH, downloaded + `SHA256 verified` all 6
  sources, repacked, and uploaded to `ffmpeg/autobuild-2026-09-05-13-10/`.
- From a **China host**: the new-tag COS objects `ffmpeg-win32-x64.tar.gz`
  (108 MB) and `ffmpeg-darwin-arm64.tar.gz` (57 MB) download and their SHA256
  **match** the recorded pins.
- Swept all workflows: the mirror was the only place broken by the move
  (`_build-reusable`/`build-and-release` carry no ffmpeg; the per-package
  `apps/desktop` ffmpeg:download script resolves correctly).
