### PR TITLE
fix/webui skill desc

### DIFF
--- a/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
+++ b/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
@@ -482,6 +482,9 @@ interface MossAgentItem {
   displayName?: string
   display_name?: string
   description?: string
+  defaultInitPrompt?: string
+  promptsI18n?: Record<string, string[]>
+  prompts_i18n?: Record<string, string[]>
   avatar?: string
   emoji?: string
   /** 'hub' | 'custom' | 'system' | 'tenant' (absent for user-created rows) */
@@ -529,7 +532,9 @@ function mossAgentToAssistantInfo(a: MossAgentItem): unknown {
       name: a.name,
       display_name: displayName,
       description: a.description,
-      avatar: a.avatar,
+      defaultInitPrompt: a.defaultInitPrompt,
+      promptsI18n: a.promptsI18n ?? a.prompts_i18n,
+      avatar: a.avatar || a.emoji || '',
       emoji: a.emoji ?? null,
       categories: Array.isArray(a.categories) ? a.categories : undefined,
       tag: typeof a.tag === 'string' ? a.tag : undefined,

--- a/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
+++ b/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
@@ -489,6 +489,7 @@ interface MossAgentItem {
   isBuiltin?: boolean
   enabled?: boolean
   categories?: string[]
+  enabledSkills?: string[]
 }
 
 /** Moss installed-skill row as projected by GET /api/skills. */
@@ -534,6 +535,7 @@ function mossAgentToAssistantInfo(a: MossAgentItem): unknown {
       tag: typeof a.tag === 'string' ? a.tag : undefined,
       source_type: typeof a.tag === 'string' ? a.tag : 'custom',
       is_builtin: a.isBuiltin === true,
+      enabledSkills: Array.isArray(a.enabledSkills) ? a.enabledSkills : undefined,
     },
   }
 }
@@ -930,6 +932,24 @@ const handlers: Record<string, (req: AnyReq) => Promise<unknown>> = {
       next_cursor: typeof body?.next_cursor === 'string' ? body.next_cursor : null,
       has_more: body?.has_more === true,
     })
+  },
+
+  // --- assistant rule read (web opens the installed-assistant drawer read-only) ---
+  // ipcBridge.fs.readAssistantRule's wire channel is 'read-assistant-rule' (the fs
+  // prefix is only the TS namespace). Desktop returns a bare string; moss returns
+  // {rules} and is admin-scoped — degrade to '' (drawer shows the empty-state)
+  // instead of surfacing an error. webui ids are moss directory names, builtin-
+  // prefixed for system rows.
+  'read-assistant-rule': async (req) => {
+    const name = String(req?.assistantId ?? '').replace(/^builtin-/, '')
+    try {
+      const body = await apiFetch<{ rules?: unknown }>(
+        `/api/agents/rules/${encodeURIComponent(name)}`,
+      )
+      return typeof body?.rules === 'string' ? body.rules : ''
+    } catch {
+      return ''
+    }
   },
 
   // --- skill-hub: installed skills (management page) ---

--- a/apps/webui/tests/unit/bridgeAdapter/mossAdapter.test.ts
+++ b/apps/webui/tests/unit/bridgeAdapter/mossAdapter.test.ts
@@ -232,6 +232,27 @@ describe('mossAdapter: assistant/skill management channels', () => {
     expect(body).toEqual({ name: 'writer' })
   })
 
+  it('read-assistant-rule unwraps {rules} and strips the builtin- id prefix (bare string)', async () => {
+    const fetchMock = stubFetch({ '/api/agents/rules/': { rules: '# writer rules' } })
+    const content = await ipcBridge.fs.readAssistantRule.invoke({
+      assistantId: 'builtin-a',
+      locale: 'zh-CN',
+    })
+
+    // Desktop provider contract: a bare string, not an IBridgeResponse envelope.
+    expect(content).toBe('# writer rules')
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/api/agents/rules/a')
+  })
+
+  it('read-assistant-rule degrades to an empty string on error (admin scope, 404)', async () => {
+    stubFetch({
+      '/api/agents/rules/': { status: 403, body: { error: 'Missing scope: admin:settings' } },
+    })
+    const content = await ipcBridge.fs.readAssistantRule.invoke({ assistantId: 'hub-a' })
+
+    expect(content).toBe('')
+  })
+
   it('get-installed-skills maps rows and backfills meta.source_type', async () => {
     stubFetch({
       '/api/skills': [

--- a/apps/webui/tests/unit/bridgeAdapter/mossAdapter.test.ts
+++ b/apps/webui/tests/unit/bridgeAdapter/mossAdapter.test.ts
@@ -192,6 +192,46 @@ describe('mossAdapter: assistant/skill management channels', () => {
     expect((result.data?.[0]?.meta as { display_name?: string })?.display_name).toBe('Hub A')
   })
 
+  it('get-installed-assistants maps avatar emoji fallback, promptsI18n dual-read and defaultInitPrompt', async () => {
+    stubFetch({
+      '/api/agents': [
+        {
+          name: 'sys-emoji',
+          displayName: 'Sys',
+          tag: 'system',
+          isBuiltin: true,
+          avatar: '',
+          emoji: '🚀',
+          defaultInitPrompt: '帮我构建一个应用',
+          prompts_i18n: { 'zh-CN': ['案例一'] },
+        },
+        {
+          name: 'hub-img',
+          displayName: 'Hub',
+          tag: 'hub',
+          avatar: 'https://example.com/a.png',
+          promptsI18n: { 'zh-CN': ['案例二'] },
+        },
+      ],
+    })
+    const result = await ipcBridge.assistantHub.getInstalledAssistants.invoke()
+
+    expect(result.success).toBe(true)
+    expect(result.data?.[0]?.meta).toEqual(
+      expect.objectContaining({
+        avatar: '🚀',
+        defaultInitPrompt: '帮我构建一个应用',
+        promptsI18n: { 'zh-CN': ['案例一'] },
+      }),
+    )
+    expect(result.data?.[1]?.meta).toEqual(
+      expect.objectContaining({
+        avatar: 'https://example.com/a.png',
+        promptsI18n: { 'zh-CN': ['案例二'] },
+      }),
+    )
+  })
+
   it('create-assistant sends only the minimal schema fields (no extra keys)', async () => {
     const fetchMock = stubFetch({ '/api/agents/create': { ok: true } })
     const result = await ipcBridge.assistantHub.createAssistant.invoke({

--- a/packages/common/src/assistantTypes.ts
+++ b/packages/common/src/assistantTypes.ts
@@ -41,6 +41,8 @@ export interface IAssistantMeta {
   profession?: string;
   nameI18n?: Record<string, string>;
   descriptionI18n?: Record<string, string>;
+  /** Un-localized plain description from moss installed rows (enterprise-synced tenant meta carries it on disk) */
+  description?: string;
   promptsI18n?: Record<string, string[]>;
   presetAgentType?: string;
   /** Skill names referenced from ~/.nexus/skills/ (SSOT) */

--- a/packages/renderer/src/layouts/components/Sider.tsx
+++ b/packages/renderer/src/layouts/components/Sider.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '@renderer/context/AuthContext';
 import { addEventListener, emitter } from '@renderer/utils/emitter';
 import { useAppMode } from '@renderer/hooks/useAppMode';
 import { useCronAccess } from '@renderer/hooks/useCronAccess';
+import { isElectronDesktop } from '@renderer/utils/platform';
 
 import WorkspaceGroupedHistory from '@renderer/pages/conversation/WorkspaceGroupedHistory';
 import { maskPhone } from '@renderer/utils';
@@ -64,7 +65,9 @@ const Sider: React.FC = () => {
   const Menus = [
     { id: 'agent', label: t('common.siderMenu.agent'), icon: Bot, path: '/app/agent' },
     { id: 'skill-store', label: t('common.siderMenu.skillStore'), icon: Sparkles, path: '/app/skills' },
-    { id: 'local-kb', label: t('common.siderMenu.localKb'), icon: BookOpen, path: '/app/local-kb' },
+    // The local knowledge base is desktop-only (WEB_CAPABILITIES.localKnowledgeBase
+    // is false and mossAdapter has no local-kb mappings), so hide it on the web host.
+    ...(isElectronDesktop() ? [{ id: 'local-kb' as const, label: t('common.siderMenu.localKb'), icon: BookOpen, path: '/app/local-kb' }] : []),
     { id: 'security', label: t('common.siderMenu.security'), icon: ShieldCheck, path: '/app/security' },
     ...(!isEnterprise ? [{ id: 'channels' as const, label: t('common.siderMenu.webui'), icon: Globe, path: '/app/channels' }] : []),
     ...(isCronVisible ? [{ id: 'cron' as const, label: t('common.siderMenu.cron'), icon: AlarmClock, path: '/app/cron' }] : []),

--- a/packages/renderer/src/pages/agents/components/HubAssistantCard.tsx
+++ b/packages/renderer/src/pages/agents/components/HubAssistantCard.tsx
@@ -9,6 +9,7 @@ import { Progress, Tooltip } from '@arco-design/web-react';
 import { Bot, Copy, Download, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { IAssistantHubSkill } from '@sudowork/host-bridge/ipcBridge';
+import { isElectronDesktop } from '@renderer/utils/platform';
 
 const HubAssistantCard: React.FC<HubAssistantCardProps> = ({ assistant, isInstalled, installing, installProgress, onInstall, onUpdate, onDuplicate, onClick, hasUpdate, updating, latestVersion }) => {
   const { t } = useTranslation();
@@ -72,11 +73,14 @@ const HubAssistantCard: React.FC<HubAssistantCardProps> = ({ assistant, isInstal
                 {t('settings.assistant.updateAvailable', '可更新')}
               </span>
             )}
-            <Tooltip content={t('settings.assistant.duplicate', '复制')}>
-              <button type='button' className='store-action-icon' onClick={onDuplicate}>
-                <Copy size={13} />
-              </button>
-            </Tooltip>
+            {/* Duplicate button - desktop only: the web host cannot copy assistants (desktop keeps it) */}
+            {isElectronDesktop() && (
+              <Tooltip content={t('settings.assistant.duplicate', '复制')}>
+                <button type='button' className='store-action-icon' onClick={onDuplicate}>
+                  <Copy size={13} />
+                </button>
+              </Tooltip>
+            )}
           </>
         )}
         {/* Install button or progress - only show if hasDownloadUrl */}

--- a/packages/renderer/src/pages/agents/components/InstalledAssistantCard.tsx
+++ b/packages/renderer/src/pages/agents/components/InstalledAssistantCard.tsx
@@ -97,10 +97,12 @@ const InstalledAssistantCard: React.FC<InstalledAssistantCardProps> = (props) =>
           </Tooltip>
         )}
         {uploadStatus}
-        {/* Duplicate button - available for all assistant types */}
-        <Tooltip content={t('settings.assistant.duplicate', '复制')}>
-          <Button shape='circle' className='!size-7' icon={<Copy size={13} />} onClick={onDuplicate} />
-        </Tooltip>
+        {/* Duplicate button - desktop only: the web host cannot copy assistants (desktop keeps it) */}
+        {isElectronDesktop() && (
+          <Tooltip content={t('settings.assistant.duplicate', '复制')}>
+            <Button shape='circle' className='!size-7' icon={<Copy size={13} />} onClick={onDuplicate} />
+          </Tooltip>
+        )}
         {enterprisePublishButton}
         {/* Delete button - only for custom assistants that are not readonly */}
         {canDelete && (

--- a/packages/renderer/src/pages/agents/index.tsx
+++ b/packages/renderer/src/pages/agents/index.tsx
@@ -194,11 +194,6 @@ const AgentSettings: React.FC = () => {
 
   // Load installed skills
   const loadInstalledSkills = useCallback(async (): Promise<IInstalledSkillInfo[]> => {
-    if (!isElectronDesktop()) {
-      setInstalledSkills([]);
-      setHubInstalledSkillsReady(true);
-      return [];
-    }
     try {
       const res = await skillHub.getInstalledSkills.invoke();
       if (res.success && res.data) {
@@ -1322,8 +1317,10 @@ const AgentSettings: React.FC = () => {
   }, [duplicateAssistant, duplicateInstalledAssistant, duplicateTenantAssistant, hubInstalledAssistants, localeKey, loadAssistants, t, isEnterprise, handleUploadCustomAssistant]);
 
   const activeAssistant = assistants.find((assistant) => assistant.id === activeAssistantId) || null;
-  // Only custom assistants can be edited; hub/tenant-installed, builtin, and extension assistants are readonly
-  const isReadonlyAssistant = Boolean(activeAssistant && (isExtensionAssistant(activeAssistant) || activeAssistant._isHubInstalled || activeAssistant.isBuiltin || (isEnterprise && (activeAssistant._category === 'hub' || activeAssistant._category === 'tenant'))));
+  // Only custom assistants can be edited; hub/tenant-installed, builtin, and extension assistants are readonly.
+  // On the web host every assistant is readonly (the moss meta endpoint cannot
+  // round-trip the edit fields, so the drawer opens in view-only mode).
+  const isReadonlyAssistant = !isElectronDesktop() || Boolean(activeAssistant && (isExtensionAssistant(activeAssistant) || activeAssistant._isHubInstalled || activeAssistant.isBuiltin || (isEnterprise && (activeAssistant._category === 'hub' || activeAssistant._category === 'tenant'))));
 
   // ===== 分类逻辑：以目录分类（_category）为主，其他字段仅作兼容兜底 =====
   // Tenant assistants: 目录分类为 tenant
@@ -1424,10 +1421,6 @@ const AgentSettings: React.FC = () => {
   // ==================== CRUD Handlers ====================
 
   const handleEdit = async (assistant: AssistantListItem) => {
-    // The moss assistant-meta endpoint cannot round-trip the renderer's edit
-    // fields (I18n/prompt), so a web "save" would silently drop everything.
-    // Gate the edit entry off on the web host; create (handleCreate) stays open.
-    if (!isElectronDesktop()) return;
     setIsCreating(false);
     setActiveAssistantId(assistant.id);
     setEditName(assistant.nameI18n?.[localeKey] || assistant.name || '');

--- a/packages/renderer/src/shared/agents/assistantAdapter.ts
+++ b/packages/renderer/src/shared/agents/assistantAdapter.ts
@@ -27,6 +27,7 @@ export function toBackendConfig(info: IAssistantInfo): AcpBackendConfig {
     name: meta.nameI18n?.['zh-CN'] || meta.nameI18n?.['en-US'] || meta.display_name || meta.name || meta.id || info.name,
     nameI18n: meta.nameI18n,
     descriptionI18n: meta.descriptionI18n,
+    description: meta.description,
     avatar: meta.avatar,
     enabled: info.enabled,
     isPreset,


### PR DESCRIPTION
- **feat(webui): open installed-assistant detail drawer read-only and hide local-kb menu**
- **fix(webui): map moss assistant prompt/avatar meta and hide duplicate button on web**
