### PR TITLE
fix(webui): every user shared one login rate-limit bucket behind the proxy

### DIFF
--- a/apps/webui/docker-compose.yml
+++ b/apps/webui/docker-compose.yml
@@ -26,6 +26,10 @@ services:
       SESSION_HMAC_KEY: ${SESSION_HMAC_KEY}
       TOKEN_AES_KEY: ${TOKEN_AES_KEY}
       PUBLIC_ORIGIN: ${PUBLIC_ORIGIN}
+      # This compose normally sits behind an nginx/Caddy layer. Left off, req.ip
+      # is always the gateway's address and the login rate limit (10 per 15
+      # minutes) is shared by every user of the deployment.
+      TRUST_PROXY: ${TRUST_PROXY:-true}
       MOSS_BASE_URL: ${MOSS_BASE_URL}
       MOSS_WS_BASE_URL: ${MOSS_WS_BASE_URL}
       PORT: '26808'

--- a/apps/webui/src/server/app.ts
+++ b/apps/webui/src/server/app.ts
@@ -62,10 +62,22 @@ export const globalTerminalManager = new TerminalManager()
 
 export interface AppDeps {
   publicOrigin: string
+  trustProxy?: boolean
 }
 
 export function createApp(deps: AppDeps): Express {
   const app = express()
+
+  // One hop, not `true`, when a reverse proxy is configured.
+  //
+  // `true` takes the leftmost X-Forwarded-For entry, which is the part a client
+  // can write itself; `1` trusts only the adjacent hop — the segment nginx
+  // appends — so a forged value is skipped. The difference is not theoretical:
+  // the five login routes share one counter of 10 per 15 minutes, bucketed by
+  // req.ip. Left unset, req.ip is always nginx's address, so everyone shares
+  // those 10 and a few bad password attempts lock out the rest; set to `true`,
+  // any caller picks their own bucket and the limit stops meaning anything.
+  app.set('trust proxy', deps.trustProxy ? 1 : false)
 
   app.get('/health/live', (_req, res) => {
     res.json({ status: 'ok' })

--- a/apps/webui/src/server/config.ts
+++ b/apps/webui/src/server/config.ts
@@ -123,6 +123,13 @@ export function loadConfig(configPath?: string): AppConfig {
   if (process.env.PORT && /^\d+$/.test(process.env.PORT)) {
     file = { ...file, server: { ...file.server, port: Number(process.env.PORT) } }
   }
+  // Container deployments ship no config file and configure everything through
+  // the environment, so this setting had no way to be turned on: present in the
+  // schema, reachable from nowhere, leaving req.ip pinned to the gateway address
+  // behind a reverse proxy.
+  if (process.env.TRUST_PROXY) {
+    file = { ...file, trustProxy: /^(1|true)$/i.test(process.env.TRUST_PROXY.trim()) }
+  }
 
   const isProduction = process.env.NODE_ENV === 'production'
   const publicOriginUrl = new URL(file.publicOrigin)

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -14,7 +14,7 @@ import { closePool, getPool } from './db.js'
 
 const config = loadConfig()
 
-const app = createApp({ publicOrigin: config.publicOrigin })
+const app = createApp({ publicOrigin: config.publicOrigin, trustProxy: config.trustProxy })
 const pool: Pool = getPool(config.databaseUrl)
 const mossAuth = createMossAuthPort(mossRequest)
 

--- a/apps/webui/tests/unit/server/trustProxy.test.ts
+++ b/apps/webui/tests/unit/server/trustProxy.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { createApp } from '@server/app'
+import { loadConfig } from '@server/config'
+
+/**
+ * Proxy trust fails silently when it is wrong: it only pins req.ip to the
+ * gateway's address.
+ *
+ * The cost lands on login rate limiting. /send-code, /login/phone,
+ * /login/password, /login/api-key and /register/phone share a single counter of
+ * 10 per 15 minutes, bucketed by req.ip. A req.ip that never varies means every
+ * user of the deployment shares those 10.
+ *
+ * These assert the wiring rather than the behaviour, because the wiring is what
+ * broke: the setting was in the schema all along, but container deployments had
+ * no way to turn it on, and nothing called app.set() even when they did.
+ */
+
+const ENV_KEYS = [
+  'TRUST_PROXY',
+  'PUBLIC_ORIGIN',
+  'MOSS_BASE_URL',
+  'MOSS_WS_BASE_URL',
+  'DATABASE_URL',
+  'SESSION_HMAC_KEY',
+  'TOKEN_AES_KEY',
+] as const
+
+const saved = new Map<string, string | undefined>()
+
+function setEnv(values: Record<string, string | undefined>): void {
+  for (const key of ENV_KEYS) {
+    if (!saved.has(key)) saved.set(key, process.env[key])
+  }
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of saved) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  saved.clear()
+})
+
+const BASE_ENV = {
+  PUBLIC_ORIGIN: 'https://webui.example.com',
+  MOSS_BASE_URL: 'https://moss.example.com',
+  MOSS_WS_BASE_URL: 'wss://moss.example.com',
+  DATABASE_URL: 'postgres://u:p@localhost:5432/db',
+  SESSION_HMAC_KEY: 'a'.repeat(64),
+  TOKEN_AES_KEY: 'b'.repeat(64),
+}
+
+describe('TRUST_PROXY (the only handle a container deployment has)', () => {
+  test('stays off when unset', () => {
+    setEnv({ ...BASE_ENV, TRUST_PROXY: undefined })
+    expect(loadConfig().trustProxy).toBe(false)
+  })
+
+  test('true / 1 turn it on, case-insensitively', () => {
+    for (const raw of ['true', 'TRUE', '1', ' true ']) {
+      setEnv({ ...BASE_ENV, TRUST_PROXY: raw })
+      expect(loadConfig().trustProxy, `TRUST_PROXY=${JSON.stringify(raw)}`).toBe(true)
+    }
+  })
+
+  test('anything else reads as off, with no generous interpretation', () => {
+    for (const raw of ['false', '0', 'yes', 'on']) {
+      setEnv({ ...BASE_ENV, TRUST_PROXY: raw })
+      expect(loadConfig().trustProxy, `TRUST_PROXY=${JSON.stringify(raw)}`).toBe(false)
+    }
+  })
+})
+
+describe("createApp's 'trust proxy' setting", () => {
+  test('trusts exactly one hop when enabled, not `true`', () => {
+    const app = createApp({ publicOrigin: 'https://webui.example.com', trustProxy: true })
+    // `true` would take the leftmost X-Forwarded-For entry, which the caller
+    // chooses — the rate limit would stop meaning anything. `1` trusts only the
+    // segment nginx itself appended.
+    expect(app.get('trust proxy')).toBe(1)
+  })
+
+  test('trusts no forwarding header when disabled', () => {
+    const app = createApp({ publicOrigin: 'https://webui.example.com', trustProxy: false })
+    expect(app.get('trust proxy')).toBe(false)
+  })
+
+  test('defaults to off, so a directly exposed deployment cannot be told a client IP', () => {
+    const app = createApp({ publicOrigin: 'https://webui.example.com' })
+    expect(app.get('trust proxy')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What was wrong

The five login routes — `/send-code`, `/login/phone`, `/login/password`, `/login/api-key`, `/register/phone` — share a single `express-rate-limit` instance of **10 requests per 15 minutes**, bucketed by `req.ip`.

Behind the production nginx, `req.ip` was always the gateway's address. So that bucket was **global**: ten attempts by any one person locked out every other user for the rest of the window — including people signing up for the first time.

## Why it was invisible

`trustProxy` has been in the config schema all along. Two gaps kept it inert:

1. Container deployments ship no config file and configure through the environment. No env var mapped to `trustProxy`, so it could not be turned on.
2. Nothing ever called `app.set('trust proxy', …)`, so setting it would not have helped.

The running container has been logging `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` on every request since it was first deployed. Requests still succeeded, so it read as noise rather than as the limiter telling us it could not identify callers.

## One hop, not `true`

`true` takes the **leftmost** `X-Forwarded-For` entry, which is the part a client writes itself — that would trade a limit shared by everyone for a limit anyone can sidestep. `1` trusts only the segment nginx appends.

## Tests

Assert the wiring rather than the limiting behaviour, because the wiring is what broke. A setting can be parsed, validated and documented while being connected to nothing, and only a test that follows it end to end notices.

- `TRUST_PROXY` is read from the environment; `true`/`1` on, anything else off
- `createApp` sets `trust proxy` to `1` when enabled, `false` otherwise, `false` by default