### PR TITLE
fix(e2e): repair the suite's bootstrap after the monorepo move

### DIFF
--- a/apps/desktop/tests/e2e/generate.py
+++ b/apps/desktop/tests/e2e/generate.py
@@ -380,8 +380,13 @@ def main():
     OPS_DIR.mkdir(exist_ok=True)
 
     # Write primitives/__init__.py
+    #
+    # encoding="utf-8" on every write, not just the spec read above: the
+    # generated code carries non-ASCII (WebDriver "§", em-dashes), and
+    # write_text defaults to the locale encoding — on a Windows GBK box that
+    # silently rewrites all 13 files with mojibake.
     (PRIMITIVES_DIR / "__init__.py").write_text(
-        "# AUTO-GENERATED — DO NOT EDIT\n"
+        "# AUTO-GENERATED — DO NOT EDIT\n", encoding="utf-8"
     )
 
 
@@ -389,13 +394,13 @@ def main():
     generated_primitives = []
     for name in CORE_PARAMS:
         code = generate_primitive(name)
-        (PRIMITIVES_DIR / f"{name}.py").write_text(code)
+        (PRIMITIVES_DIR / f"{name}.py").write_text(code, encoding="utf-8")
         generated_primitives.append(name)
         print(f"  primitives/{name}.py")
 
     # Write ops/__init__.py
     (OPS_DIR / "__init__.py").write_text(
-        "# AUTO-GENERATED — DO NOT EDIT\n"
+        "# AUTO-GENERATED — DO NOT EDIT\n", encoding="utf-8"
     )
 
     # Keep registry.py (not generated)
@@ -406,7 +411,7 @@ def main():
     for name in CORE_PARAMS:
         spec = primitives_spec.get(name, {})
         code = generate_op(name, spec)
-        (OPS_DIR / f"{name}.py").write_text(code)
+        (OPS_DIR / f"{name}.py").write_text(code, encoding="utf-8")
         generated_ops.append(name)
         print(f"  ops/{name}.py")
 

--- a/apps/desktop/tests/e2e/ops/_ui_ready.py
+++ b/apps/desktop/tests/e2e/ops/_ui_ready.py
@@ -1,12 +1,22 @@
-"""Shared UI-readiness probe: is the chat send-box present and interactive?
+"""Shared UI-readiness probes: how far has the renderer actually got?
 
-Single source of truth for "the app is in a usable conversation view",
-consumed by `wait_for_app_ready` and `reset_conversation`. Locale-independent
-by design — it keys off the send-box <textarea>'s visibility
-(offsetHeight/Width > 0), never a localized label. The login screen and the
-InitLoading dialog carry no visible chat textarea (only hidden inputs), so a
-visible one is a reliable "ready" signal in any language.
+Single source of truth for two questions the rest of the framework keeps
+asking, consumed by `wait_for_app_ready`, `reset_conversation`,
+`dismiss_init_dialog` and the auth seeding in `restart_electron.py`:
+
+- `has_visible_sendbox` — "is the app in a usable conversation view", the
+  readiness gate. It keys off the send-box <textarea>'s visibility
+  (offsetHeight/Width > 0), never a localized label. The login screen and the
+  InitLoading dialog carry no visible chat textarea (only hidden inputs), so a
+  visible one is a reliable "ready" signal in any language.
+- `shell_state` — the coarser "has the shell mounted, and are we past the
+  login screen", for callers that must tell "still booting" apart from
+  "booted, just not on a chat route".
+
+Both are locale-independent by design.
 """
+
+import asyncio
 
 from ai_dev_browser.core.page import js_evaluate
 
@@ -17,8 +27,35 @@ _VISIBLE_SENDBOX_JS = """
 })()
 """
 
+# 'pending' (renderer not mounted) | 'login' | 'in-app'. Any route but the
+# login screen counts as in-app, rather than an allowlist of in-app routes
+# that would go stale the next time a route is renamed.
+SHELL_STATE_JS = """
+(function() {
+    var root = document.getElementById('root');
+    if (!root || root.childElementCount === 0) return 'pending';
+    return (location.hash || '').indexOf('#/login') === 0 ? 'login' : 'in-app';
+})()
+"""
+
 
 async def has_visible_sendbox(tab) -> bool:
     """True when a visible (interactive) chat send-box textarea is on screen."""
     r = await js_evaluate(tab, _VISIBLE_SENDBOX_JS)
     return bool(r.get("result"))
+
+
+async def shell_state(tab) -> str:
+    """Current shell state: 'pending', 'login' or 'in-app'."""
+    r = await js_evaluate(tab, SHELL_STATE_JS)
+    return r.get("result") if isinstance(r, dict) else str(r)
+
+
+async def wait_for_shell_state(tab, wanted: set, timeout: float, poll_interval: float = 1) -> bool:
+    """Poll until the shell reaches one of `wanted`, or `timeout` elapses."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if await shell_state(tab) in wanted:
+            return True
+        await asyncio.sleep(poll_interval)
+    return False

--- a/apps/desktop/tests/e2e/ops/dismiss_init_dialog.py
+++ b/apps/desktop/tests/e2e/ops/dismiss_init_dialog.py
@@ -23,10 +23,21 @@ import asyncio
 from ai_dev_browser.core.page import js_evaluate
 
 
-# Probe both terminal states in one round-trip: the Skip button (init gate up)
-# and a visible send-box textarea (already in the app). Mirrors the visibility
-# rule in wait_for_app_ready — a textarea in the DOM but offscreen (login
-# screen, unmounted dialog) does not count as booted.
+# Probe every terminal state in one round-trip: the Skip button (init gate up),
+# a visible send-box textarea (already in a conversation view), and the app
+# shell mounted on some other route. Mirrors the visibility rule in
+# wait_for_app_ready — a textarea in the DOM but offscreen (login screen,
+# unmounted dialog) does not count as booted.
+#
+# The off-route state is why the shell check exists at all: cases share one
+# app instance, so the previous case can leave the app on Skill Store or
+# Settings, where no send-box exists. Treating that as `pending` burned the
+# full timeout and then blamed a renderer that had mounted minutes earlier.
+# Being off-route is booted — the prelude's `reset_conversation` navigates to
+# /guid next and `wait_for_app_ready` still has to prove interactivity there,
+# so a wrong guess here costs seconds downstream instead of the whole case.
+# Any route but the login screen counts, rather than an allowlist of in-app
+# routes that would go stale the next time a route is renamed.
 _PROBE = """
 (function() {
     var buttons = Array.prototype.slice.call(document.querySelectorAll('button'));
@@ -38,6 +49,12 @@ _PROBE = """
 
     var ta = document.querySelector('textarea');
     if (ta && ta.offsetHeight > 0 && ta.offsetWidth > 0) return 'already-booted';
+
+    var root = document.getElementById('root');
+    var hash = location.hash || '';
+    if (root && root.childElementCount > 0 && hash.length > 2 && hash.indexOf('#/login') !== 0) {
+        return 'booted-off-route';
+    }
 
     return 'pending';
 })()
@@ -53,9 +70,11 @@ async def dismiss_init_dialog(tab, timeout: float = 180, poll_interval: float = 
         poll_interval: Seconds between probes.
 
     Returns:
-        {"pass": True, "state": "dismissed"}      — init dialog was up; Skip clicked.
-        {"pass": True, "state": "already-booted"} — app was already in the main UI.
-        {"pass": False, "reason": ...}            — neither state within `timeout`
+        {"pass": True, "state": "dismissed"}         — init dialog was up; Skip clicked.
+        {"pass": True, "state": "already-booted"}    — app was already in a conversation view.
+        {"pass": True, "state": "booted-off-route"}  — app shell is up on a non-chat
+            route left behind by the previous case.
+        {"pass": False, "reason": ...}               — no such state within `timeout`
             (renderer never mounted, stuck on login, crashed on boot).
     """
     deadline = asyncio.get_running_loop().time() + timeout
@@ -71,8 +90,8 @@ async def dismiss_init_dialog(tab, timeout: float = 180, poll_interval: float = 
             await asyncio.sleep(2)
             return {"pass": True, "state": "dismissed"}
 
-        if state == "already-booted":
-            return {"pass": True, "state": "already-booted"}
+        if state in ("already-booted", "booted-off-route"):
+            return {"pass": True, "state": state}
 
         await asyncio.sleep(poll_interval)
 

--- a/apps/desktop/tests/e2e/ops/dismiss_init_dialog.py
+++ b/apps/desktop/tests/e2e/ops/dismiss_init_dialog.py
@@ -22,6 +22,8 @@ import asyncio
 
 from ai_dev_browser.core.page import js_evaluate
 
+from ._ui_ready import SHELL_STATE_JS
+
 
 # Probe every terminal state in one round-trip: the Skip button (init gate up),
 # a visible send-box textarea (already in a conversation view), and the app
@@ -36,8 +38,6 @@ from ai_dev_browser.core.page import js_evaluate
 # Being off-route is booted — the prelude's `reset_conversation` navigates to
 # /guid next and `wait_for_app_ready` still has to prove interactivity there,
 # so a wrong guess here costs seconds downstream instead of the whole case.
-# Any route but the login screen counts, rather than an allowlist of in-app
-# routes that would go stale the next time a route is renamed.
 _PROBE = """
 (function() {
     var buttons = Array.prototype.slice.call(document.querySelectorAll('button'));
@@ -50,15 +50,9 @@ _PROBE = """
     var ta = document.querySelector('textarea');
     if (ta && ta.offsetHeight > 0 && ta.offsetWidth > 0) return 'already-booted';
 
-    var root = document.getElementById('root');
-    var hash = location.hash || '';
-    if (root && root.childElementCount > 0 && hash.length > 2 && hash.indexOf('#/login') !== 0) {
-        return 'booted-off-route';
-    }
-
-    return 'pending';
+    return __SHELL_STATE__ === 'in-app' ? 'booted-off-route' : 'pending';
 })()
-"""
+""".replace("__SHELL_STATE__", f"({SHELL_STATE_JS.strip()})")
 
 
 async def dismiss_init_dialog(tab, timeout: float = 180, poll_interval: float = 2) -> dict:

--- a/apps/desktop/tests/e2e/restart_electron.py
+++ b/apps/desktop/tests/e2e/restart_electron.py
@@ -12,6 +12,7 @@ Usage:
 import argparse
 import asyncio
 import json
+import socket
 import subprocess
 import sys
 import time
@@ -29,7 +30,31 @@ from ops._enterprise_config import (
 )
 
 
-def kill_electron():
+def _port_is_free(port: int) -> bool:
+    """Can a listener take this port right now?
+
+    Binding is the same test launch-dev.js's findAvailablePort runs, so the
+    two agree on what "free" means — a connect probe would call a socket in
+    TIME_WAIT free while the launcher still refuses it.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(('127.0.0.1', port))
+            return True
+        except OSError:
+            return False
+
+
+def _wait_for_port_free(port: int, timeout: float = 30) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _port_is_free(port):
+            return True
+        time.sleep(1)
+    return False
+
+
+def kill_electron(port=None):
     """Kill any running Electron processes.
 
     Uses `pkill -x` (exact process-name match) on POSIX rather than `-f` (full
@@ -47,11 +72,21 @@ def kill_electron():
                        shell=True, capture_output=True, timeout=10)
     else:
         subprocess.run(['pkill', '-x', 'electron'], capture_output=True, timeout=10)
-    time.sleep(3)
+
+    # Wait for the CDP port to actually come free, rather than sleeping a flat
+    # 3s and hoping. The kill returns as soon as the process is gone, but the
+    # listening socket lingers a few seconds more — and launch-dev.js reacts to
+    # a busy port by silently shifting the app to the next one (9232 -> 9233),
+    # after which wait_for_cdp polls the requested port for its full timeout
+    # and reports "Electron did not start in time" about an app that started
+    # fine somewhere else.
+    if port is not None and not _wait_for_port_free(port, timeout=30):
+        print(f"WARNING: CDP port {port} still bound after 30s — "
+              f"the launcher may shift the app to {port + 1}")
 
 
-def launch_electron():
-    """Launch Electron app in dev mode.
+def launch_electron(port=None):
+    """Launch Electron app in dev mode on `port`.
 
     Redirects stdout/stderr into a per-launch log file under /tmp so a
     failing CDP handshake is diagnosable — DEVNULL made prior CI failures
@@ -67,7 +102,10 @@ def launch_electron():
     log_fh = open(log_path, 'wb')
     print(f"Launching Electron from {project_root} (log: {log_path})...")
     env = os.environ.copy()
-    env['NEXUS_CDP_PORT'] = env.get('NEXUS_CDP_PORT', '9232')
+    # --port is the port the app is launched on, not merely the one we poll.
+    # It used to reach only wait_for_cdp: `--port 9233` launched the app on
+    # 9232 and then waited on 9233 until the timeout.
+    env['NEXUS_CDP_PORT'] = str(port) if port else env.get('NEXUS_CDP_PORT', '9232')
 
     if sys.platform == 'win32':
         proc = subprocess.Popen(
@@ -112,9 +150,11 @@ async def _seed_renderer_localstorage_async(port: int) -> str:
     presented as an auth failure 120s downstream. An eval evaluates; navigation
     is `page_reload`'s job, and it knows to wait for the new document.
     """
-    from ai_dev_browser.core.connection import connect_browser, get_active_tab
     from ai_dev_browser.core.navigation import page_reload, page_wait_ready
     from ai_dev_browser.core.page import js_evaluate
+
+    from ops._ui_ready import wait_for_shell_state
+    from ops.connect import connect
 
     blob = build_enterprise_localstorage_blob()
     # json.dumps twice: the inner call builds the blob the app will parse, the
@@ -138,24 +178,46 @@ async def _seed_renderer_localstorage_async(port: int) -> str:
         }})()
     """
 
-    browser = await connect_browser(host="127.0.0.1", port=port)
-    tab = await get_active_tab(browser)
+    # Pick the tab the way every op does (ops.connect), not via get_active_tab:
+    # the CDP target list also carries webview preview panes and the avatar
+    # window, and seeding localStorage into one of those writes the blob into a
+    # document AuthContext never reads. Connecting is retried because right
+    # after launch the renderer target does not exist yet.
+    deadline = time.time() + 90
+    while True:
+        try:
+            _browser, tab = await connect(port)
+            break
+        except ConnectionError:
+            if time.time() >= deadline:
+                raise RuntimeError("no sudowork renderer target appeared on CDP — nothing to seed auth into")
+            await asyncio.sleep(2)
 
-    result = await js_evaluate(tab, expression)
-    outcome = result.get("result") if isinstance(result, dict) else str(result)
+    # CDP answers before the renderer has mounted, and seeding into a document
+    # that is still booting loses the race: the main process emits authRequired
+    # somewhere in its own startup, AuthContext clears eeclaw_auth_v1, and the
+    # app parks on /login with the seed reporting success. Wait for a mounted
+    # shell first, and afterwards prove the app actually left the login screen
+    # rather than that the key merely survived the reload.
+    if not await wait_for_shell_state(tab, {"login", "in-app"}, timeout=90):
+        raise RuntimeError("renderer never mounted — nothing to seed auth into")
 
-    # Reload so AuthContext.refresh() re-reads localStorage on a fresh document
-    # and takes the authenticated fastpath.
-    await page_reload(tab)
-    await page_wait_ready(tab)
+    for attempt in range(3):
+        result = await js_evaluate(tab, expression)
+        outcome = result.get("result") if isinstance(result, dict) else str(result)
 
-    # Prove the value survived the reload. Without this the seed can report
-    # success while the app boots to the login screen anyway.
-    verify = await js_evaluate(tab, "!!localStorage.getItem('eeclaw_auth_v1')")
-    if not (verify.get("result") if isinstance(verify, dict) else verify):
-        raise RuntimeError("eeclaw_auth_v1 missing from localStorage after reload — auth seed did not stick")
+        # Reload so AuthContext.refresh() re-reads localStorage on a fresh
+        # document and takes the authenticated fastpath.
+        await page_reload(tab)
+        await page_wait_ready(tab)
 
-    return outcome
+        if await wait_for_shell_state(tab, {"in-app"}, timeout=45):
+            return outcome
+
+    raise RuntimeError(
+        "app stayed on the login screen after 3 auth seeds — the mock session is "
+        "being rejected (check the enterprise serverUrl and MOCK_* constants)"
+    )
 
 
 def seed_renderer_localstorage(port: int) -> bool:
@@ -191,6 +253,20 @@ def wait_for_cdp(port=9232, timeout=180):
         except Exception:
             if i % 5 == 0:
                 print(f"  ... still waiting ({i*2}s)")
+
+    # Before declaring the app dead, look where launch-dev.js would have put it:
+    # it shifts to the next free port when the requested one is busy, so the app
+    # can be perfectly healthy a port or two over. Naming that port is the
+    # difference between a one-line fix and debugging a launch that never failed.
+    for probe in range(port + 1, port + 21):
+        try:
+            if urllib.request.urlopen(f'http://localhost:{probe}/json/version', timeout=1).status == 200:
+                print(f"ERROR: nothing on CDP {port}, but an app IS listening on {probe} — "
+                      f"the launcher shifted ports because {port} was still bound; "
+                      f"re-run once {port} is free, or drive the suite with --port {probe}")
+                return False
+        except Exception:
+            continue
     return False
 
 
@@ -206,7 +282,7 @@ def main():
     args = parser.parse_args()
 
     # Kill existing Electron
-    kill_electron()
+    kill_electron(args.port)
 
     # Modify config
     if args.clean or (not args.enterprise and not args.consumer):
@@ -225,7 +301,7 @@ def main():
             set_enterprise_auth_config()
 
     # Launch
-    proc = launch_electron()
+    proc = launch_electron(args.port)
 
     # Wait for CDP
     if not wait_for_cdp(args.port):


### PR DESCRIPTION
## Why

First run of `tests/e2e` since the monorepo restructure moved it to
`apps/desktop/tests/e2e`. The move itself is clean — it was a pure rename, the
workflow already carries `working-directory: apps/desktop`, `restart_electron.py`
derives its project root from `__file__`, and the bun-workspace symlink keeps
`launch-dev.js`'s native-module prereq check resolving. Driving the suite for
real on Windows surfaced four framework defects underneath that, each of which
reports a healthy app as dead, unauthenticated, or unmounted.

No product code touched — changes are confined to `tests/e2e/`.

## What

1. **`generate.py` corrupted its own output on a GBK box.** It read
   `ops-spec.yaml` as UTF-8 but wrote every generated file with `write_text`'s
   locale default, so one regeneration rewrote all 13 op/primitive files with
   mojibake where the WebDriver `§` and em-dashes are. Verified: regenerating
   now produces byte-identical files.

2. **A case that navigated broke the next case's prelude.** Cases share one app
   instance, so a case ending on Skill Store left `dismiss_init_dialog` with no
   send-box to find. It scored that `pending`, burned the full 300s timeout and
   then reported "renderer likely never mounted" about a renderer that had
   mounted minutes earlier. A mounted shell on any route but login now counts as
   booted; `reset_conversation` + `wait_for_app_ready` still prove interactivity
   at `/guid`.

3. **The restart bootstrap landed the app where the suite wasn't looking.**
   `kill_electron` slept a flat 3s, but the CDP socket outlives the process —
   `launch-dev.js` answers a busy port by shifting the app to the next one, so
   the app came up on 9233 while `wait_for_cdp` polled 9232 for 180s and blamed
   a launch that had succeeded. It now waits for the port to be bindable (the
   same test the launcher runs) and, if CDP still never appears, names the port
   the app actually took. `--port` also reached only `wait_for_cdp` — it now
   sets `NEXUS_CDP_PORT`, so `--port 9233` launches on 9233.

4. **The auth seed could write into the wrong document, or too early.** It
   picked its tab with `get_active_tab` while every op picks the renderer via
   `ops.connect`'s URL match, so the blob could land in a webview pane or the
   avatar window. It also seeded into a still-booting document, where
   AuthContext clears `eeclaw_auth_v1` mid-startup and the app parks on `/login`
   with the seed reporting success. It now seeds the renderer tab after the
   shell has mounted, and holds until the app has actually left the login
   screen, re-seeding if it has not.

The shell-state probe added for (2) lives in `ops/_ui_ready.py` next to the
send-box probe, so the init gate and the seeder share one definition of
"mounted, and past login".

## Live validation (Windows, real dev instance)

- Inventory: all 34 cases parse as UTF-8 and every step's `op` resolves against
  the registry; locale pinning intact (8 `zh-CN`, 26 default `en-US`).
- `restart_electron.py --enterprise --auth --port 9233` from a logged-out
  profile: seeded, app lands on `#/guid`. Before (4), the same command reported
  success and left the app on `#/login`.
- `sidebar-nav-by-text` → **5 passed, 0 failed**; `model-command` → **2 passed,
  0 failed**, run directly after a navigating case so it exercises (2);
  `hub-empty-state-token-missing` → step 7 (the DOM negative assertion) passes,
  step 6 remains the pre-existing judge that needs a fresh no-creds profile to
  reproduce TOKEN_MISSING. Same results as before the monorepo move.
- Model-dependent `scode-*` cases were not exercised here: under mock
  enterprise auth scode has no model configured (`claude-sonnet-4-6 not found in
  config`), which is what the CI job's mock-LLM seeding is for.
