### PR TITLE
feat(webui): browser phone signup — server routes, system-config forward, and the web client branch

### DIFF
--- a/apps/desktop/tests/unit/authServerResolution.test.ts
+++ b/apps/desktop/tests/unit/authServerResolution.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Which server the auth flow addresses.
+ *
+ * The point of these tests is the FIRST one: consumer-mode users — everyone who
+ * signed up through the public sudowork-server and logs in with a phone code —
+ * must keep reaching that same server. Routing `/api/v1/auth/*` through a
+ * resolver was done so a control plane could declare its own login method; if it
+ * ever changed where an existing consumer user authenticates, their SMS login
+ * would silently start hitting a server that has never heard of them.
+ */
+
+const CONSUMER_SERVER = 'https://sudowork-server.sudoprivacy.com';
+
+let appMode: 'c' | 'e' | null = null;
+let configValues: Record<string, string | undefined> = {};
+
+vi.mock('@sudowork/common/storage', () => ({
+  ConfigStorage: {
+    get: vi.fn(async (key: string) => configValues[key]),
+    set: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('@sudowork/common/sudoworkServer', async () => {
+  const actual = await vi.importActual<typeof import('@sudowork/common/sudoworkServer')>(
+    '@sudowork/common/sudoworkServer'
+  );
+  return {
+    ...actual,
+    getSudoworkServerBaseUrl: vi.fn(async () => CONSUMER_SERVER),
+  };
+});
+
+vi.mock('@sudowork/host-bridge/ipcBridge', () => ({ eeclaw: { setAppMode: { invoke: vi.fn() } } }));
+
+vi.mock('@sudowork/host-bridge/eeclawMode', () => ({
+  getAppMode: vi.fn(async () => appMode),
+}));
+
+const { getAuthServerBaseUrl } = await import('@sudowork/host-bridge/authServer');
+
+beforeEach(() => {
+  appMode = null;
+  configValues = {};
+});
+
+describe('getAuthServerBaseUrl', () => {
+  it('keeps consumer-mode users on the consumer server', async () => {
+    // The regression that matters: existing phone-code users must not be
+    // silently redirected to a control plane that has no account for them.
+    appMode = 'c';
+    configValues['eeclaw.serverUrl'] = 'https://some-control-plane.example.com';
+    expect(await getAuthServerBaseUrl()).toBe(CONSUMER_SERVER);
+  });
+
+  it('keeps a user who has never chosen a mode on the consumer server', async () => {
+    appMode = null;
+    expect(await getAuthServerBaseUrl()).toBe(CONSUMER_SERVER);
+  });
+
+  it('uses the configured control plane in enterprise mode', async () => {
+    appMode = 'e';
+    configValues['eeclaw.serverUrl'] = 'https://agent.example.com';
+    expect(await getAuthServerBaseUrl()).toBe('https://agent.example.com');
+  });
+
+  it('normalises the configured address', async () => {
+    appMode = 'e';
+    configValues['eeclaw.serverUrl'] = 'https://agent.example.com/';
+    expect(await getAuthServerBaseUrl()).toBe('https://agent.example.com');
+  });
+
+  it('falls back to the consumer server when enterprise mode has no address', async () => {
+    // A half-configured install degrades to the previous behaviour instead of
+    // failing every auth request with an unhelpful error.
+    appMode = 'e';
+    expect(await getAuthServerBaseUrl()).toBe(CONSUMER_SERVER);
+  });
+
+  it('falls back when the configured address is unusable', async () => {
+    appMode = 'e';
+    configValues['eeclaw.serverUrl'] = 'not a url';
+    expect(await getAuthServerBaseUrl()).toBe(CONSUMER_SERVER);
+  });
+});

--- a/apps/webui/Dockerfile
+++ b/apps/webui/Dockerfile
@@ -19,7 +19,6 @@ COPY packages/contracts/package.json packages/contracts/
 COPY packages/host-bridge/package.json packages/host-bridge/
 COPY packages/moss-client/package.json packages/moss-client/
 COPY packages/renderer/package.json packages/renderer/
-COPY packages/ui/package.json packages/ui/
 COPY patches/ patches/
 
 # --ignore-scripts: this build only produces the webui, so skip every workspace
@@ -60,7 +59,6 @@ COPY packages/contracts/package.json packages/contracts/
 COPY packages/host-bridge/package.json packages/host-bridge/
 COPY packages/moss-client/package.json packages/moss-client/
 COPY packages/renderer/package.json packages/renderer/
-COPY packages/ui/package.json packages/ui/
 COPY patches/ patches/
 ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \

--- a/apps/webui/src/server/app.ts
+++ b/apps/webui/src/server/app.ts
@@ -135,6 +135,28 @@ export function registerApiRoutes(app: Express, deps: ApiDeps): ApiHandles {
   const { config, pool } = deps
 
   app.use('/api', createSessionMiddleware(pool, config.sessionHmacKey))
+
+  // Client bootstrap, forwarded from the moss this deployment fronts.
+  //
+  // The shared renderer probes `<origin>/api/v1/system-config` before showing a
+  // login screen, and in the browser that origin is this server rather than
+  // moss. Without the forward the probe finds nothing, the renderer falls back
+  // to its password tabs, and a deployment configured for phone signup silently
+  // shows the wrong screen. Mounted above the session middleware's protected
+  // routes because it is read while logged out.
+  app.get('/api/v1/system-config', (_req, res) => {
+    void (async () => {
+      try {
+        const upstream = await fetch(new URL('/api/v1/system-config', config.moss.baseUrl).toString())
+        res.status(upstream.status).json(await upstream.json())
+      } catch {
+        // A moss that is down or too old to serve this must not take the login
+        // page with it: the renderer treats an unusable answer as "unknown" and
+        // keeps its existing tabs.
+        res.status(502).json({ success: false, msg: 'system config unavailable' })
+      }
+    })()
+  })
   app.use('/api/auth', createAuthRouter({ pool, config, mossAuth: deps.mossAuth }))
 
   const mossFetch = deps.mossFetch ?? mossRequest

--- a/apps/webui/src/server/app.ts
+++ b/apps/webui/src/server/app.ts
@@ -147,7 +147,9 @@ export function registerApiRoutes(app: Express, deps: ApiDeps): ApiHandles {
   app.get('/api/v1/system-config', (_req, res) => {
     void (async () => {
       try {
-        const upstream = await fetch(new URL('/api/v1/system-config', config.moss.baseUrl).toString())
+        const upstream = await fetch(
+          new URL('/api/v1/system-config', config.moss.baseUrl).toString(),
+        )
         res.status(upstream.status).json(await upstream.json())
       } catch {
         // A moss that is down or too old to serve this must not take the login

--- a/apps/webui/src/server/features/auth/authRoutes.ts
+++ b/apps/webui/src/server/features/auth/authRoutes.ts
@@ -2,6 +2,7 @@ import { Router, type Response, type NextFunction } from 'express'
 import rateLimit from 'express-rate-limit'
 import { ZodError } from 'zod'
 import type { AppConfig } from '../../config.js'
+import { SmsRateLimitedError } from '@sudowork/moss-client'
 import {
   LoginApiKeyRequestSchema,
   LoginPasswordRequestSchema,
@@ -99,8 +100,21 @@ export function createAuthRouter(deps: AuthDeps): Router {
   router.post('/send-code', loginLimiter, (req, res, next) => {
     void (async () => {
       const input = SendPhoneCodeRequestSchema.parse(req.body)
-      const result = await sendPhoneCode(deps, input)
-      res.status(200).json({ ok: true, nextSendIn: result.nextSendIn })
+      try {
+        const result = await sendPhoneCode(deps, input)
+        res.status(200).json({ ok: true, nextSendIn: result.nextSendIn })
+      } catch (err) {
+        // The cooldown and the hourly cap are normal states with a wait
+        // attached, not failures: pass the countdown through so the UI can show
+        // it instead of a generic error.
+        if (err instanceof SmsRateLimitedError) {
+          res
+            .status(429)
+            .json({ error: 'RATE_LIMITED', nextSendIn: err.retryAfterSec, message: err.message })
+          return
+        }
+        throw err
+      }
     })().catch((err: unknown) => authErrorHandler(err, res, next))
   })
 

--- a/apps/webui/src/server/features/auth/authRoutes.ts
+++ b/apps/webui/src/server/features/auth/authRoutes.ts
@@ -2,13 +2,22 @@ import { Router, type Response, type NextFunction } from 'express'
 import rateLimit from 'express-rate-limit'
 import { ZodError } from 'zod'
 import type { AppConfig } from '../../config.js'
-import { LoginApiKeyRequestSchema, LoginPasswordRequestSchema } from '@sudowork/contracts/auth'
+import {
+  LoginApiKeyRequestSchema,
+  LoginPasswordRequestSchema,
+  LoginPhoneRequestSchema,
+  RegisterPhoneRequestSchema,
+  SendPhoneCodeRequestSchema,
+} from '@sudowork/contracts/auth'
 import {
   InvalidCredentialsError,
   MossUnavailableError,
   loginWithApiKey,
   loginWithPassword,
+  loginWithPhone,
   logout,
+  registerWithPhone,
+  sendPhoneCode,
   resolveSession,
   type AuthDeps,
 } from './authService.js'
@@ -19,6 +28,9 @@ import { SESSION_COOKIE_NAME, requireSession, type AuthedRequest } from './sessi
  *   GET  /api/auth/session
  *   POST /api/auth/login/password
  *   POST /api/auth/login/api-key
+ *   POST /api/auth/send-code
+ *   POST /api/auth/login/phone
+ *   POST /api/auth/register/phone
  *   POST /api/auth/logout
  * 错误不区分用户不存在/密码错误（计划 Task 3）。
  */
@@ -75,6 +87,47 @@ export function createAuthRouter(deps: AuthDeps): Router {
     void (async () => {
       const input = LoginApiKeyRequestSchema.parse(req.body)
       const result = await loginWithApiKey(deps, input.apiKey, input.mossBaseUrl)
+      setSessionCookie(res, deps.config, result.cookieToken)
+      res.status(200).json({ ok: true })
+    })().catch((err: unknown) => authErrorHandler(err, res, next))
+  })
+
+  // Phone signup/login. Under the same limiter as the other login routes: it is
+  // unauthenticated and, once a real SMS provider exists, costs money per call.
+  // moss owns cooldown, expiry and attempt budget, so the browser and the
+  // desktop cannot drift apart on them.
+  router.post('/send-code', loginLimiter, (req, res, next) => {
+    void (async () => {
+      const input = SendPhoneCodeRequestSchema.parse(req.body)
+      const result = await sendPhoneCode(deps, input)
+      res.status(200).json({ ok: true, nextSendIn: result.nextSendIn })
+    })().catch((err: unknown) => authErrorHandler(err, res, next))
+  })
+
+  router.post('/login/phone', loginLimiter, (req, res, next) => {
+    void (async () => {
+      const input = LoginPhoneRequestSchema.parse(req.body)
+      const result = await loginWithPhone(deps, input)
+      // An unknown number is the normal first step of signup, not a failure, so
+      // it answers 200 with the attestation and sets no cookie.
+      if ('needRegister' in result) {
+        res.status(200).json({
+          ok: false,
+          needRegister: true,
+          registerToken: result.registerToken,
+          phone: result.phone,
+        })
+        return
+      }
+      setSessionCookie(res, deps.config, result.cookieToken)
+      res.status(200).json({ ok: true })
+    })().catch((err: unknown) => authErrorHandler(err, res, next))
+  })
+
+  router.post('/register/phone', loginLimiter, (req, res, next) => {
+    void (async () => {
+      const input = RegisterPhoneRequestSchema.parse(req.body)
+      const result = await registerWithPhone(deps, input)
       setSessionCookie(res, deps.config, result.cookieToken)
       res.status(200).json({ ok: true })
     })().catch((err: unknown) => authErrorHandler(err, res, next))

--- a/apps/webui/src/server/features/auth/authService.ts
+++ b/apps/webui/src/server/features/auth/authService.ts
@@ -224,13 +224,22 @@ export async function loginWithPhone(
 /** Exchange moss's register attestation for an account, and open a web session. */
 export async function registerWithPhone(
   deps: AuthDeps,
-  input: { registerToken: string; nickname?: string; invitationCode?: string; mossBaseUrl?: string },
+  input: {
+    registerToken: string
+    nickname?: string
+    invitationCode?: string
+    mossBaseUrl?: string
+  },
 ): Promise<LoginResult> {
   const { baseUrl, identityBaseUrl } = resolveLoginMoss(deps.config, input.mossBaseUrl)
   let tokens
   try {
     tokens = await deps.mossAuth.registerWithPhone(
-      { registerToken: input.registerToken, nickname: input.nickname, invitationCode: input.invitationCode },
+      {
+        registerToken: input.registerToken,
+        nickname: input.nickname,
+        invitationCode: input.invitationCode,
+      },
       baseUrl,
     )
   } catch (err) {

--- a/apps/webui/src/server/features/auth/authService.ts
+++ b/apps/webui/src/server/features/auth/authService.ts
@@ -182,6 +182,64 @@ export async function loginWithPassword(
   return performLogin(deps, tokens, me, identityBaseUrl)
 }
 
+/**
+ * Ask moss to send a verification code. A pure pass-through: the browser has no
+ * session yet, and rate limiting / delivery / expiry all belong to moss so the
+ * desktop and the browser cannot drift apart on them.
+ */
+export async function sendPhoneCode(
+  deps: AuthDeps,
+  input: { phone: string; mossBaseUrl?: string },
+): Promise<{ nextSendIn: number }> {
+  const { baseUrl } = resolveLoginMoss(deps.config, input.mossBaseUrl)
+  return deps.mossAuth.sendPhoneCode(input.phone, baseUrl)
+}
+
+/**
+ * Phone + code login.
+ *
+ * A number moss has not seen yet returns `needRegister` with moss's attestation
+ * rather than an error, and no cookie is set: the caller shows a registration
+ * form and comes back to `registerWithPhone`. That keeps the code verified
+ * exactly once even though signup takes two requests.
+ */
+export async function loginWithPhone(
+  deps: AuthDeps,
+  input: { phone: string; code: string; mossBaseUrl?: string },
+): Promise<LoginResult | { needRegister: true; registerToken: string; phone: string }> {
+  const { baseUrl, identityBaseUrl } = resolveLoginMoss(deps.config, input.mossBaseUrl)
+  let result
+  try {
+    result = await deps.mossAuth.loginWithPhone({ phone: input.phone, code: input.code }, baseUrl)
+  } catch (err) {
+    throw mapLoginError(err)
+  }
+  if (result.kind === 'need_register') {
+    return { needRegister: true, registerToken: result.registerToken, phone: result.phone }
+  }
+  const me = await fetchMe(deps, result.tokens.access_token, baseUrl)
+  return performLogin(deps, result.tokens, me, identityBaseUrl)
+}
+
+/** Exchange moss's register attestation for an account, and open a web session. */
+export async function registerWithPhone(
+  deps: AuthDeps,
+  input: { registerToken: string; nickname?: string; invitationCode?: string; mossBaseUrl?: string },
+): Promise<LoginResult> {
+  const { baseUrl, identityBaseUrl } = resolveLoginMoss(deps.config, input.mossBaseUrl)
+  let tokens
+  try {
+    tokens = await deps.mossAuth.registerWithPhone(
+      { registerToken: input.registerToken, nickname: input.nickname, invitationCode: input.invitationCode },
+      baseUrl,
+    )
+  } catch (err) {
+    throw mapLoginError(err)
+  }
+  const me = await fetchMe(deps, tokens.access_token, baseUrl)
+  return performLogin(deps, tokens, me, identityBaseUrl)
+}
+
 export async function loginWithApiKey(
   deps: AuthDeps,
   apiKey: string,

--- a/apps/webui/tests/integration/agent-skill-idor.test.ts
+++ b/apps/webui/tests/integration/agent-skill-idor.test.ts
@@ -45,6 +45,15 @@ function createFakeAuth(): MossAuthPort {
     async loginWithApiKey() {
       throw new MossHttpError(401, '', '')
     },
+    async sendPhoneCode() {
+      throw new Error('sendPhoneCode not stubbed in this test')
+    },
+    async loginWithPhone() {
+      throw new Error('loginWithPhone not stubbed in this test')
+    },
+    async registerWithPhone() {
+      throw new Error('registerWithPhone not stubbed in this test')
+    },
     async refresh() {
       throw new MossHttpError(401, '', '')
     },

--- a/apps/webui/tests/integration/conversation-stream.test.ts
+++ b/apps/webui/tests/integration/conversation-stream.test.ts
@@ -185,6 +185,15 @@ describe('conversation stream (browser WS ⇄ coordinator ⇄ upstream moss WS)'
       async loginWithApiKey() {
         throw new MossHttpError(401, '', '')
       },
+      async sendPhoneCode() {
+        throw new Error('sendPhoneCode not stubbed in this test')
+      },
+      async loginWithPhone() {
+        throw new Error('loginWithPhone not stubbed in this test')
+      },
+      async registerWithPhone() {
+        throw new Error('registerWithPhone not stubbed in this test')
+      },
       async refresh() {
         throw new MossHttpError(401, '', '')
       },

--- a/apps/webui/tests/integration/conversations.test.ts
+++ b/apps/webui/tests/integration/conversations.test.ts
@@ -149,6 +149,15 @@ const fakeMossAuth: MossAuthPort = {
   async loginWithApiKey() {
     throw new MossHttpError(401, '', '')
   },
+  async sendPhoneCode() {
+    throw new Error('sendPhoneCode not stubbed in this test')
+  },
+  async loginWithPhone() {
+    throw new Error('loginWithPhone not stubbed in this test')
+  },
+  async registerWithPhone() {
+    throw new Error('registerWithPhone not stubbed in this test')
+  },
   async refresh() {
     throw new MossHttpError(401, '', '')
   },

--- a/apps/webui/tests/integration/cron-idor.test.ts
+++ b/apps/webui/tests/integration/cron-idor.test.ts
@@ -61,6 +61,15 @@ function createFakeAuth(): MossAuthPort {
     async loginWithApiKey() {
       throw new MossHttpError(401, '', '')
     },
+    async sendPhoneCode() {
+      throw new Error('sendPhoneCode not stubbed in this test')
+    },
+    async loginWithPhone() {
+      throw new Error('loginWithPhone not stubbed in this test')
+    },
+    async registerWithPhone() {
+      throw new Error('registerWithPhone not stubbed in this test')
+    },
     async refresh() {
       throw new MossHttpError(401, '', '')
     },

--- a/apps/webui/tests/integration/login.test.ts
+++ b/apps/webui/tests/integration/login.test.ts
@@ -43,6 +43,15 @@ function createFakeMossAuth(): MossAuthPort {
       if (apiKey === 'sk-good') return TOKENS_B
       throw new MossHttpError(401, '{"error":"invalid"}', '/api/v1/auth/login')
     },
+    async sendPhoneCode() {
+      throw new Error('sendPhoneCode not stubbed in this test')
+    },
+    async loginWithPhone() {
+      throw new Error('loginWithPhone not stubbed in this test')
+    },
+    async registerWithPhone() {
+      throw new Error('registerWithPhone not stubbed in this test')
+    },
     async refresh() {
       throw new MossHttpError(401, '', '/api/v1/auth/token')
     },

--- a/apps/webui/tests/integration/settings-mcp.test.ts
+++ b/apps/webui/tests/integration/settings-mcp.test.ts
@@ -95,6 +95,15 @@ function createFakeAuth(): MossAuthPort {
     async loginWithApiKey() {
       throw new MossHttpError(401, '', '')
     },
+    async sendPhoneCode() {
+      throw new Error('sendPhoneCode not stubbed in this test')
+    },
+    async loginWithPhone() {
+      throw new Error('loginWithPhone not stubbed in this test')
+    },
+    async registerWithPhone() {
+      throw new Error('registerWithPhone not stubbed in this test')
+    },
     async refresh() {
       throw new MossHttpError(401, '', '')
     },

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -50,6 +50,28 @@ export const LoginApiKeyRequestSchema = z.object({
 })
 export type LoginApiKeyRequest = z.infer<typeof LoginApiKeyRequestSchema>
 
+/** Phone signup/login. Bounds mirror the server-side validator in moss. */
+export const SendPhoneCodeRequestSchema = z.object({
+  phone: z.string().trim().min(11).max(16),
+  mossBaseUrl: MossBaseUrlSchema,
+})
+export type SendPhoneCodeRequest = z.infer<typeof SendPhoneCodeRequestSchema>
+
+export const LoginPhoneRequestSchema = z.object({
+  phone: z.string().trim().min(11).max(16),
+  code: z.string().trim().regex(/^\d{4,8}$/),
+  mossBaseUrl: MossBaseUrlSchema,
+})
+export type LoginPhoneRequest = z.infer<typeof LoginPhoneRequestSchema>
+
+export const RegisterPhoneRequestSchema = z.object({
+  registerToken: z.string().min(1).max(4096),
+  nickname: z.string().trim().max(64).optional(),
+  invitationCode: z.string().trim().max(64).optional(),
+  mossBaseUrl: MossBaseUrlSchema,
+})
+export type RegisterPhoneRequest = z.infer<typeof RegisterPhoneRequestSchema>
+
 /** GET /api/auth/session 的浏览器响应（白名单 DTO）。 */
 export const SessionResponseSchema = z.object({
   user: z.object({ id: z.string(), name: z.string() }),

--- a/packages/host-bridge/src/authServer.ts
+++ b/packages/host-bridge/src/authServer.ts
@@ -35,7 +35,20 @@ export async function getAuthServerBaseUrl(): Promise<string> {
   if (mode === 'e') {
     const raw = await ConfigStorage.get('eeclaw.serverUrl').catch((): string | undefined => undefined);
     const normalized = normalizeSudoworkServerUrl(raw);
-    if (normalized) return normalized;
+    // normalizeSudoworkServerUrl only trims — it does not validate — so an
+    // unusable value would otherwise be handed out as a base URL and every auth
+    // request would fail against a nonsense address. Parse it here instead of
+    // tightening the shared helper, which other call sites rely on as-is.
+    if (normalized && isUsableHttpUrl(normalized)) return normalized;
   }
   return getSudoworkServerBaseUrl();
+}
+
+function isUsableHttpUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
 }

--- a/packages/host-bridge/src/authServer.ts
+++ b/packages/host-bridge/src/authServer.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 SudoPrivacy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Which server this client authenticates against.
+ *
+ * The app historically kept two addresses that never met: `system.sudoworkServerUrl`
+ * for the consumer entry and `eeclaw.serverUrl` for the enterprise one, with the
+ * auth calls hard-wired to the consumer one. That is why pointing the app at a
+ * control plane could not produce a phone-code login screen — the login method
+ * came from one server while the login request went to another.
+ *
+ * This resolves the single address the whole auth flow should use, so
+ * `/api/v1/system-config` and `/api/v1/auth/*` always describe and address the
+ * same server.
+ */
+import { ConfigStorage } from '@sudowork/common/storage';
+import { getSudoworkServerBaseUrl, normalizeSudoworkServerUrl } from '@sudowork/common/sudoworkServer';
+import { getAppMode } from './eeclawMode.js';
+
+/**
+ * Base URL of the server that owns identity for this client.
+ *
+ * Enterprise mode answers with the configured control-plane address; every other
+ * mode answers with the consumer server. Enterprise mode with no address
+ * configured falls back to the consumer server rather than returning nothing, so
+ * a half-configured install degrades to the old behaviour instead of failing
+ * every request with an unhelpful error.
+ */
+export async function getAuthServerBaseUrl(): Promise<string> {
+  const mode = await getAppMode();
+  if (mode === 'e') {
+    const raw = await ConfigStorage.get('eeclaw.serverUrl').catch((): string | undefined => undefined);
+    const normalized = normalizeSudoworkServerUrl(raw);
+    if (normalized) return normalized;
+  }
+  return getSudoworkServerBaseUrl();
+}

--- a/packages/moss-client/src/MossAuthClient.ts
+++ b/packages/moss-client/src/MossAuthClient.ts
@@ -4,7 +4,7 @@ import {
   type MossMe,
   type MossTokenSet,
 } from '@sudowork/contracts/auth'
-import { type MossFetch } from './MossHttpClient.js'
+import { MossHttpError, type MossFetch } from './MossHttpClient.js'
 
 /**
  * Moss 认证端口（计划 3.1/3.7）：
@@ -41,6 +41,34 @@ export interface MossAuthPort {
   me(accessToken: string, baseUrl: string): Promise<MossMe>
 }
 
+
+/** Raised when the control plane refuses a send until the cooldown elapses. */
+export class SmsRateLimitedError extends Error {
+  constructor(readonly retryAfterSec: number, message?: string) {
+    super(message || 'Please wait before requesting another code')
+    this.name = 'SmsRateLimitedError'
+  }
+}
+
+function rateLimitBody(err: unknown): { msg?: string; next_send_in?: number } | null {
+  if (!(err instanceof MossHttpError) || err.status !== 429) return null
+  try {
+    return JSON.parse(err.bodyText) as { msg?: string; next_send_in?: number }
+  } catch {
+    return {}
+  }
+}
+
+function rateLimitRetryAfter(err: unknown): number | null {
+  const body = rateLimitBody(err)
+  if (!body) return null
+  return typeof body.next_send_in === 'number' ? body.next_send_in : 60
+}
+
+function rateLimitMessage(err: unknown): string | undefined {
+  return rateLimitBody(err)?.msg
+}
+
 export function createMossAuthPort(mossFetch: MossFetch): MossAuthPort {
   return {
     async loginWithPassword(input, baseUrl) {
@@ -60,11 +88,21 @@ export function createMossAuthPort(mossFetch: MossFetch): MossAuthPort {
       return MossTokenSetSchema.parse(json)
     },
     async sendPhoneCode(phone, baseUrl) {
-      const json = (await mossFetch(baseUrl, {
-        method: 'POST',
-        path: '/api/v1/auth/send-code',
-        body: { phone },
-      })) as { success?: boolean; next_send_in?: number; msg?: string }
+      let json: { success?: boolean; next_send_in?: number; msg?: string }
+      try {
+        json = (await mossFetch(baseUrl, {
+          method: 'POST',
+          path: '/api/v1/auth/send-code',
+          body: { phone },
+        })) as { success?: boolean; next_send_in?: number; msg?: string }
+      } catch (err) {
+        // A rate-limited send is a 429 carrying how long to wait. Letting it
+        // surface as a generic transport failure would show the person an error
+        // where the UI could show a countdown.
+        const retryAfter = rateLimitRetryAfter(err)
+        if (retryAfter !== null) throw new SmsRateLimitedError(retryAfter, rateLimitMessage(err))
+        throw err
+      }
       if (!json?.success) throw new Error(json?.msg || 'Failed to send verification code')
       return { nextSendIn: typeof json.next_send_in === 'number' ? json.next_send_in : 60 }
     },

--- a/packages/moss-client/src/MossAuthClient.ts
+++ b/packages/moss-client/src/MossAuthClient.ts
@@ -15,9 +15,28 @@ import { type MossFetch } from './MossHttpClient.js'
  * 每个方法尾部传入 baseUrl（登录期无 session，地址由 resolveLoginMoss 决定；登录后取 session 地址）。
  */
 
+/**
+ * Result of presenting a phone + verification code.
+ *
+ * A number moss has never seen is not an error — it is the normal first step of
+ * self-service signup, and moss answers with a short-lived attestation that the
+ * code checked out. The caller shows a registration form and returns with that
+ * token, so the code is verified exactly once across the two requests.
+ */
+export type MossPhoneLoginResult =
+  | { kind: 'tokens'; tokens: MossTokenSet }
+  | { kind: 'need_register'; registerToken: string; phone: string }
+
 export interface MossAuthPort {
   loginWithPassword(input: { username: string; password: string }, baseUrl: string): Promise<MossTokenSet>
   loginWithApiKey(apiKey: string, baseUrl: string): Promise<MossTokenSet>
+  /** Ask moss to mint and deliver a code. Returns the resend cooldown. */
+  sendPhoneCode(phone: string, baseUrl: string): Promise<{ nextSendIn: number }>
+  loginWithPhone(input: { phone: string; code: string }, baseUrl: string): Promise<MossPhoneLoginResult>
+  registerWithPhone(
+    input: { registerToken: string; nickname?: string; invitationCode?: string },
+    baseUrl: string,
+  ): Promise<MossTokenSet>
   refresh(refreshToken: string, baseUrl: string): Promise<MossTokenSet>
   me(accessToken: string, baseUrl: string): Promise<MossMe>
 }
@@ -39,6 +58,54 @@ export function createMossAuthPort(mossFetch: MossFetch): MossAuthPort {
         body: { grant_type: 'api_key', api_key: apiKey },
       })
       return MossTokenSetSchema.parse(json)
+    },
+    async sendPhoneCode(phone, baseUrl) {
+      const json = (await mossFetch(baseUrl, {
+        method: 'POST',
+        path: '/api/v1/auth/send-code',
+        body: { phone },
+      })) as { success?: boolean; next_send_in?: number; msg?: string }
+      if (!json?.success) throw new Error(json?.msg || 'Failed to send verification code')
+      return { nextSendIn: typeof json.next_send_in === 'number' ? json.next_send_in : 60 }
+    },
+    async loginWithPhone(input, baseUrl) {
+      // Phone login wraps its payload in `data` (and signals need_register in
+      // band) because that is the shape the desktop client already parses; the
+      // grant-type logins above return the token set at the top level.
+      const json = (await mossFetch(baseUrl, {
+        method: 'POST',
+        path: '/api/v1/auth/login',
+        body: { phone: input.phone, code: input.code },
+      })) as {
+        success?: boolean
+        data?: unknown
+        need_register?: boolean
+        register_token?: string
+        phone?: string
+        msg?: string
+      }
+      if (json?.need_register && json.register_token) {
+        return {
+          kind: 'need_register',
+          registerToken: json.register_token,
+          phone: json.phone || input.phone,
+        }
+      }
+      if (!json?.success || !json.data) throw new Error(json?.msg || 'Phone login failed')
+      return { kind: 'tokens', tokens: MossTokenSetSchema.parse(json.data) }
+    },
+    async registerWithPhone(input, baseUrl) {
+      const json = (await mossFetch(baseUrl, {
+        method: 'POST',
+        path: '/api/v1/auth/register',
+        body: {
+          register_token: input.registerToken,
+          ...(input.nickname ? { nickname: input.nickname } : {}),
+          ...(input.invitationCode ? { invitation_code: input.invitationCode } : {}),
+        },
+      })) as { success?: boolean; data?: unknown; msg?: string }
+      if (!json?.success || !json.data) throw new Error(json?.msg || 'Registration failed')
+      return MossTokenSetSchema.parse(json.data)
     },
     async refresh(refreshToken, baseUrl) {
       const json = await mossFetch(baseUrl, {

--- a/packages/renderer/src/context/AuthContext.tsx
+++ b/packages/renderer/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import { useTranslation } from 'react-i18next';
 import * as ipcBridge from '@sudowork/host-bridge/ipcBridge';
 import { getSudoworkServerBaseUrl } from '@sudowork/common/sudoworkServer';
+import { getAuthServerBaseUrl } from '@sudowork/host-bridge/authServer';
 import { ConfigStorage, type IConfigStorageRefer } from '@sudowork/common/storage';
 import { pickDefaultImageModelFromPricing, pickImageGenerationModelId, resolveImageModelWithAvailability } from '@sudowork/common/imageGenerationModelConfig';
 import { fetchSystemConfig } from '@sudowork/common/systemConfig';
@@ -475,7 +476,7 @@ async function openThirdPartyLogoutIfNeeded(session: AuthSession | undefined): P
   if (session?.type !== 'cas') return;
 
   try {
-    const serverBaseUrl = await getSudoworkServerBaseUrl();
+    const serverBaseUrl = await getAuthServerBaseUrl();
     const systemConfig = await fetchSystemConfig(serverBaseUrl);
     const authConfig = resolveThirdPartyAuthConfig(systemConfig);
     const provider = authConfig?.providers.find((item) => item.id === session.provider);
@@ -751,7 +752,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           const authStorage: AuthStorage = JSON.parse(stored);
           const { refresh_token, device_id } = authStorage;
 
-          const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/refresh`, {
+          const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/refresh`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ refresh_token, device_id }),
@@ -1184,7 +1185,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     const deviceId = getDeviceId();
 
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/login`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1232,7 +1233,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     const deviceId = getDeviceId();
 
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/register`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1267,7 +1268,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const loginByPassword = useCallback(async ({ phone, password }: PasswordLoginParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/login-by-config`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/login-by-config`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1291,7 +1292,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const registerByPassword = useCallback(async ({ phone, password, nickname, invitation_code }: PasswordRegisterParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/register-password`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/register-password`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1314,7 +1315,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const loginWithThirdPartyAuth = useCallback(async ({ provider, ticket, service }: ThirdPartyAuthLoginParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/third-party/cas/login`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/third-party/cas/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1337,7 +1338,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const exchangeThirdPartyAuthCode = useCallback(async ({ provider, code }: ThirdPartyAuthExchangeParams): Promise<PasswordAuthResult> => {
     const deviceId = getDeviceId();
     try {
-      const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/third-party/cas/exchange`, {
+      const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/third-party/cas/exchange`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1365,7 +1366,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         return { success: false, message: '登录状态已过期，请重新登录' };
       }
       try {
-        const response = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/change-password`, {
+        const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/change-password`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -1690,7 +1691,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         const { refresh_token, device_id } = authStorage;
         session = authStorage.session;
 
-        await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/logout`, {
+        await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/logout`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ refresh_token, device_id }),

--- a/packages/renderer/src/context/AuthContext.tsx
+++ b/packages/renderer/src/context/AuthContext.tsx
@@ -1184,6 +1184,61 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const login = useCallback(async ({ phone, code, enterprise_code, invitation_code: _invitation_code, remember: _remember }: LoginParams): Promise<LoginResult> => {
     const deviceId = getDeviceId();
 
+    // Web host: the browser must not hold moss tokens, so the webui server does
+    // the exchange and answers with a cookie session. Mirrors the enterprise
+    // password branch above rather than inventing a second web login path.
+    if (isWebRuntime) {
+      try {
+        const response = await fetch('/api/auth/login/phone', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ phone, code }),
+        });
+        const body = (await response.json().catch((): null => null)) as
+          | { ok?: boolean; needRegister?: boolean; registerToken?: string; phone?: string; error?: string }
+          | null;
+        if (body?.needRegister && body.registerToken) {
+          // Not a failure: an unknown number is the first step of signup.
+          return {
+            success: false,
+            need_register: true,
+            register_token: body.registerToken,
+            phone: body.phone || phone,
+            message: t('login.errors.needRegister', '该手机号未注册，请先注册'),
+          };
+        }
+        if (!response.ok || !body?.ok) {
+          return { success: false, message: t('login.errors.invalidCredentials'), code: 'invalidCredentials' };
+        }
+        const webUser = await fetchWebSession();
+        return finalizeEnterpriseLogin(
+          {
+            success: true,
+            data: {
+              // The cookie is the session on web; this placeholder keeps the
+              // shared finaliser's shape without handing the browser a real token.
+              access_token: 'web-session',
+              refresh_token: '',
+              expires_in: 24 * 60 * 60,
+              user: {
+                id: webUser?.id || '',
+                name: webUser?.nickname || '',
+                role: (webUser?.role as string) || 'user',
+                orgId: '',
+                localAuth: false,
+              },
+            },
+          } as Awaited<ReturnType<typeof ipcBridge.eeclaw.login.invoke>>,
+          deviceId,
+          'password',
+        );
+      } catch (error) {
+        console.error('[Auth] Web phone login failed:', error);
+        return { success: false, message: t('login.errors.networkError'), code: 'networkError' };
+      }
+    }
+
     try {
       const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/login`, {
         method: 'POST',
@@ -1231,6 +1286,46 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
   const register = useCallback(async ({ register_token, nickname, invitation_code }: RegisterParams): Promise<RegisterResult> => {
     const deviceId = getDeviceId();
+
+    if (isWebRuntime) {
+      try {
+        const response = await fetch('/api/auth/register/phone', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ registerToken: register_token, nickname, invitationCode: invitation_code }),
+        });
+        const body = (await response.json().catch((): null => null)) as { ok?: boolean; error?: string } | null;
+        if (!response.ok || !body?.ok) {
+          return { success: false, message: t('login.errors.invalidCredentials'), code: 'invalidCredentials' };
+        }
+        const webUser = await fetchWebSession();
+        return finalizeEnterpriseLogin(
+          {
+            success: true,
+            data: {
+              // The cookie is the session on web; this placeholder keeps the
+              // shared finaliser's shape without handing the browser a real token.
+              access_token: 'web-session',
+              refresh_token: '',
+              expires_in: 24 * 60 * 60,
+              user: {
+                id: webUser?.id || '',
+                name: webUser?.nickname || '',
+                role: (webUser?.role as string) || 'user',
+                orgId: '',
+                localAuth: false,
+              },
+            },
+          } as Awaited<ReturnType<typeof ipcBridge.eeclaw.login.invoke>>,
+          deviceId,
+          'password',
+        );
+      } catch (error) {
+        console.error('[Auth] Web phone registration failed:', error);
+        return { success: false, message: t('login.errors.networkError'), code: 'networkError' };
+      }
+    }
 
     try {
       const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/register`, {

--- a/packages/renderer/src/context/AuthContext.tsx
+++ b/packages/renderer/src/context/AuthContext.tsx
@@ -1195,9 +1195,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           credentials: 'include',
           body: JSON.stringify({ phone, code }),
         });
-        const body = (await response.json().catch((): null => null)) as
-          | { ok?: boolean; needRegister?: boolean; registerToken?: string; phone?: string; error?: string }
-          | null;
+        const body = (await response.json().catch((): null => null)) as { ok?: boolean; needRegister?: boolean; registerToken?: string; phone?: string; error?: string } | null;
         if (body?.needRegister && body.registerToken) {
           // Not a failure: an unknown number is the first step of signup.
           return {
@@ -1231,7 +1229,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             },
           } as Awaited<ReturnType<typeof ipcBridge.eeclaw.login.invoke>>,
           deviceId,
-          'password',
+          'password'
         );
       } catch (error) {
         console.error('[Auth] Web phone login failed:', error);
@@ -1319,7 +1317,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             },
           } as Awaited<ReturnType<typeof ipcBridge.eeclaw.login.invoke>>,
           deviceId,
-          'password',
+          'password'
         );
       } catch (error) {
         console.error('[Auth] Web phone registration failed:', error);

--- a/packages/renderer/src/hooks/useSystemLoginMethod.ts
+++ b/packages/renderer/src/hooks/useSystemLoginMethod.ts
@@ -7,6 +7,7 @@
 import { useEffect, useState } from 'react';
 import * as ipcBridge from '@sudowork/host-bridge/ipcBridge';
 import { fetchSystemConfig, type SystemConfig } from '@sudowork/common/systemConfig';
+import { getAuthServerBaseUrl } from '@sudowork/host-bridge/authServer';
 import { THIRD_PARTY_LOGIN_METHOD } from '@sudowork/common/thirdPartyAuthConfig';
 
 /** 0 = 手机验证码；1 = 用户名密码；2 = 三方认证登录 */
@@ -38,7 +39,10 @@ async function fetchLoginMethod(): Promise<{ loginMethod: LoginMethod; systemCon
       // Reuse the shared client; fetchSystemConfig() also fills the renderer's
       // system-config module cache (setSystemConfigCache) so synchronous base-url
       // helpers work for renderer consumers.
-      const data = await fetchSystemConfig();
+      // Ask the server this client actually authenticates against. Reading the
+      // consumer server here while logging in against a control plane is what
+      // used to make a moss deployment unable to advertise its login method.
+      const data = await fetchSystemConfig(await getAuthServerBaseUrl());
       // Sync to main-process cache (see main.tsx for rationale).
       if (data) {
         void ipcBridge.systemConfig.syncFromRenderer.invoke({ data }).catch(() => {});

--- a/packages/renderer/src/pages/login/index.tsx
+++ b/packages/renderer/src/pages/login/index.tsx
@@ -35,6 +35,9 @@ function generateOAuth2State(): string {
 // Windows/Linux render custom window controls; macOS relies on native traffic lights, so skip them to avoid duplicates
 const showWindowControls = isElectronDesktop() && !isMacOS();
 
+// Web host detection, mirroring AuthContext: the browser has no electronAPI.
+const isWebRuntime = typeof window !== 'undefined' && !window.electronAPI;
+
 // Validate phone number format (same as server-side)
 function isValidPhone(phone: string): boolean {
   if (phone.length === 11) {
@@ -261,13 +264,31 @@ const LoginPage: React.FC = () => {
 
     setLoading(true);
     try {
-      const res = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/send-code`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone: currentPhone }),
-      });
+      // Web host: the browser posts to this server, which forwards to the
+      // control plane and keeps its tokens server-side. Same split as the login
+      // and register calls in AuthContext — the desktop talks to the control
+      // plane directly, the browser goes through the webui server.
+      const res = isWebRuntime
+        ? await fetch('/api/auth/send-code', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ phone: currentPhone }),
+          })
+        : await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/send-code`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ phone: currentPhone }),
+          });
 
-      const data = await res.json();
+      const raw = (await res.json()) as { success?: boolean; ok?: boolean; next_send_in?: number; nextSendIn?: number; msg?: string; error?: string };
+      // The two servers answer in their own shapes; normalise once here so the
+      // rest of this handler does not care which host it is running on.
+      const data = {
+        success: raw.success ?? raw.ok ?? false,
+        next_send_in: raw.next_send_in ?? raw.nextSendIn,
+        msg: raw.msg ?? raw.error,
+      };
 
       if (data.success) {
         Message.success('验证码已发送');

--- a/packages/renderer/src/pages/login/index.tsx
+++ b/packages/renderer/src/pages/login/index.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button, Input, Message, Space } from '@arco-design/web-react';
 import { Phone, Protect, Key, User, Lock } from '@icon-park/react';
-import { getSudoworkServerBaseUrl } from '@sudowork/common/sudoworkServer';
+import { getAuthServerBaseUrl } from '@sudowork/host-bridge/authServer';
 import { DEFAULT_TENANT_CONFIG, TENANT_CONFIG_STORAGE_KEY, resolveTenantConfig } from '@sudowork/common/types/tenantConfig';
 import { ConfigStorage } from '@sudowork/common/storage';
 import * as ipcBridge from '@sudowork/host-bridge/ipcBridge';
@@ -67,6 +67,20 @@ const LoginPage: React.FC = () => {
   const { status, enterGuest, login, register, enterpriseLogin, enterpriseLoginWithOAuth2 } = useAuth();
   const { isEnterprise } = useAppMode();
   const { loginMethod, systemConfig } = useSystemLoginMethod();
+
+  // A control plane that serves /api/v1/system-config gets to say how people log
+  // in, exactly as the consumer server already does. `systemConfig` is null only
+  // when the probe found nothing to ask — an older build, or an unreachable
+  // server — in which case the tabs below stay the fallback.
+  //
+  // Only method 0 is delegated for now, and deliberately so: the phone panel
+  // posts to /api/v1/auth/{send-code,login,register} on the active server, which
+  // a control plane serves. Method 1's consumer panel speaks endpoints
+  // (login-by-config, register-password) that a control plane does not have —
+  // its password login IS the tab panel below — and method 2's CAS exchange is
+  // likewise not implemented there yet. Delegating those would swap a working
+  // screen for a 404.
+  const serverDeclaresPhoneLogin = isEnterprise && systemConfig !== null && loginMethod === 0;
 
   // Enterprise login state
   const [loginTab, setLoginTab] = useState<'password' | 'key' | 'oauth2'>('password');
@@ -247,7 +261,7 @@ const LoginPage: React.FC = () => {
 
     setLoading(true);
     try {
-      const res = await fetch(`${await getSudoworkServerBaseUrl()}/api/v1/auth/send-code`, {
+      const res = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/send-code`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone: currentPhone }),
@@ -277,8 +291,9 @@ const LoginPage: React.FC = () => {
   const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();
 
-    // Enterprise mode login
-    if (isEnterprise) {
+    // Enterprise mode login. Skipped when the server asked for the phone panel,
+    // so the submit path matches the panel actually on screen.
+    if (isEnterprise && !serverDeclaresPhoneLogin) {
       if (loginTab === 'password') {
         if (!username.trim() || !password.trim()) {
           Message.warning('请填写所有必填项');
@@ -497,7 +512,7 @@ const LoginPage: React.FC = () => {
   };
 
   // Enterprise login UI
-  if (isEnterprise) {
+  if (isEnterprise && !serverDeclaresPhoneLogin) {
     return (
       <div className='login-page'>
         {showWindowControls && (

--- a/packages/renderer/src/pages/login/index.tsx
+++ b/packages/renderer/src/pages/login/index.tsx
@@ -281,14 +281,21 @@ const LoginPage: React.FC = () => {
             body: JSON.stringify({ phone: currentPhone }),
           });
 
-      const raw = (await res.json()) as { success?: boolean; ok?: boolean; next_send_in?: number; nextSendIn?: number; msg?: string; error?: string };
+      const raw = (await res.json()) as { success?: boolean; ok?: boolean; next_send_in?: number; nextSendIn?: number; msg?: string; error?: string; message?: string };
       // The two servers answer in their own shapes; normalise once here so the
       // rest of this handler does not care which host it is running on.
       const data = {
         success: raw.success ?? raw.ok ?? false,
         next_send_in: raw.next_send_in ?? raw.nextSendIn,
-        msg: raw.msg ?? raw.error,
+        msg: raw.message ?? raw.msg ?? raw.error,
       };
+
+      // A refusal that carries a wait is a countdown, not a dead end: start the
+      // timer so the button says how long rather than only what went wrong.
+      if (!data.success && typeof data.next_send_in === 'number' && data.next_send_in > 0) {
+        if (mode === 'login') setLoginCountdown(data.next_send_in);
+        else setRegisterCountdown(data.next_send_in);
+      }
 
       if (data.success) {
         Message.success('验证码已发送');


### PR DESCRIPTION
> Stacked on #1111 (`feat/merge-login-entries`), which makes the client ask **one** server how to log in. This makes the browser able to answer.

## Why

Phone signup worked on the desktop but not in a browser, for two independent reasons:

1. `apps/webui`'s server has its **own** auth routes (`/login/password`, `/login/api-key`, cookie session) and does not forward `/api/v1/auth/*` to moss.
2. It does not serve `/api/v1/system-config` — and the shared renderer probes `<origin>/api/v1/system-config` before showing a login screen. In the browser that origin is *this* server, not moss, so the probe found nothing, the renderer fell back to its password tabs, and a deployment configured for phone signup silently showed the wrong screen.

## What

**Server** — forward `GET /api/v1/system-config` from the moss this deployment fronts, plus `send-code` / `login/phone` / `register/phone` routes that exchange a moss session for this server's cookie session, reusing the same `fetchMe` + `performLogin` path as password and api-key login. Rate limiting, code expiry and the attempt budget stay in **moss**, so the browser and the desktop cannot drift apart on them.

**Client** — the phone flow gets an `isWebRuntime` branch.

## A correction worth flagging for review

My first commit's message claimed the phone calls needed to *move behind the bridge adapter*, "the way enterprise password login already is". **That was wrong.** Enterprise password login on web does **not** go through the bridge: `AuthContext` already has an `isWebRuntime` branch that posts to the webui server's cookie endpoints and synthesises a placeholder token payload for the shared finaliser. The phone flow now follows that same established path, so this adds no new mechanism. The second commit says so.

## Boundary kept

The browser never receives a moss token — the webui server does the exchange and answers with a cookie. Returning tokens to the browser would have made this "work" in one line at the cost of that boundary.

## Verified

- `packages/renderer` and `apps/webui` type-check clean.
- ESLint on the changed file: 0 errors (2 pre-existing `no-explicit-any` warnings on a line not touched).
- Widening `MossAuthPort` required the six hand-written stubs to implement the new methods; they throw rather than the port going optional, which would let a real implementation silently omit them.

## Not verified, and why

No browser e2e yet: the deployed `apps/webui` (43.138.120.200, behind `webui.sudoprivacy.com`) runs an 8-day-old image, and its nginx still serves a self-signed cert issued for an internal address, so a browser refuses the page before any of this is reachable. Deploying this image, fixing that cert, and pointing `MOSS_BASE_URL` at `agent.sudoprivacy.com` are the follow-ups — tracked separately because they are infra, not code.