### PR TITLE
fix(auth): redirect expired sessions to login

### DIFF
--- a/apps/desktop/src/process/bridge/eeclawBridge.ts
+++ b/apps/desktop/src/process/bridge/eeclawBridge.ts
@@ -42,6 +42,17 @@ function emitAuthRequired(reason: 'no_refresh_token' | 'refresh_failed'): void {
   }
 }
 
+async function markAuthRequired(reason: 'no_refresh_token' | 'refresh_failed'): Promise<void> {
+  await withAuthStorageLock(async () => {
+    await ProcessConfig.set('eeclaw.authStorage', null);
+    await ProcessConfig.set('eeclaw.localModeAvailable', null);
+    setCachedAuthToken('');
+    setCachedLocalModeAvailable(null);
+    resetConversationProvider();
+  });
+  emitAuthRequired(reason);
+}
+
 export async function getValidToken(forceRefresh = false): Promise<string> {
   const authStorage = ProcessConfig.getSync('eeclaw.authStorage');
   const serverUrl = ProcessConfig.getSync('eeclaw.serverUrl');
@@ -72,7 +83,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
   // token): there is nothing to retry — surface a single re-login prompt
   // instead of looping on "No refresh token available".
   if (!refresh_token) {
-    emitAuthRequired('no_refresh_token');
+    await markAuthRequired('no_refresh_token');
     throw new Error('AUTH_REQUIRED: session is not refreshable, please sign in again');
   }
 
@@ -149,7 +160,7 @@ export async function getValidToken(forceRefresh = false): Promise<string> {
         // The server definitively rejected the refresh (not a network blip) —
         // the session is dead and only an interactive re-login can recover it.
         if (response.status === 401 || data?.error === 'Invalid refresh token') {
-          emitAuthRequired('refresh_failed');
+          await markAuthRequired('refresh_failed');
         }
         throw new Error(data?.error || 'token_refresh_failed');
       }
@@ -391,9 +402,9 @@ export function initEeclawBridge(): void {
         return { success: false, error: 'no_server_url' as const, data: undefined };
       }
 
-      const accessToken = await getValidToken();
+      let accessToken = await getValidToken();
 
-      const response = await fetch(`${serverUrl}/api/v1/user/profile`, {
+      let response = await fetch(`${serverUrl}/api/v1/user/profile`, {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -403,6 +414,19 @@ export function initEeclawBridge(): void {
       });
 
       if (response.status === 401) {
+        accessToken = await getValidToken(true);
+        response = await fetch(`${serverUrl}/api/v1/user/profile`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          signal: AbortSignal.timeout(10000),
+        });
+      }
+
+      if (response.status === 401) {
+        await markAuthRequired('refresh_failed');
         return { success: false, error: 'unauthorized' as const, data: undefined };
       }
 
@@ -418,6 +442,9 @@ export function initEeclawBridge(): void {
       return { success: false, error: 'server_error' as const, data: undefined };
     } catch (error) {
       mainWarn('eeclawBridge', 'getUserProfile error:', error);
+      if (error instanceof Error && (error.message.includes('AUTH_REQUIRED') || error.message.includes('Invalid refresh token'))) {
+        return { success: false, error: 'unauthorized' as const, data: undefined };
+      }
       return { success: false, error: 'network_error' as const, data: undefined };
     }
   });
@@ -429,9 +456,9 @@ export function initEeclawBridge(): void {
         return { success: false, error: 'no_server_url' as const, data: undefined };
       }
 
-      const accessToken = await getValidToken();
+      let accessToken = await getValidToken();
 
-      const response = await fetch(`${serverUrl}/api/v1/agents/installed`, {
+      let response = await fetch(`${serverUrl}/api/v1/agents/installed`, {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -441,6 +468,19 @@ export function initEeclawBridge(): void {
       });
 
       if (response.status === 401) {
+        accessToken = await getValidToken(true);
+        response = await fetch(`${serverUrl}/api/v1/agents/installed`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          signal: AbortSignal.timeout(10000),
+        });
+      }
+
+      if (response.status === 401) {
+        await markAuthRequired('refresh_failed');
         return { success: false, error: 'unauthorized' as const, data: undefined };
       }
 
@@ -461,6 +501,9 @@ export function initEeclawBridge(): void {
       return { success: true, data: assistants };
     } catch (error) {
       mainWarn('eeclawBridge', 'getCloudAssistants error:', error);
+      if (error instanceof Error && (error.message.includes('AUTH_REQUIRED') || error.message.includes('Invalid refresh token'))) {
+        return { success: false, error: 'unauthorized' as const, data: undefined };
+      }
       return { success: false, error: 'network_error' as const, data: undefined };
     }
   });

--- a/apps/desktop/tests/unit/useModelUsageStats.dom.test.ts
+++ b/apps/desktop/tests/unit/useModelUsageStats.dom.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 SudoPrivacy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAuthFetch, mockGetServerConfig } = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockGetServerConfig: vi.fn(),
+}));
+
+vi.mock('@renderer/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { token: 'cached-token' },
+    authFetch: mockAuthFetch,
+  }),
+}));
+
+vi.mock('@sudowork/host-bridge/ipcBridge', () => ({
+  sudoworkServer: {
+    getConfig: { invoke: (...args: unknown[]) => mockGetServerConfig(...args) },
+  },
+}));
+
+import { useModelUsageStats } from '@renderer/hooks/useModelUsageStats';
+
+describe('useModelUsageStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerConfig.mockResolvedValue({ baseUrl: 'https://sudowork.example' });
+    mockAuthFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: [{ date: '2026-09-11', model: 'scode', prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 }],
+        }),
+    });
+  });
+
+  it('loads model usage through the shared authenticated fetch path', async () => {
+    const { result } = renderHook(() => useModelUsageStats());
+
+    await act(async () => {
+      await result.current.fetchStats('2026-09-01', '2026-09-11');
+    });
+
+    expect(mockAuthFetch).toHaveBeenCalledWith('https://sudowork.example/api/v1/user/model-usage-stats?start_date=2026-09-01&end_date=2026-09-11');
+    expect(result.current.data).toEqual([{ date: '2026-09-11', model: 'scode', prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 }]);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/renderer/src/context/AuthContext.tsx
+++ b/packages/renderer/src/context/AuthContext.tsx
@@ -190,6 +190,7 @@ type SetAuthUser = (user: AuthUser | null) => void;
 type SetAuthStatus = (status: AuthStatus) => void;
 type SetAuthReady = (ready: boolean) => void;
 type SetSyncMessage = (message: string | null) => void;
+type RefreshResult = { status: 'success'; accessToken: string } | { status: 'auth_expired' | 'failed'; reason?: string };
 
 // Enterprise login params
 interface EnterpriseLoginParams {
@@ -211,6 +212,7 @@ interface AuthContextValue {
   status: AuthStatus;
   isGuest: boolean;
   syncMessage: string | null;
+  authFetch: (url: string, options?: RequestInit) => Promise<Response>;
   login: (params: LoginParams) => Promise<LoginResult>;
   register: (params: RegisterParams) => Promise<RegisterResult>;
   logout: () => Promise<void>;
@@ -424,6 +426,20 @@ function resolveConsumerUserId(user: Partial<AuthUser>): string | undefined {
 
 function resolveConsumerTenantId(user: Partial<AuthUser> & { tenant_id?: string }, fallbackTenantId?: string): string | undefined {
   return resolveString(user.tenant_id) || resolveString(user.enterprise_code) || resolveString(fallbackTenantId);
+}
+
+function isAuthRejectedResponse(status: number, body?: unknown): boolean {
+  if (status === 401 || status === 403) return true;
+  const record = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+  const code = resolveString(record.error) || resolveString(record.code) || resolveString(record.msg) || resolveString(record.message);
+  if (!code) return false;
+  return /invalid.*refresh|refresh.*invalid|expired|unauthorized|forbidden|auth.*required/i.test(code);
+}
+
+function withAuthorizationHeader(headers: HeadersInit | undefined, token: string): Headers {
+  const nextHeaders = new Headers(headers);
+  nextHeaders.set('Authorization', `Bearer ${token}`);
+  return nextHeaders;
 }
 
 // 同步图像生成模型到 sudocode/sudoclaw：尊重用户已保存的选择，不再无条件覆盖为默认值
@@ -678,10 +694,41 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   const abortRef = useRef<AbortController | null>(null);
 
   // Mutex to prevent concurrent refresh calls
-  const refreshPromiseRef = useRef<Promise<boolean> | null>(null);
+  const refreshPromiseRef = useRef<Promise<RefreshResult> | null>(null);
   // Cooldown to prevent rapid repeated refresh
   const lastRefreshAtRef = useRef<number>(0);
   const REFRESH_COOLDOWN_MS = 30_000;
+  const isExpiringAuthRef = useRef(false);
+
+  const expireAuth = useCallback(async (reason: string) => {
+    if (isExpiringAuthRef.current) return;
+    isExpiringAuthRef.current = true;
+    try {
+      console.warn('[Auth] Session expired, clearing local auth state:', reason);
+      localStorage.removeItem(AUTH_STORAGE_KEY);
+      localStorage.removeItem('sudowork_auth_v1');
+      localStorage.removeItem(EECLAW_AUTH_STORAGE_KEY);
+      localStorage.removeItem(GUEST_FLAG_KEY);
+
+      setUser(null);
+      setStatus('unauthenticated');
+      setSyncMessage(null);
+      setReady(true);
+
+      if (!isDesktopRuntime) return;
+
+      await Promise.allSettled([
+        ConfigStorage.set('consumer.userInfo', undefined),
+        ConfigStorage.set('eeclaw.authStorage', undefined),
+        ConfigStorage.set('eeclaw.userInfo', undefined),
+        ConfigStorage.set('eeclaw.localModeAvailable', undefined),
+        ipcBridge.sudoworkAuth.clearConsumerUserId.invoke(),
+        ipcBridge.eeclaw.logout.invoke(),
+      ]);
+    } finally {
+      isExpiringAuthRef.current = false;
+    }
+  }, []);
 
   // Enter guest mode (unauthenticated use): restore guest custom models, set flag + status.
   // Caller is responsible for navigate('/guid').
@@ -692,10 +739,10 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   }, []);
 
   // Token 刷新函数 — supports both C-side and enterprise mode
-  const refreshTokens = useCallback(async (): Promise<boolean> => {
+  const refreshTokens = useCallback(async ({ force = false }: { force?: boolean } = {}): Promise<RefreshResult> => {
     // Cooldown: skip if refreshed recently
-    if (Date.now() - lastRefreshAtRef.current < REFRESH_COOLDOWN_MS) {
-      return false;
+    if (!force && Date.now() - lastRefreshAtRef.current < REFRESH_COOLDOWN_MS) {
+      return { status: 'failed', reason: 'refresh_cooldown' };
     }
 
     // Dedup: if already refreshing, wait for it
@@ -719,7 +766,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
               /* malformed storage — refresh() will clear it */
             }
             lastRefreshAtRef.current = Date.now();
-            return true;
+            return { status: 'success', accessToken: 'web-session' };
           }
           try {
             const authStorage: EeclawAuthStorage = JSON.parse(eeclawStored);
@@ -738,23 +785,27 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
               setUser({ ...authStorage.user, token: result.data.access_token });
               lastRefreshAtRef.current = Date.now();
               console.log('[Auth] Enterprise token refreshed successfully via IPC');
-              return true;
+              return { status: 'success', accessToken: result.data.access_token };
             }
             console.error('[Auth] Enterprise token refresh via IPC failed');
-            return false;
+            const error = 'error' in result ? result.error : result.msg;
+            return isAuthRejectedResponse(0, { error }) || String(error || '').includes('AUTH_REQUIRED') ? { status: 'auth_expired', reason: String(error || 'enterprise_refresh_failed') } : { status: 'failed', reason: String(error || 'enterprise_refresh_failed') };
           } catch (error) {
             console.error('[Auth] Enterprise token refresh via IPC failed:', error);
-            return false;
+            return { status: 'failed', reason: error instanceof Error ? error.message : String(error) };
           }
         }
 
         // C-side mode: refresh from sudowork server
         const stored = localStorage.getItem(AUTH_STORAGE_KEY);
-        if (!stored) return false;
+        if (!stored) return { status: 'failed', reason: 'missing_auth_storage' };
 
         try {
           const authStorage: AuthStorage = JSON.parse(stored);
           const { refresh_token, device_id } = authStorage;
+          if (!refresh_token) {
+            return { status: 'auth_expired', reason: 'missing_refresh_token' };
+          }
 
           const response = await fetch(`${await getAuthServerBaseUrl()}/api/v1/auth/refresh`, {
             method: 'POST',
@@ -762,28 +813,33 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             body: JSON.stringify({ refresh_token, device_id }),
           });
 
-          const data = await response.json();
-          if (data.success) {
+          const data = (await response.json().catch((): unknown => ({}))) as Record<string, unknown>;
+          if (data.success === true) {
+            const body = data as { access_token: string; refresh_token: string; expires_in: number };
             const newStorage: AuthStorage = {
-              access_token: data.access_token,
-              refresh_token: data.refresh_token,
-              expires_at: Date.now() + data.expires_in * 1000,
+              access_token: body.access_token,
+              refresh_token: body.refresh_token,
+              expires_at: Date.now() + body.expires_in * 1000,
               user: authStorage.user,
               device_id: device_id || getDeviceId(),
               session: authStorage.session,
             };
 
             localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(newStorage));
-            setUser({ ...authStorage.user, token: data.access_token });
+            setUser({ ...authStorage.user, token: body.access_token });
             lastRefreshAtRef.current = Date.now();
             console.log('[Auth] Token refreshed successfully');
-            return true;
+            return { status: 'success', accessToken: body.access_token };
+          }
+          if (isAuthRejectedResponse(response.status, data)) {
+            return { status: 'auth_expired', reason: 'consumer_refresh_rejected' };
           }
         } catch (error) {
           console.error('[Auth] Token refresh failed:', error);
+          return { status: 'failed', reason: error instanceof Error ? error.message : String(error) };
         }
 
-        return false;
+        return { status: 'failed', reason: 'refresh_failed' };
       } finally {
         refreshPromiseRef.current = null;
       }
@@ -806,16 +862,18 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           const { access_token, expires_at } = authStorage;
 
           if (forceRefresh || (expires_at && Date.now() > expires_at - 5 * 60 * 1000)) {
-            const refreshed = await refreshTokens();
-            if (refreshed) {
-              const newStorage = JSON.parse(localStorage.getItem(EECLAW_AUTH_STORAGE_KEY) || '{}');
-              return newStorage.access_token || null;
+            const refreshed = await refreshTokens({ force: forceRefresh });
+            if (refreshed.status === 'success') {
+              return refreshed.accessToken;
             }
             // Refresh failed (e.g. provider has no refresh API). Keep using the
             // current access_token while it is still valid; only give up once it
             // has actually expired, at which point re-login is required.
             if (!forceRefresh && expires_at && Date.now() < expires_at) {
               return access_token;
+            }
+            if (refreshed.status === 'auth_expired') {
+              await expireAuth(refreshed.reason || 'enterprise_refresh_failed');
             }
             return null;
           }
@@ -835,12 +893,15 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           const { access_token, expires_at } = authStorage;
 
           if (forceRefresh || (expires_at && Date.now() > expires_at - 5 * 60 * 1000)) {
-            const refreshed = await refreshTokens();
-            if (!refreshed) {
+            const refreshed = await refreshTokens({ force: forceRefresh });
+            if (refreshed.status === 'success') {
+              return refreshed.accessToken;
+            }
+            if (refreshed.status === 'auth_expired') {
+              await expireAuth(refreshed.reason || 'consumer_refresh_failed');
               return null;
             }
-            const newStorage = JSON.parse(localStorage.getItem(AUTH_STORAGE_KEY) || '{}');
-            return newStorage.access_token || null;
+            return null;
           }
 
           return access_token;
@@ -862,7 +923,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
       return null;
     },
-    [refreshTokens]
+    [expireAuth, refreshTokens]
   );
 
   // 强制刷新 Token — supports both modes
@@ -872,34 +933,54 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     // Enterprise mode
     const eeclawStored = localStorage.getItem(EECLAW_AUTH_STORAGE_KEY);
     if (eeclawStored) {
-      try {
-        const authStorage: EeclawAuthStorage = JSON.parse(eeclawStored);
-        if (authStorage.refresh_token) {
-          return ensureValidToken(true);
-        }
-      } catch (error) {
-        console.error('[Auth] Failed to check enterprise auth storage:', error);
-      }
-      console.warn('[Auth] No enterprise refresh_token available, user needs to re-login');
-      return null;
+      return ensureValidToken(true);
     }
 
     // C-side
     const stored = localStorage.getItem(AUTH_STORAGE_KEY);
     if (stored) {
-      try {
-        const authStorage: AuthStorage = JSON.parse(stored);
-        if (authStorage.refresh_token) {
-          return ensureValidToken(true);
-        }
-      } catch (error) {
-        console.error('[Auth] Failed to check auth storage:', error);
-      }
+      return ensureValidToken(true);
     }
 
     console.warn('[Auth] No refresh_token available, user needs to re-login');
     return null;
   }, [ensureValidToken]);
+
+  const authFetch = useCallback(
+    async (url: string, options: RequestInit = {}): Promise<Response> => {
+      const token = await ensureValidToken();
+      if (!token) {
+        throw new Error('AUTH_UNAVAILABLE');
+      }
+
+      const response = await fetch(url, {
+        ...options,
+        headers: withAuthorizationHeader(options.headers, token),
+      });
+
+      if (response.status !== 401 && response.status !== 403) {
+        return response;
+      }
+
+      const newToken = await forceRefreshToken();
+      if (!newToken) {
+        throw new Error('AUTH_UNAVAILABLE');
+      }
+
+      const retryResponse = await fetch(url, {
+        ...options,
+        headers: withAuthorizationHeader(options.headers, newToken),
+      });
+
+      if (retryResponse.status === 401 || retryResponse.status === 403) {
+        await expireAuth('authenticated_request_unauthorized_after_retry');
+        throw new Error('AUTH_EXPIRED');
+      }
+
+      return retryResponse;
+    },
+    [ensureValidToken, expireAuth, forceRefreshToken]
+  );
 
   const refresh = useCallback(async () => {
     // === Web host (webui shared-renderer): restore from the webui cookie session ===
@@ -927,11 +1008,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
         if (!authStorage.user) {
           localStorage.removeItem(EECLAW_AUTH_STORAGE_KEY);
         } else {
-          setUser(authStorage.user);
-          setStatus('authenticated');
-          setReady(true);
-          await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
-
           // Sync token to ConfigStorage for eeclawBridge
           // Prefer ProcessConfig's refresh_token if it's newer (main process may have rotated it)
           try {
@@ -967,8 +1043,23 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
           // Check if token needs refresh
           if (authStorage.expires_at && Date.now() > authStorage.expires_at - 5 * 60 * 1000) {
-            await refreshTokens();
+            const refreshed = await refreshTokens({ force: true });
+            if (refreshed.status === 'auth_expired') {
+              await expireAuth(refreshed.reason || 'enterprise_refresh_rejected_on_restore');
+              return;
+            }
+            if (refreshed.status === 'failed' && Date.now() >= authStorage.expires_at) {
+              setUser(null);
+              setStatus('unauthenticated');
+              setReady(true);
+              return;
+            }
           }
+          const latestAuth = JSON.parse(localStorage.getItem(EECLAW_AUTH_STORAGE_KEY) || JSON.stringify(authStorage)) as EeclawAuthStorage;
+          setUser({ ...latestAuth.user, token: latestAuth.access_token });
+          setStatus('authenticated');
+          setReady(true);
+          await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
           return;
         }
       } catch {
@@ -989,11 +1080,6 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
           setReady(true);
           return;
         }
-
-        setUser({ ...authStorage.user, token: authStorage.access_token });
-        setStatus('authenticated');
-        setReady(true);
-        await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
 
         const restoredUserId = resolveConsumerUserId(authStorage.user);
         // 从 localStorage 恢复登录状态时，也保存手机号到文件
@@ -1031,8 +1117,23 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
         // 检查 token 是否需要刷新
         if (authStorage.expires_at && Date.now() > authStorage.expires_at - 5 * 60 * 1000) {
-          await refreshTokens();
+          const refreshed = await refreshTokens({ force: true });
+          if (refreshed.status === 'auth_expired') {
+            await expireAuth(refreshed.reason || 'consumer_refresh_rejected_on_restore');
+            return;
+          }
+          if (refreshed.status === 'failed' && Date.now() >= authStorage.expires_at) {
+            setUser(null);
+            setStatus('unauthenticated');
+            setReady(true);
+            return;
+          }
         }
+        const latestAuth = JSON.parse(localStorage.getItem(AUTH_STORAGE_KEY) || JSON.stringify(authStorage)) as AuthStorage;
+        setUser({ ...latestAuth.user, token: latestAuth.access_token });
+        setStatus('authenticated');
+        setReady(true);
+        await syncScodeGuidModelPreference(SCODE_AUTO_MODEL_ALIAS);
         // §6.4 凭据注入必须在 token 刷新之后:冷启动时 access_token 可能已过期,
         // 若在刷新前注入,/system-config/credentials 会用过期 JWT 返回 401,凭据无法注入。
         void fetchAndCacheCredentials();
@@ -1127,7 +1228,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setStatus('unauthenticated');
     }
     setReady(true);
-  }, [refreshTokens]);
+  }, [expireAuth, refreshTokens]);
 
   useEffect(() => {
     void refresh();
@@ -1176,14 +1277,12 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   useEffect(() => {
     const unsubscribe = ipcBridge.eeclaw.authRequired.on(({ reason }) => {
       console.warn(`[Auth] Enterprise session requires re-login (${reason})`);
-      localStorage.removeItem(EECLAW_AUTH_STORAGE_KEY);
-      setUser(null);
-      setStatus('unauthenticated');
+      void expireAuth(`enterprise_auth_required:${reason}`);
     });
     return () => {
       unsubscribe();
     };
-  }, []);
+  }, [expireAuth]);
 
   const login = useCallback(async ({ phone, code, enterprise_code, invitation_code: _invitation_code, remember: _remember }: LoginParams): Promise<LoginResult> => {
     const deviceId = getDeviceId();
@@ -1852,6 +1951,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       status,
       isGuest: status === 'guest',
       syncMessage,
+      authFetch,
       login,
       register,
       logout,
@@ -1867,7 +1967,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       changePassword,
       enterGuest,
     }),
-    [login, register, logout, ready, refresh, status, syncMessage, user, ensureValidToken, forceRefreshToken, enterpriseLogin, enterpriseLoginWithOAuth2, loginByPassword, registerByPassword, loginWithThirdPartyAuth, exchangeThirdPartyAuthCode, changePassword, enterGuest]
+    [authFetch, login, register, logout, ready, refresh, status, syncMessage, user, ensureValidToken, forceRefreshToken, enterpriseLogin, enterpriseLoginWithOAuth2, loginByPassword, registerByPassword, loginWithThirdPartyAuth, exchangeThirdPartyAuthCode, changePassword, enterGuest]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/packages/renderer/src/context/DashboardStatsContext.tsx
+++ b/packages/renderer/src/context/DashboardStatsContext.tsx
@@ -31,7 +31,7 @@ const DashboardStatsContext = createContext<DashboardStatsContextValue | null>(n
 const STALE_MS = 30_000;
 
 export const DashboardStatsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const { user, ensureValidToken, forceRefreshToken } = useAuth();
+  const { user, authFetch } = useAuth();
   const [profile, setProfile] = useState<any | null>(null);
   const [stats, setStats] = useState<ConsumerDashboardStats | null>(null);
   const [loading, setLoading] = useState(false);
@@ -45,34 +45,12 @@ export const DashboardStatsProvider: React.FC<React.PropsWithChildren> = ({ chil
       if (!force && Date.now() - lastFetchedAtRef.current < STALE_MS) return;
       if (inFlightRef.current) return inFlightRef.current;
 
-      const fetchWithAuth = async (url: string, options: RequestInit = {}, retry = true): Promise<Response> => {
-        const token = await ensureValidToken();
-        if (!token) {
-          throw new Error('NO_TOKEN');
-        }
-        const headers = { ...options.headers, Authorization: `Bearer ${token}` };
-        const response = await fetch(url, { ...options, headers });
-        if (response.status === 401 && retry) {
-          const newToken = await forceRefreshToken();
-          if (newToken) {
-            const retryHeaders = { ...options.headers, Authorization: `Bearer ${newToken}` };
-            return fetch(url, { ...options, headers: retryHeaders });
-          }
-        }
-        return response;
-      };
-
       const task = (async () => {
         setLoading(true);
         setError(null);
         try {
           const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-          const [profileRes, dashboardRes] = await Promise.all([fetchWithAuth(`${serverConfig.baseUrl}/api/v1/user/profile`), fetchWithAuth(`${serverConfig.baseUrl}/api/v1/user/dashboard`)]);
-
-          if (profileRes.status === 401 || dashboardRes.status === 401) {
-            // Token refresh already attempted inside fetchWithAuth; leave state as-is.
-            return;
-          }
+          const [profileRes, dashboardRes] = await Promise.all([authFetch(`${serverConfig.baseUrl}/api/v1/user/profile`), authFetch(`${serverConfig.baseUrl}/api/v1/user/dashboard`)]);
 
           const profileData = await profileRes.json();
           const dashboardData = await dashboardRes.json();
@@ -93,7 +71,7 @@ export const DashboardStatsProvider: React.FC<React.PropsWithChildren> = ({ chil
       inFlightRef.current = task;
       return task;
     },
-    [user?.token, ensureValidToken, forceRefreshToken]
+    [user?.token, authFetch]
   );
 
   // Auto-fetch when a token becomes available; clear state on logout.

--- a/packages/renderer/src/hooks/useModelUsageStats.ts
+++ b/packages/renderer/src/hooks/useModelUsageStats.ts
@@ -30,7 +30,7 @@ interface UseModelUsageStatsResult {
 }
 
 export function useModelUsageStats(): UseModelUsageStatsResult {
-  const { user: currentUser, ensureValidToken } = useAuth();
+  const { user: currentUser, authFetch } = useAuth();
   const [data, setData] = useState<ModelUsageData[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -44,16 +44,7 @@ export function useModelUsageStats(): UseModelUsageStatsResult {
 
       try {
         const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-        const token = await ensureValidToken();
-        if (!token) {
-          setError('NO_TOKEN');
-          setLoading(false);
-          return;
-        }
-
-        const response = await fetch(`${serverConfig.baseUrl}/api/v1/user/model-usage-stats?start_date=${startDate}&end_date=${endDate}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const response = await authFetch(`${serverConfig.baseUrl}/api/v1/user/model-usage-stats?start_date=${startDate}&end_date=${endDate}`);
 
         const result: ModelUsageStatsResponse = await response.json();
 
@@ -69,7 +60,7 @@ export function useModelUsageStats(): UseModelUsageStatsResult {
         setLoading(false);
       }
     },
-    [currentUser?.token, ensureValidToken]
+    [currentUser?.token, authFetch]
   );
 
   return { data, loading, error, fetchStats };

--- a/packages/renderer/src/pages/settings/profile/index.tsx
+++ b/packages/renderer/src/pages/settings/profile/index.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Avatar, Button, Modal, Input, Message, Spin } from '@arco-design/web-react';
 import { IconEdit, IconLock, IconMobile, IconUser } from '@arco-design/web-react/icon';
 import { useTranslation } from 'react-i18next';
@@ -22,7 +22,7 @@ import ChangePasswordModal from './components/ChangePasswordModal';
 
 const UserProfile: React.FC = () => {
   const { t } = useTranslation();
-  const { user: currentUser, refresh: refreshAuth, ensureValidToken, forceRefreshToken } = useAuth();
+  const { user: currentUser, refresh: refreshAuth, authFetch } = useAuth();
   const { profile, stats, refresh: refreshDashboard } = useDashboardStats();
   const { isEnterprise } = useAppMode();
   const [editingNickname, setEditingNickname] = useState('');
@@ -32,40 +32,6 @@ const UserProfile: React.FC = () => {
 
   // Enterprise mode state
   const [enterpriseProfile, setEnterpriseProfile] = useState<UserProfileData | null>(null);
-
-  // 带自动刷新的 fetch 封装（仅用于昵称更新等写操作；读路径已迁移到 DashboardStatsContext）
-  const fetchWithAuth = useCallback(
-    async (url: string, options: RequestInit = {}, retry = true): Promise<Response> => {
-      const token = await ensureValidToken();
-      if (!token) {
-        throw new Error('NO_TOKEN');
-      }
-
-      const headers = {
-        ...options.headers,
-        Authorization: `Bearer ${token}`,
-      };
-
-      const response = await fetch(url, { ...options, headers });
-
-      // 如果返回 401，尝试强制刷新 token 后重试一次
-      if (response.status === 401 && retry) {
-        console.log('[UserProfile] Got 401, attempting force token refresh...');
-        const newToken = await forceRefreshToken();
-        if (newToken) {
-          // 用新 token 重试
-          const retryHeaders = {
-            ...options.headers,
-            Authorization: `Bearer ${newToken}`,
-          };
-          return fetch(url, { ...options, headers: retryHeaders });
-        }
-      }
-
-      return response;
-    },
-    [ensureValidToken, forceRefreshToken]
-  );
 
   // Enterprise mode: fetch user profile from MOSS server
   const fetchEnterpriseProfile = async () => {
@@ -106,17 +72,11 @@ const UserProfile: React.FC = () => {
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
 
-      const res = await fetchWithAuth(`${serverConfig.baseUrl}/api/v1/user/update-profile`, {
+      const res = await authFetch(`${serverConfig.baseUrl}/api/v1/user/update-profile`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nickname: editingNickname.trim() }),
       });
-
-      // 检查 401
-      if (res.status === 401) {
-        Message.error(t('settings.userProfile.loginExpired', '登录状态已过期，请重新登录'));
-        return;
-      }
 
       const data = await res.json();
       if (data.success) {

--- a/packages/renderer/src/pages/settings/recharge/components/CreditApplicationPanel.tsx
+++ b/packages/renderer/src/pages/settings/recharge/components/CreditApplicationPanel.tsx
@@ -17,7 +17,7 @@ const STATUS_COLOR: Record<CreditApplicationStatus, string> = {
 
 export default function CreditApplicationPanel({ onSubmitted }: ICreditApplicationPanelProps) {
   const { t } = useTranslation();
-  const { user: currentUser, ensureValidToken } = useAuth();
+  const { user: currentUser, authFetch } = useAuth();
   const [form] = Form.useForm();
   const [applications, setApplications] = useState<CreditApplication[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -40,11 +40,7 @@ export default function CreditApplicationPanel({ onSubmitted }: ICreditApplicati
     setIsLoading(true);
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const token = await ensureValidToken();
-      if (!token) return;
-      const response = await fetch(`${serverConfig.baseUrl}/api/v1/credit-applications?page=1&pageSize=50`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const response = await authFetch(`${serverConfig.baseUrl}/api/v1/credit-applications?page=1&pageSize=50`);
       const data = await response.json();
       if (data.success) {
         setApplications(data.data?.list || []);
@@ -57,7 +53,7 @@ export default function CreditApplicationPanel({ onSubmitted }: ICreditApplicati
     } finally {
       setIsLoading(false);
     }
-  }, [currentUser?.token, ensureValidToken, t]);
+  }, [currentUser?.token, authFetch, t]);
 
   useEffect(() => {
     void fetchApplications();
@@ -68,12 +64,9 @@ export default function CreditApplicationPanel({ onSubmitted }: ICreditApplicati
     setIsSubmitting(true);
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const token = await ensureValidToken();
-      if (!token) return;
-      const response = await fetch(`${serverConfig.baseUrl}/api/v1/credit-applications`, {
+      const response = await authFetch(`${serverConfig.baseUrl}/api/v1/credit-applications`, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({

--- a/packages/renderer/src/pages/settings/recharge/components/OrderList.tsx
+++ b/packages/renderer/src/pages/settings/recharge/components/OrderList.tsx
@@ -17,7 +17,7 @@ import { formatAmount, formatDateTime } from '../utils';
 
 const OrderList: React.FC<IOrderListProps> = ({ onContinuePay, refreshKey }) => {
   const { t } = useTranslation();
-  const { user: currentUser, ensureValidToken } = useAuth();
+  const { user: currentUser, authFetch } = useAuth();
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(false);
 
@@ -27,12 +27,7 @@ const OrderList: React.FC<IOrderListProps> = ({ onContinuePay, refreshKey }) => 
     setLoading(true);
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const token = await ensureValidToken();
-      if (!token) return;
-
-      const response = await fetch(`${serverConfig.baseUrl}/api/v1/recharge/list?page=1&pageSize=100`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const response = await authFetch(`${serverConfig.baseUrl}/api/v1/recharge/list?page=1&pageSize=100`);
       const data = await response.json();
 
       if (data.success) {
@@ -44,7 +39,7 @@ const OrderList: React.FC<IOrderListProps> = ({ onContinuePay, refreshKey }) => 
     } finally {
       setLoading(false);
     }
-  }, [currentUser?.token, ensureValidToken, t]);
+  }, [currentUser?.token, authFetch, t]);
 
   useEffect(() => {
     void fetchOrders();

--- a/packages/renderer/src/pages/settings/recharge/index.tsx
+++ b/packages/renderer/src/pages/settings/recharge/index.tsx
@@ -29,7 +29,7 @@ const PANEL_CLASS = 'p-6 bg-muted rd-16px border border-light';
 
 const RechargeCenter: React.FC = () => {
   const { t } = useTranslation();
-  const { user: currentUser, refresh, ensureValidToken, forceRefreshToken } = useAuth();
+  const { user: currentUser, refresh, authFetch } = useAuth();
 
   // Points state
   const [stats, setStats] = useState<any>(null);
@@ -53,38 +53,6 @@ const RechargeCenter: React.FC = () => {
   const pollCountRef = useRef(0);
   const MAX_POLL_COUNT = 600; // 30 minutes / 3 seconds
 
-  // Fetch with auth
-  const fetchWithAuth = useCallback(
-    async (url: string, options: RequestInit = {}, retry = true): Promise<Response> => {
-      const token = await ensureValidToken();
-      if (!token) {
-        throw new Error('NO_TOKEN');
-      }
-
-      const headers = {
-        ...options.headers,
-        Authorization: `Bearer ${token}`,
-      };
-
-      const response = await fetch(url, { ...options, headers });
-
-      if (response.status === 401 && retry) {
-        console.log('[RechargeCenter] Got 401, attempting force token refresh...');
-        const newToken = await forceRefreshToken();
-        if (newToken) {
-          const retryHeaders = {
-            ...options.headers,
-            Authorization: `Bearer ${newToken}`,
-          };
-          return fetch(url, { ...options, headers: retryHeaders });
-        }
-      }
-
-      return response;
-    },
-    [ensureValidToken, forceRefreshToken]
-  );
-
   // Fetch stats and packages
   const fetchStats = useCallback(async () => {
     if (!currentUser?.token) return;
@@ -92,7 +60,7 @@ const RechargeCenter: React.FC = () => {
     setStatsLoading(true);
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const response = await fetchWithAuth(`${serverConfig.baseUrl}/api/v1/user/dashboard`);
+      const response = await authFetch(`${serverConfig.baseUrl}/api/v1/user/dashboard`);
       const data = await response.json();
       if (data.success) {
         setStats(data.data.points);
@@ -102,7 +70,7 @@ const RechargeCenter: React.FC = () => {
     } finally {
       setStatsLoading(false);
     }
-  }, [currentUser?.token, fetchWithAuth]);
+  }, [currentUser?.token, authFetch]);
 
   const fetchPackages = useCallback(async () => {
     if (!currentUser?.token) return;
@@ -110,7 +78,7 @@ const RechargeCenter: React.FC = () => {
     setLoading(true);
     try {
       const serverConfig = await ipcBridge.sudoworkServer.getConfig.invoke();
-      const response = await fetchWithAuth(`${serverConfig.baseUrl}/api/v1/recharge/packages`);
+      const response = await authFetch(`${serverConfig.baseUrl}/api/v1/recharge/packages`);
       const data = await response.json();
       if (data.success) {
         setPackages(data.data);
@@ -121,7 +89,7 @@ const RechargeCenter: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [currentUser?.token, fetchWithAuth, t]);
+  }, [currentUser?.token, authFetch, t]);
 
   // Stop polling
   const stopPolling = useCallback(() => {
@@ -191,7 +159,7 @@ const RechargeCenter: React.FC = () => {
       const baseUrl = serverConfig.baseUrl;
 
       // Step 1: Create order
-      const createRes = await fetchWithAuth(`${baseUrl}/api/v1/recharge/create`, {
+      const createRes = await authFetch(`${baseUrl}/api/v1/recharge/create`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -211,7 +179,7 @@ const RechargeCenter: React.FC = () => {
       setExpiredAt(new Date(order.expired_at));
 
       // Step 2: Get QR code
-      const payRes = await fetchWithAuth(`${baseUrl}/api/v1/recharge/pay`, {
+      const payRes = await authFetch(`${baseUrl}/api/v1/recharge/pay`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ order_no: order.order_no }),
@@ -235,7 +203,7 @@ const RechargeCenter: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [currentUser?.token, selectedPackage, paymentMethod, fetchWithAuth, t, startPolling]);
+  }, [currentUser?.token, selectedPackage, paymentMethod, authFetch, t, startPolling]);
 
   // Cancel order
   const handleCancelOrder = useCallback(async () => {


### PR DESCRIPTION
## Summary
- add a shared authenticated fetch path that refreshes once on 401/403 and clears auth state when the server still rejects the session
- clear stale consumer and enterprise auth storage when refresh tokens are missing or rejected
- migrate dashboard, profile, recharge, credit application, order list, and model usage requests to the shared auth path
- add coverage for model usage loading through authFetch

## Tests
- bunx eslint apps/desktop/src/process/bridge/eeclawBridge.ts apps/desktop/tests/unit/useModelUsageStats.dom.test.ts --fix
- bunx eslint src/context/AuthContext.tsx src/context/DashboardStatsContext.tsx src/hooks/useModelUsageStats.ts src/pages/settings/profile/index.tsx src/pages/settings/recharge/index.tsx src/pages/settings/recharge/components/CreditApplicationPanel.tsx src/pages/settings/recharge/components/OrderList.tsx --fix
- bun run type:check
- bunx vitest run tests/unit/useModelUsageStats.dom.test.ts
- bun run test