### PR TITLE
fix(acp): a session that never reached the nexus tunnel left no trace

### DIFF
--- a/apps/desktop/src/agent/acp/AcpConnection.ts
+++ b/apps/desktop/src/agent/acp/AcpConnection.ts
@@ -392,6 +392,10 @@ export class AcpConnection {
 
     await this.initialize();
     this.isSetupComplete = true;
+    // Assert the positive. Every other outcome on this path is logged — the
+    // dial failing, the daemon not serving — so without a line here the one
+    // case that cannot be confirmed from a log is the one that worked.
+    mainLog('[ACP]', `${backend} connected over the nexus tunnel (${endpoint})`);
   }
 
   /**

--- a/apps/desktop/src/agent/acp/tunnelEnv.ts
+++ b/apps/desktop/src/agent/acp/tunnelEnv.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Sudowork (sudowork.ai)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mainWarn } from '@process/utils/mainLogger';
+
+/** Backends routed through the nexus managed_agent tunnel when one is serving. */
+const TUNNELLED_BACKENDS = new Set(['scode']);
+
+/**
+ * Decides whether a backend's spawn goes through the nexus tunnel, and says so
+ * either way.
+ *
+ * Pulled out of the spawn path so the decision is testable on its own. The
+ * value here is not the branch — it is that every outcome is stated. Three
+ * things can happen and two of them used to be silent, which made a session
+ * that never reached nexus indistinguishable from one that ran entirely over
+ * the tunnel.
+ *
+ * Scoped to scode: it is the only backend proven end-to-end over the tunnel.
+ * Others stay local until validated, and that is a deliberate allowlist rather
+ * than a capability check.
+ */
+export function resolveTunnelEnv(backend: string, tunnelEndpoint: string | null): Record<string, string> {
+  if (!TUNNELLED_BACKENDS.has(backend)) return {};
+
+  if (!tunnelEndpoint) {
+    mainWarn('[AcpAgent]', `nexus tunnel unavailable (nexusd-cluster not serving); spawning ${backend} locally`);
+    return {};
+  }
+
+  return { ACP_GRPC_ENDPOINT: tunnelEndpoint };
+}

--- a/apps/desktop/src/process/task/AcpAgent.ts
+++ b/apps/desktop/src/process/task/AcpAgent.ts
@@ -457,6 +457,12 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
         const tunnelEndpoint = dynamicNexusVfsService.acpTunnelEndpoint;
         if (tunnelEndpoint) {
           customEnv = { ...customEnv, ACP_GRPC_ENDPOINT: tunnelEndpoint };
+        } else {
+          // Say so. A dial that fails is already warned about downstream, but
+          // this branch — the daemon not serving at all — used to take the local
+          // path without a word, so a session that never went near nexus was
+          // indistinguishable in the logs from one that did.
+          mainWarn('[AcpAgent]', 'nexus tunnel unavailable (nexusd-cluster not serving); spawning scode locally');
         }
       }
 

--- a/apps/desktop/src/process/task/AcpAgent.ts
+++ b/apps/desktop/src/process/task/AcpAgent.ts
@@ -16,6 +16,7 @@ import { transformMessage } from '@sudowork/common/chatLib';
 import { AcpAdapter } from '@/agent/acp/AcpAdapter';
 import { AcpApprovalStore, createAcpApprovalKey } from '@/agent/acp/ApprovalStore';
 import { AcpConnection } from '@/agent/acp/AcpConnection';
+import { resolveTunnelEnv } from '@/agent/acp/tunnelEnv';
 import { CLAUDE_YOLO_SESSION_MODE, CODEBUDDY_YOLO_SESSION_MODE, IFLOW_YOLO_SESSION_MODE, QWEN_YOLO_SESSION_MODE } from '@/agent/acp/constants';
 import { acpDetector } from '@/agent/acp/AcpDetector';
 import { getClaudeModel } from '@/agent/acp/utils';
@@ -453,18 +454,10 @@ class AcpAgent extends BaseAgent<AcpAgentData, AcpPermissionOption> {
       // platform as of nexus-vfs#255 / nexusd-cluster 0.1.1. Scoped to scode —
       // the only backend proven end-to-end over the tunnel; others stay local
       // until validated.
-      if (data.backend === 'scode') {
-        const tunnelEndpoint = dynamicNexusVfsService.acpTunnelEndpoint;
-        if (tunnelEndpoint) {
-          customEnv = { ...customEnv, ACP_GRPC_ENDPOINT: tunnelEndpoint };
-        } else {
-          // Say so. A dial that fails is already warned about downstream, but
-          // this branch — the daemon not serving at all — used to take the local
-          // path without a word, so a session that never went near nexus was
-          // indistinguishable in the logs from one that did.
-          mainWarn('[AcpAgent]', 'nexus tunnel unavailable (nexusd-cluster not serving); spawning scode locally');
-        }
-      }
+      customEnv = {
+        ...customEnv,
+        ...resolveTunnelEnv(data.backend, dynamicNexusVfsService.acpTunnelEndpoint),
+      };
 
       this.extra = {
         ...this.extra,

--- a/apps/desktop/tests/unit/acpTunnelEnv.test.ts
+++ b/apps/desktop/tests/unit/acpTunnelEnv.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mainWarn = vi.fn();
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: (...args: unknown[]) => mainWarn(...args),
+}));
+
+const { resolveTunnelEnv } = await import('@/agent/acp/tunnelEnv');
+
+/**
+ * The third outcome of the tunnel decision, and the one that was silent
+ * longest: the daemon is not serving at all, so the spawn goes local without
+ * ever attempting a dial. A dial that fails is warned about downstream in
+ * AcpConnection; this branch never gets that far.
+ */
+describe('resolveTunnelEnv', () => {
+  beforeEach(() => mainWarn.mockClear());
+
+  it('routes scode through the tunnel when one is serving', () => {
+    expect(resolveTunnelEnv('scode', '127.0.0.1:12022')).toEqual({
+      ACP_GRPC_ENDPOINT: '127.0.0.1:12022',
+    });
+    expect(mainWarn).not.toHaveBeenCalled();
+  });
+
+  it('says so when the daemon is not serving, rather than going local in silence', () => {
+    expect(resolveTunnelEnv('scode', null)).toEqual({});
+    expect(mainWarn).toHaveBeenCalledWith('[AcpAgent]', expect.stringContaining('tunnel unavailable'));
+    expect(mainWarn).toHaveBeenCalledWith('[AcpAgent]', expect.stringContaining('scode'));
+  });
+
+  it('leaves other backends alone, and stays quiet about them', () => {
+    // Not a capability check — a deliberate allowlist. scode is the only
+    // backend proven end-to-end over the tunnel, so the others are not
+    // "failing" to tunnel and must not be reported as though they were.
+    for (const backend of ['claude', 'codex', 'gemini', 'qwen']) {
+      expect(resolveTunnelEnv(backend, '127.0.0.1:12022'), backend).toEqual({});
+      expect(resolveTunnelEnv(backend, null), backend).toEqual({});
+    }
+    expect(mainWarn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/tests/unit/acpTunnelWiring.test.ts
+++ b/apps/desktop/tests/unit/acpTunnelWiring.test.ts
@@ -11,7 +11,9 @@ type SpawnImpl = () => Promise<unknown>;
 async function loadAcpConnection(opts: { grpcConnect: ConnectImpl; spawnGeneric: SpawnImpl }) {
   vi.resetModules();
   vi.doMock('@process/telemetry', () => ({ recordFirstToken: vi.fn() }));
-  vi.doMock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn() }));
+  const mainLog = vi.fn();
+  const mainWarn = vi.fn();
+  vi.doMock('@process/utils/mainLogger', () => ({ mainLog, mainWarn }));
   vi.doMock('@process/utils/shellEnv', () => ({ resolveNpxPath: vi.fn(() => 'npx') }));
   vi.doMock('@process/services/authProxy', () => ({
     getAuthProxyPort: vi.fn(() => null),
@@ -39,10 +41,13 @@ async function loadAcpConnection(opts: { grpcConnect: ConnectImpl; spawnGeneric:
     spawnGenericBackend: spawnGeneric,
   }));
 
+  const grpcSent: Array<{ id?: number; method?: string }> = [];
   class MockGrpcAcpTransport {
     connect = grpcConnect;
     close = grpcClose;
-    send = vi.fn();
+    send = vi.fn((message: { id?: number; method?: string }) => {
+      grpcSent.push(message);
+    });
     get connected() {
       return false;
     }
@@ -69,7 +74,7 @@ async function loadAcpConnection(opts: { grpcConnect: ConnectImpl; spawnGeneric:
   }));
 
   const mod = await import('@/agent/acp/AcpConnection');
-  return { AcpConnection: mod.AcpConnection, grpcConnect, spawnGeneric, buildSpec };
+  return { AcpConnection: mod.AcpConnection, grpcConnect, spawnGeneric, buildSpec, mainLog, mainWarn, grpcSent };
 }
 
 describe('AcpConnection nexus-tunnel routing', () => {
@@ -88,6 +93,45 @@ describe('AcpConnection nexus-tunnel routing', () => {
     expect(buildSpec).toHaveBeenCalledTimes(1); // tunnel path built the spawn-spec
     expect(grpcConnect).toHaveBeenCalledTimes(1); // tunnel connect was attempted
     expect(spawnGeneric).toHaveBeenCalledTimes(1); // …then fell back to local spawn
+  });
+
+  it('says which path a session took, in both directions', async () => {
+    // The defect this pins: two of the three outcomes used to be silent, so a
+    // session that never reached nexus read exactly like one that ran wholly
+    // over the tunnel. Asserting the log IS the regression guard — there is no
+    // other artefact that distinguishes them after the fact.
+    const failed = await loadAcpConnection({
+      grpcConnect: () => Promise.reject(new Error('TUNNEL_UNAVAILABLE')),
+      spawnGeneric: () => Promise.reject(new Error('LOCAL_SPAWN_REACHED')),
+    });
+    await expect(new failed.AcpConnection().connect('scode', '/opt/scode', '/tmp/ws', [], { ACP_GRPC_ENDPOINT: '127.0.0.1:65535' })).rejects.toThrow('LOCAL_SPAWN_REACHED');
+    expect(failed.mainWarn).toHaveBeenCalledWith('[ACP]', expect.stringContaining('falling back to local spawn'));
+
+    const ok = await loadAcpConnection({
+      grpcConnect: () => Promise.resolve(),
+      spawnGeneric: () => Promise.reject(new Error('LOCAL_SPAWN_MUST_NOT_RUN')),
+    });
+    const connection = new ok.AcpConnection();
+    const connecting = connection.connect('scode', '/opt/scode', '/tmp/ws', [], {
+      ACP_GRPC_ENDPOINT: '127.0.0.1:12022',
+    });
+    // The tunnel connects, then the ACP handshake runs. Answer it, or the
+    // connect never resolves and the success line is never reached.
+    await vi.waitFor(() => {
+      expect(ok.grpcSent.some((m) => m.method === 'initialize')).toBe(true);
+    });
+    const init = ok.grpcSent.find((m) => m.method === 'initialize')!;
+    (connection as unknown as { handleMessage: (m: unknown) => void }).handleMessage({
+      jsonrpc: '2.0',
+      id: init.id,
+      result: { protocolVersion: 1 },
+    });
+    await connecting;
+
+    expect(ok.spawnGeneric).not.toHaveBeenCalled();
+    // Names the endpoint, so the log says WHICH daemon served it, not merely
+    // that something did.
+    expect(ok.mainLog).toHaveBeenCalledWith('[ACP]', expect.stringContaining('127.0.0.1:12022'));
   });
 
   it('never attempts the tunnel when no endpoint is advertised', async () => {


### PR DESCRIPTION
Tracked upstream as **gap #12** (silent backend fallback).

## What was invisible

`AcpAgent` routes scode through nexus `managed_agent` when the daemon is serving, and `AcpConnection` falls back to a local spawn when it cannot. Three outcomes, one of them logged:

| outcome | before |
|---|---|
| tunnel dial failed | `mainWarn` — fine |
| `acpTunnelEndpoint` is null (daemon not serving) | **silent** |
| tunnel connected | **silent** |

So a session that never went near nexus was indistinguishable in the logs from one that ran entirely over the tunnel. The case you would want to confirm and the case you would want to notice both looked like nothing.

## The change

Two log lines. The skip says why it skipped; the success names the endpoint it connected over — asserting the positive rather than the absence of a failure, which is the only way a fallback of this shape stays observable.

## What is deliberately unchanged

The fallback itself. The tunnel is an optimization, not a hard dependency, and degrading to a local spawn is better than failing the connection outright. The defect was never that it degrades — it is that it degraded invisibly, which is the same shape as a probe that cannot tell "absent" from "the call does not exist" (#1125) or an `exists()` that returns false for both.