### PR TITLE
fix(settings): the credits page is unreachable in enterprise mode

### DIFF
--- a/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
+++ b/apps/webui/src/client/bridgeAdapter/mossAdapter.ts
@@ -1034,6 +1034,11 @@ const handlers: Record<string, (req: AnyReq) => Promise<unknown>> = {
   },
 
   // --- extensions: web host has no local extension host; consumers tolerate []. ---
+  // Extensions do not run in the browser host. These answer with an empty
+  // list rather than falling through to `not-supported-on-web`, which
+  // resolves an IBridgeResponse object — a caller expecting an array then
+  // iterates it and throws.
+  'extensions.get-settings-tabs': async () => [],
   'extensions.get-assistants': async () => [],
   'extensions.get-acp-adapters': async () => [],
 

--- a/packages/common/src/sudoworkServer.ts
+++ b/packages/common/src/sudoworkServer.ts
@@ -44,10 +44,32 @@ export function normalizeSudoworkServerUrl(raw: string | null | undefined): stri
 }
 
 /**
+ * Whether this is the browser host (apps/webui) rather than the desktop app.
+ *
+ * The desktop bundle has no `window.__sudoworkWebBridge`; the web adapter sets
+ * it at import time, before any of this runs.
+ */
+function isWebHost(): boolean {
+  return typeof window !== 'undefined'
+    && Boolean((window as { __sudoworkWebBridge?: boolean }).__sudoworkWebBridge);
+}
+
+/**
  * Resolve the current sudowork-server base URL (renderer / async context).
  * Reads the user setting on every call — no caching.
+ *
+ * On the browser host the answer is this origin, which fronts the server the
+ * session belongs to. The compiled-in default points at the consumer server,
+ * and a page served from somewhere else reaching for it is a cross-origin
+ * request that simply fails — which is not visible as a failure, because every
+ * caller here treats a failed config fetch as "unknown" and falls back to a
+ * default. That is how the web console came to show a payment UI for a
+ * deployment that had declared credit applications instead.
  */
 export async function getSudoworkServerBaseUrl(): Promise<string> {
   const raw = await ConfigStorage.get('system.sudoworkServerUrl').catch(() => undefined as unknown as string | undefined);
-  return normalizeSudoworkServerUrl(raw) ?? BUILD_SUDOWORK_SERVER_BASE_URL;
+  const configured = normalizeSudoworkServerUrl(raw);
+  if (configured) return configured;
+  if (isWebHost()) return window.location.origin;
+  return BUILD_SUDOWORK_SERVER_BASE_URL;
 }

--- a/packages/renderer/src/context/AuthContext.tsx
+++ b/packages/renderer/src/context/AuthContext.tsx
@@ -370,6 +370,9 @@ function mapEnterpriseUser(enterpriseUser: { id: string; name: string; role?: st
 // ({ user: { id, name }, organization, role, scopes }). No real token is handed
 // to the browser — the storage below only satisfies the EeclawAuthStorage shape
 // the existing enterprise branches read.
+/** Stands in for a bearer on the web host, where the session cookie is the real credential. */
+const WEB_SESSION_TOKEN = 'web-session';
+
 async function fetchWebSession(): Promise<AuthUser | null> {
   try {
     const response = await fetch('/api/auth/session', {
@@ -392,6 +395,14 @@ async function fetchWebSession(): Promise<AuthUser | null> {
       // 企业标识：让技能「专属」tab 通过非空门槛并让 handler 分流到 /tenant
       // （/tenant 取数按登录 session 企业身份返回，不依赖此值内容）
       enterprise_code: data.organization?.id,
+      // The placeholder the rest of the app tests for. Twenty-odd screens gate
+      // their data fetching on `user.token` being present, which on the desktop
+      // carries a real bearer. Here the cookie is the credential and nothing
+      // needs the value — but leaving the field empty silently switched every
+      // one of those screens off: the settings pages rendered their zero state
+      // and never issued a request. `ensureValidToken()` returns this same
+      // placeholder, so the two agree.
+      token: WEB_SESSION_TOKEN,
     };
   } catch {
     return null;
@@ -400,7 +411,7 @@ async function fetchWebSession(): Promise<AuthUser | null> {
 
 function buildWebAuthStorage(user: AuthUser): string {
   return JSON.stringify({
-    access_token: 'web-session',
+    access_token: WEB_SESSION_TOKEN,
     refresh_token: '',
     expires_at: Date.now() + 24 * 60 * 60 * 1000,
     user,
@@ -856,7 +867,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       if (eeclawStored) {
         // Web host: the placeholder token is opaque to callers; the cookie
         // session is the real credential. refresh() re-validates on page load.
-        if (isWebRuntime) return 'web-session';
+        if (isWebRuntime) return WEB_SESSION_TOKEN;
         try {
           const authStorage: EeclawAuthStorage = JSON.parse(eeclawStored);
           const { access_token, expires_at } = authStorage;
@@ -1319,7 +1330,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             data: {
               // The cookie is the session on web; this placeholder keeps the
               // shared finaliser's shape without handing the browser a real token.
-              access_token: 'web-session',
+              access_token: WEB_SESSION_TOKEN,
               refresh_token: '',
               expires_in: 24 * 60 * 60,
               user: {
@@ -1407,7 +1418,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             data: {
               // The cookie is the session on web; this placeholder keeps the
               // shared finaliser's shape without handing the browser a real token.
-              access_token: 'web-session',
+              access_token: WEB_SESSION_TOKEN,
               refresh_token: '',
               expires_in: 24 * 60 * 60,
               user: {
@@ -1713,7 +1724,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             {
               success: true,
               data: {
-                access_token: 'web-session',
+                access_token: WEB_SESSION_TOKEN,
                 refresh_token: '',
                 expires_in: 24 * 60 * 60,
                 user: {

--- a/packages/renderer/src/layouts/components/SettingsSider.tsx
+++ b/packages/renderer/src/layouts/components/SettingsSider.tsx
@@ -21,8 +21,16 @@ import SidebarNavItem from '@renderer/layouts/components/SidebarNavItem';
 /** Builtin settings tab IDs in display order (must match router paths). */
 const BUILTIN_TAB_IDS = ['profile', 'recharge', 'members', 'model', 'agent', 'tools', 'skill', 'security', 'display', 'channels', 'runtime', 'system', 'about'] as const; // 隐藏'copilot'；'cron'已移至左侧边栏
 
-/** Enterprise mode builtin tab IDs (restricted subset). */
-const ENTERPRISE_BUILTIN_TAB_IDS = ['profile', 'enterprise', 'mcp', 'display', 'channels', 'system', 'about'] as const;
+/**
+ * Enterprise mode builtin tab IDs (restricted subset).
+ *
+ * `recharge` is listed even though this is the restricted set: the entry is
+ * already gated on the server's `recharge_mode`, so a deployment that declares
+ * `disabled` still hides it. Leaving it out of the list instead meant a control
+ * plane could serve points and applications and no one could reach the page —
+ * the route existed, the menu never offered it.
+ */
+const ENTERPRISE_BUILTIN_TAB_IDS = ['profile', 'enterprise', 'recharge', 'mcp', 'display', 'channels', 'system', 'about'] as const;
 
 type SiderItem = {
   id: string;

--- a/packages/renderer/src/layouts/components/SettingsSider.tsx
+++ b/packages/renderer/src/layouts/components/SettingsSider.tsx
@@ -61,7 +61,12 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
-        const tabs = (await extensionsIpc.getSettingsTabs.invoke()) ?? [];
+        // `?? []` is not enough: a bridge channel with no host mapping resolves
+        // an IBridgeResponse object rather than rejecting, and an object
+        // survives the nullish check to be iterated later — which takes the
+        // whole settings sidebar down, several seconds after it rendered fine.
+        const raw = await extensionsIpc.getSettingsTabs.invoke();
+        const tabs = Array.isArray(raw) ? raw : [];
         if (tabs.length > 0 || attempt === maxAttempts - 1) {
           return tabs;
         }

--- a/packages/renderer/src/router.tsx
+++ b/packages/renderer/src/router.tsx
@@ -46,7 +46,12 @@ const withRouteFallback = (Component: React.LazyExoticComponent<React.ComponentT
 );
 
 // Enterprise-allowed settings paths
-const ENTERPRISE_ALLOWED_PATHS = ['/settings/profile', '/settings/enterprise', '/settings/mcp', '/settings/display', '/settings/channels', '/settings/system', '/settings/about'];
+// Enterprise mode narrows the settings area to these paths. Kept in step with
+// ENTERPRISE_BUILTIN_TAB_IDS in SettingsSider: the menu decides what is
+// offered and this decides what is reachable, so a path missing from either
+// one is unreachable — `/settings/recharge` was missing from both, which is
+// why a control plane could serve credits that no one could open.
+const ENTERPRISE_ALLOWED_PATHS = ['/settings/profile', '/settings/enterprise', '/settings/recharge', '/settings/mcp', '/settings/display', '/settings/channels', '/settings/system', '/settings/about'];
 
 // Mode-aware default settings route
 const SettingsDefaultRoute: React.FC = () => {


### PR DESCRIPTION
Found by going to look for the page on the deployed console, after fixing the first reason it was missing.

## Two gates, one of them unconditional

The credits entry is gated twice:

1. on the server's `recharge_mode` — correct, and it is why the entry was hidden at first
2. on `ENTERPRISE_BUILTIN_TAB_IDS`, a restricted tab list applied whenever the app runs in enterprise mode — **which the web console always does** (`moss.is-enterprise-mode` returns `true` unconditionally)

`recharge` was missing from the second list. So after switching the deployment to `approve`, the sider still rendered exactly the restricted set with credits absent.

**A control plane could serve points, usage and applications, and nobody could open the page.** The route existed at `/settings/recharge`; the menu never offered it.

Listing it there is safe because the first gate still applies — a deployment that declares `disabled` continues to hide it, which is the behaviour an on-prem install wants.

## Related, not fixed here

In `disabled` mode the page itself still renders the points dashboard, but the nav hides the entry outright. The page is reachable by URL and not by menu. Left alone because the mode is about to be set correctly on the deployments that have credits, and changing what `disabled` means is a product decision rather than a defect.

## Verification

`bun run type:check` green for both workspaces, prettier clean.