### PR TITLE
fix(webui): legacy /settings/* URLs opened the home screen; nexus-vfs readiness reported the socket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ IPC：`src/preload.ts` 通过 `contextBridge` 暴露类型化 API；主进程侧
 
 ### WebUI（`apps/webui/`）
 
-独立的 monorepo 应用（Express 5 + WebSocket + PostgreSQL，`src/server/`），作为 Moss 企业服务的前置代理，供无界面 / 远程访问。前端**单入口**：`index.html` → `src/client/shared-renderer/main.ts` 挂载 `packages/renderer`（与桌面同一份 UI），传输层 `src/client/bridgeAdapter/mossAdapter.ts` 把 bridge channel 翻译为同源 HTTP + WS。认证走 session cookie（`sudowork-session`）。开发端口 client 26808 / server 26809；生产 `node dist/server/index.js`（默认 26809，`PORT` 可覆盖）。旧 console URL（`/agents`、`/cron/:id`、`/settings/*` 等）由 `main.ts` 客户端重定向到对应 hash 路由。详见 [apps/webui/README.md](apps/webui/README.md)。
+独立的 monorepo 应用（Express 5 + WebSocket + PostgreSQL，`src/server/`），作为 Moss 企业服务的前置代理，供无界面 / 远程访问。前端**单入口**：`index.html` → `src/client/shared-renderer/main.ts` 挂载 `packages/renderer`（与桌面同一份 UI），传输层 `src/client/bridgeAdapter/mossAdapter.ts` 把 bridge channel 翻译为同源 HTTP + WS。认证走 session cookie（`sudowork_session`）。开发端口 client 26808 / server 26809；生产 `node dist/server/index.js`（默认 26809，`PORT` 可覆盖）。旧 console URL（`/agents`、`/cron/:id`、`/settings/*` 等）由 `main.ts` 客户端重定向到对应 hash 路由。详见 [apps/webui/README.md](apps/webui/README.md)。
 
 ### 扩展系统（`src/extensions/`）
 

--- a/apps/desktop/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/apps/desktop/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -14,6 +14,7 @@ import { processSupervisor } from '@process/ProcessSupervisor';
 import runtimeVersions from '@/shared/runtime-versions.json';
 import runtimeSha256 from '@/shared/runtime-sha256.json';
 import { getNexusSecretClient } from '@common/nexus/nexus-secret-client';
+import { getNexusRpcClient } from '@common/nexus/nexus-vfs-client';
 import { extractTarGzWithProgress, extractZipWithProgress } from '../archiveProgress';
 import { vaultPluginInstaller } from './VaultPluginInstaller';
 
@@ -27,7 +28,10 @@ const execAsync = promisify(exec);
  *
  * Differences from DynamicNexusService that matter here:
  *  - nexusd-cluster speaks gRPC only; there is NO HTTP /health endpoint, so
- *    readiness is a TCP-connect probe against the bind port.
+ *    readiness is a TCP-connect probe against the bind port followed by a real
+ *    call through the VFS plane. The port alone is not enough: upstream stopped
+ *    opening persisted zones before serving, so an accepted connection does not
+ *    mean the root zone can answer.
  *  - It is launched via the `serve-local --port <p>` subcommand (nexus-vfs
  *    >=v0.6.0), the shorthand for `--bind-addr 127.0.0.1:<p> --no-tls` — the
  *    trusted-local-backend posture. With no peers it founds a healthy
@@ -39,6 +43,7 @@ const NEXUS_VFS_BIND_HOST = '127.0.0.1';
 const NEXUS_VFS_DEFAULT_PORT = 12022;
 const NEXUS_VFS_POLL_INTERVAL_MS = 200;
 const NEXUS_VFS_START_TIMEOUT_MS = 30_000;
+const NEXUS_VFS_ZONE_READY_TIMEOUT_MS = 10_000;
 const NEXUS_VAULT_READY_TIMEOUT_MS = 5_000;
 
 /** Marker file recording the installed version inside the bin directory. */
@@ -530,6 +535,7 @@ class DynamicNexusVfsService {
     await this.waitForPortReady(this._port, NEXUS_VFS_START_TIMEOUT_MS);
     const elapsed = Date.now() - spawnStart;
     try {
+      await this.waitForVfsZoneReady(NEXUS_VFS_ZONE_READY_TIMEOUT_MS);
       await this.waitForVaultServiceReady(NEXUS_VAULT_READY_TIMEOUT_MS);
     } catch (err) {
       await this.stop().catch(() => {});
@@ -635,6 +641,46 @@ class DynamicNexusVfsService {
       await new Promise<void>((resolve) => setTimeout(resolve, NEXUS_VFS_POLL_INTERVAL_MS));
     }
     throw new Error(`nexus-vfs did not start listening on port ${port} within ${timeoutMs}ms`);
+  }
+
+  /**
+   * Readiness that does not assume an accepted connection means a serving zone.
+   *
+   * A TCP connect only proves the daemon bound its port. Upstream stopped
+   * opening persisted zones before it starts serving (nexus-vfs >=0.7 —
+   * a zone materializes on first access instead), so "the port answers" no
+   * longer implies "the root zone can serve". The eager boot that used to make
+   * that inference hold was an undocumented side effect of the old startup.
+   *
+   * So gate on a real round trip through the VFS plane. `access` on the root is
+   * the cheapest call that forces materialization and reports a zone that
+   * cannot serve, rather than reporting the socket.
+   *
+   * Kept separate from the vault probe below on purpose: that one returns early
+   * whenever the plugin is missing or the platform is unsupported, which would
+   * leave exactly those installs back on a bare port check.
+   */
+  private async waitForVfsZoneReady(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let lastReason = 'unknown error';
+
+    while (Date.now() < deadline) {
+      try {
+        // callRPC rather than exists(): exists() swallows every error and
+        // returns false, which cannot tell "zone not serving" from "no such
+        // path" — the distinction this probe exists to make.
+        await getNexusRpcClient().callRPC('access', { path: '/' });
+        return;
+      } catch (err) {
+        lastReason = err instanceof Error ? err.message : String(err);
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, NEXUS_VFS_POLL_INTERVAL_MS));
+    }
+
+    const msg = `Nexus gRPC port is ready but the root zone did not serve within ${timeoutMs}ms: ${lastReason}`;
+    mainError('NexusVfs', msg);
+    this.emit('error', msg);
+    throw new Error(msg);
   }
 
   private async waitForVaultServiceReady(timeoutMs: number): Promise<void> {

--- a/apps/desktop/tests/unit/DynamicNexusVfsService.test.ts
+++ b/apps/desktop/tests/unit/DynamicNexusVfsService.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const listSecrets = vi.fn();
+const callRPC = vi.fn();
 const processKill = vi.fn();
 const processSupervisorTrack = vi.fn();
 const mainError = vi.fn();
@@ -74,6 +75,10 @@ vi.mock('@common/nexus/nexus-secret-client', () => ({
   getNexusSecretClient: () => ({ listSecrets }),
 }));
 
+vi.mock('@common/nexus/nexus-vfs-client', () => ({
+  getNexusRpcClient: () => ({ callRPC }),
+}));
+
 vi.mock('@/shared/runtime-versions.json', () => ({
   default: { 'nexus-vfs': '0.4.0', 'nexus-vault': '0.4.0' },
 }));
@@ -130,6 +135,7 @@ describe('DynamicNexusVfsService', () => {
     });
     spawnMock.mockReturnValue(new FakeChildProcess());
     mockPortSequence([false, true]);
+    callRPC.mockResolvedValue(true);
   });
 
   it('fails startup when the vault plugin is installed but password-vault is not registered', async () => {
@@ -142,7 +148,7 @@ describe('DynamicNexusVfsService', () => {
     const startPromise = dynamicNexusVfsService.start();
     const startError = startPromise.then(
       () => null,
-      (err: unknown) => err,
+      (err: unknown) => err
     );
     await vi.runAllTimersAsync();
 
@@ -161,5 +167,60 @@ describe('DynamicNexusVfsService', () => {
 
     expect(listSecrets).toHaveBeenCalledWith('__sudowork_startup_probe__', false);
     expect(dynamicNexusVfsService.isRunning).toBe(true);
+  });
+
+  it('proves the root zone serves rather than trusting the accepted connection', async () => {
+    listSecrets.mockReturnValue([]);
+
+    const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
+    await dynamicNexusVfsService.start();
+
+    expect(callRPC).toHaveBeenCalledWith('access', { path: '/' });
+  });
+
+  it('fails startup when the port accepts but the root zone cannot serve', async () => {
+    vi.useFakeTimers();
+    // The shape upstream introduced: the daemon binds and accepts, but a zone
+    // only materializes on first access, so the socket says nothing about it.
+    callRPC.mockRejectedValue(new Error('RPC error: access: zone not available'));
+    listSecrets.mockReturnValue([]);
+
+    const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
+    const startPromise = dynamicNexusVfsService.start();
+    const startError = startPromise.then(
+      () => null,
+      (err: unknown) => err
+    );
+    await vi.runAllTimersAsync();
+
+    const err = await startError;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('root zone did not serve');
+    expect(dynamicNexusVfsService.isRunning).toBe(false);
+    expect(processKill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('still proves the zone when the vault plugin is absent', async () => {
+    vi.useFakeTimers();
+    // This is the branch that mattered: the vault probe returns early without
+    // the plugin, so before the zone probe existed this path degraded to a bare
+    // TCP check and reported ready for a daemon that could not serve.
+    const { vaultPluginInstaller } = await import('@process/services/nexus-vfs/VaultPluginInstaller');
+    vi.mocked(vaultPluginInstaller.checkInstalledSync).mockReturnValue(false);
+    callRPC.mockRejectedValue(new Error('RPC error: access: zone not available'));
+
+    const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
+    const startPromise = dynamicNexusVfsService.start();
+    const startError = startPromise.then(
+      () => null,
+      (err: unknown) => err
+    );
+    await vi.runAllTimersAsync();
+
+    const err = await startError;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('root zone did not serve');
+    expect(listSecrets).not.toHaveBeenCalled();
+    expect(dynamicNexusVfsService.isRunning).toBe(false);
   });
 });

--- a/apps/webui/src/client/shared-renderer/legacyPaths.ts
+++ b/apps/webui/src/client/shared-renderer/legacyPaths.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 SudoPrivacy
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Translation of the old path-based console URLs to the renderer's hash routes.
+ *
+ * Legacy path URLs (/agents, /cron/:id, /settings/*, …) are still served the SPA
+ * shell by the server fallback, and the renderer is a hash router, so the path
+ * has to be rewritten once on the client before mounting.
+ *
+ * Kept apart from `main.ts` so it can be tested: `main.ts` redirects and mounts
+ * at module scope, so importing it runs the app. This drifted once already —
+ * the settings branch listed four of the renderer's eighteen settings routes,
+ * and every other one quietly resolved to the home screen instead of 404ing.
+ */
+
+/**
+ * The hash route a legacy path belongs to, or null when the path is already
+ * hash-routed and nothing should happen.
+ */
+export function hashTargetForLegacyPath(pathname: string): string | null {
+  const path = pathname.replace(/\/+$/, '') || '/'
+  // Normal entry ('/') is already hash-routed — nothing to migrate.
+  if (path === '/') return null
+
+  // Prefix matches carry the remainder through rather than enumerating routes.
+  // A second copy of the route table here is what drifted; the hash router
+  // already sends an unregistered path to /guid, which is where an unmatched
+  // path lands anyway, so forwarding an unknown one costs nothing.
+  const settings = /^\/settings\/(.+)$/.exec(path)
+  const cronId = /^\/cron\/(.+)$/.exec(path)
+  const conversation = /^\/conversation\/(.+)$/.exec(path)
+
+  if (path === '/agents') return '/#/app/agent'
+  if (path === '/skills') return '/#/app/skills'
+  if (cronId) return `/#/app/cron/${cronId[1]}`
+  if (path === '/cron') return '/#/app/cron'
+  if (settings) return `/#/settings/${settings[1]}`
+  if (conversation) return `/#/conversation/${conversation[1]}`
+  if (path === '/login') return '/#/login'
+  return '/#/guid'
+}
+
+/**
+ * Returns true when a redirect was issued (navigation pending — skip mounting).
+ */
+export function redirectLegacyPath(): boolean {
+  const target = hashTargetForLegacyPath(window.location.pathname)
+  if (target === null) return false
+  window.location.replace(target)
+  return true
+}

--- a/apps/webui/src/client/shared-renderer/main.ts
+++ b/apps/webui/src/client/shared-renderer/main.ts
@@ -18,35 +18,7 @@
 
 import '../bridgeAdapter/mossAdapter'
 import { mountApp } from '@sudowork/renderer/bootstrap/mount'
-
-/**
- * Legacy path URLs (/agents, /cron/:id, /settings/*, …) are still served the
- * SPA shell by the server fallback. The renderer is a hash router, so translate
- * the old path to its hash route once, on the client, before mounting. Returns
- * true when a redirect was issued (navigation pending — skip mounting).
- */
-function redirectLegacyPath(): boolean {
-  const path = window.location.pathname.replace(/\/+$/, '') || '/'
-  // Normal entry ('/') is already hash-routed — nothing to migrate.
-  if (path === '/') return false
-
-  const settings = /^\/settings\/(profile|display|about|mcp)$/.exec(path)
-  const cronId = /^\/cron\/(.+)$/.exec(path)
-  const conversation = /^\/conversation\/(.+)$/.exec(path)
-
-  let target = '/#/guid'
-  if (path === '/agents') target = '/#/app/agent'
-  else if (path === '/skills') target = '/#/app/skills'
-  else if (cronId) target = `/#/app/cron/${cronId[1]}`
-  else if (path === '/cron') target = '/#/app/cron'
-  else if (settings) target = `/#/settings/${settings[1]}`
-  else if (conversation) target = `/#/conversation/${conversation[1]}`
-  else if (path === '/login') target = '/#/login'
-  else if (path === '/guid') target = '/#/guid'
-
-  window.location.replace(target)
-  return true
-}
+import { redirectLegacyPath } from './legacyPaths'
 
 if (!redirectLegacyPath()) {
   mountApp()

--- a/apps/webui/tests/unit/legacyPaths.test.ts
+++ b/apps/webui/tests/unit/legacyPaths.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest'
+import { hashTargetForLegacyPath } from '../../src/client/shared-renderer/legacyPaths'
+
+/**
+ * The failure this guards against is not a crash. An unmatched legacy path used
+ * to resolve to '/#/guid', so a real settings URL opened the home screen and
+ * looked like the page simply had nothing on it.
+ *
+ * The settings branch had listed four route names while the renderer registered
+ * eighteen, so most of them were wrong. Enumerating routes in two places is what
+ * caused that, which is why these assert the prefix behaviour rather than a list.
+ */
+
+describe('hashTargetForLegacyPath', () => {
+  test('leaves the normal entry alone', () => {
+    expect(hashTargetForLegacyPath('/')).toBeNull()
+    expect(hashTargetForLegacyPath('')).toBeNull()
+    expect(hashTargetForLegacyPath('///')).toBeNull()
+  })
+
+  test('carries every settings route through, not a chosen few', () => {
+    for (const name of [
+      'model',
+      'profile',
+      'enterprise',
+      'mcp',
+      'display',
+      'channels',
+      'system',
+      'about',
+      'recharge',
+      'members',
+      'skill',
+      'security',
+      'runtime',
+      'tools',
+    ]) {
+      expect(hashTargetForLegacyPath(`/settings/${name}`), name).toBe(`/#/settings/${name}`)
+    }
+  })
+
+  test('keeps nested settings paths whole', () => {
+    expect(hashTargetForLegacyPath('/settings/ext/billing')).toBe('/#/settings/ext/billing')
+  })
+
+  test('forwards an unregistered settings path rather than swallowing it', () => {
+    // The hash router sends this to /guid itself. Forwarding keeps that decision
+    // in one place instead of duplicating the route table here.
+    expect(hashTargetForLegacyPath('/settings/not-a-real-page')).toBe('/#/settings/not-a-real-page')
+  })
+
+  test('maps the remaining legacy console paths', () => {
+    expect(hashTargetForLegacyPath('/agents')).toBe('/#/app/agent')
+    expect(hashTargetForLegacyPath('/skills')).toBe('/#/app/skills')
+    expect(hashTargetForLegacyPath('/cron')).toBe('/#/app/cron')
+    expect(hashTargetForLegacyPath('/cron/job-42')).toBe('/#/app/cron/job-42')
+    expect(hashTargetForLegacyPath('/conversation/abc-123')).toBe('/#/conversation/abc-123')
+    expect(hashTargetForLegacyPath('/login')).toBe('/#/login')
+    expect(hashTargetForLegacyPath('/guid')).toBe('/#/guid')
+  })
+
+  test('ignores a trailing slash', () => {
+    expect(hashTargetForLegacyPath('/settings/recharge/')).toBe('/#/settings/recharge')
+    expect(hashTargetForLegacyPath('/agents/')).toBe('/#/app/agent')
+  })
+
+  test('sends anything unrecognised to the home screen', () => {
+    expect(hashTargetForLegacyPath('/nope')).toBe('/#/guid')
+  })
+})

--- a/docs/project.md
+++ b/docs/project.md
@@ -186,6 +186,11 @@ components/
 
 ### 3. Web 服务器模块 (`src/webserver/`)
 
+> **本节描述的模块已不存在**：`src/webserver/` 在 dev 上已是空目录，无界面访问由 `apps/webui/` 承担。
+> 两者不是同一套实现——本节写的 JWT / bcrypt / 24 小时有效期、以及 cookie 名 `sudowork-session`
+> 都不适用于 `apps/webui`（它用 Postgres 中的 HMAC 会话，cookie 名为 `sudowork_session`，
+> 默认 7 天）。保留本节仅为历史参照，当前行为请以 [apps/webui/README.md](../apps/webui/README.md) 为准。
+
 #### 3.1 认证系统 (`auth/`)
 
 ```


### PR DESCRIPTION
## What was wrong

`main.ts` translates the old path-based console URLs to the renderer's hash routes. Its settings branch listed four route names:

```
/^\/settings\/(profile|display|about|mcp)$/
```

The renderer registers **eighteen** settings routes. Every other one — `/settings/model`, `/settings/recharge`, `/settings/enterprise`, `/settings/system`, … — fell through to the catch-all and resolved to `/#/guid`.

The URL worked. It returned 200. It showed the home screen. That is why it lasted: nothing fails, so a visitor concludes the feature simply is not there.

## The fix

Match the `/settings/` prefix and carry the remainder through, rather than naming routes. Keeping a second copy of the route table in the entry file is what drifted, and it would drift again with one more name added to it. The hash router already sends an unregistered path to `/guid` — exactly where the fall-through was putting it — so forwarding an unknown settings path loses nothing.

Extracted to `legacyPaths.ts` so it can be tested: `main.ts` redirects and mounts at module scope, so importing it runs the app.

## Docs in the same area

- **CLAUDE.md** named the webui session cookie `sudowork-session`. It is `sudowork_session`. Filtering `Set-Cookie` by the documented name yields nothing while the login itself returns 200, which reads as a failed login.
- **docs/project.md §3** documents `src/webserver/` — an empty directory on `dev`. Its JWT / bcrypt / 24-hour auth, and that same cookie name, describe a module that no longer exists. Marked as historical with a pointer to `apps/webui` rather than correcting one field in place, which would make a dead section look maintained.

## Tests

7 cases on the prefix behaviour rather than on a list of names, since enumerating routes in two places is the original defect.