### PR TITLE
chore(e2e): ignore the ad-hoc screenshot output dir

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -34,5 +34,9 @@ tests/e2e/screenshots/
 tests/e2e/results/
 tests/e2e/report/
 tests/e2e/output/
+# ai-dev-browser drops screenshots in ./output/ relative to cwd when run_op.py
+# is called without --path, so this lands here whenever the suite is driven
+# from apps/desktop.
+output/
 tests/e2e/__pycache__/
 tests/e2e/ops/__pycache__/


### PR DESCRIPTION
`run_op.py --op screenshot` without `--path` writes `./output/<timestamp>.png` relative to cwd (ai-dev-browser's documented default), so driving the suite from `apps/desktop` leaves an untracked PNG dump in the worktree. The case YAMLs pass an explicit `screenshots/…` path and were already covered; this covers the ad-hoc diagnostic calls.

Follow-up to #1120.