### PR TITLE
fix(nexus): file ops went through a surface the daemon does not carry them on

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -172,7 +172,7 @@
     "@larksuiteoapi/node-sdk": "^1.58.0",
     "@lydell/node-pty": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.20.0",
-    "@nexus-ai-fs/vfs-client": "https://sudowork-runtime-1309794936.cos.accelerate.myqcloud.com/nexus-vfs/clients/node/0.2.4/nexus-ai-fs-vfs-client-0.2.4.tgz",
+    "@nexus-ai-fs/vfs-client": "https://sudowork-runtime-1309794936.cos.accelerate.myqcloud.com/nexus-vfs/clients/node/0.3.0/nexus-ai-fs-vfs-client-0.3.0.tgz",
     "@office-ai/aioncli-core": "^0.30.0",
     "@office-ai/platform": "^0.3.16",
     "@sudowork/common": "workspace:*",

--- a/apps/desktop/src/common/nexus/nexus-vfs-client.ts
+++ b/apps/desktop/src/common/nexus/nexus-vfs-client.ts
@@ -7,8 +7,11 @@
  * Nexus RPC Client
  *
  * File I/O client backed by nexusd-cluster gRPC (port 12022).
- * Uses the official @nexus-ai-fs/vfs-client for typed Read/Write RPCs
- * and the generic Call RPC for stat/readdir/unlink/mkdir.
+ * Every file operation is a typed RPC on @nexus-ai-fs/vfs-client. The generic
+ * Call surface is kept only for what genuinely lives there (registry ops,
+ * `<service>.<method>` plugin dispatch) — it does NOT carry file operations,
+ * and hand-rolling them over it is how `exists`/`list`/`mkdir` came to fail
+ * silently against this daemon.
  *
  * Migrated from HTTP JSON-RPC (:12012) to gRPC (:12022) — all callers
  * (safety hooks, etc.) keep the same public API.
@@ -53,11 +56,9 @@ export class Nexus {
   /**
    * Server identity and the zone currently serving, as a typed RPC.
    *
-   * One of the few calls `nexusd-cluster` answers without a plugin behind it —
-   * `read`/`write` and this. The generic `call` dispatch below reaches kernel
-   * methods that this daemon does not register (`access`, `mkdir`, `readdir`
-   * and `ping` all come back as "unknown Call method"), so anything that must
-   * simply establish the daemon is answering has to go through here.
+   * A typed RPC, like every other file operation here. The generic `call`
+   * dispatch below does not carry these — `access`, `mkdir`, `readdir` and
+   * `ping` all come back as "unknown Call method" on it.
    *
    * Returning `zone_id` is what makes it usable as a liveness check rather than
    * a transport check: it names the zone that answered.
@@ -99,8 +100,8 @@ export class Nexus {
     try {
       const buf = await this.client.read(path, this.authToken);
       if (returnMetadata) {
-        // Fetch stat separately for metadata
-        const stat = (await this.callRPC('sys_stat', { path })) as Record<string, unknown> | null;
+        // Metadata comes from the typed Stat RPC, not the generic surface.
+        const stat = await this.client.stat(path, this.authToken);
         return { content: buf, ...(stat ?? {}) };
       }
       return buf;
@@ -110,13 +111,21 @@ export class Nexus {
     }
   }
 
+  /**
+   * Whether a path is there.
+   *
+   * False means the daemon said "not there". Every other failure throws —
+   * losing that distinction is what let a broken call read as a clean absence
+   * for months: this used to dispatch `access` through the generic Call
+   * surface, which `nexusd-cluster` does not register, and swallow the
+   * resulting "unknown Call method" as `false`.
+   */
   public async exists(path: string): Promise<boolean> {
     try {
-      const raw = await this.client.call('access', JSON.stringify({ path }), this.authToken);
-      const result = JSON.parse(raw);
-      return !!result;
-    } catch {
-      return false;
+      return await this.client.exists(path, this.authToken);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new NexusError(`RPC error: exists ${path}: ${msg}`);
     }
   }
 
@@ -126,7 +135,12 @@ export class Nexus {
    * @param parents If true, create parent directories as needed (like mkdir -p)
    */
   public async mkdir(path: string, parents?: boolean): Promise<void> {
-    await this.callRPC('mkdir', { path, parents: parents ?? true });
+    try {
+      await this.client.mkdir(path, this.authToken, { parents: parents ?? true, existOk: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new NexusError(`RPC error: mkdir ${path}: ${msg}`);
+    }
   }
 
   /**
@@ -135,37 +149,23 @@ export class Nexus {
    * @returns Array of directory items with name, path, isDirectory, etc.
    */
   public async list(path: string): Promise<NexusListItem[]> {
+    let entries;
     try {
-      const raw = await this.client.call('sys_readdir', JSON.stringify({ path }), this.authToken);
-      const result = JSON.parse(raw);
-      // sys_readdir returns array of [path, entry_type] tuples or objects
-      if (Array.isArray(result)) {
-        return result.map((item: unknown): NexusListItem => {
-          if (Array.isArray(item) && item.length >= 2) {
-            const itemPath = String(item[0]);
-            return {
-              path: itemPath,
-              name: itemPath.split('/').pop() || itemPath,
-              entry_type: Number(item[1]),
-              isDirectory: Number(item[1]) === 1,
-            };
-          }
-          if (item && typeof item === 'object') {
-            const obj = item as Record<string, unknown>;
-            const itemPath = typeof obj.path === 'string' ? obj.path : '';
-            return {
-              ...obj,
-              path: itemPath,
-              name: typeof obj.name === 'string' ? obj.name : itemPath.split('/').pop() || itemPath,
-            } as NexusListItem;
-          }
-          return { path: '', name: '' };
-        });
-      }
-      return [];
-    } catch {
-      return [];
+      entries = await this.client.readdir(path, this.authToken);
+    } catch (err) {
+      // Deliberately not `return []`. An empty listing and a failed listing are
+      // different facts, and collapsing them is why the safety poller reported
+      // "no events" for every event it could not enumerate.
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new NexusError(`RPC error: readdir ${path}: ${msg}`);
     }
+    // entryType follows DT_*: 0 file, 1 dir, 2 mount, 4 stream.
+    return entries.map((entry) => ({
+      path: entry.name,
+      name: entry.name.split('/').pop() || entry.name,
+      entry_type: entry.entryType,
+      isDirectory: entry.entryType === 1,
+    }));
   }
 
   /**
@@ -175,10 +175,11 @@ export class Nexus {
    */
   public async delete(path: string): Promise<boolean> {
     try {
-      await this.callRPC('sys_unlink', { path });
+      await this.client.delete(path, this.authToken);
       return true;
-    } catch {
-      return false;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new NexusError(`RPC error: delete ${path}: ${msg}`);
     }
   }
 

--- a/apps/desktop/src/process/services/safety/SecurityHookFile.ts
+++ b/apps/desktop/src/process/services/safety/SecurityHookFile.ts
@@ -83,11 +83,18 @@ export async function readNexusFileAsUtf8(filePath: string): Promise<string | nu
 export async function ensureSecurityHookDirs(): Promise<void> {
   try {
     const client = getNexusClient();
+    // existOk is handled inside mkdir, so reaching the catch means the daemon
+    // could not create them — which the poller cannot work around. The previous
+    // comment here claimed "directories may already exist", and that plausible
+    // reason hid the real one for months: mkdir was dispatched over the generic
+    // Call surface, which this daemon does not carry file operations on, so the
+    // directories were never created at all.
     await client.mkdir(EVENT_DIR, true);
     await client.mkdir(ACTION_DIR, true);
     await client.mkdir(CONFIG_DIR, true);
-  } catch {
-    // Directories may already exist, ignore errors
+  } catch (err) {
+    mainError('SecurityHook', 'Failed to create security hook directories:', err);
+    throw err;
   }
 }
 

--- a/apps/desktop/src/shared/runtime-sha256.json
+++ b/apps/desktop/src/shared/runtime-sha256.json
@@ -1,24 +1,24 @@
 {
   "_doc": "Canonical SHA256 sums for every downloadable nexus-vfs runtime artifact. Single source of truth — scripts/download-nexus-vfs.js (build/install-time), DynamicNexusVfsService.ts (runtime cluster re-installer), and VaultPluginInstaller.ts (runtime vault re-installer) all read from this file. Bump versions in runtime-versions.json AND update the matching entry here in one commit; do NOT inline a SHA back into any source file. Verified against the per-release SHA256SUMS.txt in the COS bucket.",
 
-  "nexusd-cluster-linux-aarch64.tar.gz": "324b7c27fac33d60850ca0ccf898900095f59c3a16d7e3cf8ac4c8a31d09c09b",
-  "nexusd-cluster-linux-x86_64.tar.gz": "123693b50cdd847d116c4beecef001d349f3fdaf26f267923a0b928c5fee06fe",
-  "nexusd-cluster-macos-aarch64.tar.gz": "992aeb8ca07f855731548b99fad8a6d4a3e5e2341af2edc8b9538c481329db75",
-  "nexusd-cluster-macos-x86_64.tar.gz": "3847222c03d706f96f2ce5e6713532bd0e8cac10833e74f237ae09446494fe84",
-  "nexusd-cluster-windows-aarch64.zip": "fe5da8d98c95f67bac4935a43b151708c24e341c7dcaf5d920e2a99a3207239c",
-  "nexusd-cluster-windows-x86_64.zip": "9017792bbfc61433648e783f3da99b5ca83d24b3b427a19c015278e0c49ecde4",
+  "nexusd-cluster-linux-aarch64.tar.gz": "82116f6a5445487cecbfb796d741616cade7e73606bf2353751ebab171b4afba",
+  "nexusd-cluster-linux-x86_64.tar.gz": "3ab747a9c29c53904da2b75c0ffb108a7fe883e6aaf24070afb7c8a4af12ee61",
+  "nexusd-cluster-macos-aarch64.tar.gz": "097117673640e768513edaba310bf887801463e39d1375b1321138bea11db3f5",
+  "nexusd-cluster-macos-x86_64.tar.gz": "f6db7325b3ed1c9645ce9800dab6626887f8f61f489b6ba3e063aa14a1aa0308",
+  "nexusd-cluster-windows-aarch64.zip": "738172f51682385b2847ed350f068cf3b55b74e9807283c65c654bbcbe326876",
+  "nexusd-cluster-windows-x86_64.zip": "5755524971e79a4f07d7652e57152723d55b64464a4e4fbd63e4bf8095b52ffd",
 
-  "nexus-vault-linux-x86_64.tar.gz": "c91295d125764e650dded78efa3ce10dac52a2712f6b4fba82204c172019d84d",
-  "nexus-vault-macos-arm64.tar.gz": "15f44275762df2df044106fd269e35b10e8be80261b8a64069a33934a7bd4f70",
-  "nexus-vault-macos-x86_64.tar.gz": "647dddb9cb9d965aafc40b1c18f23bd50760ed2c1e474a2c0659bcb86d84c33e",
-  "nexus-vault-windows-x86_64.zip": "f3a7b9a8203eef80fd99f239aae91274c05806597e197ac7fe145749e9774143",
+  "nexus-vault-linux-x86_64.tar.gz": "93bb9c7744f1711a570bb309848b37769d9a8a7883c83d8a30ef407f97d73833",
+  "nexus-vault-macos-arm64.tar.gz": "b671aa12913317c4011a337dde0a983cf80e2230fb7f7eeec764d87a33fee0ac",
+  "nexus-vault-macos-x86_64.tar.gz": "a51e19576c18776ea5089d80f3b9dd5d409c94dca5fb631827ad921157f54643",
+  "nexus-vault-windows-x86_64.zip": "d3793400979ecb508c28a57610a5022089815bab2333777e2d547145f290e3e6",
 
-  "nexus-local-connector-linux-x86_64.tar.gz": "1ec39da8fb1368668427d0ae164fac3bc3fbfb01838b3123b6ec5a786a21c205",
-  "nexus-local-connector-macos-arm64.tar.gz": "f22bca9d7e5d54aae7c005842b515fe593677b752a180e06f8f464a7a2a6cae6",
-  "nexus-local-connector-macos-x86_64.tar.gz": "5fa94c62c372c0292ad29a8c67aec934b697ef37bec200bcfcf927a5f8949554",
-  "nexus-local-connector-windows-x86_64.zip": "3a84e8d62124fa15a0555180cda248700879451b784f7ed9f9cf3181b3fe6013",
+  "nexus-local-connector-linux-x86_64.tar.gz": "3bb576d94eba44d4b805c8fe699969bab5ed7f6accea7d953f1933413d404613",
+  "nexus-local-connector-macos-arm64.tar.gz": "565448d429e0785b827d3c89a88a22038e4ba8d4e97a53a66da2475248eafb10",
+  "nexus-local-connector-macos-x86_64.tar.gz": "836baa611054245f74e2348a7cd91a7c2778b5608ae535e797c3627465b64de8",
+  "nexus-local-connector-windows-x86_64.zip": "a8888a7520cba41f2f2f0fbbf4bf77c1ab29917d064e2f118102854eb9bc10df",
 
-  "nexus-fuse-plugin-linux-x86_64.tar.gz": "4e36e9f96cba10bfb165ffd8139f8303a8fa42a95045afeaa35e5f1a2cac0757",
-  "nexus-fuse-plugin-macos-arm64.tar.gz": "4b29eaf81c2dfea7dc54d4e8ee4ca46abee0962f8c8ace610c8393a99cb6e624",
-  "nexus-fuse-plugin-macos-x86_64.tar.gz": "9c8179608b3945fa4e0a3ce37236ac1e145e78dba7f0b8f308c9c6af03c5ac24"
+  "nexus-fuse-plugin-linux-x86_64.tar.gz": "d12ac151c2eb1a07566f19cd3c12154a49c98b3b37c7121ecc442a173b9c2453",
+  "nexus-fuse-plugin-macos-arm64.tar.gz": "49c09fe8a41778fad299e1f80fb012583b711150d821d46f2cf33b63ed485f94",
+  "nexus-fuse-plugin-macos-x86_64.tar.gz": "ac4636a5e754da667344b7e586340d7435a9fcad69e9c0d0390728ea4fff4b39"
 }

--- a/apps/desktop/src/shared/runtime-versions.json
+++ b/apps/desktop/src/shared/runtime-versions.json
@@ -1,10 +1,10 @@
 {
   "nexus": "0.9.43",
-  "nexus-vfs": "0.7.3",
-  "nexusd-cluster": "0.1.2",
-  "nexus-vault": "0.5.54",
-  "nexus-local-connector": "0.4.54",
-  "nexus-fuse-plugin": "0.6.54",
+  "nexus-vfs": "0.7.4",
+  "nexusd-cluster": "0.1.3",
+  "nexus-vault": "0.5.56",
+  "nexus-local-connector": "0.4.56",
+  "nexus-fuse-plugin": "0.6.56",
   "fuse-t": "1.2.7",
   "sudoclaw": "v0.3.0-v2026.3.23-2",
   "scode": "0.1.24"

--- a/apps/desktop/tests/unit/nexusVfsTypedOps.test.ts
+++ b/apps/desktop/tests/unit/nexusVfsTypedOps.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const typed = {
+  exists: vi.fn(),
+  readdir: vi.fn(),
+  mkdir: vi.fn(),
+  delete: vi.fn(),
+  stat: vi.fn(),
+  read: vi.fn(),
+  write: vi.fn(),
+  call: vi.fn(),
+  callBinary: vi.fn(),
+  serverInfo: vi.fn(),
+};
+
+vi.mock('@nexus-ai-fs/vfs-client', () => ({
+  NexusVfsClient: class {
+    exists = (...a: unknown[]) => typed.exists(...a);
+    readdir = (...a: unknown[]) => typed.readdir(...a);
+    mkdir = (...a: unknown[]) => typed.mkdir(...a);
+    delete = (...a: unknown[]) => typed.delete(...a);
+    stat = (...a: unknown[]) => typed.stat(...a);
+    read = (...a: unknown[]) => typed.read(...a);
+    write = (...a: unknown[]) => typed.write(...a);
+    call = (...a: unknown[]) => typed.call(...a);
+    callBinary = (...a: unknown[]) => typed.callBinary(...a);
+    serverInfo = (...a: unknown[]) => typed.serverInfo(...a);
+  },
+}));
+
+const { Nexus } = await import('@common/nexus/nexus-vfs-client');
+
+/**
+ * These file operations were hand-rolled over the generic Call surface, which
+ * `nexusd-cluster` does not carry them on. Every call failed, and every failure
+ * was swallowed into a benign-looking value — `false` from exists, `[]` from
+ * list — so the safety poller reported "no events" for months while never
+ * having been able to enumerate anything.
+ *
+ * What these pin is therefore not "the happy path works". It is that a failure
+ * can no longer arrive disguised as an answer.
+ */
+describe('Nexus file ops go through typed RPCs', () => {
+  let nexus: InstanceType<typeof Nexus>;
+  beforeEach(() => {
+    for (const fn of Object.values(typed)) fn.mockReset();
+    nexus = new Nexus();
+  });
+
+  it('uses the typed RPC, not the generic Call surface', async () => {
+    typed.exists.mockResolvedValue(true);
+    typed.readdir.mockResolvedValue([]);
+    typed.mkdir.mockResolvedValue(undefined);
+    typed.delete.mockResolvedValue(undefined);
+
+    await nexus.exists('/a');
+    await nexus.list('/a');
+    await nexus.mkdir('/a');
+    await nexus.delete('/a');
+
+    expect(typed.exists).toHaveBeenCalled();
+    expect(typed.readdir).toHaveBeenCalled();
+    expect(typed.mkdir).toHaveBeenCalled();
+    expect(typed.delete).toHaveBeenCalled();
+    // The generic surface must not be used for file operations at all.
+    expect(typed.call).not.toHaveBeenCalled();
+  });
+
+  it('propagates a failed listing instead of returning an empty one', async () => {
+    typed.readdir.mockRejectedValue(new Error('unknown Call method: readdir'));
+    await expect(nexus.list('/safe/event')).rejects.toThrow(/readdir/);
+  });
+
+  it('propagates a failed existence check instead of returning false', async () => {
+    typed.exists.mockRejectedValue(new Error('daemon unreachable'));
+    await expect(nexus.exists('/safe/action/x')).rejects.toThrow(/exists/);
+  });
+
+  it('still reports a clean not-found as false', async () => {
+    // The one case that must stay a boolean: the daemon answered, and said no.
+    typed.exists.mockResolvedValue(false);
+    await expect(nexus.exists('/nope')).resolves.toBe(false);
+  });
+
+  it('propagates a failed delete instead of reporting success-by-omission', async () => {
+    typed.delete.mockRejectedValue(new Error('permission denied'));
+    await expect(nexus.delete('/safe/event/x')).rejects.toThrow(/delete/);
+  });
+
+  it('maps directory entries onto the shape callers read', async () => {
+    typed.readdir.mockResolvedValue([
+      { name: '/safe/event/abc', entryType: 0 },
+      { name: '/safe/event/sub', entryType: 1 },
+    ]);
+    const items = await nexus.list('/safe/event');
+    // listEventFilenames() takes the basename off these; a full path in `name`
+    // would silently produce filenames that match no event.
+    expect(items.map((i) => i.name)).toEqual(['abc', 'sub']);
+    expect(items.map((i) => i.isDirectory)).toEqual([false, true]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "@larksuiteoapi/node-sdk": "^1.58.0",
         "@lydell/node-pty": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
-        "@nexus-ai-fs/vfs-client": "https://sudowork-runtime-1309794936.cos.accelerate.myqcloud.com/nexus-vfs/clients/node/0.2.4/nexus-ai-fs-vfs-client-0.2.4.tgz",
+        "@nexus-ai-fs/vfs-client": "https://sudowork-runtime-1309794936.cos.accelerate.myqcloud.com/nexus-vfs/clients/node/0.3.0/nexus-ai-fs-vfs-client-0.3.0.tgz",
         "@office-ai/aioncli-core": "^0.30.0",
         "@office-ai/platform": "^0.3.16",
         "@sudowork/common": "workspace:*",
@@ -1172,7 +1172,7 @@
 
     "@napi-rs/wasm-tools-win32-x64-msvc": ["@napi-rs/wasm-tools-win32-x64-msvc@1.0.1", "http://registry.npm.taobao.org/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.0.1.tgz", { "os": "win32", "cpu": "x64" }, "sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ=="],
 
-    "@nexus-ai-fs/vfs-client": ["@nexus-ai-fs/vfs-client@https://sudowork-runtime-1309794936.cos.accelerate.myqcloud.com/nexus-vfs/clients/node/0.2.4/nexus-ai-fs-vfs-client-0.2.4.tgz", { "dependencies": { "@grpc/grpc-js": "^1.14.4", "@grpc/proto-loader": "^0.8.0", "protobufjs": "^7.6.6" } }, "sha512-s3bkga3w1RcoUsFcBiskxRjfaydclxNXxikta1Vc8l4YAV14CKiAigpXn357qVzGdcFRV93+p3BmUlLh+wQupg=="],
+    "@nexus-ai-fs/vfs-client": ["@nexus-ai-fs/vfs-client@https://sudowork-runtime-1309794936.cos.accelerate.myqcloud.com/nexus-vfs/clients/node/0.3.0/nexus-ai-fs-vfs-client-0.3.0.tgz", { "dependencies": { "@grpc/grpc-js": "^1.14.4", "@grpc/proto-loader": "^0.8.0", "protobufjs": "^7.6.6" } }, "sha512-UWTV2IT3LBQjbpZEOqsA4MPvTKNHcZ+fLlmrIICveENo81RVAeI0koePK9NMynog8fxaCtHkgOhXCDNYSwAtOw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 


### PR DESCRIPTION
## The defect

`exists`, `list`, `mkdir` and `delete` were hand-rolled over the **generic Call dispatch** (`access`, `sys_readdir`, `mkdir`, `sys_unlink`). `nexusd-cluster` does not carry file operations there — it carries registry ops and `<service>.<method>` plugin dispatch. Every one of those calls failed.

Every failure was then caught and turned into a benign value:

| call | on failure | read by the caller as |
|---|---|---|
| `exists` | `return false` | "not there" |
| `list` | `return []` | "empty directory" |
| `delete` | `return false` | "delete failed" (indistinguishable from "cannot call") |

Nothing logged. Nothing threw.

## What it cost

`SafetyPollingService` enumerates `/safe/event` on every poll to find security events to act on. It has been receiving an empty list since it was written — **the safety layer has never seen a single event**. Its three directories were never created either, behind a `catch {}` whose comment read *"Directories may already exist, ignore errors"*: a plausible reason that concealed the real one for months.

## The fix

Every file operation now uses the typed RPC. These have existed on the daemon all along — what was missing was the **client method**, added in `vfs-client 0.3.0`. Failures propagate. `exists` returns `false` only when the daemon says not-found; every other outcome throws, because collapsing "absent" into "broken" is the same defect one layer down.

`ensureSecurityHookDirs` no longer swallows. Both call sites are guarded (the IPC bridge returns `{success:false, msg}` to the user who asked to enable the hook; `ServiceManager` logs and continues), so this surfaces the failure without breaking app startup — checked, not assumed.

## Runtime set moves together

The daemon and every dylib it loads share a plugin ABI, and `load_plugin_dir` fails boot rather than skipping:

| artifact | from | to |
|---|---|---|
| `nexusd-cluster` (assembly) | 0.1.2 | **0.1.3** |
| `nexus-vault` | 0.5.54 | **0.5.56** |
| `nexus-local-connector` | 0.4.54 | **0.4.56** |
| `nexus-fuse-plugin` | 0.6.54 | **0.6.56** |
| `@nexus-ai-fs/vfs-client` | 0.2.4 | **0.3.0** |

`.56` rather than `.55`: the `.55` plugins built on ubuntu-24.04 and needed `GLIBC_2.39`, while the daemon ships from 22.04 (2.34) — any Linux host in between got a daemon that refused to boot once a dylib was present.

## Verification — against a real daemon

v0.1.3 with the v6 dylibs on Windows, driven **through this wrapper** rather than the raw client, since the wrapper is where the bug lived:

```
driver plugin loaded name="local-connector"
service plugin loaded + registered name="password-vault"
service brought up service=managed_agent
```

```
mkdir /safe/event            PASS      write two event files        PASS
mkdir again (existOk)        PASS      enumerate them -> 2          PASS
exists on a fresh dir        PASS      filenames are basenames      PASS
exists on absent path        PASS      read one back                PASS
readdir on empty dir -> []   PASS      delete one, one left         PASS
readdir on a missing path    throws, instead of answering []        PASS
```

`--version` now reads `nexusd-cluster-v0.1.3 (nexus-cluster 0.1.1, plugin-abi 6)` — the ABI is assertable on the wire for the first time.

Sums taken from the COS mirror the installer downloads from; the six assembly artifacts cross-check byte-for-byte against the release `SHA256SUMS.txt`. All four tags resolve to commits pinning nexus-vfs `35df7535`.

## Tests

6 new cases pinning the contract that broke: the typed RPC is used (generic `call` is not), a failed listing propagates instead of returning `[]`, a failed existence check propagates instead of returning `false`, a clean not-found still returns `false`, a failed delete propagates, and directory entries map to the basenames `listEventFilenames` reads.