### PR TITLE
fix(nexus-vfs): name the Windows crash we are exposed to, correct the readiness rationale

### DIFF
--- a/apps/desktop/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/apps/desktop/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -46,6 +46,26 @@ const NEXUS_VFS_START_TIMEOUT_MS = 30_000;
 const NEXUS_VFS_ZONE_READY_TIMEOUT_MS = 10_000;
 const NEXUS_VAULT_READY_TIMEOUT_MS = 5_000;
 
+/**
+ * Windows NTSTATUS codes a crashing daemon exits with, named so the log says
+ * what happened instead of a nine-digit number nobody will recognise.
+ *
+ * Heap corruption is here for a specific reason. Up to nexus-vfs plugin ABI v5,
+ * a buffer allocated inside a plugin and freed by the host crossed two
+ * allocators — the host links mimalloc, plugin cdylibs link the system one. On
+ * Windows that traps as 0xC0000374; on Linux a foreign free does not trap, so
+ * the same bug is silent there. Every plugin that hands buffers back is in that
+ * shape, the vault service plugin included, and we ship Windows desktops on a
+ * v5 daemon until the 0.7.x upgrade lands. ABI v6 is the fix.
+ */
+// Unsigned, which is how Node surfaces them on Windows — 0xC0000374 arrives as
+// 3221226356, not as a negative int32.
+const WINDOWS_CRASH_EXIT_CODES: Record<number, string> = {
+  3221226356: 'heap corruption (STATUS_HEAP_CORRUPTION) — known plugin-ABI-v5 cross-allocator free',
+  3221225477: 'access violation (STATUS_ACCESS_VIOLATION)',
+  3221225725: 'stack overflow (STATUS_STACK_OVERFLOW)',
+};
+
 /** Marker file recording the installed version inside the bin directory. */
 const NEXUS_VFS_READY_MARKER = '.nexus-vfs-bin-ready';
 
@@ -523,6 +543,9 @@ class DynamicNexusVfsService {
     });
     this.process.on('exit', (code, signal) => {
       mainLog('NexusVfs', `Process exited — code=${code} signal=${signal} uptime=${Date.now() - spawnStart}ms`);
+      if (code !== null && WINDOWS_CRASH_EXIT_CODES[code]) {
+        mainError('NexusVfs', `Daemon crashed: ${WINDOWS_CRASH_EXIT_CODES[code]} (exit code ${code}).`);
+      }
       this._running = false;
     });
     this.process.on('error', (err) => {
@@ -646,15 +669,22 @@ class DynamicNexusVfsService {
   /**
    * Readiness that does not assume an accepted connection means a serving zone.
    *
-   * A TCP connect only proves the daemon bound its port. Upstream stopped
-   * opening persisted zones before it starts serving (nexus-vfs >=0.7 —
-   * a zone materializes on first access instead), so "the port answers" no
-   * longer implies "the root zone can serve". The eager boot that used to make
-   * that inference hold was an undocumented side effect of the old startup.
+   * A TCP connect only proves the daemon bound its port.
+   *
+   * Narrower than it first looks, and worth stating precisely because the
+   * obvious version of this claim is wrong: on a RESTART of a root-only install
+   * the port does still imply a live root zone, on 0.6.0 and on 0.7.x alike —
+   * 0.7's ZoneManager materializes the eager set (root, plus the credential
+   * zone) before the gRPC server accepts.
+   *
+   * Where it fails is FIRST boot: with no root on disk, the boot path creates it
+   * after the server is already accepting. That has never been true, 0.6.0
+   * included. It also stops holding for any node that hosts zones beyond the
+   * eager set, which is where the hosted model is headed.
    *
    * So gate on a real round trip through the VFS plane. `access` on the root is
-   * the cheapest call that forces materialization and reports a zone that
-   * cannot serve, rather than reporting the socket.
+   * the cheapest call that reports a zone which cannot serve, rather than
+   * reporting the socket.
    *
    * Kept separate from the vault probe below on purpose: that one returns early
    * whenever the plugin is missing or the platform is unsupported, which would

--- a/apps/desktop/tests/unit/DynamicNexusVfsService.test.ts
+++ b/apps/desktop/tests/unit/DynamicNexusVfsService.test.ts
@@ -169,6 +169,35 @@ describe('DynamicNexusVfsService', () => {
     expect(dynamicNexusVfsService.isRunning).toBe(true);
   });
 
+  it('names a Windows heap-corruption crash instead of logging a bare number', async () => {
+    listSecrets.mockReturnValue([]);
+    const child = new FakeChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
+    await dynamicNexusVfsService.start();
+
+    // 0xC0000374, as Node surfaces it on Windows — unsigned, not a negative
+    // int32. Getting that wrong makes the lookup silently never match.
+    child.emit('exit', 3221226356, null);
+
+    expect(mainError).toHaveBeenCalledWith('NexusVfs', expect.stringContaining('heap corruption'));
+    expect(mainError).toHaveBeenCalledWith('NexusVfs', expect.stringContaining('plugin-ABI-v5'));
+    expect(dynamicNexusVfsService.isRunning).toBe(false);
+  });
+
+  it('stays quiet on an ordinary exit', async () => {
+    listSecrets.mockReturnValue([]);
+    const child = new FakeChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
+    await dynamicNexusVfsService.start();
+    child.emit('exit', 0, null);
+
+    expect(mainError).not.toHaveBeenCalled();
+  });
+
   it('proves the root zone serves rather than trusting the accepted connection', async () => {
     listSecrets.mockReturnValue([]);
 


### PR DESCRIPTION
Two follow-ups after the nexus team corrected their own earlier report to us.

## The readiness comment gave the wrong reason

#1122 added a probe that round-trips `access /` before declaring the daemon ready. The probe is right. The rationale in the comment was not.

It claimed 0.7 stopped opening persisted zones before serving, so an accepted port stopped implying a live root zone. The real semantics are narrower: 0.7's `ZoneManager` materializes the **eager set** — root plus the credential zone — *before* the gRPC server accepts. On a restart of a root-only install, port-open ⇒ root-live still holds, on 0.6.0 and 0.7.x alike.

Where it actually fails:
- **First boot.** With no root on disk, the boot path creates it *after* the server is already accepting. That was already false on 0.6.0 — not something 0.7 introduced.
- **Any node hosting zones beyond the eager set**, which is where the hosted model is headed.

The probe stays. Only the justification changes. A wrong *why* in a comment outlives a wrong *what*.

## Naming the Windows crash we are currently exposed to

Through plugin ABI **v5**, a buffer allocated inside a plugin and freed by the host crosses two allocators — the host links mimalloc, plugin cdylibs link the system one. On Windows that traps as `0xC0000374` (`STATUS_HEAP_CORRUPTION`). On Linux a foreign `free` does not trap, so the same bug is invisible there. The nexus team hit it as a hard daemon crash in their search plugin.

Every plugin that returns buffers to the host is in that shape — **the vault service plugin included**. We pin `nexus-vfs 0.6.0` (ABI v5) and we ship Windows desktops.

Today such a crash logs as `Process exited — code=3221226356` and is read by nobody. This maps the three NTSTATUS codes worth recognising so the log says what happened.

**This is not the fix.** ABI v6 is, and it arrives with the 0.7.3 upgrade — which is forced rather than optional, because the loader hard-fails on an ABI mismatch and fails *boot* rather than skipping a plugin. That upgrade needs the vault dylib rebuilt and re-signed against the same rev as the daemon, so it is its own piece of work. This change only makes the symptom recognisable until then.

Codes are stored unsigned, which is how Node surfaces them on Windows. Writing `0xC0000374 | 0` would wrap to a negative int32 and never match; the tests pin the value Node actually reports.