### PR TITLE
fix(nexus-vfs): the readiness probe called a method the daemon does not have

### DIFF
--- a/apps/desktop/src/common/nexus/nexus-vfs-client.ts
+++ b/apps/desktop/src/common/nexus/nexus-vfs-client.ts
@@ -51,6 +51,27 @@ export class Nexus {
   }
 
   /**
+   * Server identity and the zone currently serving, as a typed RPC.
+   *
+   * One of the few calls `nexusd-cluster` answers without a plugin behind it —
+   * `read`/`write` and this. The generic `call` dispatch below reaches kernel
+   * methods that this daemon does not register (`access`, `mkdir`, `readdir`
+   * and `ping` all come back as "unknown Call method"), so anything that must
+   * simply establish the daemon is answering has to go through here.
+   *
+   * Returning `zone_id` is what makes it usable as a liveness check rather than
+   * a transport check: it names the zone that answered.
+   */
+  public async serverInfo(): Promise<{ version?: string; zone_id?: string; uptime_seconds?: string }> {
+    try {
+      return await this.client.serverInfo(this.authToken);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new NexusError(`RPC error: serverInfo: ${msg}`);
+    }
+  }
+
+  /**
    * Generic gRPC Call RPC — dispatches to kernel method by name.
    */
   public async callRPC(method: string, params: Record<string, unknown>): Promise<unknown> {

--- a/apps/desktop/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
+++ b/apps/desktop/src/process/services/nexus-vfs/DynamicNexusVfsService.ts
@@ -682,9 +682,17 @@ class DynamicNexusVfsService {
    * included. It also stops holding for any node that hosts zones beyond the
    * eager set, which is where the hosted model is headed.
    *
-   * So gate on a real round trip through the VFS plane. `access` on the root is
-   * the cheapest call that reports a zone which cannot serve, rather than
-   * reporting the socket.
+   * So gate on a real round trip through the VFS plane. `serverInfo` is the
+   * call to use, and this is worth spelling out because the obvious choices are
+   * not available: `nexusd-cluster` answers `read`, `write` and `serverInfo`,
+   * while `access`, `mkdir`, `readdir` and `ping` all come back as "unknown
+   * Call method" — on 0.7.x and on the 0.6.0 we ship today alike. A probe built
+   * on any of those would never succeed, and since a failed probe aborts
+   * startup, it would stop the daemon from coming up at all.
+   *
+   * `serverInfo` also answers the question actually being asked: it returns the
+   * `zone_id` that served the call, so a reply names a live zone rather than
+   * merely proving the socket accepted.
    *
    * Kept separate from the vault probe below on purpose: that one returns early
    * whenever the plugin is missing or the platform is unsupported, which would
@@ -696,11 +704,12 @@ class DynamicNexusVfsService {
 
     while (Date.now() < deadline) {
       try {
-        // callRPC rather than exists(): exists() swallows every error and
-        // returns false, which cannot tell "zone not serving" from "no such
-        // path" — the distinction this probe exists to make.
-        await getNexusRpcClient().callRPC('access', { path: '/' });
-        return;
+        // Not exists(): it swallows every error and returns false, which cannot
+        // tell "zone not serving" from "no such path" — the distinction this
+        // probe exists to draw.
+        const info = await getNexusRpcClient().serverInfo();
+        if (info?.zone_id) return;
+        lastReason = `serverInfo answered without a zone_id: ${JSON.stringify(info)}`;
       } catch (err) {
         lastReason = err instanceof Error ? err.message : String(err);
       }

--- a/apps/desktop/tests/unit/DynamicNexusVfsService.test.ts
+++ b/apps/desktop/tests/unit/DynamicNexusVfsService.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const listSecrets = vi.fn();
-const callRPC = vi.fn();
+const serverInfo = vi.fn();
 const processKill = vi.fn();
 const processSupervisorTrack = vi.fn();
 const mainError = vi.fn();
@@ -76,7 +76,7 @@ vi.mock('@common/nexus/nexus-secret-client', () => ({
 }));
 
 vi.mock('@common/nexus/nexus-vfs-client', () => ({
-  getNexusRpcClient: () => ({ callRPC }),
+  getNexusRpcClient: () => ({ serverInfo }),
 }));
 
 vi.mock('@/shared/runtime-versions.json', () => ({
@@ -135,7 +135,7 @@ describe('DynamicNexusVfsService', () => {
     });
     spawnMock.mockReturnValue(new FakeChildProcess());
     mockPortSequence([false, true]);
-    callRPC.mockResolvedValue(true);
+    serverInfo.mockResolvedValue({ version: 'nexusd-cluster', zone_id: 'root' });
   });
 
   it('fails startup when the vault plugin is installed but password-vault is not registered', async () => {
@@ -204,14 +204,35 @@ describe('DynamicNexusVfsService', () => {
     const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
     await dynamicNexusVfsService.start();
 
-    expect(callRPC).toHaveBeenCalledWith('access', { path: '/' });
+    expect(serverInfo).toHaveBeenCalled();
+  });
+
+  it('refuses a reply that names no zone', async () => {
+    vi.useFakeTimers();
+    // A daemon answering the RPC while serving no zone is the case the port
+    // check cannot see. An empty answer must not read as ready.
+    serverInfo.mockResolvedValue({ version: 'nexusd-cluster' });
+    listSecrets.mockReturnValue([]);
+
+    const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
+    const startPromise = dynamicNexusVfsService.start();
+    const startError = startPromise.then(
+      () => null,
+      (err: unknown) => err
+    );
+    await vi.runAllTimersAsync();
+
+    const err = await startError;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('root zone did not serve');
+    expect(dynamicNexusVfsService.isRunning).toBe(false);
   });
 
   it('fails startup when the port accepts but the root zone cannot serve', async () => {
     vi.useFakeTimers();
     // The shape upstream introduced: the daemon binds and accepts, but a zone
     // only materializes on first access, so the socket says nothing about it.
-    callRPC.mockRejectedValue(new Error('RPC error: access: zone not available'));
+    serverInfo.mockRejectedValue(new Error('RPC error: serverInfo: zone not available'));
     listSecrets.mockReturnValue([]);
 
     const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
@@ -236,7 +257,7 @@ describe('DynamicNexusVfsService', () => {
     // TCP check and reported ready for a daemon that could not serve.
     const { vaultPluginInstaller } = await import('@process/services/nexus-vfs/VaultPluginInstaller');
     vi.mocked(vaultPluginInstaller.checkInstalledSync).mockReturnValue(false);
-    callRPC.mockRejectedValue(new Error('RPC error: access: zone not available'));
+    serverInfo.mockRejectedValue(new Error('RPC error: serverInfo: zone not available'));
 
     const { dynamicNexusVfsService } = await import('@process/services/nexus-vfs/DynamicNexusVfsService');
     const startPromise = dynamicNexusVfsService.start();


### PR DESCRIPTION
## The bug

The probe added in #1122 calls `access` through the generic Call dispatch:

```ts
await getNexusRpcClient().callRPC('access', { path: '/' })
```

`nexusd-cluster` does not register that method. The reply is:

```
{"code":-32603,"message":"unknown Call method: access"}
```

The probe therefore could never succeed. A failed probe aborts startup and stops the daemon, so **nexus-vfs would have failed to start on every desktop** — on the version we ship today, not only after the upgrade.

This is on `dev` now. No release has been cut since it merged.

## How it was found, and why the tests did not

By running the actual daemon against the actual plugins. The unit tests passed throughout — they mock the client, so they assert the call was made, not that the daemon answers it. That gap is the whole reason to smoke a runtime bump against the real binary.

## What the daemon actually answers

Verified by running both the 0.1.1 daemon we ship and the 0.1.2 one we are moving to, and calling each:

| method | v0.1.1 | v0.1.2 |
|---|---|---|
| `access`, `mkdir`, `readdir`, `ping` | unknown Call method | unknown Call method |
| `read`, `write` | ok | ok |
| `serverInfo` | ok | ok |

Identical on both, so this is not an upgrade regression — it is a mistake in #1122 that the upgrade work happened to surface.

**Wider consequence, not fixed here:** the same dispatch backs `Nexus.exists()`, `.mkdir()`, `.list()` and `.delete()`. Those have never worked against this daemon. `exists()` returns `false` for every error, which is exactly why it went unnoticed. Worth a separate look at who calls them.

## The fix

`serverInfo`, which answers the question the probe is actually asking:

```json
{"version":"nexusd-cluster","zone_id":"root","uptime_seconds":"202"}
```

It returns the `zone_id` that served the call, so a reply names a live zone rather than proving a socket accepted. A reply without a `zone_id` is treated as not ready.

Confirmed against both running daemons:

```
READY  v0.1.2 (new)  zone_id=root
READY  v0.1.1 (old)  zone_id=root
```