### PR TITLE
fix(consumer): the points pages must ask the server that signed you in

### DIFF
--- a/apps/desktop/src/process/bridge/sudoworkServerBridge.ts
+++ b/apps/desktop/src/process/bridge/sudoworkServerBridge.ts
@@ -5,12 +5,22 @@
  */
 
 import { sudoworkServer } from '@sudowork/host-bridge/ipcBridge';
-import { getSudoworkServerBaseUrlSync } from '@process/initStorage';
+import { getAuthServerBaseUrl } from '@sudowork/host-bridge/authServer';
 
 export function initSudoworkServerBridge(): void {
   sudoworkServer.getConfig.provider(async () => {
-    // Resolve on every call so user-updated `system.sudoworkServerUrl` takes effect immediately.
-    return { baseUrl: getSudoworkServerBaseUrlSync() };
+    // The server that owns this client's identity — not a separately-resolved
+    // consumer address.
+    //
+    // Everything reached through this channel (points, usage, orders, tenant
+    // config, config items) is scoped to the signed-in user, so it has to be
+    // asked of the server that signed them in. While the two were resolved
+    // independently, anyone authenticated against a control plane sent that
+    // server's token to the consumer server, which does not know it: the points
+    // panel came back empty and nothing reported an error.
+    //
+    // Resolved on every call so a change of server takes effect immediately.
+    return { baseUrl: await getAuthServerBaseUrl() };
   });
 
   sudoworkServer.updateConfig.provider(async (_config) => {

--- a/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
+++ b/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
@@ -825,6 +825,14 @@ const handlers: Record<string, (req: AnyReq) => Promise<unknown>> = {
   'moss.get-config': async () => ({ serverUrl: location.origin, hasToken: true }),
   'moss.set-auth-token': async () => ok(),
 
+  // The pages that show points, usage and orders ask this channel where to send
+  // their requests. On the web that is this origin, which proxies to the moss
+  // this browser is signed in to — the same server that issued the session.
+  // Without it those pages fell through to `not-supported-on-web` and rendered
+  // an empty panel with no error.
+  'sudowork-server.get-config': async () => ({ baseUrl: location.origin }),
+  'sudowork-server.update-config': async () => ok(),
+
   // --- zoom / font scale: RAW number providers. Display prefs live in the
   //     browser (R8); no server round-trip. useFontScale calls these directly. ---
   'app.get-zoom-factor': async () => {

--- a/apps/webui/src/server/app.ts
+++ b/apps/webui/src/server/app.ts
@@ -35,6 +35,7 @@ import { createMossAgentPort, type MossAgentPort } from '@sudowork/moss-client'
 import { createMossSkillPort, type MossSkillPort } from '@sudowork/moss-client'
 import { createMossCronPort } from '@sudowork/moss-client'
 import { createMossMcpPort, type MossMcpPort } from '@sudowork/moss-client'
+import { createConsumerRouter } from './features/consumer/consumerRoutes.js'
 import { createAgentRouter } from './features/agents/agentRoutes.js'
 import { createSkillRouter } from './features/skills/skillRoutes.js'
 import { createCronRouter } from './features/cron/cronRoutes.js'
@@ -182,6 +183,9 @@ export function registerApiRoutes(app: Express, deps: ApiDeps): ApiHandles {
       closeTerminals: (conversationId) => globalTerminalManager.closeByConversation(conversationId),
     }),
   )
+  // The consumer endpoints the points/usage/orders pages read, forwarded to
+  // moss under this session. Allowlisted, not a blanket /api/v1 proxy.
+  app.use('/api/v1', createConsumerRouter({ auth }))
   app.use('/api/agents', createAgentRouter({ pool, config, auth, agents }))
   app.use('/api/skills', createSkillRouter({ pool, config, auth, skills }))
 

--- a/apps/webui/src/server/features/consumer/consumerRoutes.ts
+++ b/apps/webui/src/server/features/consumer/consumerRoutes.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 SudoPrivacy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Forwards the user-scoped consumer endpoints to the moss this deployment fronts.
+ *
+ * The shared renderer's points, usage and order pages ask the transport where to
+ * send their requests, and in the browser that answer is this origin. Without a
+ * forward they 404 here and the panels render empty with nothing reported.
+ *
+ * An allowlist rather than a blanket `/api/v1/*` proxy. A catch-all would hand
+ * the browser every moss admin route under this server's session cookie, which
+ * is a much larger grant than these pages need — the cookie is the credential,
+ * so whatever is reachable through it is reachable to any page on this origin.
+ */
+import { Router, type NextFunction, type Response } from 'express'
+import { getMossContext } from '../auth/authService.js'
+import { requireSession, type AuthedRequest } from '../auth/sessionMiddleware.js'
+import type { AuthDeps } from '../auth/authService.js'
+
+/**
+ * Paths this server will forward, exact match on the leading segments.
+ *
+ * Read-only except for credit applications, which a user submits for their own
+ * account. Every one of these is scoped by moss to the calling user, so the
+ * forward adds no authority beyond what the session already carries.
+ */
+const FORWARDED = [
+  { method: 'GET', path: '/user/dashboard' },
+  { method: 'GET', path: '/user/profile' },
+  { method: 'GET', path: '/user/model-usage-stats' },
+  { method: 'GET', path: '/credit-applications' },
+  { method: 'POST', path: '/credit-applications' },
+] as const
+
+export function createConsumerRouter(deps: { auth: AuthDeps }): Router {
+  const router = Router()
+
+  for (const route of FORWARDED) {
+    const handler = async (
+      req: AuthedRequest,
+      res: Response,
+      next: NextFunction,
+    ): Promise<void> => {
+      try {
+        const ctx = await getMossContext(deps.auth, req.webSession!)
+        // The query string is carried through: model-usage-stats is scoped by
+        // start_date/end_date, and the applications list is paged.
+        const query = req.originalUrl.includes('?')
+          ? req.originalUrl.slice(req.originalUrl.indexOf('?'))
+          : ''
+        const upstream = await fetch(
+          new URL(`/api/v1${route.path}${query}`, ctx.baseUrl).toString(),
+          {
+            method: route.method,
+            headers: {
+              Authorization: `Bearer ${ctx.accessToken}`,
+              ...(route.method === 'POST' ? { 'Content-Type': 'application/json' } : {}),
+            },
+            ...(route.method === 'POST' ? { body: JSON.stringify(req.body ?? {}) } : {}),
+          },
+        )
+        const text = await upstream.text()
+        // Passed through verbatim, status included: these pages read moss's own
+        // `{success, msg}` shape, and re-wrapping would lose the reason a
+        // submission was refused.
+        res.status(upstream.status).type('application/json').send(text)
+      } catch (err) {
+        next(err)
+      }
+    }
+
+    if (route.method === 'GET') router.get(route.path, requireSession, handler)
+    else router.post(route.path, requireSession, handler)
+  }
+
+  return router
+}


### PR DESCRIPTION
Answers "why can I not see my credits on the web console", and closes a gap that only became reachable once users existed on both servers.

## What was wrong

The points, usage and order pages resolve their base URL through the `sudowork-server.get-config` bridge channel. That channel returned a **consumer address resolved independently of the server the user actually authenticated against**.

For anyone signed in to a control plane that is wrong by construction: the client sends that server's token to a different server, which does not know it. The panel comes back empty and **nothing reports an error** — the page has no way to tell "no credits" from "wrong server".

On web it was worse: the channel had no mapping at all, so those pages fell through to `not-supported-on-web` and rendered empty.

This has been latent since the two addresses were introduced. It became reachable the moment there were users on both servers, which is now.

## The fix

- **Desktop** resolves the channel through `getAuthServerBaseUrl` — the same resolver the login flow already uses. Everything behind this channel is scoped to the signed-in user, so it has to be asked of the server that signed them in.
- **Web** answers with this origin, which fronts the moss the browser holds a session for, and the server forwards the five user-scoped paths upstream under that session.

## Why an allowlist and not a proxy

The forward names five paths rather than passing `/api/v1/*` through. The session cookie is the credential, so a catch-all would make **every moss admin route** reachable from any page on this origin — a far larger grant than these pages need. Four of the five are reads; the fifth is a user submitting an application for their own account. moss scopes all of them to the caller, so the forward adds no authority the session did not already carry.

Responses pass through verbatim, status included: these pages read moss's own `{success, msg}` shape, and re-wrapping would lose the reason a submission was refused.

## Verification

`bun run type:check` green (desktop + renderer), webui `tsc --noEmit` green, webui lint clean, prettier clean on both workspaces.

End-to-end verification needs this deployed to the web console — the credits path on moss is already verified server-side (the admin token reads a real balance from the gateway, ÷500 matching the previous server's own figure exactly), so this is the last link between it and a user's screen.