### PR TITLE
feat(auth): one auth server address, so a control plane can declare its login method

### DIFF
--- a/packages/host-bridge/src/authServer.ts
+++ b/packages/host-bridge/src/authServer.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 SudoPrivacy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Which server this client authenticates against.
+ *
+ * The app historically kept two addresses that never met: `system.sudoworkServerUrl`
+ * for the consumer entry and `eeclaw.serverUrl` for the enterprise one, with the
+ * auth calls hard-wired to the consumer one. That is why pointing the app at a
+ * control plane could not produce a phone-code login screen — the login method
+ * came from one server while the login request went to another.
+ *
+ * This resolves the single address the whole auth flow should use, so
+ * `/api/v1/system-config` and `/api/v1/auth/*` always describe and address the
+ * same server.
+ */
+import { ConfigStorage } from '@sudowork/common/storage';
+import { getSudoworkServerBaseUrl, normalizeSudoworkServerUrl } from '@sudowork/common/sudoworkServer';
+import { getAppMode } from './eeclawMode.js';
+
+/**
+ * Base URL of the server that owns identity for this client.
+ *
+ * Enterprise mode answers with the configured control-plane address; every other
+ * mode answers with the consumer server. Enterprise mode with no address
+ * configured falls back to the consumer server rather than returning nothing, so
+ * a half-configured install degrades to the old behaviour instead of failing
+ * every request with an unhelpful error.
+ */
+export async function getAuthServerBaseUrl(): Promise<string> {
+  const mode = await getAppMode();
+  if (mode === 'e') {
+    const raw = await ConfigStorage.get('eeclaw.serverUrl').catch((): string | undefined => undefined);
+    const normalized = normalizeSudoworkServerUrl(raw);
+    if (normalized) return normalized;
+  }
+  return getSudoworkServerBaseUrl();
+}

--- a/packages/renderer/src/context/AuthContext.tsx
+++ b/packages/renderer/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import { useTranslation } from 'react-i18next';
 import * as ipcBridge from '@sudowork/host-bridge/ipcBridge';
 import { getSudoworkServerBaseUrl } from '@sudowork/common/sudoworkServer';
+import { getAuthServerBaseUrl } from '@sudowork/host-bridge/authServer';
 import { ConfigStorage, type IConfigStorageRefer } from '@sudowork/common/storage';
 import { pickDefaultImageModelFromPricing, pickImageGenerationModelId, resolveImageModelWithAvailability } from '@sudowork/common/imageGenerationModelConfig';
 import { fetchSystemConfig } from '@sudowork/common/systemConfig';
@@ -475,7 +476,7 @@ async function openThirdPartyLogoutIfNeeded(session: AuthSession | undefined): P
   if (session?.type !== 'cas') return;
 
   try {
-    const serverBaseUrl = await getSudoworkServerBaseUrl();
+    const serverBaseUrl = await getAuthServerBaseUrl();
     const systemConfig = await fetchSystemConfig(serverBaseUrl);
     const authConfig = resolveThirdPartyAuthConfig(systemConfig);
     const provider = authConfig?.providers.find((item) => item.id === session.provider);
@@ -751,7 +752,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           const authStorage: AuthStorage = JSON.parse(stored);
           const { refresh_token, device_id } = authStorage;
 
-          const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/refresh`, {
+          const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/refresh`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ refresh_token, device_id }),
@@ -1184,7 +1185,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     const deviceId = getDeviceId();
 
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/login`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1232,7 +1233,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     const deviceId = getDeviceId();
 
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/register`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1267,7 +1268,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const loginByPassword = useCallback(async ({ phone, password }: PasswordLoginParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/login-by-config`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/login-by-config`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1291,7 +1292,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const registerByPassword = useCallback(async ({ phone, password, nickname, invitation_code }: PasswordRegisterParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/register-password`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/register-password`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1314,7 +1315,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const loginWithThirdPartyAuth = useCallback(async ({ provider, ticket, service }: ThirdPartyAuthLoginParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/third-party/cas/login`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/third-party/cas/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1337,7 +1338,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const exchangeThirdPartyAuthCode = useCallback(async ({ provider, code }: ThirdPartyAuthExchangeParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/third-party/cas/exchange`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/third-party/cas/exchange`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1365,7 +1366,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         return { success: false, message: '登录状态已过期，请重新登录' };
       }
       try {
-        const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/change-password`, {
+        const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/change-password`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -1690,7 +1691,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         const { refresh_token, device_id } = authStorage;
         session = authStorage.session;
 
-        await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/logout`, {
+        await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/logout`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ refresh_token, device_id }),

--- a/packages/renderer/src/hooks/useSystemLoginMethod.ts
+++ b/packages/renderer/src/hooks/useSystemLoginMethod.ts
@@ -7,6 +7,7 @@
 import { useEffect, useState } from 'react';
 import * as ipcBridge from '@sudowork/host-bridge/ipcBridge';
 import { fetchSystemConfig, type SystemConfig } from '@sudowork/common/systemConfig';
+import { getAuthServerBaseUrl } from '@sudowork/host-bridge/authServer';
 import { THIRD_PARTY_LOGIN_METHOD } from '@sudowork/common/thirdPartyAuthConfig';
 
 /** 0 = 手机验证码；1 = 用户名密码；2 = 三方认证登录 */
@@ -38,7 +39,10 @@ async function fetchLoginMethod(): Promise<{ loginMethod: LoginMethod; systemCon
       // Reuse the shared client; fetchSystemConfig() also fills the renderer's
       // system-config module cache (setSystemConfigCache) so synchronous base-url
       // helpers work for renderer consumers.
-      const data = await fetchSystemConfig();
+      // Ask the server this client actually authenticates against. Reading the
+      // consumer server here while logging in against a control plane is what
+      // used to make a moss deployment unable to advertise its login method.
+      const data = await fetchSystemConfig(await getAuthServerBaseUrl());
       // Sync to main-process cache (see main.tsx for rationale).
       if (data) {
         void ipcBridge.systemConfig.syncFromRenderer.invoke({ data }).catch(() => {});

--- a/packages/renderer/src/pages/login/index.tsx
+++ b/packages/renderer/src/pages/login/index.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button, Input, Message, Space } from '@arco-design/web-react';
 import { Phone, Protect, Key, User, Lock } from '@icon-park/react';
-import { getSudoworkServerBaseUrl } from '@sudowork/common/sudoworkServer';
+import { getAuthServerBaseUrl } from '@sudowork/host-bridge/authServer';
 import { DEFAULT_TENANT_CONFIG, TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@sudowork/common/types/tenantConfig';
 import { ConfigStorage } from '@sudowork/common/storage';
 import * as ipcBridge from '@sudowork/host-bridge/ipcBridge';
@@ -67,6 +67,20 @@ const LoginPage: React.FC = () => {
   const { status, enterGuest, login, register, enterpriseLogin, enterpriseLoginWithOAuth2 } = useAuth();
   const { isEnterprise } = useAppMode();
   const { loginMethod, systemConfig } = useSystemLoginMethod();
+
+  // A control plane that serves /api/v1/system-config gets to say how people log
+  // in, exactly as the consumer server already does. `systemConfig` is null only
+  // when the probe found nothing to ask — an older build, or an unreachable
+  // server — in which case the tabs below stay the fallback.
+  //
+  // Only method 0 is delegated for now, and deliberately so: the phone panel
+  // posts to /api/v1/auth/{send-code,login,register} on the active server, which
+  // a control plane serves. Method 1's consumer panel speaks endpoints
+  // (login-by-config, register-password) that a control plane does not have —
+  // its password login IS the tab panel below — and method 2's CAS exchange is
+  // likewise not implemented there yet. Delegating those would swap a working
+  // screen for a 404.
+  const serverDeclaresPhoneLogin = isEnterprise && systemConfig !== null && loginMethod === 0;
 
   // Enterprise login state
   const [loginTab, setLoginTab] = useState<'password' | 'key' | 'oauth2'>('password');
@@ -247,7 +261,7 @@ const LoginPage: React.FC = () => {
 
     setLoading(true);
     try {
-      const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/send-code`, {
+      const res = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/send-code`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone: currentPhone }),
@@ -277,8 +291,9 @@ const LoginPage: React.FC = () => {
   const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();
 
-    // Enterprise mode login
-    if (isEnterprise) {
+    // Enterprise mode login. Skipped when the server asked for the phone panel,
+    // so the submit path matches the panel actually on screen.
+    if (isEnterprise && !serverDeclaresPhoneLogin) {
       if (loginTab === 'password') {
         if (!username.trim() || !password.trim()) {
           Message.warning('请填写所有必填项');
@@ -497,7 +512,7 @@ const LoginPage: React.FC = () => {
   };
 
   // Enterprise login UI
-  if (isEnterprise) {
+  if (isEnterprise && !serverDeclaresPhoneLogin) {
     return (
       <div className='login-page'>
         {showWindowControls && (


### PR DESCRIPTION
## Why

The app kept **two server addresses that never met** — `system.sudoworkServerUrl` for the consumer entry, `eeclaw.serverUrl` for the enterprise one — while every `/api/v1/auth/*` call was hard-wired to the consumer one.

That is why pointing sudowork at a control plane could not produce a phone-code login screen: **the login method came from one server and the login request went to another.** The client already asks a server how to log in (`useSystemLoginMethod` → `/api/v1/system-config`); it just asked the wrong one.

## What

- **`getAuthServerBaseUrl()`** (new, `packages/host-bridge`) resolves the single address the whole auth flow uses. Enterprise mode → the configured control plane; otherwise → the consumer server. Enterprise with nothing configured falls back to the consumer server, so a half-configured install degrades to today's behaviour instead of failing every request.
- The **system-config probe** and **every `/api/v1/auth/*` call** (9 in `AuthContext`, 1 on the login page) now follow it. `/system-config/credentials` stays on the consumer server — it is a consumer-server feature.
- The **enterprise screen defers to the declared method** when the server answers the probe.

## The one deliberate narrowing

**Only `login_method: 0` is delegated.** The phone panel posts to `/auth/{send-code,login,register}`, which a control plane serves. The consumer *password* panel speaks `login-by-config` / `register-password`, which it does not have — a control plane's password login **is** the existing tab panel — and CAS exchange is likewise not implemented there yet. Delegating those would swap a working screen for a 404.

A server that does not answer the probe (older build, or unreachable) keeps today's tabs, so this is backwards compatible.

The submit handler shares the same predicate as the render, so the path taken on submit always matches the panel on screen — otherwise the phone panel would submit through the password branch.

## Both hosts, one change

`apps/desktop` and `apps/webui` mount the same `packages/renderer`, so the login page is shared and both get this.

⚠️ **The browser is not fully there yet, and this PR does not claim otherwise.** `apps/webui`'s server has its own auth routes (`/login/password`, `/login/api-key`, cookie session) and does **not** forward `/api/v1/auth/*` to the control plane, so browser phone-signup additionally needs a proxy route in `apps/webui`. Separately, CAS in a browser cannot use the `sudowork://` deep-link callback and must be configured for `server_callback` mode.

## Verified

- `packages/renderer` type-check clean.
- ESLint on the changed files: 0 errors (2 pre-existing `no-explicit-any` warnings on a line I did not touch).
- The 3 `Cannot find module` errors from `bun run type:check` are pre-existing and in files this PR does not touch (`@sudowork/moss-client` needs `build:packages`; `@nexus-ai-fs/vfs-client` is COS-distributed).

Full-flow e2e against a control plane follows once the server side lands (moss #227 + #228).